### PR TITLE
PEN-564: Overline text and URL can be overriden by `label` in ANS doc

### DIFF
--- a/blocks/overline-block/features/overline/default.jsx
+++ b/blocks/overline-block/features/overline/default.jsx
@@ -10,36 +10,38 @@ const StyledLink = styled.a`
   text-decoration: none;
 `;
 
-function _get (obj, ...args) {
-  return args.reduce((obj, level) => obj && obj[level], obj)
-}
-
 const Overline = () => {
-  const { globalContent: content, arcSite } = useFusionContext();
+  const { globalContent: content = {}, arcSite } = useFusionContext();
 
-  const shouldUseLabel = !!_get(content, 'label', 'basic', 'display')
+  const {
+    display: labelDisplay,
+    url: labelUrl,
+    text: labelText,
+  } = (content.label && content.label.basic) || {};
+  const shouldUseLabel = !!(labelDisplay);
 
-  const labelText = _get(content, 'label', 'basic', 'text')
-  const labelUrl = _get(content, 'label', 'basic', 'url')
+  const {
+    _id: sectionUrl,
+    name: sectionText,
+  } = (content.websites
+    && content.websites[arcSite]
+    && content.websites[arcSite].website_section) || {};
 
-  const sectionText = _get(content, 'websites', arcSite, 'website_section', 'name')
-  const sectionUrl = _get(content, 'websites', arcSite, 'website_section', '_id')
-
-  const [text, url] = shouldUseLabel ? [labelText, labelUrl] : [sectionText, sectionUrl]
+  const [text, url] = shouldUseLabel ? [labelText, labelUrl] : [sectionText, sectionUrl];
 
   return text
     ? (
       <StyledLink
         href={url}
         primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-        className='overline'
+        className="overline"
       >
         {text}
       </StyledLink>
     )
-    : null
-}
+    : null;
+};
 
-Overline.label = 'Overline – Arc Block'
+Overline.label = 'Overline – Arc Block';
 
-export default Overline
+export default Overline;

--- a/blocks/overline-block/features/overline/default.jsx
+++ b/blocks/overline-block/features/overline/default.jsx
@@ -10,27 +10,36 @@ const StyledLink = styled.a`
   text-decoration: none;
 `;
 
+function _get (obj, ...args) {
+  return args.reduce((obj, level) => obj && obj[level], obj)
+}
+
 const Overline = () => {
   const { globalContent: content, arcSite } = useFusionContext();
 
-  return (
-    !!(
-      content
-      && content.websites[arcSite].website_section
-      && content.websites[arcSite].website_section.name
-      && content.websites[arcSite].website_section._id
-    ) && (
+  const shouldUseLabel = !!_get(content, 'label', 'basic', 'display')
+
+  const labelText = _get(content, 'label', 'basic', 'text')
+  const labelUrl = _get(content, 'label', 'basic', 'url')
+
+  const sectionText = _get(content, 'websites', arcSite, 'website_section', 'name')
+  const sectionUrl = _get(content, 'websites', arcSite, 'website_section', '_id')
+
+  const [text, url] = shouldUseLabel ? [labelText, labelUrl] : [sectionText, sectionUrl]
+
+  return text
+    ? (
       <StyledLink
-        href={content.websites[arcSite].website_section._id}
+        href={url}
         primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-        className="overline"
+        className='overline'
       >
-        {content.websites[arcSite].website_section.name}
+        {text}
       </StyledLink>
     )
-  );
-};
+    : null
+}
 
-Overline.label = 'Overline – Arc Block';
+Overline.label = 'Overline – Arc Block'
 
-export default Overline;
+export default Overline

--- a/blocks/overline-block/features/overline/default.test.jsx
+++ b/blocks/overline-block/features/overline/default.test.jsx
@@ -1,9 +1,7 @@
-/* global jest, describe, it, expect, beforeEach */
-
-import React from 'react'
-import { shallow, mount } from 'enzyme'
-import { useFusionContext } from 'fusion:context'
-import Overline from './default'
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { useFusionContext } from 'fusion:context';
+import Overline from './default';
 
 const mockContextObj = {
   arcSite: 'site',
@@ -12,120 +10,118 @@ const mockContextObj = {
       site: {
         website_section: {
           _id: '/news',
-          name: 'News'
-        }
-      }
-    }
-  }
-}
+          name: 'News',
+        },
+      },
+    },
+  },
+};
 
