### PR TITLE
PEN-940 - update developer notes with Gallery events

### DIFF
--- a/News Theme Development.md
+++ b/News Theme Development.md
@@ -358,20 +358,42 @@ from the blocks list in `blocks.json` to prevent a Fusion error because of the n
 ## Event Listening
 The EventEmitter object, located in @wpmedia/engine-theme-sdk can be used to 
 publish and subscribe to events.  This can be useful for adding analytic tracking for a custom block.
-In fact, the Gallery component sends off events for when the next or previous image is viewed. These Gallery events are named
-`galleryImageNext` and `galleryImagePrevious` respectively.  If you wanted to listen to these events, the first thing is to import the EventEmitter object 
-into the block:<br /><br />
-`import { EventEmitter } from '@wpmedia/engine-theme-sdk'`
-<br /><br />
+In fact, the Gallery component sends off events for when the next or previous image is viewed. 
+
+These Gallery events are:
+
+|                      |                                                              |
+| -------------------- | ------------------------------------------------------------ |
+| galleryImageNext     | When the next button is pressed.                             |
+| galleryImagePrevious | When the next button is pressed.                             |
+| galleryExpandEnter   | When the expand button is pressed                            |
+| galleryExpandExit    | When the close button on the lightbox is pressed             |
+
+If you wanted to listen to these events, the first thing is to import the EventEmitter object into the block:
+
+```jsx
+import { EventEmitter } from '@wpmedia/engine-theme-sdk'
+```
+
 Then create a callback function such as:
-<br /><br />
-`const myGalleryImageNext = (event) => {console.log('Here is the event: ', event);}`<br />
-`const myGalleryImagePrevious = (event) => {console.log('Here is the event: ', event);}`
-<br /><br />
+
+```jsx
+const myGalleryImageNext = (event) => {console.log('Here is the event: ', event);}
+const myGalleryImagePrevious = (event) => {console.log('Here is the event: ', event);}
+```
+
 Then use you use your callback in subscribing to the event:
-<br /><br />
-`EventEmitter.subscribe('galleryImageNext', (event) => myGalleryImageNext(event));`
-`EventEmitter.subscribe('galleryImagePrevious', (event) => myGalleryImagePrevious(event));`
+
+```jsx
+EventEmitter.subscribe(
+    'galleryImageNext',
+    (event) => myGalleryImageNext(event)
+);
+EventEmitter.subscribe(
+    'galleryImagePrevious',
+    (event) => myGalleryImagePrevious(event)
+);
+```
 
 ## Local Development Process
 


### PR DESCRIPTION
[PEN-940](https://arcpublishing.atlassian.net/browse/PEN-940)

# What does this implement or fix?
- Update developer notes about events en general y Gallery events in particular

# How was this tested?

no needed.

# Dependencies or Side Effects

- none
