### PR TITLE
PEN-937: Missing trailing slashes

### DIFF
--- a/blocks/header-nav-block/features/navigation/_children/section-nav.jsx
+++ b/blocks/header-nav-block/features/navigation/_children/section-nav.jsx
@@ -19,13 +19,27 @@ function parseLinkData(node) {
   return {};
 }
 
+function fixTrailingSlash(item) {
+  let fixedItem = item;
+  if (fixedItem[fixedItem.length - 1] !== '/') {
+    fixedItem += '/';
+  }
+  return fixedItem;
+}
+
 const SectionItem = ({ item }) => {
   const { text = '', url = '' } = parseLinkData(item);
   return (
     <li className="section-item">
-      <a href={url} title={text}>
+      <a href={fixTrailingSlash(url)} title={text}>
         {text}
-        {hasChildren(item) && <span className="submenu-caret"><ChevronRight fill="rgba(255, 255, 255, 0.5)" height={12} width={12} /></span>}
+        {
+          hasChildren(item) && (
+            <span className="submenu-caret">
+              <ChevronRight fill="rgba(255, 255, 255, 0.5)" height={12} width={12} />
+            </span>
+          )
+        }
       </a>
       {hasChildren(item) && <SubSectionMenu items={item.children} />}
     </li>
@@ -35,7 +49,13 @@ const SectionItem = ({ item }) => {
 const SubSectionMenu = ({ items }) => {
   const itemsList = items.map((item) => {
     const { text = '', url = '' } = parseLinkData(item);
-    return (<li className="subsection-item" key={item._id}><a href={url} title={text}>{text}</a></li>);
+    return (
+      <li className="subsection-item" key={item._id}>
+        <a href={fixTrailingSlash(url)} title={text}>
+          {text}
+        </a>
+      </li>
+    );
   });
 
   return (

--- a/blocks/header-nav-block/features/navigation/_children/section-nav.test.jsx
+++ b/blocks/header-nav-block/features/navigation/_children/section-nav.test.jsx
@@ -59,7 +59,7 @@ describe('the SectionNav component', () => {
   it('should render the href for a section node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
-    expect(wrapper.find('li.section-item > a').at(0)).toHaveProp('href', '/sports');
+    expect(wrapper.find('li.section-item > a').at(0)).toHaveProp('href', '/sports/');
   });
 
   it('should render the text for a link node correctly', () => {
@@ -71,7 +71,7 @@ describe('the SectionNav component', () => {
   it('should render the href for a link node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
-    expect(wrapper.find('li.section-item > a').at(1)).toHaveProp('href', '/entertainment');
+    expect(wrapper.find('li.section-item > a').at(1)).toHaveProp('href', '/entertainment/');
   });
 
   describe('when a section has child nodes', () => {
@@ -104,7 +104,30 @@ describe('the SectionNav component', () => {
     it('should render the href for a subsection link node correctly', () => {
       const wrapper = mount(<SectionNav sections={items} />);
 
-      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > a').at(0)).toHaveProp('href', '/basketball');
+      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > a').at(0)).toHaveProp('href', '/basketball/');
+    });
+  });
+
+  describe('when a link is not missing a trailing slash', () => {
+    const itemsNoSlash = [
+      {
+        _id: '/sports',
+        node_type: 'section',
+        name: 'Sports',
+        children: [
+          {
+            _id: 'foo',
+            node_type: 'link',
+            display_name: 'Basketball',
+            url: '/basketball/',
+          },
+        ],
+      },
+    ];
+    it('should not add a slash at the end of the link', () => {
+      const wrapper = mount(<SectionNav sections={itemsNoSlash} />);
+
+      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > a').at(0)).toHaveProp('href', '/basketball/');
     });
   });
 });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
@@ -19,13 +19,27 @@ function parseLinkData(node) {
   return {};
 }
 
+function fixTrailingSlash(item) {
+  let fixedItem = item;
+  if (fixedItem[fixedItem.length - 1] !== '/') {
+    fixedItem += '/';
+  }
+  return fixedItem;
+}
+
 const SectionItem = ({ item }) => {
   const { text = '', url = '' } = parseLinkData(item);
   return (
     <li className="section-item">
-      <a href={url} title={text}>
+      <a href={fixTrailingSlash(url)} title={text}>
         {text}
-        {hasChildren(item) && <span className="submenu-caret"><ChevronRight fill="rgba(255, 255, 255, 0.5)" height={12} width={12} /></span>}
+        {
+          hasChildren(item) && (
+            <span className="submenu-caret">
+              <ChevronRight fill="rgba(255, 255, 255, 0.5)" height={12} width={12} />
+            </span>
+          )
+        }
       </a>
       {hasChildren(item) && <SubSectionMenu items={item.children} />}
     </li>
@@ -35,7 +49,13 @@ const SectionItem = ({ item }) => {
 const SubSectionMenu = ({ items }) => {
   const itemsList = items.map((item) => {
     const { text = '', url = '' } = parseLinkData(item);
-    return (<li className="subsection-item" key={item._id}><a href={url} title={text}>{text}</a></li>);
+    return (
+      <li className="subsection-item" key={item._id}>
+        <a href={fixTrailingSlash(url)} title={text}>
+          {text}
+        </a>
+      </li>
+    );
   });
 
   return (

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
@@ -59,7 +59,7 @@ describe('the SectionNav component', () => {
   it('should render the href for a section node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
-    expect(wrapper.find('li.section-item > a').at(0)).toHaveProp('href', '/sports');
+    expect(wrapper.find('li.section-item > a').at(0)).toHaveProp('href', '/sports/');
   });
 
   it('should render the text for a link node correctly', () => {
@@ -71,7 +71,7 @@ describe('the SectionNav component', () => {
   it('should render the href for a link node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
-    expect(wrapper.find('li.section-item > a').at(1)).toHaveProp('href', '/entertainment');
+    expect(wrapper.find('li.section-item > a').at(1)).toHaveProp('href', '/entertainment/');
   });
 
   describe('when a section has child nodes', () => {
@@ -104,7 +104,30 @@ describe('the SectionNav component', () => {
     it('should render the href for a subsection link node correctly', () => {
       const wrapper = mount(<SectionNav sections={items} />);
 
-      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > a').at(0)).toHaveProp('href', '/basketball');
+      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > a').at(0)).toHaveProp('href', '/basketball/');
+    });
+  });
+
+  describe('when a link is not missing a trailing slash', () => {
+    const itemsNoSlash = [
+      {
+        _id: '/sports',
+        node_type: 'section',
+        name: 'Sports',
+        children: [
+          {
+            _id: 'foo',
+            node_type: 'link',
+            display_name: 'Basketball',
+            url: '/basketball/',
+          },
+        ],
+      },
+    ];
+    it('should not add a slash at the end of the link', () => {
+      const wrapper = mount(<SectionNav sections={itemsNoSlash} />);
+
+      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > a').at(0)).toHaveProp('href', '/basketball/');
     });
   });
 });

--- a/blocks/links-bar-block/features/links-bar/_children/link.jsx
+++ b/blocks/links-bar-block/features/links-bar/_children/link.jsx
@@ -1,15 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+function fixTrailingSlash(item) {
+  let fixedItem = item;
+  if (fixedItem[fixedItem.length - 1] !== '/') {
+    fixedItem += '/';
+  }
+  return fixedItem;
+}
+
 const Link = ({ href, name }) => {
   const externalUrl = /(http(s?)):\/\//i.test(href);
   return (
     externalUrl ? (
-      <a href={href} target="_blank" rel="noopener noreferrer">
+      <a href={fixTrailingSlash(href)} target="_blank" rel="noopener noreferrer">
         {name}
         <span className="sr-only">(Opens in new window)</span>
       </a>
-    ) : <a href={href}>{name}</a>
+    ) : <a href={fixTrailingSlash(href)}>{name}</a>
   );
 };
 

--- a/blocks/links-bar-block/features/links-bar/default.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.jsx
@@ -28,7 +28,11 @@ const LinksBar = ({ customFields: { navigationConfig = {} } }) => {
     <nav key={id} className="links-bar">
       {menuItems && menuItems.map((item) => (
         <LinkBarSpan className="links-menu" key={item._id} primaryFont={getThemeStyle(arcSite)['primary-font-family']}>
-          {item.node_type === 'link' ? <Link href={item.url} name={item.display_name} /> : <Link href={item._id} name={item.name} />}
+          {
+            item.node_type === 'link'
+              ? <Link href={item.url} name={item.display_name} />
+              : <Link href={item._id} name={item.name} />
+          }
         </LinkBarSpan>
       ))}
     </nav>

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -94,6 +94,7 @@ describe('the links bar feature for the default output type', () => {
       expect(wrapper.find('[href="/testurl/"]').length).toBe(1);
     });
   });
+
   describe('when a link is not missing a trailing slash', () => {
     it('should not add a slash at the end of the link', () => {
       const { default: Link } = require('./_children/link');

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -84,4 +84,23 @@ describe('the links bar feature for the default output type', () => {
 
     expect(wrapper.find('nav > span')).toHaveLength(0);
   });
+
+  describe('when a link is missing a trailing slash', () => {
+    it('should add a slash at the end of the link', () => {
+      const { default: Link } = require('./_children/link');
+      const wrapper = mount(<Link href="/testurl" name="test" />);
+
+      expect(wrapper.props().href).toBe('/testurl');
+      expect(wrapper.find('[href="/testurl/"]').length).toBe(1);
+    });
+  });
+  describe('when a link is not missing a trailing slash', () => {
+    it('should not add a slash at the end of the link', () => {
+      const { default: Link } = require('./_children/link');
+      const wrapper = mount(<Link href="/testurl/" name="test" />);
+
+      expect(wrapper.props().href).toBe('/testurl/');
+      expect(wrapper.find('[href="/testurl/"]').length).toBe(2);
+    });
+  });
 });

--- a/blocks/overline-block/features/overline/default.jsx
+++ b/blocks/overline-block/features/overline/default.jsx
@@ -13,6 +13,14 @@ const StyledLink = styled.a`
   text-decoration: none;
 `;
 
+function fixTrailingSlash(item) {
+  let fixedItem = item;
+  if (fixedItem[fixedItem.length - 1] !== '/') {
+    fixedItem += '/';
+  }
+  return fixedItem;
+}
+
 const Overline = (props) => {
   const { globalContent: content = {}, arcSite } = useFusionContext();
   const { editableContent } = useEditableContent();
@@ -41,7 +49,7 @@ const Overline = (props) => {
   return text
     ? (
       <StyledLink
-        href={url}
+        href={fixTrailingSlash(url)}
         primaryFont={getThemeStyle(arcSite)['primary-font-family']}
         className="overline"
         {...edit}

--- a/blocks/overline-block/features/overline/default.test.jsx
+++ b/blocks/overline-block/features/overline/default.test.jsx
@@ -51,7 +51,7 @@ describe('overline feature for default output type', () => {
     it('should have the href of the website_section _id', () => {
       const wrapper = shallow(<Overline />);
 
-      expect(wrapper.at(0).prop('href')).toStrictEqual('/news');
+      expect(wrapper.at(0).prop('href')).toStrictEqual('/news/');
     });
   });
 
@@ -80,14 +80,14 @@ describe('overline feature for default output type', () => {
       it('should render the href of the label instead of the website section', () => {
         const wrapper = shallow(<Overline />);
 
-        expect(wrapper.at(0).prop('href')).toStrictEqual('/exclusive');
+        expect(wrapper.at(0).prop('href')).toStrictEqual('/exclusive/');
       });
     });
 
     describe('when label.basic.display is NOT true', () => {
       beforeEach(() => {
         const labelObj = {
-          label: { basic: { display: false, text: 'EXCLUSIVE', url: '/exclusive' } },
+          label: { basic: { display: false, text: 'EXCLUSIVE', url: '/exclusive/' } },
         };
         const contextObjWithLabel = {
 
@@ -109,7 +109,7 @@ describe('overline feature for default output type', () => {
       it('should have the href of the website_section _id', () => {
         const wrapper = shallow(<Overline />);
 
-        expect(wrapper.at(0).prop('href')).toStrictEqual('/news');
+        expect(wrapper.at(0).prop('href')).toStrictEqual('/news/');
       });
     });
   });
@@ -123,6 +123,30 @@ describe('overline feature for default output type', () => {
       const wrapper = mount(<Overline />);
 
       expect(wrapper).toBeEmptyRender();
+    });
+  });
+
+  describe('when a link is not missing a trailing slash', () => {
+    beforeEach(() => {
+      const mockTrailingSlash = {
+        arcSite: 'site',
+        globalContent: {
+          websites: {
+            site: {
+              website_section: {
+                _id: '/test/',
+                name: 'Test',
+              },
+            },
+          },
+        },
+      };
+      useFusionContext.mockImplementation(() => mockTrailingSlash);
+    });
+    it('should not add a slash at the end of the link', () => {
+      const wrapper = shallow(<Overline />);
+
+      expect(wrapper.at(0).prop('href')).toStrictEqual('/test/');
     });
   });
 });


### PR DESCRIPTION
Made a function to add a trailing slash if missing one for the following blocks:
- Links Bar
- Header nav feature
- Header nav chain
- Overline

Would be good to make a directory for reusable functions like this and the `extractImage` and `constructHref` functions to avoid repeated code.

[Jira ticket](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=545&projectKey=PEN&modal=detail&selectedIssue=PEN-937)