### PR TITLE
Height and width ratio not supported by resizer config

### DIFF
--- a/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
@@ -156,11 +156,11 @@ class CustomSearchResultsList extends React.Component {
                           url={extractImage(promoItems)}
                           alt={headlineText}
                           smallWidth={274}
-                          smallHeight={148}
+                          smallHeight={154}
                           mediumWidth={274}
-                          mediumHeight={148}
+                          mediumHeight={154}
                           largeWidth={274}
-                          largeHeight={148}
+                          largeHeight={154}
                           resizedImageOptions={resizedImageOptions}
                           resizerURL={resizerURL}
                           breakpoints={getProperties(arcSite)?.breakpoints}
@@ -168,11 +168,11 @@ class CustomSearchResultsList extends React.Component {
                       ) : (
                         <PlaceholderImage
                           smallWidth={274}
-                          smallHeight={148}
+                          smallHeight={154}
                           mediumWidth={274}
-                          mediumHeight={148}
+                          mediumHeight={154}
                           largeWidth={274}
-                          largeHeight={148}
+                          largeHeight={154}
                         />
                       )}
                     </a>

--- a/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
@@ -156,22 +156,22 @@ class GlobalSearchResultsList extends React.Component {
                           url={extractImage(promoItems)}
                           alt={headlineText}
                           smallWidth={274}
-                          smallHeight={148}
+                          smallHeight={154}
                           mediumWidth={274}
-                          mediumHeight={148}
+                          mediumHeight={154}
                           largeWidth={274}
-                          largeHeight={148}
+                          largeHeight={154}
                           breakpoints={getProperties(arcSite)?.breakpoints}
                           resizerURL={resizerURL}
                         />
                       ) : (
                         <PlaceholderImage
                           smallWidth={274}
-                          smallHeight={148}
+                          smallHeight={154}
                           mediumWidth={274}
-                          mediumHeight={148}
+                          mediumHeight={154}
                           largeWidth={274}
-                          largeHeight={148}
+                          largeHeight={154}
                         />
                       )}
                     </a>


### PR DESCRIPTION
Need to use documented image widths and heights 

  "engineSDK": "@wpmedia/engine-theme-sdk@beta",

* 274x0: "/7lwbXw39fsb7SslOOiUxu1ly4gc=/fit-in/274x0/filters:quality(70):fill(white):background_color(white)/" 274x154: "/DdErna-7pp6myk9CrCpHdgiGQrA=/fit-in/274x154/filters:quality(70):fill(white):background_color(white)/" 274x183: "/74FUDjj5P9QGqVekHa1JSdaSU1M=/fit-in/274x183/filters:quality(70):fill(white):background_color(white)/" 274x206: "/NL8g53815dsUhgTS3jXC7rdAt4U=/fit-in/274x206/filters:quality(70):fill(white):background_color(white)/" 274x274: "/MDrtZOPpTHNfa 
* working 
https://github.com/WPMedia/fusion-news-theme-blocks/commit/c2632b2170fca7a1de31c6b917b149a392e874e9#diff-8d9ceb945ff208b3d50a33a68dc5b38e