### PR TITLE
Fixed the thumbor dimensions for the results list

### DIFF
--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -74,12 +74,12 @@ class ResultsList extends Component {
                   <Image
                     url={extractImage(element.promo_items)}
                     alt={headlineText}
-                    smallWidth={160}
-                    smallHeight={0}
-                    mediumWidth={240}
-                    mediumHeight={0}
-                    largeWidth={320}
-                    largeHeight={0}
+                    smallWidth={274}
+                    smallHeight={148}
+                    mediumWidth={274}
+                    mediumHeight={148}
+                    largeWidth={274}
+                    largeHeight={148}
                   />
                 ) : <div className="image-placeholder" />}
               </a>

--- a/blocks/results-list-block/features/results-list/results-list.scss
+++ b/blocks/results-list-block/features/results-list/results-list.scss
@@ -5,7 +5,7 @@
 
   .list-anchor {
     text-decoration: none;
-    height: 148.26px;
+    height: 148px;
     width: 274px;
     overflow-y: hidden;
 


### PR DESCRIPTION
I broke the images in the results list and it made them a bunch of different weird widths so I fixed it. The current SCSS for the results list never makes the image any smaller or any bigger than 274x148 so we're just gonna do that for all the viewport widths.