### PR TITLE
Pen 915

### DIFF
--- a/blocks/default-output-block/package-lock.json
+++ b/blocks/default-output-block/package-lock.json
@@ -13,11 +13,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.1.tgz",
-      "integrity": "sha512-AT0YPLQw9DI21tliuJIdplVfLHya6mcGa8ctkv7n4Qv+hYacJrKmNWIteAK1P9iyLikFIAkwqJ7HAOqIDLFfgA==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+      "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
       "requires": {
-        "@babel/types": "^7.10.1",
+        "@babel/types": "^7.10.2",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -81,14 +81,14 @@
       }
     },
     "@babel/parser": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.1.tgz",
-      "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg=="
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+      "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
     },
     "@babel/runtime": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.1.tgz",
-      "integrity": "sha512-nQbbCbQc9u/rpg1XCxoMYQTbSMVZjCDxErQ1ClCn9Pvcmv1lGads19ep0a2VsEiIJeHqjZley6EQGEC3Yo1xMA==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+      "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -120,9 +120,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.1.tgz",
-      "integrity": "sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+      "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.1",
         "lodash": "^4.17.13",
@@ -165,9 +165,9 @@
       }
     },
     "@wpmedia/news-theme-css": {
-      "version": "2.1.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/2.1.6/81bc2f825db0a3a978ae3a7b77679475bb7dfa96f6afe7dd7d2480684922c1d2",
-      "integrity": "sha512-gml0kc3GpbM1DPFvKNkw3ws1T6K4n+ENoAtuQG8+5Z/KJqiEpp4u8oz3/MCOJ/So/HEAfqvzhXX8cYa1CALzrA=="
+      "version": "2.1.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/2.1.7/bb6889299b5a822475b2e407470a34a148ac9580b49a05b4127aa7ba9d0fa82f",
+      "integrity": "sha512-8gZ6KfM8dqh6gc8b5VdX7bwBm4Lw8PiLF+rOP6548TsrD5iFJ1pxKwfibTFycQRm8YM3WRYWAZInE08K5OEcDw=="
     },
     "ansi-styles": {
       "version": "3.2.1",

--- a/blocks/double-chain-block/chains/double-chain/default.jsx
+++ b/blocks/double-chain-block/chains/double-chain/default.jsx
@@ -13,10 +13,10 @@ const DoubleChain = ({ children, customFields }) => {
       return (
         <div className="container-fluid double-chain">
           <div className="row">
-            <div className="col-sm-12 col-md-xl-6 ie-flex-100-percent-sm column-1">
+            <div className="col-sm-12 col-md-xl-6 ie-flex-100-percent-sm column-1 reduce-internal-row-col-gap">
               {children.slice(0, columnOneLength)}
             </div>
-            <div className="col-sm-12 col-md-xl-6 ie-flex-100-percent-sm column-2">
+            <div className="col-sm-12 col-md-xl-6 ie-flex-100-percent-sm column-2 reduce-internal-row-col-gap">
               {children.slice(columnOneLength)}
             </div>
           </div>

--- a/blocks/quad-chain-block/chains/quad-chain/default.jsx
+++ b/blocks/quad-chain-block/chains/quad-chain/default.jsx
@@ -20,16 +20,16 @@ const QuadChain = ({ children, customFields }) => {
       return (
         <div className="container-fluid">
           <div className="row">
-            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm">
+            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap">
               {children.slice(0, columnOneLength)}
             </div>
-            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm">
+            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap">
               {children.slice(columnOneLength, endOfColumnTwoIndex)}
             </div>
-            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm">
+            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap">
               {children.slice(endOfColumnTwoIndex, endOfColumnThreeIndex)}
             </div>
-            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm">
+            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap">
               {children.slice(endOfColumnThreeIndex)}
             </div>
           </div>

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -30,7 +30,7 @@
       width: calc((100% - #{map-get($spacers, 'md')}) / 2);
     }
 
-    &:nth-child(2n-1) {
+    &:nth-child(2n) {
       margin-right: 0;
       @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
         margin-right: map-get($spacers, 'md');

--- a/blocks/triple-chain-block/chains/triple-chain/default.jsx
+++ b/blocks/triple-chain-block/chains/triple-chain/default.jsx
@@ -17,13 +17,13 @@ const TripleChain = ({ children, customFields }) => {
       return (
         <div className="container-fluid">
           <div className="row">
-            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm">
+            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm reduce-internal-row-col-gap">
               {children.slice(0, columnOneLength)}
             </div>
-            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm">
+            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm reduce-internal-row-col-gap">
               {children.slice(columnOneLength, endOfColumnTwoIndex)}
             </div>
-            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm">
+            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm reduce-internal-row-col-gap">
               {children.slice(endOfColumnTwoIndex)}
             </div>
           </div>


### PR DESCRIPTION
FYI: added a util class in the CSS Framework called "reduce-internal-row-col-gap" that can be applied to parent divs to convert the grid-column-gap for child .row elements to a percent instead of rems.  This is useful to prevent overflow.