### PR TITLE
[PEN-697]: Turn Nav Header into a chain

### DIFF
--- a/blocks/header-nav-chain-block/README.md
+++ b/blocks/header-nav-chain-block/README.md
@@ -1,0 +1,11 @@
+# `@wpmedia/header-nav-chain-block`
+
+> TODO: description
+
+## Usage
+
+```
+const headerNavChainBlock = require('@wpmedia/header-nav-chain-block');
+
+// TODO: DEMONSTRATE API
+```

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/search-box.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/search-box.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef, useState } from 'react';
+import SearchIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/SearchIcon';
+
+export default ({ alwaysOpen = false, iconSize = 16 }) => {
+  const [shouldSearchOpen, setShouldSearchOpen] = useState(false);
+  const searchInput = useRef(null);
+
+  useEffect(() => {
+    const el = searchInput.current;
+    if (shouldSearchOpen) {
+      el.focus();
+    } else {
+      el.blur();
+    }
+  }, [shouldSearchOpen]);
+
+  const handleSearchBtnMousedown = (event) => {
+    // if open, prevent blur event so we don't get a race condition on click vs blur
+    if (shouldSearchOpen) {
+      event.preventDefault();
+    } else {
+      setShouldSearchOpen(true);
+    }
+  };
+
+  const isSearchBarOpen = shouldSearchOpen || alwaysOpen;
+  const navClassNames = `nav-search${isSearchBarOpen ? ' open' : ''}`;
+  const btnClassNames = `nav-btn transparent${!isSearchBarOpen ? ' border' : ''}`;
+  const iconFill = isSearchBarOpen ? '#666666' : 'white';
+
+  return (
+    <div className={navClassNames}>
+      <input ref={searchInput} onBlur={() => { setShouldSearchOpen(false); }} type="text" placeholder="Search" />
+      <button className={btnClassNames} onMouseDown={handleSearchBtnMousedown} type="button">
+        <SearchIcon fill={iconFill} height={iconSize} width={iconSize} />
+      </button>
+    </div>
+  );
+};

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/search-box.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/search-box.test.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import SearchBox from './search-box';
+
+const fakeEvent = { preventDefault: () => {} };
+
+describe('the SearchBox component', () => {
+  it('should render a search button', () => {
+    const wrapper = shallow(<SearchBox />);
+
+    expect(wrapper.find('.nav-search button')).toHaveLength(1);
+  });
+
+  it('should *not* have a class of .open on the .nav-search by default', () => {
+    const wrapper = shallow(<SearchBox />);
+
+    expect(wrapper.find('.nav-search')).not.toHaveClassName('open');
+  });
+
+  describe('when the search button is clicked', () => {
+    it('should add .open class to .nav-search', () => {
+      const wrapper = shallow(<SearchBox />);
+
+      wrapper.find('.nav-search button').simulate('mousedown', fakeEvent); // need to use mousedown instead of click to prevent race condition
+
+      expect(wrapper.find('.nav-search')).toHaveClassName('open');
+    });
+  });
+
+  describe('when .nav-search is open', () => {
+    it('should focus on the input element', () => {
+      const wrapper = mount(<SearchBox />);
+      expect(wrapper.find('input').getElement() === document.activeElement);
+    });
+
+    describe('when input loses focus', () => {
+      it('should remove the .open class from .nav-search', () => {
+        const wrapper = shallow(<SearchBox />);
+
+        wrapper.find('.nav-search button').simulate('mousedown', fakeEvent);
+        expect(wrapper.find('.nav-search')).toHaveClassName('open');
+
+        wrapper.find('.nav-search input').simulate('blur', fakeEvent);
+        expect(wrapper.find('.nav-search')).not.toHaveClassName('open');
+      });
+    });
+
+    describe('when alwaysOpen prop is true', () => {
+      it('should add .open class to .nav-search', () => {
+        const wrapper = shallow(<SearchBox alwaysOpen />);
+
+        wrapper.find('.nav-search button').simulate('mousedown', fakeEvent);
+        expect(wrapper.find('.nav-search')).toHaveClassName('open');
+      });
+    });
+  });
+
+  describe('when alwaysOpen prop is true', () => {
+    it('should add .open class to .nav-search', () => {
+      const wrapper = shallow(<SearchBox alwaysOpen />);
+
+      expect(wrapper.find('.nav-search')).toHaveClassName('open');
+    });
+  });
+});

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import ChevronRight from '@wpmedia/engine-theme-sdk/dist/es/components/icons/ChevronRightIcon';
+
+function hasChildren(node) { return node.children && node.children.length > 0; }
+
+function parseLinkData(node) {
+  if (node.node_type === 'section') {
+    return {
+      text: node.name,
+      url: node._id,
+    };
+  } if (node.node_type === 'link') {
+    return {
+      text: node.display_name,
+      url: node.url,
+    };
+  }
+
+  return {};
+}
+
+const SectionItem = ({ item }) => {
+  const { text = '', url = '' } = parseLinkData(item);
+  return (
+    <li className="section-item">
+      <a href={url} title={text}>
+        {text}
+        {hasChildren(item) && <span className="submenu-caret"><ChevronRight fill="rgba(255, 255, 255, 0.5)" height={12} width={12} /></span>}
+      </a>
+      {hasChildren(item) && <SubSectionMenu items={item.children} />}
+    </li>
+  );
+};
+
+const SubSectionMenu = ({ items }) => {
+  const itemsList = items.map((item) => {
+    const { text = '', url = '' } = parseLinkData(item);
+    return (<li className="subsection-item" key={item._id}><a href={url} title={text}>{text}</a></li>);
+  });
+
+  return (
+    <div className="subsection-container">
+      <span className="arrow-left" />
+      <ul className="subsection-menu">{itemsList}</ul>
+    </div>
+  );
+};
+
+export default ({ children = [], sections = [] }) => {
+  const active = sections.filter((s) => !s.inactive);
+
+  return (
+    <>
+      {children}
+      <ul className="section-menu">
+        {active.map((item) => <SectionItem key={item._id} item={item} />)}
+      </ul>
+    </>
+  );
+};

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import SectionNav from './section-nav';
+
+const items = [
+  {
+    _id: '/sports',
+    node_type: 'section',
+    name: 'Sports',
+    children: [
+      {
+        _id: 'foo',
+        node_type: 'link',
+        display_name: 'Basketball',
+        url: '/basketball',
+      },
+      {
+        _id: 'bar',
+        node_type: 'link',
+        display_name: 'Dodgeball',
+        url: '/dodgeball',
+      },
+    ],
+  },
+  {
+    _id: 'bar',
+    node_type: 'link',
+    display_name: 'Entertainment',
+    url: '/entertainment',
+  },
+  {
+    _id: '/some-inactive-section',
+    inactive: true,
+    node_type: 'section',
+    name: 'Some Inactive Section',
+  },
+];
+
+describe('the SectionNav component', () => {
+  it('should render a .section-menu list', () => {
+    const wrapper = shallow(<SectionNav />);
+
+    expect(wrapper.find('ul.section-menu')).toHaveLength(1);
+  });
+
+  it('should render the correct number of active .section-item elements', () => {
+    const wrapper = mount(<SectionNav sections={items} />);
+    const numActiveItems = items.filter((i) => !i.inactive).length;
+
+    expect(wrapper.find('li.section-item')).toHaveLength(numActiveItems);
+  });
+
+  it('should render the text for a section node correctly', () => {
+    const wrapper = mount(<SectionNav sections={items} />);
+
+    expect(wrapper.find('li.section-item > a').at(0)).toIncludeText('Sports');
+  });
+
+  it('should render the href for a section node correctly', () => {
+    const wrapper = mount(<SectionNav sections={items} />);
+
+    expect(wrapper.find('li.section-item > a').at(0)).toHaveProp('href', '/sports');
+  });
+
+  it('should render the text for a link node correctly', () => {
+    const wrapper = mount(<SectionNav sections={items} />);
+
+    expect(wrapper.find('li.section-item > a').at(1)).toIncludeText('Entertainment');
+  });
+
+  it('should render the href for a link node correctly', () => {
+    const wrapper = mount(<SectionNav sections={items} />);
+
+    expect(wrapper.find('li.section-item > a').at(1)).toHaveProp('href', '/entertainment');
+  });
+
+  describe('when a section has child nodes', () => {
+    it('should render a .submenu-caret element inside the anchor tag', () => {
+      const wrapper = mount(<SectionNav sections={items} />);
+
+      expect(wrapper.find('li.section-item > a > span.submenu-caret').at(0)).toHaveLength(1);
+    });
+
+    it('should render a .subsection-container', () => {
+      const wrapper = mount(<SectionNav sections={items} />);
+      const numSubsectionContainers = items.filter((i) => i.children && i.children.length).length;
+
+      expect(wrapper.find('.subsection-container')).toHaveLength(numSubsectionContainers); // one of the 3 items is inactive
+    });
+
+    it('should render the correct number of active .subsection-item elements', () => {
+      const wrapper = mount(<SectionNav sections={items} />);
+      const numActiveSubItems = items[0].children.length;
+
+      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item')).toHaveLength(numActiveSubItems);
+    });
+
+    it('should render the text for a subsection link node correctly', () => {
+      const wrapper = mount(<SectionNav sections={items} />);
+
+      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > a').at(0)).toIncludeText('Basketball');
+    });
+
+    it('should render the href for a subsection link node correctly', () => {
+      const wrapper = mount(<SectionNav sections={items} />);
+
+      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > a').at(0)).toHaveProp('href', '/basketball');
+    });
+  });
+});

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { useContent } from 'fusion:content';
+import { useAppContext } from 'fusion:context';
+import getProperties from 'fusion:properties';
+import getThemeStyle from 'fusion:themes';
+import HamburgerMenuIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/HamburgerMenuIcon';
+import ArcLogo from '@wpmedia/engine-theme-sdk/dist/es/components/ArcLogo';
+import SectionNav from './_children/section-nav';
+import SearchBox from './_children/search-box';
+import './navigation.scss';
+
+/* Global Constants */
+// Since these values are used to coordinate multiple components, I thought I'd make them variables
+// so we could just change the vars instead of multiple CSS values
+const iconSize = 16;
+const navHeight = '56px';
+const navZIdx = 9;
+const sectionZIdx = navZIdx - 1;
+
+/* Styled Components */
+const StyledNav = styled.nav`
+background-color: #000;
+height: ${navHeight};
+z-index: ${navZIdx};
+  * {
+    font-family: ${(props) => props.font};
+  }
+`;
+const StyledSectionDrawer = styled.div`
+  font-family: ${(props) => props.font};
+  position: fixed;
+  top: ${navHeight};
+  z-index: ${sectionZIdx};
+`;
+
+/* Main Component */
+const Nav = (props) => {
+  const { arcSite } = useAppContext();
+
+  const { primaryLogo, primaryLogoAlt } = getProperties(arcSite);
+
+  const {
+    'primary-font-family': primaryFont,
+  } = getThemeStyle(arcSite);
+
+  const { children = [], customFields: { hierarchy, signInOrder } = {} } = props;
+
+  // signInOrder is 1-based instead of 0-based, so we subtract 1
+  const signInButton = (Number.isInteger(signInOrder) && children[signInOrder - 1])
+    ? children[signInOrder - 1]
+    : null;
+
+  const mainContent = useContent({
+    source: 'site-service-hierarchy',
+    query: {
+      site: arcSite,
+      hierarchy,
+    },
+  });
+
+  const sections = (mainContent && mainContent.children) ? mainContent.children : [];
+
+  const [isSectionDrawerOpen, setSectionDrawerOpen] = useState(false);
+
+  const handleEscKey = (event) => {
+    if (event.keyCode === 27) {
+      setSectionDrawerOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleEscKey, true);
+    return () => {
+      window.removeEventListener('keydown', handleEscKey);
+    };
+  });
+
+  return (
+    <>
+      <StyledNav id="main-nav" className="news-theme-navigation" font={primaryFont}>
+
+        <div className="nav-left">
+          <SearchBox iconSize={20} />
+          <button onClick={() => setSectionDrawerOpen(!isSectionDrawerOpen)} className="nav-btn nav-sections-btn border transparent" type="button">
+            <span>Sections</span>
+            <HamburgerMenuIcon fill="white" height={iconSize} width={iconSize} />
+          </button>
+        </div>
+
+        <div className="nav-logo">
+          <a href="/" title={primaryLogoAlt}>
+            {primaryLogo
+              ? <img src={primaryLogo} alt={primaryLogoAlt || 'Navigation bar logo'} />
+              : <ArcLogo />}
+          </a>
+        </div>
+
+        <div className="nav-right">
+          {signInButton}
+        </div>
+      </StyledNav>
+
+      <StyledSectionDrawer id="nav-sections" className={isSectionDrawerOpen ? 'open' : 'closed'} font={primaryFont}>
+        <SectionNav sections={sections}>
+          <SearchBox alwaysOpen />
+        </SectionNav>
+      </StyledSectionDrawer>
+
+      {isSectionDrawerOpen ? <div id="overlay" role="dialog" onKeyDown={handleEscKey} onClick={() => setSectionDrawerOpen(false)} /> : null}
+    </>
+  );
+};
+
+Nav.propTypes = {
+  customFields: PropTypes.shape({
+    hierarchy: PropTypes.string,
+    signInOrder: PropTypes.number,
+  }),
+};
+
+Nav.label = 'Header Nav Chain – Arc Block';
+
+export default Nav;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import getProperties from 'fusion:properties';
+import Navigation from './default';
+import SearchBox from './_children/search-box';
+
+jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+jest.mock('fusion:context', () => ({
+  useAppContext: jest.fn(() => ({})),
+}));
+jest.mock('fusion:content', () => ({
+  useContent: jest.fn(() => ({})),
+}));
+
+describe('the header navigation feature for the default output type', () => {
+  it('should be a nav element with class .news-theme-navigation', () => {
+    const wrapper = mount(<Navigation />);
+
+    expect(wrapper.find('nav').hasClass('news-theme-navigation')).toBe(true);
+  });
+
+  it('should render a SearchBox component in the top navbar', () => {
+    const wrapper = mount(<Navigation />);
+
+    expect(wrapper.find('.nav-left').find(SearchBox)).toHaveLength(1);
+  });
+
+  it('should render a SearchBox component in the side navbar', () => {
+    const wrapper = mount(<Navigation />);
+
+    expect(wrapper.find('#nav-sections').find(SearchBox)).toHaveLength(1);
+  });
+
+  it('should render nothing inside the .nav-right', () => {
+    const wrapper = mount(<Navigation />);
+
+    expect(wrapper.find('.nav-right').children()).toHaveLength(0);
+  });
+
+  describe('when the signInOrder customField is set', () => {
+    describe('when no child component exists at the signInOrder index', () => {
+      it('should render nothing inside the .nav-right', () => {
+        const wrapper = mount(
+          <Navigation customFields={{ signInOrder: 2 }}>
+            {[<button type="button">Sign In</button>]}
+          </Navigation>,
+        );
+
+        expect(wrapper.find('.nav-right').children()).toHaveLength(0);
+      });
+    });
+
+    describe('when a child component exists at the signInOrder index', () => {
+      it('should render the child component inside the .nav-right', () => {
+        const wrapper = mount(
+          <Navigation customFields={{ signInOrder: 1 }}>
+            {[<button type="button">Sign In</button>]}
+          </Navigation>,
+        );
+
+        expect(wrapper.find('.nav-right').children()).toHaveLength(1);
+        expect(wrapper.find('.nav-right > button')).toHaveText('Sign In');
+      });
+    });
+  });
+
+  describe('the navigation bar image/logo', () => {
+    describe('when the theme manifest provides a logo url', () => {
+      it('should make the src of the logo the provided image', () => {
+        getProperties.mockImplementation(() => ({ primaryLogo: 'my-nav-logo.svg' }));
+        const wrapper = mount(<Navigation />);
+
+        expect(wrapper.find('div.nav-logo > a > img')).toHaveProp('src', 'my-nav-logo.svg');
+      });
+
+      it('should make the alt text of the logo the default text', () => {
+        const wrapper = mount(<Navigation />);
+
+        expect(wrapper.find('div.nav-logo > a > img')).toHaveProp('alt', 'Navigation bar logo');
+      });
+
+      describe('when the theme manifest provides alt text for the logo', () => {
+        it('should make the alt text of the logo the provided text', () => {
+          getProperties.mockImplementation(() => ({ primaryLogo: 'my-nav-logo.svg', primaryLogoAlt: 'My Nav Logo' }));
+          const wrapper = mount(<Navigation />);
+
+          expect(wrapper.find('div.nav-logo > a > img')).toHaveProp('alt', 'My Nav Logo');
+        });
+      });
+    });
+
+    describe('when the theme does not provide a logo url', () => {
+      it('should render a default SVG', () => {
+        getProperties.mockImplementation(() => ({}));
+        const wrapper = mount(<Navigation />);
+
+        expect(wrapper.find('div.nav-logo svg > title')).toIncludeText('Arc Publishing logo');
+      });
+    });
+  });
+});

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/navigation.scss
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/navigation.scss
@@ -1,0 +1,299 @@
+$arrow-size: calculateRem(10px);
+$border-color-dull: rgba(255, 255, 255, 0.5);
+$border-color-bright: rgba(255, 255, 255, 1);
+$border-width: 1px;
+$btn-size: calculateRem(32px);
+$nav-search-border-color: #5c6364;
+$overlay-color: #2a2a2a;
+$overlay-z-index: 2;
+$section-bg: #3B3B3B;
+$section-width: 315px;
+$submenu-link-color: #7F8C8D;
+
+.nav-btn {
+  border: 0;
+  height: $btn-size;
+  outline: none;
+  position: relative;
+  white-space: nowrap;
+
+  &.border {
+    border: $border-width solid $border-color-dull;
+    transition: border 100ms linear;
+  }
+
+  &.transparent {
+    background-color: transparent;
+  }
+
+  &:hover {
+    outline: none;
+
+    &.border {
+      border: $border-width solid $border-color-bright;
+    }
+  }
+
+  > img {
+    fill: white;
+  }
+}
+
+.nav-sections-btn {
+  align-items: center;
+  display: flex;
+  margin-left: 10px;
+
+  @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+    margin: 0;
+  }
+
+  > span, > img {
+    flex: 0;
+  }
+
+  > span {
+    color: white;
+    font-weight: bold;
+    font-size: calculateRem(14px);
+    padding-right: 8px;
+  }
+}
+
+.nav-search {
+  display: flex;
+  justify-content: center;
+  position: relative;
+
+  &.open {
+    input {
+      height: $btn-size;
+      padding: 4px;
+      padding-right: $btn-size;
+      width: 200px;
+    }
+
+    button {
+      border: 0;
+      margin: 0;
+      position: absolute;
+      right: 0;
+    }
+  }
+
+  input {
+    border: 0;
+    border-radius: 2px;
+    box-shadow: none;
+    font-size: 0.9em;
+    line-height: 20px;
+    margin: 0;
+    outline: none;
+    padding: 0;
+    transition: all .25s cubic-bezier(.49,.37,.45,.71);
+    width: 0;
+  }
+}
+
+#main-nav.news-theme-navigation {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 20px;
+  position: relative;
+
+  @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+    .nav-search, .nav-sections-btn span {
+      display: none;
+    }
+  }
+
+  * {
+    display: flex;
+  }
+
+  button {
+    border-radius: 2px;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  > div {
+    text-align: center;
+    display: flex;
+    flex: 1;
+    align-items: center;
+
+    &.nav-left {
+      justify-content: flex-start;
+    }
+
+    &.nav-right {
+      justify-content: flex-end;
+    }
+
+    &.nav-logo {
+      flex: 2;
+      justify-content: center;
+
+      img {
+        height: auto;
+        max-height: 30px;
+        min-width: 30px;
+        width: auto;
+      }
+    }
+  }
+}
+
+#nav-sections {
+  background: $section-bg;
+  bottom: 0;
+  flex-direction: column;
+  left: 0;
+  transition: transform 300ms ease-in-out;
+  width: $section-width;
+
+  &.open {
+    transform: translate(0px, 0px);
+  }
+
+  &.closed {
+    transform: translate(-$section-width, 0px);
+  }
+
+  @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
+    .nav-search {
+      display: none;
+    }
+
+    ul.section-menu > li a {
+      padding: 12px 0;
+    }
+  }
+
+  @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+    .submenu-caret, .subsection-container {
+      display: none;
+    }
+  }
+
+  * {
+    display: flex;
+  }
+
+  .nav-search {
+    border-bottom: $border-width solid $nav-search-border-color;
+    padding-bottom: 16px;
+    margin: 16px 20px 0;
+
+    input {
+      flex: 1;
+    }
+  }
+
+  ul.section-menu, ul.subsection-menu {
+    flex: 1;
+    flex-direction: column;
+  }
+
+  ul.section-menu {
+    padding: 0;
+
+    > li {
+      font-size: 14px;
+      font-weight: bold;
+      list-style: none;
+      padding: 0 20px;
+      position: relative;
+
+      a {
+        align-items: center;
+        color: white;
+        flex: 1;
+        justify-content: space-between;
+        padding: 14px 0;
+        text-decoration: none;
+
+        @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+          padding: 12px 0;
+        }
+      }
+
+      &:hover {
+        background: darken($section-bg, 20%);
+
+        .subsection-container {
+          opacity: 1;
+          visibility: visible;
+        }
+      }
+    }
+  }
+
+  .subsection-container {
+    opacity: 0;
+    position: relative;
+    transition: visibility 0s, opacity 250ms step-end 200ms;
+    visibility: hidden;
+
+    .arrow-left {
+      border-bottom: $arrow-size solid transparent;
+      border-right: $arrow-size solid white;
+      border-top: $arrow-size solid transparent;
+      height: 0;
+      left: -$arrow-size;
+      position: absolute;
+      top: 15px;
+      width: 0;
+      z-index: ($overlay-z-index + 2);
+    }
+  }
+
+  ul.subsection-menu {
+    background: white;
+    border-radius: 2px;
+    box-shadow: 0px 0px 20px 0 rgba(42, 42, 42, 0.5);
+    left: 0;
+    list-style: none;
+    margin: 0;
+    padding: 24px;
+    position: absolute;
+    top: 0;
+    width: 200px;
+    z-index: ($overlay-z-index + 1);
+
+    > li {
+
+      > a {
+        color: $submenu-link-color;
+        padding: 8px 0;
+
+        &:hover {
+          color: darken($submenu-link-color, 20%);
+        }
+      }
+
+      &:first-of-type > a {
+        padding-top: 0;
+      }
+
+      &:last-of-type > a {
+        padding-bottom: 0;
+      }
+    }
+  }
+}
+
+#overlay {
+  background: $overlay-color;
+  height: 100%;
+  left: 0;
+  opacity: 0.5;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: $overlay-z-index;
+}

