### PR TITLE
[PEN-864] Re-added fontUrl support to the default outpute type

### DIFF
--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -54,7 +54,7 @@ const SampleOutputType = ({
 }) => {
   const { globalContent: gc, arcSite } = useFusionContext();
   const {
-    websiteName, twitterSite, gtmID, dangerouslyInjectJS = [],
+    websiteName, twitterSite, gtmID, dangerouslyInjectJS = [], fontUrl,
   } = getProperties(arcSite);
   const pageType = metaValue('page-type') || '';
   let storyMetaDataTags = null;
@@ -92,7 +92,7 @@ const SampleOutputType = ({
           <link href="https://fonts.googleapis.com/css?family=Space Mono" rel="stylesheet" />
         );
       default:
-        return '';
+        return fontUrl ? <link href={fontUrl} rel="stylesheet" /> : '';
     }
   };
 


### PR DESCRIPTION
Minimal change to make the `fontUrl` property work.