### PR TITLE
PEN-501: Search API Content Soure

### DIFF
--- a/blocks/search-content-source-block/README.md
+++ b/blocks/search-content-source-block/README.md
@@ -1,0 +1,51 @@
+# `@wpmedia/search-content-source-block`
+
+Fusion News Theme unpublished API content source block
+
+## Usage
+
+```
+const searchContentSourceBlock = require('@wpmedia/search-content-source-block');
+```
+
+## Example input
+```
+query: obama
+page: 1
+```
+
+## Example output
+```
+{
+  data: [
+    ANS Object
+    ANS Object
+    ANS Object
+    ANS Object
+    ANS Object
+    ANS Object
+    ANS Object
+    ANS Object
+    ANS Object
+    ANS Object
+  ],
+  metadata: {
+  q: "obama"
+    page: "1"
+    per_page: 10
+    t: "*"
+    s: "score"
+    timeframe: "*"
+    total_hits: 1876
+    took: 41
+  },
+  aggregations: {
+    all: 1876
+    story: 1865
+    image: 0
+    video: 11
+    gallery: 0
+  },
+  _id: "7d23d241bfcb79e1891c13f8fae45183c49e1356667429ef2f064cde493335a1"
+}
+```

--- a/blocks/search-content-source-block/index.js
+++ b/blocks/search-content-source-block/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/blocks/search-content-source-block/jest.config.js
+++ b/blocks/search-content-source-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require('../../jest/jest.config.base');
+
+module.exports = {
+  ...base,
+};

--- a/blocks/search-content-source-block/package-lock.json
+++ b/blocks/search-content-source-block/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wpmedia/search-content-source-block",
+  "version": "0.1.0",
+  "lockfileVersion": 1
+}

--- a/blocks/search-content-source-block/package.json
+++ b/blocks/search-content-source-block/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@wpmedia/search-content-source-block",
+  "version": "0.1.0",
+  "description": "Fusion News Theme search API content source block",
+  "author": "Beltran Caliz <beltran.caliz@washpost.com>",
+  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "license": "UNLICENSED",
+  "main": "index.js",
+  "files": [
+    "sources"
+  ],
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "lint": "eslint --ext js --ext jsx sources"
+  }
+}

--- a/blocks/search-content-source-block/sources/search-api.js
+++ b/blocks/search-content-source-block/sources/search-api.js
@@ -3,7 +3,7 @@ import getProperties from 'fusion:properties';
 export default {
   resolve(contentOptions) {
     const { query, page, 'arc-site': arcSite } = contentOptions;
-    if (query.length > 0) {
+    if (query) {
       return `https://search.arcpublishing.com/search?&q=${query}&page=${page || 1}&key=${getProperties(arcSite).searchKey}`;
     }
     return '';

--- a/blocks/search-content-source-block/sources/search-api.js
+++ b/blocks/search-content-source-block/sources/search-api.js
@@ -1,0 +1,15 @@
+import getProperties from 'fusion:properties';
+
+export default {
+  resolve(contentOptions) {
+    const { query, page, 'arc-site': arcSite } = contentOptions;
+    if (query.length > 0) {
+      return `https://search.arcpublishing.com/search?&q=${query}&page=${page || 1}&key=${getProperties(arcSite).searchKey}`;
+    }
+    return '';
+  },
+  params: {
+    query: 'text',
+    page: 'text',
+  },
+};

--- a/blocks/search-content-source-block/sources/search-api.test.js
+++ b/blocks/search-content-source-block/sources/search-api.test.js
@@ -1,0 +1,51 @@
+import getProperties from 'fusion:properties';
+import contentSource from './search-api';
+
+describe('the search content source block', () => {
+  it('should use the proper param types', () => {
+    expect(contentSource.params).toEqual({
+      query: 'text',
+      page: 'text',
+    });
+  });
+
+  describe('when a query is provided', () => {
+    it('should build the correct url', () => {
+      getProperties.mockImplementation(() => ({ searchKey: '1234' }));
+      const url = contentSource.resolve({
+        query: 'test',
+        'arc-site': 'the-sun',
+      });
+      expect(url).toEqual('https://search.arcpublishing.com/search?&q=test&page=1&key=1234');
+    });
+  });
+
+  describe('when a page number is provided', () => {
+    it('should build the a url with the provided page number', () => {
+      const url = contentSource.resolve({
+        query: 'test',
+        page: '3',
+        'arc-site': 'the-sun',
+      });
+      expect(url).toEqual('https://search.arcpublishing.com/search?&q=test&page=3&key=1234');
+    });
+  });
+
+  describe('when a query is NOT provided', () => {
+    it('should not build a url', () => {
+      getProperties.mockImplementation(() => ({ }));
+      const url = contentSource.resolve({
+        page: '3',
+        'arc-site': 'the-sun',
+      });
+      expect(url).toEqual('');
+    });
+  });
+
+  describe('when a key is not provided', () => {
+    it('should not build a url with a key', () => {
+      const url = contentSource.resolve({ query: 'test' });
+      expect(url).toEqual('https://search.arcpublishing.com/search?&q=test&page=1&key=undefined');
+    });
+  });
+});


### PR DESCRIPTION
Implemented search API content source
Skipping website_id as a param until the searchKeys for the websites are available
[Jira ticket](https://arcpublishing.atlassian.net/browse/PEN-501)