### PR TITLE
MM-63: Links bar fix

### DIFF
--- a/blocks/links-bar-block/features/links-bar/links-bar.scss
+++ b/blocks/links-bar-block/features/links-bar/links-bar.scss
@@ -3,9 +3,11 @@
   align-items: center;
   box-shadow: inset 0 -1px 0 0 $ui-light-gray;
   height: calculateRem(60px);
+  text-align: left;
   width: 100%;
   @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
     height: calculateRem(40px);
+    text-align: center;
   }
 
   .links-menu {


### PR DESCRIPTION
Made links bar elements left-aligned on mobile and centered on desktop