### PR TITLE
PEN-397 Add better server-side render for Date block

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,6 +11,7 @@ module.exports = {
             'fusion:themes': './jest/mocks/themes.js',
             'fusion:context': './jest/mocks/context.js',
             'fusion:consumer': './jest/mocks/consumer.js',
+            'fusion:environment': './jest/mocks/environment.js',
           },
         }],
       ],

--- a/blocks/date-block/features/date/default.jsx
+++ b/blocks/date-block/features/date/default.jsx
@@ -24,7 +24,7 @@ class ArticleDate extends Component {
         month: 'long',
         hour: 'numeric',
         minute: 'numeric',
-        timeZone: (TIMEZONE) || 'America/New_York', // Default to EST if no timezone is provided in env
+        timeZone: (TIMEZONE) || undefined, // If no timezone is defined, let it use the default value
         timeZoneName: 'short',
       }).format(new Date(dateString))
         .replace(/(,)(.*?)(,)/, '$1$2 at')

--- a/blocks/date-block/features/date/default.jsx
+++ b/blocks/date-block/features/date/default.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Consumer from 'fusion:consumer';
+import { TIMEZONE } from 'fusion:environment';
 import PropTypes from 'prop-types';
 import './date.scss';
 
@@ -17,15 +18,16 @@ class ArticleDate extends Component {
     // Convert the time to browser's local time using the ECMAScript Internationalization API
     // Browser support found here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
     const displayDate = (dateString && Date.parse(dateString)) // check if it's a valid time string
-      ? new Date(dateString)
-        .toLocaleString('default', {
-          year: 'numeric',
-          day: 'numeric',
-          month: 'long',
-          hour: 'numeric',
-          minute: 'numeric',
-          timeZoneName: 'short',
-        }).replace(/(,)(.*?)(,)/, '$1$2 at')
+      ? new Intl.DateTimeFormat('en', {
+        year: 'numeric',
+        day: 'numeric',
+        month: 'long',
+        hour: 'numeric',
+        minute: 'numeric',
+        timeZone: (TIMEZONE) || 'America/New_York', // Default to EST if no timezone is provided in env
+        timeZoneName: 'short',
+      }).format(new Date(dateString))
+        .replace(/(,)(.*?)(,)/, '$1$2 at')
         .replace('PM', 'p.m.')
         .replace('AM', 'a.m.')
       : '';
@@ -46,6 +48,7 @@ class ArticleDate extends Component {
 }
 ArticleDate.propTypes = {
   customFields: PropTypes.shape({
+    // eslint-disable-next-line react/no-typos
     blockDisplay: PropTypes.boolean,
   }),
 };

--- a/blocks/date-block/features/date/default.jsx
+++ b/blocks/date-block/features/date/default.jsx
@@ -24,7 +24,7 @@ class ArticleDate extends Component {
         month: 'long',
         hour: 'numeric',
         minute: 'numeric',
-        timeZone: (TIMEZONE) || undefined, // If no timezone is defined, let it use the default value
+        timeZone: (TIMEZONE && TIMEZONE !== '') ? TIMEZONE : undefined,
         timeZoneName: 'short',
       }).format(new Date(dateString))
         .replace(/(,)(.*?)(,)/, '$1$2 at')

--- a/blocks/date-block/features/date/default.test.jsx
+++ b/blocks/date-block/features/date/default.test.jsx
@@ -2,24 +2,25 @@ const React = require('react');
 const { render } = require('enzyme');
 
 describe('Given the display time from ANS, it should convert to the proper timezone format we want', () => {
-  it('should return proper long form with correctly converted timezone', () => {
+  it('should return proper long form with correctly converted timezone (mocked timezone is in CDT)', () => {
     const { default: ArticleDate } = require('./default');
     const display_date = '2019-08-11T16:45:33.209Z';
     const globalContent = { display_date };
     const customFields = { blockDisplay: true }
     const wrapper = render(<ArticleDate globalContent={globalContent} customFields={customFields} />);
 
-    const testDate = new Date(display_date)
-      .toLocaleString("default", {
-        year: "numeric",
-        day: "numeric",
-        month: "long",
-        hour: "numeric",
-        minute: "numeric",
-        timeZoneName: "short"
-      }).replace(/(,)(.*?)(,)/, "$1$2 at")
-        .replace('PM', 'p.m.')
-        .replace('AM', 'a.m.');
+    const testDate = new Intl.DateTimeFormat('en', {
+      year: 'numeric',
+      day: 'numeric',
+      month: 'long',
+      hour: 'numeric',
+      minute: 'numeric',
+      timeZone: 'America/Chicago', // Default to EST if no timezone is provided in env
+      timeZoneName: 'short',
+    }).format(new Date(display_date))
+      .replace(/(,)(.*?)(,)/, '$1$2 at')
+      .replace('PM', 'p.m.')
+      .replace('AM', 'a.m.');
 
     expect(wrapper.text()).toEqual(testDate);
   });

--- a/blocks/date-block/features/date/default.test.jsx
+++ b/blocks/date-block/features/date/default.test.jsx
@@ -15,7 +15,7 @@ describe('Given the display time from ANS, it should convert to the proper timez
       month: 'long',
       hour: 'numeric',
       minute: 'numeric',
-      timeZone: 'America/Chicago', // Default to EST if no timezone is provided in env
+      timeZone: 'America/Chicago',
       timeZoneName: 'short',
     }).format(new Date(display_date))
       .replace(/(,)(.*?)(,)/, '$1$2 at')

--- a/jest/mocks/environment.js
+++ b/jest/mocks/environment.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export */
+const TIMEZONE = 'America/Chicago';
+
+// Don't export as default so the conventional destructuring assignment can be used
+export {
+  TIMEZONE,
+};


### PR DESCRIPTION
[JIRA Ticket](https://arcpublishing.atlassian.net/browse/PEN-397)
Because the full-icu library is too big (50mb uncompressed), we'll scrap the internationalization of the dates for now. Instead, we can leverage the `Intl` object and just use English locale at all times, which will match the client-side formatting. This will obviously be an issue for international customers if they wish to use their local time formatting - will have to address that in the future.

Also dependent on adding an additional timezone env variable on Maestro so that the customers can set their own timezone if they prefer. Otherwise it'll use default timezone on the server before showing (and flickering) the client's timezone retrieved from the browser