--- a/blocks/header-nav-chain-block/index.js
+++ b/blocks/header-nav-chain-block/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/blocks/header-nav-chain-block/jest.config.js
+++ b/blocks/header-nav-chain-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require('../../jest/jest.config.base');
+
+module.exports = {
+  ...base,
+};

--- a/blocks/header-nav-chain-block/package.json
+++ b/blocks/header-nav-chain-block/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@wpmedia/header-nav-chain-block",
+  "version": "0.0.0",
+  "description": "Fusion News Theme header nav chain block",
+  "author": "Sean Shannon <sean.shannon@washpost.com>",
+  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "license": "UNLICENSED",
+  "main": "index.js",
+  "files": [
+    "features",
+    "chains",
+    "layouts"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "directory": "blocks/header-nav-chain-block"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "lint": "eslint --ext js --ext jsx features"
+  },
+  "dependencies": {
+    "@wpmedia/engine-theme-sdk": "latest",
+    "@wpmedia/news-theme-css": "latest",
+    "styled-components": "^4.4.0"
+  }
+}


### PR DESCRIPTION
https://arcpublishing.atlassian.net/browse/PEN-697

Turning the navigation header into a chain with a `signInOrder`custom field that lets users specify the index (1-based) of a child component that should be rendered. Tests added.