### PR TITLE
incorporated base styled components for background and svg link hovers

### DIFF
--- a/blocks/article-tag-block/features/tag/default.jsx
+++ b/blocks/article-tag-block/features/tag/default.jsx
@@ -3,13 +3,13 @@ import styled from 'styled-components';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
 import getProperties from 'fusion:properties';
+import { LinkBackgroundHover } from '@wpmedia/news-theme-css/js/styled/linkHovers';
 import './tags.scss';
 
-const Tags = styled.a`
+const Tags = styled(LinkBackgroundHover)`
   font-family:  ${(props) => props.primaryFont};
   background-color:  ${(props) => props.primaryColor};
 `;
-
 
 const ArticleTags = () => {
   const { arcSite, globalContent: content } = useFusionContext();

--- a/blocks/article-tag-block/features/tag/tags.scss
+++ b/blocks/article-tag-block/features/tag/tags.scss
@@ -22,10 +22,6 @@
   text-decoration: none;
   color: #fff;
   padding: 0 0.9375rem;
-  &:hover, &:active{
-    color:#fff;
-    background-color: lighten($primary-color, 20%);;
-  }
   @media screen and (min-width: map-get($grid-breakpoints, 'md')){
     line-height: .875rem;
   }

--- a/blocks/author-bio-block/features/author-bio/author-bio.scss
+++ b/blocks/author-bio-block/features/author-bio/author-bio.scss
@@ -49,10 +49,6 @@
         width: map-get($spacers, 'md');
         margin-right: map-get($spacers, 'xs');
         text-align: center;
-
-        &:hover svg path{
-          fill: lighten($primary-color, 20%);
-        }
       }
     }
   }

--- a/blocks/author-bio-block/features/author-bio/default.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.jsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
 import styled from 'styled-components';
+import { LinkSVGHover } from '@wpmedia/news-theme-css/js/styled/linkHovers';
 import {
   Image,
   EnvelopeIcon,
@@ -21,6 +22,7 @@ import {
 } from '@wpmedia/engine-theme-sdk';
 import constructSocialURL from './shared/constructSocialURL';
 
+
 import './author-bio.scss';
 
 /*
@@ -38,6 +40,8 @@ const AuthorBioStyled = styled.section`
   }
 `;
 
+const MediaLinksStyled = styled(LinkSVGHover)``;
+
 const AuthorBio = () => {
   const { globalContent: content, arcSite } = useFusionContext();
   const { credits } = content;
@@ -52,9 +56,9 @@ const AuthorBio = () => {
     // Also check for their bio, which means that they are a staff
     if (
       author.description
-      && author.description.length > 0
-      && original.bio
-      && original.bio.length > 0
+            && author.description.length > 0
+            && original.bio
+            && original.bio.length > 0
     ) {
       // A loop to generate the list of social media links.
       // If no url is provided, then the social link will be skipped.
@@ -67,161 +71,162 @@ const AuthorBio = () => {
             switch (socialLink.site) {
               case 'linkedin':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <LinkedInIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="LinkedIn"
                       description="Connect on LinkedIn"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'twitter':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <TwitterIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="Twitter"
                       description="Connect on Twitter"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'instagram':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <InstagramIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="Instagram"
                       description="Connect on Instagram"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'facebook':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <FacebookIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="Facebook"
                       description="Connect on Facebook"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'reddit':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <RedditIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="Reddit"
                       description="Connect on Reddit"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'youtube':
                 socialButton = (
-                  <a
+                  <MediaLinksStyled
                     href={constructedURL}
                     target="_blank"
                     rel="noreferrer noopener"
                     id="link-social-youtube"
+                    primaryColor={getThemeStyle(arcSite)['primary-color']}
                   >
                     <YoutubeIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="YouTube"
                       description="Connect on YouTube"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'medium':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <MediumIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="Medium"
                       description="Connect on Medium"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'tumblr':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <TumblrIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="Tumblr"
                       description="Connect on Tumblr"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'pinterest':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <PinterestIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="Pinterest"
                       description="Connect on Pinterest"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'snapchat':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <SnapchatIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="Snapchat"
                       description="Connect on Snapchat"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'whatsapp':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <WhatsAppIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="WhatsApp"
                       description="Connect on WhatsApp"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'soundcloud':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <SoundCloudIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="SoundCloud"
                       description="Listen on SoundCloud"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               case 'rss':
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <RssIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="RSS"
                       description="Subscribe to RSS feed"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
               default:
                 socialButton = (
-                  <a href={constructedURL} target="_blank" rel="noreferrer noopener">
+                  <MediaLinksStyled href={constructedURL} target="_blank" rel="noreferrer noopener" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                     <EnvelopeIcon
                       fill={getThemeStyle(arcSite)['primary-color']}
                       title="Email"
                       description="Send an email"
                     />
-                  </a>
+                  </MediaLinksStyled>
                 );
                 break;
             }
@@ -240,21 +245,21 @@ const AuthorBio = () => {
         <section key={(author.name) ? author.name : ''} className="authors">
           <section className="author">
             {
-              (author.image && author.image.url)
-                ? (
-                  <Image
-                    url={author.image.url}
-                    alt={(author.image.alt_text || author.name)}
-                    smallWidth={84}
-                    smallHeight={0}
-                    mediumWidth={84}
-                    mediumHeight={0}
-                    largeWidth={84}
-                    largeHeight={0}
-                  />
-                )
-                : null
-            }
+                            (author.image && author.image.url)
+                              ? (
+                                <Image
+                                  url={author.image.url}
+                                  alt={(author.image.alt_text || author.name)}
+                                  smallWidth={84}
+                                  smallHeight={0}
+                                  mediumWidth={84}
+                                  mediumHeight={0}
+                                  largeWidth={84}
+                                  largeHeight={0}
+                                />
+                              )
+                              : null
+                        }
             <section className="descriptions">
               {authorNameWithHyperlink || authorName}
               {/* there will always be a description via conditional on 52 */}

--- a/blocks/author-bio-block/features/author-bio/default.test.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.test.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
-jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+jest.mock('@wpmedia/news-theme-css', () => ({
+  lightenDarkenColor: () => 'blue',
+}));
+
+jest.mock('fusion:themes', () => (jest.fn(() => ({
+  'primary-color': 'blue',
+}))));
+
+
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
   EnvelopeIcon: () => <svg>EnvelopeIcon</svg>,

--- a/blocks/default-output-block/package-lock.json
+++ b/blocks/default-output-block/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@wpmedia/news-theme-css": {
-      "version": "2.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/2.1.0/cfc3d9599bee732743e4b8154ab682ac1e6becc6cc72871f29ac7a1535ea0482",
-      "integrity": "sha512-iVhay9D3wd/uQBu2zvqJFrhWMlnXH/cxkk93MDKZ5pgNdK81skPJ9grn1gz6MNbLle5f43jGTufBvsRyhfEGoA=="
+      "version": "2.1.5",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/2.1.5/82c5054d13c0c31c3f3425282fc8801fcb0ec042e95601daddf3f27b1a83db38",
+      "integrity": "sha512-yh4WnHosFtEss1HNo05rcq7tFNyF0KHGTurNMCnqgUfLZbOqwX1gsVrkA2wQK3ozlbeyWyuWEMzrRLEdSHvHww=="
     },
     "cipher-base": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2842,7 +2842,7 @@
       "version": "file:blocks/article-body-block",
       "requires": {
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "@wpmedia/video-player-block": "^0.2.4",
         "react-oembed-container": "^0.3.0",
         "styled-components": "^4.4.0"
@@ -2850,7 +2850,7 @@
       "dependencies": {
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -2868,21 +2868,21 @@
     "@wpmedia/article-tag-block": {
       "version": "file:blocks/article-tag-block",
       "requires": {
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "styled-components": "^4.4.0"
       }
     },
     "@wpmedia/byline-block": {
       "version": "file:blocks/byline-block",
       "requires": {
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "styled-components": "^4.4.0"
       }
     },
     "@wpmedia/date-block": {
       "version": "file:blocks/date-block",
       "requires": {
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "styled-components": "^4.4.0"
       }
     },
@@ -2896,7 +2896,7 @@
       "dependencies": {
         "@wpmedia/news-theme-css": {
           "version": "2.0.5",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -2920,14 +2920,14 @@
       "version": "file:blocks/extra-large-manual-promo-block",
       "requires": {
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "@wpmedia/shared-styles": "^0.0.8",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -2942,7 +2942,7 @@
         },
         "@wpmedia/shared-styles": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -2952,28 +2952,28 @@
         "@wpmedia/byline-block": "^0.4.4",
         "@wpmedia/date-block": "^1.5.4",
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "@wpmedia/shared-styles": "^0.0.8",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/byline-block": {
           "version": "0.4.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "styled-components": "^4.4.0"
           }
         },
         "@wpmedia/date-block": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "styled-components": "^4.4.0"
           }
         },
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -2988,7 +2988,7 @@
         },
         "@wpmedia/shared-styles": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -2996,13 +2996,13 @@
       "version": "file:blocks/header-nav-block",
       "requires": {
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -3020,7 +3020,7 @@
     "@wpmedia/headline-block": {
       "version": "file:blocks/headline-block",
       "requires": {
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "styled-components": "^4.4.0"
       }
     },
@@ -3028,14 +3028,14 @@
       "version": "file:blocks/large-manual-promo-block",
       "requires": {
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "@wpmedia/shared-styles": "^0.0.8",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -3050,7 +3050,7 @@
         },
         "@wpmedia/shared-styles": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -3060,28 +3060,28 @@
         "@wpmedia/byline-block": "^0.4.4",
         "@wpmedia/date-block": "^1.5.4",
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "@wpmedia/shared-styles": "^0.0.8",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/byline-block": {
           "version": "0.4.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "styled-components": "^4.4.0"
           }
         },
         "@wpmedia/date-block": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "styled-components": "^4.4.0"
           }
         },
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -3096,7 +3096,7 @@
         },
         "@wpmedia/shared-styles": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -3104,14 +3104,14 @@
       "version": "file:blocks/lead-art-block",
       "requires": {
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "@wpmedia/video-player-block": "^0.2.4",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -3130,14 +3130,14 @@
       "version": "file:blocks/medium-manual-promo-block",
       "requires": {
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "@wpmedia/shared-styles": "^0.0.8",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -3152,7 +3152,7 @@
         },
         "@wpmedia/shared-styles": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -3162,28 +3162,28 @@
         "@wpmedia/byline-block": "^0.4.4",
         "@wpmedia/date-block": "^1.5.4",
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "@wpmedia/shared-styles": "^0.0.8",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/byline-block": {
           "version": "0.4.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "styled-components": "^4.4.0"
           }
         },
         "@wpmedia/date-block": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "styled-components": "^4.4.0"
           }
         },
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -3198,26 +3198,26 @@
         },
         "@wpmedia/shared-styles": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": false
         }
       }
     },
     "@wpmedia/news-theme-css": {
-      "version": "2.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/2.1.0/cfc3d9599bee732743e4b8154ab682ac1e6becc6cc72871f29ac7a1535ea0482",
-      "integrity": "sha512-iVhay9D3wd/uQBu2zvqJFrhWMlnXH/cxkk93MDKZ5pgNdK81skPJ9grn1gz6MNbLle5f43jGTufBvsRyhfEGoA=="
+      "version": "2.1.5",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/2.1.5/82c5054d13c0c31c3f3425282fc8801fcb0ec042e95601daddf3f27b1a83db38",
+      "integrity": "sha512-yh4WnHosFtEss1HNo05rcq7tFNyF0KHGTurNMCnqgUfLZbOqwX1gsVrkA2wQK3ozlbeyWyuWEMzrRLEdSHvHww=="
     },
     "@wpmedia/numbered-list-block": {
       "version": "file:blocks/numbered-list-block",
       "requires": {
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -3238,27 +3238,27 @@
         "@wpmedia/byline-block": "^0.4.4",
         "@wpmedia/date-block": "^1.5.4",
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/byline-block": {
           "version": "0.4.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "styled-components": "^4.4.0"
           }
         },
         "@wpmedia/date-block": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "styled-components": "^4.4.0"
           }
         },
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -3276,21 +3276,21 @@
     "@wpmedia/shared-styles": {
       "version": "file:blocks/shared-styles",
       "requires": {
-        "@wpmedia/news-theme-css": "^2.1.0"
+        "@wpmedia/news-theme-css": "^2.1.5"
       }
     },
     "@wpmedia/small-manual-promo-block": {
       "version": "file:blocks/small-manual-promo-block",
       "requires": {
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "@wpmedia/shared-styles": "^0.0.8",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -3305,7 +3305,7 @@
         },
         "@wpmedia/shared-styles": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -3313,14 +3313,14 @@
       "version": "file:blocks/small-promo-block",
       "requires": {
         "@wpmedia/engine-theme-sdk": "^1.0.0",
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "@wpmedia/shared-styles": "^0.0.8",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/engine-theme-sdk": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-react": "^1.3.3",
             "polished": "^3.4.4",
@@ -3335,14 +3335,14 @@
         },
         "@wpmedia/shared-styles": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": false
         }
       }
     },
     "@wpmedia/subheadline-block": {
       "version": "file:blocks/subheadline-block",
       "requires": {
-        "@wpmedia/news-theme-css": "^2.1.0",
+        "@wpmedia/news-theme-css": "^2.1.5",
         "styled-components": "^4.4.0"
       }
     },
@@ -6610,7 +6610,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6634,13 +6635,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6657,19 +6660,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6800,7 +6806,8 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6814,6 +6821,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6830,6 +6838,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6838,13 +6847,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6865,6 +6876,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6963,7 +6975,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6977,6 +6990,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7072,7 +7086,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7114,6 +7129,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7135,6 +7151,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7183,13 +7200,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
For reference:  

https://github.com/WPMedia/news-theme-css/blob/master/js/framework.js

https://github.com/WPMedia/news-theme-css/blob/master/js/styled/linkHovers.js

For the linkHovers, I provided base styled components as well as styled literals.  The literals are for decorating either component or vanilla html element adhoc if needed.  See:  https://styled-components.com/docs/api#css-prop. Although, I initially tried to use this and didn't have luck getting it to work....so maybe just remove it?