-jest.mock('fusion:themes', () => (jest.fn(() => ({}))))
+jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:context', () => ({
-  useFusionContext: jest.fn(() => {
-    return mockContextObj
-  })
-}))
+  useFusionContext: jest.fn(() => mockContextObj),
+}));
 
 describe('overline feature for default output type', () => {
   describe('when website_section content from globalContent is present', () => {
     it('should render an a', () => {
-      const wrapper = mount(<Overline />)
+      const wrapper = mount(<Overline />);
 
-      expect(wrapper.find('a')).toHaveClassName('overline')
-    })
+      expect(wrapper.find('a')).toHaveClassName('overline');
+    });
 
     it('should dangerously set the inner HTML to the website_section content', () => {
-      const wrapper = shallow(<Overline />)
+      const wrapper = shallow(<Overline />);
 
-      expect(wrapper.text()).toMatch('News')
-    })
+      expect(wrapper.text()).toMatch('News');
+    });
 
     it('should set a styled component class on the rendered a', () => {
-      const wrapper = mount(<Overline />)
+      const wrapper = mount(<Overline />);
 
-      expect(wrapper.find('a').hasClass(/sc-/)).toBe(true)
-    })
+      expect(wrapper.find('a').hasClass(/sc-/)).toBe(true);
+    });
 
     it('should have the href of the website_section _id', () => {
-      const wrapper = shallow(<Overline />)
+      const wrapper = shallow(<Overline />);
 
-      expect(wrapper.at(0).prop('href')).toStrictEqual('/news')
-    })
-  })
+      expect(wrapper.at(0).prop('href')).toStrictEqual('/news');
+    });
+  });
 
   describe('when label content from globalContent is present', () => {
     describe('when label.basic.display is true', () => {
       beforeEach(() => {
         const labelObj = {
-          label: { basic: { display: true, text: 'EXCLUSIVE', url: '/exclusive' } }
-        }
+          label: { basic: { display: true, text: 'EXCLUSIVE', url: '/exclusive' } },
+        };
         const contextObjWithLabel = Object.assign(
           {},
           mockContextObj,
           {
             globalContent: {
               ...labelObj,
-              ...mockContextObj.globalContent
-            }
-          }
-        )
-        useFusionContext.mockImplementation(() => contextObjWithLabel)
-      })
+              ...mockContextObj.globalContent,
+            },
+          },
+        );
+        useFusionContext.mockImplementation(() => contextObjWithLabel);
+      });
 
       it('should display the label name instead of the website section name', () => {
-        const wrapper = shallow(<Overline />)
+        const wrapper = shallow(<Overline />);
 
-        expect(wrapper.text()).toMatch('EXCLUSIVE')
-      })
+        expect(wrapper.text()).toMatch('EXCLUSIVE');
+      });
 
       it('should render the href of the label instead of the website section', () => {
-        const wrapper = shallow(<Overline />)
+        const wrapper = shallow(<Overline />);
 
-        expect(wrapper.at(0).prop('href')).toStrictEqual('/exclusive')
-      })
-    })
+        expect(wrapper.at(0).prop('href')).toStrictEqual('/exclusive');
+      });
+    });
 
     describe('when label.basic.display is NOT true', () => {
       beforeEach(() => {
         const labelObj = {
-          label: { basic: { display: false, text: 'EXCLUSIVE', url: '/exclusive' } }
-        }
+          label: { basic: { display: false, text: 'EXCLUSIVE', url: '/exclusive' } },
+        };
         const contextObjWithLabel = Object.assign(
           {},
           mockContextObj,
           {
             globalContent: {
               ...labelObj,
-              ...mockContextObj.globalContent
-            }
-          }
-        )
-        useFusionContext.mockImplementation(() => contextObjWithLabel)
-      })
+              ...mockContextObj.globalContent,
+            },
+          },
+        );
+        useFusionContext.mockImplementation(() => contextObjWithLabel);
+      });
 
       it('should dangerously set the inner HTML to the website_section content', () => {
-        const wrapper = shallow(<Overline />)
+        const wrapper = shallow(<Overline />);
 
-        expect(wrapper.text()).toMatch('News')
-      })
+        expect(wrapper.text()).toMatch('News');
+      });
 
       it('should have the href of the website_section _id', () => {
-        const wrapper = shallow(<Overline />)
+        const wrapper = shallow(<Overline />);
 
-        expect(wrapper.at(0).prop('href')).toStrictEqual('/news')
-      })
-    })
-  })
+        expect(wrapper.at(0).prop('href')).toStrictEqual('/news');
+      });
+    });
+  });
 
   describe('when headline content from globalContent is NOT present', () => {
     beforeEach(() => {
-      useFusionContext.mockImplementation(() => ({}))
-    })
+      useFusionContext.mockImplementation(() => ({}));
+    });
 
     it('should not render anything', () => {
-      const wrapper = mount(<Overline />)
+      const wrapper = mount(<Overline />);
 
-      expect(wrapper).toBeEmptyRender()
-    })
-  })
-})
+      expect(wrapper).toBeEmptyRender();
+    });
+  });
+});

