### PR TITLE
PEN-762: Adding ans-feed to collections content source

### DIFF
--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -19,4 +19,5 @@ const resolve = (key = {}) => {
 export default {
   params,
   resolve,
+  schemaName: 'ans-feed',
 };

--- a/blocks/collections-content-source-block/sources/content-api-collections.test.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.test.js
@@ -10,6 +10,10 @@ describe('the collections content source block', () => {
     });
   });
 
+  it('should be associated with the ans-feed schema', () => {
+    expect(contentSource.schemaName).toEqual('ans-feed');
+  });
+
   describe('when an id and website are provided', () => {
     it('should build the correct url', () => {
       const url = contentSource.resolve({

--- a/blocks/story-feed-query-content-source-block/sources/story-feed-query.test.js
+++ b/blocks/story-feed-query-content-source-block/sources/story-feed-query.test.js
@@ -9,7 +9,7 @@ describe('the story feed query block', () => {
     });
   });
 
-  it('should use the proper param types', () => {
+  it('should be associated with the ans-feed schema', () => {
     expect(storyQuery.schemaName).toEqual('ans-feed');
   });
 


### PR DESCRIPTION
https://arcpublishing.atlassian.net/browse/PEN-762

This is a simple one, we just want the `collections` content source to be associated with the `ans-feed` schema so it can show up in the proper dropdown in PB. Added a test.