### PR TITLE
Remove warnings from story container per #126

### DIFF
--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -94,6 +94,7 @@ const TopTableList = (props) => {
               element={element}
               storySize={storyTypeArray[index]}
               primaryFont={primaryFont}
+              key={itemId}
             />
           );
         })


### PR DESCRIPTION
#126 saw warnings for keys on test
- goal would be to have no warnings in `npm run test` so that we can debug, if we need to console log from within. 
- Also a good practice

 PASS  blocks/top-table-list-block/features/top-table-list/default.test.jsx
 PASS  blocks/top-table-list-block/features/top-table-list/_children/story-item-container.test.jsx