--- a/blocks/overline-block/features/overline/default.test.jsx
+++ b/blocks/overline-block/features/overline/default.test.jsx
@@ -53,34 +53,67 @@ describe('overline feature for default output type', () => {
     })
   })
 
-  describe('when label content from globalContent is present and set to display', () => {
-    beforeEach(() => {
-      const labelObj = {
-        label: { basic: { display: true, text: 'EXCLUSIVE', url: '/exclusive' } }
-      }
-      const contextObjWithLabel = Object.assign(
-        {},
-        mockContextObj,
-        {
-          globalContent: {
-            ...labelObj,
-            ...mockContextObj.globalContent
-          }
+  describe('when label content from globalContent is present', () => {
+    describe('when label.basic.display is true', () => {
+      beforeEach(() => {
+        const labelObj = {
+          label: { basic: { display: true, text: 'EXCLUSIVE', url: '/exclusive' } }
         }
-      )
-      useFusionContext.mockImplementation(() => contextObjWithLabel)
+        const contextObjWithLabel = Object.assign(
+          {},
+          mockContextObj,
+          {
+            globalContent: {
+              ...labelObj,
+              ...mockContextObj.globalContent
+            }
+          }
+        )
+        useFusionContext.mockImplementation(() => contextObjWithLabel)
+      })
+
+      it('should display the label name instead of the website section name', () => {
+        const wrapper = shallow(<Overline />)
+
+        expect(wrapper.text()).toMatch('EXCLUSIVE')
+      })
+
+      it('should render the href of the label instead of the website section', () => {
+        const wrapper = shallow(<Overline />)
+
+        expect(wrapper.at(0).prop('href')).toStrictEqual('/exclusive')
+      })
     })
 
-    it('should display the label name instead of the website section name', () => {
-      const wrapper = shallow(<Overline />)
+    describe('when label.basic.display is NOT true', () => {
+      beforeEach(() => {
+        const labelObj = {
+          label: { basic: { display: false, text: 'EXCLUSIVE', url: '/exclusive' } }
+        }
+        const contextObjWithLabel = Object.assign(
+          {},
+          mockContextObj,
+          {
+            globalContent: {
+              ...labelObj,
+              ...mockContextObj.globalContent
+            }
+          }
+        )
+        useFusionContext.mockImplementation(() => contextObjWithLabel)
+      })
 
-      expect(wrapper.text()).toMatch('EXCLUSIVE')
-    })
+      it('should dangerously set the inner HTML to the website_section content', () => {
+        const wrapper = shallow(<Overline />)
 
-    it('should render the href of the label instead of the website section', () => {
-      const wrapper = shallow(<Overline />)
+        expect(wrapper.text()).toMatch('News')
+      })
 
-      expect(wrapper.at(0).prop('href')).toStrictEqual('/exclusive')
+      it('should have the href of the website_section _id', () => {
+        const wrapper = shallow(<Overline />)
+
+        expect(wrapper.at(0).prop('href')).toStrictEqual('/news')
+      })
     })
   })
 

--- a/blocks/overline-block/features/overline/default.test.jsx
+++ b/blocks/overline-block/features/overline/default.test.jsx
@@ -1,62 +1,98 @@
-import React from 'react';
-import { shallow, mount } from 'enzyme';
-import { useFusionContext } from 'fusion:context';
-import Overline from './default';
+/* global jest, describe, it, expect, beforeEach */
 
-jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import { useFusionContext } from 'fusion:context'
+import Overline from './default'
+
+const mockContextObj = {
+  arcSite: 'site',
+  globalContent: {
+    websites: {
+      site: {
+        website_section: {
+          _id: '/news',
+          name: 'News'
+        }
+      }
+    }
+  }
+}
+
+jest.mock('fusion:themes', () => (jest.fn(() => ({}))))
 jest.mock('fusion:context', () => ({
-  useFusionContext: jest.fn(() => ({
-    arcSite: 'site',
-    globalContent: {
-      websites: {
-        site: {
-          website_section: {
-            _id: '/news',
-            name: 'News',
-          },
-        },
-      },
-    },
-  })),
-}));
-
+  useFusionContext: jest.fn(() => {
+    return mockContextObj
+  })
+}))
 
 describe('overline feature for default output type', () => {
-  describe('when overline content from globalContent is present', () => {
+  describe('when website_section content from globalContent is present', () => {
     it('should render an a', () => {
-      const wrapper = mount(<Overline />);
+      const wrapper = mount(<Overline />)
 
-      expect(wrapper.find('a')).toHaveClassName('overline');
-    });
+      expect(wrapper.find('a')).toHaveClassName('overline')
+    })
 
-    it('should dangerously set the inner HTML to the overline content', () => {
-      const wrapper = shallow(<Overline />);
+    it('should dangerously set the inner HTML to the website_section content', () => {
+      const wrapper = shallow(<Overline />)
 
-      expect(wrapper.text()).toMatch('News');
-    });
+      expect(wrapper.text()).toMatch('News')
+    })
 
     it('should set a styled component class on the rendered a', () => {
-      const wrapper = mount(<Overline />);
+      const wrapper = mount(<Overline />)
 
-      expect(wrapper.find('a').hasClass(/sc-/)).toBe(true);
-    });
+      expect(wrapper.find('a').hasClass(/sc-/)).toBe(true)
+    })
 
-    it('should have a href', () => {
-      const wrapper = shallow(<Overline />);
+    it('should have the href of the website_section _id', () => {
+      const wrapper = shallow(<Overline />)
 
-      expect(wrapper.at(0).prop('href')).toStrictEqual('/news');
-    });
-  });
+      expect(wrapper.at(0).prop('href')).toStrictEqual('/news')
+    })
+  })
+
+  describe('when label content from globalContent is present and set to display', () => {
+    beforeEach(() => {
+      const labelObj = {
+        label: { basic: { display: true, text: 'EXCLUSIVE', url: '/exclusive' } }
+      }
+      const contextObjWithLabel = Object.assign(
+        {},
+        mockContextObj,
+        {
+          globalContent: {
+            ...labelObj,
+            ...mockContextObj.globalContent
+          }
+        }
+      )
+      useFusionContext.mockImplementation(() => contextObjWithLabel)
+    })
+
+    it('should display the label name instead of the website section name', () => {
+      const wrapper = shallow(<Overline />)
+
+      expect(wrapper.text()).toMatch('EXCLUSIVE')
+    })
+
+    it('should render the href of the label instead of the website section', () => {
+      const wrapper = shallow(<Overline />)
+
+      expect(wrapper.at(0).prop('href')).toStrictEqual('/exclusive')
+    })
+  })
 
   describe('when headline content from globalContent is NOT present', () => {
     beforeEach(() => {
-      useFusionContext.mockImplementation(() => ({}));
-    });
+      useFusionContext.mockImplementation(() => ({}))
+    })
 
     it('should not render anything', () => {
-      const wrapper = mount(<Overline />);
+      const wrapper = mount(<Overline />)
 
-      expect(wrapper).toBeEmptyRender();
-    });
-  });
-});
+      expect(wrapper).toBeEmptyRender()
+    })
+  })
+})


### PR DESCRIPTION
JIRA ticket: https://arcpublishing.atlassian.net/browse/PEN-564

This changes which text/URL combo the `Overline` block uses based on the structure of the ANS document it is based on. Previously it just displayed the text from `websites[site-name]. website_section.name` as the text of the `<a>` tag, and `websites[site-name]. website_section._id` as the URL for the href. Now, if the ANS property `label.basic.display` exists and is set to true, the text of the anchor text should be the value of `label.basic.text` and the href should be `label.basic.url`.

I added tests to make sure the name and URL are overriden properly when the `label.basic.display` is true, and when it is NOT true.

Here's an example ANS doc with `label.basic` data set properly to override the section name (obv needs creds to access): https://api.corecomponents.arcpublishing.com/content/v4/?website_url=/2019/09/17/article-with-a-long-headline-lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit/&website=the-sun