### PR TITLE
Suppress content editable warnings in tests for #140

### DIFF
--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -51,6 +51,7 @@ const MediumPromo = ({ customFields, arcSite }) => {
             primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
             className="md-promo-headline"
             {...editableContent(content, 'headlines.basic')}
+            suppressContentEditableWarning
           >
             {headlineText}
           </HeadlineText>
@@ -67,6 +68,7 @@ const MediumPromo = ({ customFields, arcSite }) => {
           secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
           className="description-text"
           {...editableContent(content, 'description.basic')}
+          suppressContentEditableWarning
         >
           {descriptionText}
         </DescriptionText>

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -40,6 +40,7 @@ const SmallPromo = ({ customFields, arcSite }) => {
                 primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
                 className="sm-promo-headline"
                 {...editableContent(content, 'headlines.basic')}
+                suppressContentEditableWarning
               >
                 {content && content.headlines ? content.headlines.basic : ''}
               </HeadlineText>


### PR DESCRIPTION

After talking with @visionbegin and @beltrancaliz, this seems to be a way to at least hide warnings. 

#140 