### PR TITLE
PEN-340 Explicitly Specify Bold Font Face

### DIFF
--- a/blocks/headline-block/features/headline/headline.scss
+++ b/blocks/headline-block/features/headline/headline.scss
@@ -3,6 +3,7 @@ $tablet-breakpoint: 700px;
 
 h1.headline{
   font-family: $theme-secondary-font-family;
+  font-weight: bold;
   font-size: 40px;
   color: #000A12;
   text-decoration: none;


### PR DESCRIPTION
[JIRA Ticket](https://arcpublishing.atlassian.net/browse/PEN-340)
The issue with this is that the h1 styling gets overridden by a random SCSS file that has the h1 font weight set to normal. We'll probably need to make sure to explicitly specify all the styling requirements as our designers put it out because it's so easy to be corrupted by random style values from directories that are nowhere close to the block's, and not rely on the built-in styling from the HTML Element