### PR TITLE
Allow clients to use lightBackgroundLogo in the footer

### DIFF
--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -8,7 +8,6 @@ import getThemeStyle from 'fusion:themes';
 import FacebookAltIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/FacebookAltIcon';
 import TwitterIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/TwitterIcon';
 import RssIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/RssIcon';
-import ArcLogo from '@wpmedia/engine-theme-sdk/dist/es/components/ArcLogo';
 
 import './footer.scss';
 
@@ -17,7 +16,21 @@ const FooterSection = styled.ul`
 `;
 
 const Footer = ({ customFields: { navigationConfig } }) => {
-  const { arcSite } = useFusionContext();
+  const { arcSite, deployment, contextPath } = useFusionContext();
+  const {
+    facebookPage,
+    twitterUsername,
+    rssUrl,
+    copyrightText,
+    lightBackgroundLogo,
+    lightBackgroundLogoAlt,
+    primaryLogo,
+    primaryLogoAlt,
+  } = getProperties(arcSite);
+
+  // Check if URL is absolute/base64
+  let logoUrl = lightBackgroundLogo || primaryLogo;
+  if (logoUrl && !(logoUrl.indexOf('http') === 0 || logoUrl.indexOf('base64') === 0)) logoUrl = deployment(`${contextPath}/${logoUrl}`);
 
   const content = useContent({
     source: navigationConfig.contentService,
@@ -32,13 +45,13 @@ const Footer = ({ customFields: { navigationConfig } }) => {
   const socialButtons = (
     <>
       {
-        (getProperties(arcSite).facebookPage)
+        (facebookPage)
           ? (
             <a
               title="Facebook page"
               target="_blank"
               rel="noopener noreferrer"
-              href={getProperties(arcSite).facebookPage}
+              href={facebookPage}
             >
               <FacebookAltIcon fill="#2980B9" />
             </a>
@@ -46,13 +59,13 @@ const Footer = ({ customFields: { navigationConfig } }) => {
           : ''
       }
       {
-        (getProperties(arcSite).twitterUsername)
+        (twitterUsername)
           ? (
             <a
               title="Twitter feed"
               target="_blank"
               rel="noopener noreferrer"
-              href={`https://twitter.com/${getProperties(arcSite).twitterUsername}`}
+              href={`https://twitter.com/${twitterUsername}`}
             >
               <TwitterIcon fill="#2980B9" />
             </a>
@@ -60,13 +73,13 @@ const Footer = ({ customFields: { navigationConfig } }) => {
           : ''
       }
       {
-        (getProperties(arcSite).rssUrl)
+        (rssUrl)
           ? (
             <a
               title="RSS feed"
               target="_blank"
               rel="noopener noreferrer"
-              href={getProperties(arcSite).rssUrl}
+              href={rssUrl}
             >
               <RssIcon fill="#2980B9" />
             </a>
@@ -89,7 +102,7 @@ const Footer = ({ customFields: { navigationConfig } }) => {
             <div className="copyright-column">
               {/* If large screen, show copyright over border */}
               <p className="copyright" id="copyright-top" style={{ width: '100%' }}>
-                {getProperties(arcSite).copyrightText}
+                {copyrightText}
               </p>
             </div>
           </div>
@@ -98,7 +111,7 @@ const Footer = ({ customFields: { navigationConfig } }) => {
       <div>
         {/* If small screen, show copyright under border */}
         <p className="copyright" id="copyright-bottom" style={{ width: '100%' }}>
-          {getProperties(arcSite).copyrightText}
+          {copyrightText}
         </p>
       </div>
       <div className="row legacy-footer-row">
@@ -122,19 +135,19 @@ const Footer = ({ customFields: { navigationConfig } }) => {
           );
         })}
       </div>
-      <div className="primaryLogo">
-        {
-          getProperties(arcSite).primaryLogo
-            ? (
+      {
+        (logoUrl)
+          ? (
+            <div className="primaryLogo">
               <img
-                src={getProperties(arcSite).primaryLogo}
-                alt={getProperties(arcSite).primaryLogoAlt || 'Footer logo'}
+                src={logoUrl}
+                alt={(lightBackgroundLogo ? lightBackgroundLogoAlt : primaryLogoAlt) || 'Footer logo'}
                 className="footer-logo"
               />
-            )
-            : <ArcLogo />
-        }
-      </div>
+            </div>
+          )
+          : null
+      }
     </div>
   );
 };

--- a/blocks/footer-block/features/footer/default.test.jsx
+++ b/blocks/footer-block/features/footer/default.test.jsx
@@ -92,7 +92,10 @@ const mockPayload = {
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
 jest.mock('fusion:context', () => ({
-  useFusionContext: jest.fn(() => ({})),
+  useFusionContext: jest.fn(() => ({
+    contextPath: 'pf',
+    deployment: jest.fn((path) => path),
+  })),
 }));
 
 jest.mock('fusion:content', () => ({
@@ -180,11 +183,25 @@ describe('the footer feature for the default output type', () => {
 
   describe('the footer image/logo', () => {
     describe('when the theme manifest provides a logo url', () => {
-      it('should make the src of the logo the provided image', () => {
+      it('should make the relative src of the logo the provided image', () => {
         getProperties.mockImplementation(() => ({ primaryLogo: 'my-nav-logo.svg' }));
         const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
 
-        expect(wrapper.find('div > img')).toHaveProp('src', 'my-nav-logo.svg');
+        expect(wrapper.find('div > img')).toHaveProp('src', 'pf/my-nav-logo.svg');
+      });
+
+      it('should make the absolute src of the logo the provided image', () => {
+        getProperties.mockImplementation(() => ({ primaryLogo: 'http://test/my-nav-logo.svg' }));
+        const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+
+        expect(wrapper.find('div > img')).toHaveProp('src', 'http://test/my-nav-logo.svg');
+      });
+
+      it('should make the base64 src of the logo the provided image', () => {
+        getProperties.mockImplementation(() => ({ primaryLogo: 'base64:my-nav-logo.svg' }));
+        const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+
+        expect(wrapper.find('div > img')).toHaveProp('src', 'base64:my-nav-logo.svg');
       });
 
       describe('when the theme manifest provides alt text', () => {
@@ -206,12 +223,67 @@ describe('the footer feature for the default output type', () => {
       });
     });
 
+    describe('when the theme manifest provides a light logo url', () => {
+      it('should use the light logo over the primary logo', () => {
+        getProperties.mockImplementation(() => ({ lightBackgroundLogo: 'light.svg', primaryLogo: 'primary.svg' }));
+        const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+
+        expect(wrapper.find('div > img')).toHaveProp('src', 'pf/light.svg');
+      });
+
+      it('should make the relative src of the logo the provided image', () => {
+        getProperties.mockImplementation(() => ({ lightBackgroundLogo: 'my-nav-logo.svg' }));
+        const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+
+        expect(wrapper.find('div > img')).toHaveProp('src', 'pf/my-nav-logo.svg');
+      });
+
+      it('should make the absolute src of the logo the provided image', () => {
+        getProperties.mockImplementation(() => ({ lightBackgroundLogo: 'http://test/my-nav-logo.svg' }));
+        const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+
+        expect(wrapper.find('div > img')).toHaveProp('src', 'http://test/my-nav-logo.svg');
+      });
+
+      it('should make the base64 src of the logo the provided image', () => {
+        getProperties.mockImplementation(() => ({ lightBackgroundLogo: 'base64:my-nav-logo.svg' }));
+        const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+
+        expect(wrapper.find('div > img')).toHaveProp('src', 'base64:my-nav-logo.svg');
+      });
+
+      describe('when the theme manifest provides alt text', () => {
+        it('should make the alt text of the logo the provided text', () => {
+          getProperties.mockImplementation(() => ({ lightBackgroundLogo: 'my-nav-logo.svg', lightBackgroundLogoAlt: 'my alt text' }));
+          const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+
+          expect(wrapper.find('div > img')).toHaveProp('alt', 'my alt text');
+        });
+
+        it('should use the light alt text over the primary alt text', () => {
+          getProperties.mockImplementation(() => ({ lightBackgroundLogo: 'my-nav-logo.svg', lightBackgroundLogoAlt: 'light', primaryLogoAlt: 'primary' }));
+          const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+
+          expect(wrapper.find('div > img')).toHaveProp('alt', 'light');
+        });
+      });
+
+      describe('when the theme manifest does not provide alt text', () => {
+        it('should make the alt text of the logo the default text', () => {
+          getProperties.mockImplementation(() => ({ lightBackgroundLogo: 'my-nav-logo.svg' }));
+          const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+
+          expect(wrapper.find('div > img')).toHaveProp('alt', 'Footer logo');
+        });
+      });
+    });
+
     describe('when the theme does not provide a logo url', () => {
-      it('should make the src of the logo the placeholder image', () => {
+      it('should not render the primary logo div', () => {
         getProperties.mockImplementation(() => ({}));
         const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
 
-        expect(wrapper.find('div.primaryLogo > ArcLogo')).toHaveLength(1);
+        expect(wrapper.find('div.primaryLogo')).toHaveLength(0);
       });
     });
   });


### PR DESCRIPTION
The footer block will use `lightBackgroundLogo` and fallback to `primaryLogo`. It will never show the arc logo. It will add contextPath and deployment id to relative paths.