### PR TITLE
PEN-515: Prepend location to first paragraph

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -193,7 +193,10 @@ const ArticleBodyChain = ({ children }) => {
   // Iterate through the content element array and place each subsequent
   //  content elements into the array. Skip if the place is taken
   let paragraphPosition = 0;
-  items.content_elements.forEach((item, index) => {
+  const { content_elements: contentElements, location } = items;
+  const firstParagraph = contentElements.find(elements => elements.type === 'text');
+  firstParagraph.content = location ? `${location} &mdash; ${firstParagraph.content}` : firstParagraph.content;
+  contentElements.forEach((item, index) => {
     const articleElement = parseArticleItem(item, index, arcSite);
 
     // If there's already an element at the specified article body position, skip


### PR DESCRIPTION
If Location property exists on global content prepend it to the first paragraph followed by a space and &mdash; and space