### PR TITLE
PEN-1113 change image ratio top table list

### DIFF
--- a/blocks/resizer-image-block/imageRatioCustomField.js
+++ b/blocks/resizer-image-block/imageRatioCustomField.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+
+const imageRatioLabels = {
+  '16:9': '16:9',
+  '3:2': '3:2',
+  '4:3': '4:3',
+};
+
+const imageRatiosKeys = Object.keys(imageRatioLabels);
+
+/**
+ * Helper to create imageRatio properties to be used on CustomFields
+ *
+ * example usage:
+ *
+ *   customFields: PropTypes.shape({
+ *    ...imageRatioProps('imageRatioMD', 'Medium story settings', '16:9'),
+ *  });
+ *
+ *
+ * @param element Base name of the element.
+ * @param group Group to witch the element belong to
+ * @param defaultValue Default value to use for this property
+ *
+ * @return A property object to be use on CustomFields
+ */
+const imageRatioCustomField = (element, group, defaultValue) => {
+  const elementTextProp = {
+    [`${element}`]: PropTypes.oneOf(imageRatiosKeys).tag({
+      labels: imageRatioLabels,
+      name: 'Image ratio',
+      defaultValue,
+      group,
+    }),
+  };
+  return { ...elementTextProp };
+};
+
+export default imageRatioCustomField;

--- a/blocks/resizer-image-block/index.js
+++ b/blocks/resizer-image-block/index.js
@@ -2,6 +2,9 @@
 import getProperties from 'fusion:properties';
 import { resizerKey as RESIZER_SECRET_KEY } from 'fusion:environment';
 
+export { default as ratiosFor } from './ratiosFor';
+export { default as imageRatioCustomField } from './imageRatioCustomField';
+
 const getResizerParam = (
   originalUrl,
   breakpoint,

--- a/blocks/resizer-image-block/ratiosFor.js
+++ b/blocks/resizer-image-block/ratiosFor.js
@@ -1,34 +1,3 @@
-import PropTypes from 'prop-types';
-
-const imageRatioLabels = {
-  '16:9': '16:9',
-  '3:2': '3:2',
-  '4:3': '4:3',
-};
-
-const imageRatiosKeys = Object.keys(imageRatioLabels);
-
-/**
- * Helper to create imageRatio properties to be used on CustomFields
- *
- * @param element Base name of the element.
- * @param group Group to witch the element belong to
- * @param defaultValue Default value to use for this property
- *
- * @return A property object to be use on CustomFields
- */
-export const imageRatioProps = (element, group, defaultValue) => {
-  const elementTextProp = {
-    [`${element}`]: PropTypes.oneOf(imageRatiosKeys).tag({
-      labels: imageRatioLabels,
-      name: 'Image ratio',
-      defaultValue,
-      group,
-    }),
-  };
-  return { ...elementTextProp };
-};
-
 const sizes = {
   XL: {
     options: [
@@ -72,12 +41,15 @@ const ratios = {
 /**
  * Helper to return the image sizes properties according to a ratio
  *
+ * @param size Label to use to determine the size (XL, LG, MD, SM)
  * @param ratioValue Ratio to use for the calc
  *
- * @return an object with all the sizes
+ * @return an object with the sizes for each option
  */
-export const ratiosPropsFor = (size, ratioValue) => {
-  const { options, defaultRatio } = sizes[size];
+const ratiosFor = (size, ratioValue) => {
+  const validOptions = Object.keys(sizes);
+  const imageSize = validOptions.some((e) => e === size) ? size : 'XL';
+  const { options, defaultRatio } = sizes[imageSize];
   const ratio = ratios[ratioValue] || ratios[defaultRatio];
 
   return options.reduce((acc, ele) => {
@@ -86,3 +58,5 @@ export const ratiosPropsFor = (size, ratioValue) => {
     return acc;
   }, {});
 };
+
+export default ratiosFor;

--- a/blocks/resizer-image-block/ratiosFor.test.js
+++ b/blocks/resizer-image-block/ratiosFor.test.js
@@ -1,0 +1,191 @@
+import ratiosFor from './ratiosFor';
+
+describe('validates arithmatic for ratios', () => {
+  describe('validate parameters', () => {
+    it('if size is missing, must use XL', () => {
+      const ratios = ratiosFor();
+      expect(ratios.smallWidth).toBe(400);
+      expect(ratios.smallHeight).toBe(300);
+      expect(ratios.mediumWidth).toBe(600);
+      expect(ratios.mediumHeight).toBe(450);
+      expect(ratios.largeWidth).toBe(800);
+      expect(ratios.largeHeight).toBe(600);
+    });
+
+    it('if size not found, must use XL', () => {
+      const ratios = ratiosFor('DUMMY');
+      expect(ratios.smallWidth).toBe(400);
+      expect(ratios.smallHeight).toBe(300);
+      expect(ratios.mediumWidth).toBe(600);
+      expect(ratios.mediumHeight).toBe(450);
+      expect(ratios.largeWidth).toBe(800);
+      expect(ratios.largeHeight).toBe(600);
+    });
+
+    it('if ratioValue invalid use defaultRatio', () => {
+      const ratios = ratiosFor('XL', 999);
+      expect(ratios.smallWidth).toBe(400);
+      expect(ratios.smallHeight).toBe(300);
+      expect(ratios.mediumWidth).toBe(600);
+      expect(ratios.mediumHeight).toBe(450);
+      expect(ratios.largeWidth).toBe(800);
+      expect(ratios.largeHeight).toBe(600);
+    });
+  });
+
+  describe('must generate default values for each size', () => {
+    it('default values for XL', () => {
+      const ratios = ratiosFor('XL');
+      expect(ratios.smallWidth).toBe(400);
+      expect(ratios.smallHeight).toBe(300);
+      expect(ratios.mediumWidth).toBe(600);
+      expect(ratios.mediumHeight).toBe(450);
+      expect(ratios.largeWidth).toBe(800);
+      expect(ratios.largeHeight).toBe(600);
+    });
+
+    it('default values for LG', () => {
+      const ratios = ratiosFor('LG');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(206);
+      expect(ratios.mediumWidth).toBe(274);
+      expect(ratios.mediumHeight).toBe(206);
+      expect(ratios.largeWidth).toBe(377);
+      expect(ratios.largeHeight).toBe(283);
+    });
+
+    it('default values for MD', () => {
+      const ratios = ratiosFor('MD');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(154);
+      expect(ratios.mediumWidth).toBe(274);
+      expect(ratios.mediumHeight).toBe(154);
+      expect(ratios.largeWidth).toBe(400);
+      expect(ratios.largeHeight).toBe(225);
+    });
+
+    it('default values for SM', () => {
+      const ratios = ratiosFor('SM');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(183);
+      expect(ratios.mediumWidth).toBe(274);
+      expect(ratios.mediumHeight).toBe(183);
+      expect(ratios.largeWidth).toBe(400);
+      expect(ratios.largeHeight).toBe(267);
+    });
+  });
+
+  describe('each size can be overwritten', () => {
+    it('XL on 16:9', () => {
+      const ratios = ratiosFor('XL', '16:9');
+      expect(ratios.smallWidth).toBe(400);
+      expect(ratios.smallHeight).toBe(225);
+      expect(ratios.mediumWidth).toBe(600);
+      expect(ratios.mediumHeight).toBe(338);
+      expect(ratios.largeWidth).toBe(800);
+      expect(ratios.largeHeight).toBe(450);
+    });
+    it('XL on 4:3', () => {
+      const ratios = ratiosFor('XL', '4:3');
+      expect(ratios.smallWidth).toBe(400);
+      expect(ratios.smallHeight).toBe(300);
+      expect(ratios.mediumWidth).toBe(600);
+      expect(ratios.mediumHeight).toBe(450);
+      expect(ratios.largeWidth).toBe(800);
+      expect(ratios.largeHeight).toBe(600);
+    });
+    it('XL on 3:2', () => {
+      const ratios = ratiosFor('XL', '3:2');
+      expect(ratios.smallWidth).toBe(400);
+      expect(ratios.smallHeight).toBe(267);
+      expect(ratios.mediumWidth).toBe(600);
+      expect(ratios.mediumHeight).toBe(400);
+      expect(ratios.largeWidth).toBe(800);
+      expect(ratios.largeHeight).toBe(533);
+    });
+
+    it('LG on 16:9', () => {
+      const ratios = ratiosFor('LG', '16:9');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(154);
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(154);
+      expect(ratios.largeWidth).toBe(377);
+      expect(ratios.largeHeight).toBe(212);
+    });
+    it('LG on 4:3', () => {
+      const ratios = ratiosFor('LG', '4:3');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(206);
+      expect(ratios.mediumWidth).toBe(274);
+      expect(ratios.mediumHeight).toBe(206);
+      expect(ratios.largeWidth).toBe(377);
+      expect(ratios.largeHeight).toBe(283);
+    });
+    it('LG on 3:2', () => {
+      const ratios = ratiosFor('LG', '3:2');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(183);
+      expect(ratios.mediumWidth).toBe(274);
+      expect(ratios.mediumHeight).toBe(183);
+      expect(ratios.largeWidth).toBe(377);
+      expect(ratios.largeHeight).toBe(251);
+    });
+
+    it('MD on 16:9', () => {
+      const ratios = ratiosFor('MD', '16:9');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(154);
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(154);
+      expect(ratios.largeWidth).toBe(400);
+      expect(ratios.largeHeight).toBe(225);
+    });
+    it('MD on 4:3', () => {
+      const ratios = ratiosFor('MD', '4:3');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(206);
+      expect(ratios.mediumWidth).toBe(274);
+      expect(ratios.mediumHeight).toBe(206);
+      expect(ratios.largeWidth).toBe(400);
+      expect(ratios.largeHeight).toBe(300);
+    });
+    it('MD on 3:2', () => {
+      const ratios = ratiosFor('MD', '3:2');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(183);
+      expect(ratios.mediumWidth).toBe(274);
+      expect(ratios.mediumHeight).toBe(183);
+      expect(ratios.largeWidth).toBe(400);
+      expect(ratios.largeHeight).toBe(267);
+    });
+
+    it('SM on 16:9', () => {
+      const ratios = ratiosFor('SM', '16:9');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(154);
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(154);
+      expect(ratios.largeWidth).toBe(400);
+      expect(ratios.largeHeight).toBe(225);
+    });
+    it('SM on 4:3', () => {
+      const ratios = ratiosFor('SM', '4:3');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(206);
+      expect(ratios.mediumWidth).toBe(274);
+      expect(ratios.mediumHeight).toBe(206);
+      expect(ratios.largeWidth).toBe(400);
+      expect(ratios.largeHeight).toBe(300);
+    });
+    it('SM on 3:2', () => {
+      const ratios = ratiosFor('SM', '3:2');
+      expect(ratios.smallWidth).toBe(274);
+      expect(ratios.smallHeight).toBe(183);
+      expect(ratios.mediumWidth).toBe(274);
+      expect(ratios.mediumHeight).toBe(183);
+      expect(ratios.largeWidth).toBe(400);
+      expect(ratios.largeHeight).toBe(267);
+    });
+  });
+});

--- a/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.jsx
@@ -55,6 +55,7 @@ const ConditionalStoryItem = (props) => {
           placeholderResizedImageOptions={placeholderResizedImageOptions}
           targetFallbackImage={targetFallbackImage}
           arcSite={arcSite}
+          imageRatio={customFields.imageRatioXL}
         />
       );
     case LARGE:
@@ -77,6 +78,7 @@ const ConditionalStoryItem = (props) => {
           placeholderResizedImageOptions={placeholderResizedImageOptions}
           targetFallbackImage={targetFallbackImage}
           arcSite={arcSite}
+          imageRatio={customFields.imageRatioLG}
         />
       );
     case MEDIUM:
@@ -96,6 +98,7 @@ const ConditionalStoryItem = (props) => {
           placeholderResizedImageOptions={placeholderResizedImageOptions}
           targetFallbackImage={targetFallbackImage}
           arcSite={arcSite}
+          imageRatio={customFields.imageRatioMD}
         />
       );
     case SMALL:
@@ -114,6 +117,7 @@ const ConditionalStoryItem = (props) => {
           paddingRight={
             (index - (storySizeMap.extraLarge + storySizeMap.large + storySizeMap.medium)) % 2 === 0
           }
+          imageRatio={customFields.imageRatioSM}
         />
       );
     default:

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -3,12 +3,12 @@ import { Image } from '@wpmedia/engine-theme-sdk';
 import ArticleDate from '@wpmedia/date-block';
 import Byline from '@wpmedia/byline-block';
 import Overline from '@wpmedia/overline-block';
+import { ratiosFor } from '@wpmedia/resizer-image-block';
 import getProperties from 'fusion:properties';
 
 import Title from './title';
 import DescriptionText from './description-text';
 import checkObjectEmpty from '../shared/checkObjectEmpty';
-import { ratiosPropsFor } from '../shared/helper';
 
 const HorizontalOverlineImageStoryItem = (props) => {
   const {
@@ -96,7 +96,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
     return null;
   };
 
-  const ratios = ratiosPropsFor('LG', imageRatio);
+  const ratios = ratiosFor('LG', imageRatio);
 
   return (
     <article key={id} className="container-fluid large-promo">

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -8,6 +8,7 @@ import getProperties from 'fusion:properties';
 import Title from './title';
 import DescriptionText from './description-text';
 import checkObjectEmpty from '../shared/checkObjectEmpty';
+import { ratiosPropsFor } from '../shared/helper';
 
 const HorizontalOverlineImageStoryItem = (props) => {
   const {
@@ -28,6 +29,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
     resizedImageOptions,
     placeholderResizedImageOptions,
     targetFallbackImage,
+    imageRatio,
   } = props;
   const showSeparator = by && by.length !== 0 && customFields.showDateLG;
   const textClass = customFields.showImageLG ? 'col-sm-12 col-md-xl-6 flex-col' : 'col-sm-xl-12 flex-col';
@@ -94,6 +96,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
     return null;
   };
 
+  const ratios = ratiosPropsFor('LG', imageRatio);
+
   return (
     <article key={id} className="container-fluid large-promo">
       <div className="row lg-promo-padding-bottom">
@@ -107,25 +111,24 @@ const HorizontalOverlineImageStoryItem = (props) => {
                 url={imageURL}
                 // todo: get the proper alt tag for this image
                 alt={itemTitle}
-                // large aspect ratio 4:3
-                smallWidth={274}
-                smallHeight={206}
-                mediumWidth={274}
-                mediumHeight={206}
-                largeWidth={377}
-                largeHeight={283}
+                smallWidth={ratios.smallWidth}
+                smallHeight={ratios.smallHeight}
+                mediumWidth={ratios.mediumWidth}
+                mediumHeight={ratios.mediumHeight}
+                largeWidth={ratios.largeWidth}
+                largeHeight={ratios.largeHeight}
                 breakpoints={getProperties(arcSite)?.breakpoints}
                 resizerURL={getProperties(arcSite)?.resizerURL}
               />
             </a>
           ) : (
             <Image
-              smallWidth={274}
-              smallHeight={206}
-              mediumWidth={274}
-              mediumHeight={206}
-              largeWidth={377}
-              largeHeight={283}
+              smallWidth={ratios.smallWidth}
+              smallHeight={ratios.smallHeight}
+              mediumWidth={ratios.mediumWidth}
+              mediumHeight={ratios.mediumHeight}
+              largeWidth={ratios.largeWidth}
+              largeHeight={ratios.largeHeight}
               alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
               url={targetFallbackImage}
               breakpoints={getProperties(arcSite)?.breakpoints}

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Image } from '@wpmedia/engine-theme-sdk';
+import { ratiosFor } from '@wpmedia/resizer-image-block';
 import getProperties from 'fusion:properties';
 
 import Title from './title';
-import { ratiosPropsFor } from '../shared/helper';
 
 const ItemTitleWithRightImage = (props) => {
   const {
@@ -21,7 +21,7 @@ const ItemTitleWithRightImage = (props) => {
     imageRatio,
   } = props;
 
-  const ratios = ratiosPropsFor('SM', imageRatio);
+  const ratios = ratiosFor('SM', imageRatio);
 
   return (
     <article key={id} className={`container-fluid small-promo ${paddingRight ? 'small-promo-padding' : ''}`}>

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -3,6 +3,7 @@ import { Image } from '@wpmedia/engine-theme-sdk';
 import getProperties from 'fusion:properties';
 
 import Title from './title';
+import { ratiosPropsFor } from '../shared/helper';
 
 const ItemTitleWithRightImage = (props) => {
   const {
@@ -17,7 +18,11 @@ const ItemTitleWithRightImage = (props) => {
     targetFallbackImage,
     placeholderResizedImageOptions,
     paddingRight = false,
+    imageRatio,
   } = props;
+
+  const ratios = ratiosPropsFor('SM', imageRatio);
+
   return (
     <article key={id} className={`container-fluid small-promo ${paddingRight ? 'small-promo-padding' : ''}`}>
       <div className="row sm-promo-padding-btm">
@@ -39,25 +44,24 @@ const ItemTitleWithRightImage = (props) => {
                   resizedImageOptions={resizedImageOptions}
                   url={imageURL}
                   alt={itemTitle}
-                  // small size aspect ratios 3:2
-                  smallWidth={274}
-                  smallHeight={183}
-                  mediumWidth={274}
-                  mediumHeight={183}
-                  largeWidth={400}
-                  largeHeight={267}
+                  smallWidth={ratios.smallWidth}
+                  smallHeight={ratios.smallHeight}
+                  mediumWidth={ratios.mediumWidth}
+                  mediumHeight={ratios.mediumHeight}
+                  largeWidth={ratios.largeWidth}
+                  largeHeight={ratios.largeHeight}
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                 />
               </a>
             ) : (
               <Image
-                smallWidth={274}
-                smallHeight={183}
-                mediumWidth={274}
-                mediumHeight={183}
-                largeWidth={400}
-                largeHeight={267}
+                smallWidth={ratios.smallWidth}
+                smallHeight={ratios.smallHeight}
+                mediumWidth={ratios.mediumWidth}
+                mediumHeight={ratios.mediumHeight}
+                largeWidth={ratios.largeWidth}
+                largeHeight={ratios.largeHeight}
                 alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
                 url={targetFallbackImage}
                 breakpoints={getProperties(arcSite)?.breakpoints}

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { Image } from '@wpmedia/engine-theme-sdk';
 import Byline from '@wpmedia/byline-block';
 import ArticleDate from '@wpmedia/date-block';
+import { ratiosFor } from '@wpmedia/resizer-image-block';
 import getProperties from 'fusion:properties';
 
 import Title from './title';
 import DescriptionText from './description-text';
 import checkObjectEmpty from '../shared/checkObjectEmpty';
-import { ratiosPropsFor } from '../shared/helper';
 
 // via results list
 const MediumListItem = (props) => {
@@ -77,7 +77,7 @@ const MediumListItem = (props) => {
     return null;
   };
 
-  const ratios = ratiosPropsFor('MD', imageRatio);
+  const ratios = ratiosFor('MD', imageRatio);
 
   return (
     <article className="container-fluid medium-promo" key={id}>

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -7,6 +7,7 @@ import getProperties from 'fusion:properties';
 import Title from './title';
 import DescriptionText from './description-text';
 import checkObjectEmpty from '../shared/checkObjectEmpty';
+import { ratiosPropsFor } from '../shared/helper';
 
 // via results list
 const MediumListItem = (props) => {
@@ -25,6 +26,7 @@ const MediumListItem = (props) => {
     resizedImageOptions,
     targetFallbackImage,
     placeholderResizedImageOptions,
+    imageRatio,
   } = props;
   const showSeparator = by && by.length !== 0 && customFields.showDateMD;
   const textClass = customFields.showImageMD ? 'col-sm-12 col-md-xl-8 flex-col' : 'col-sm-xl-12 flex-col';
@@ -74,6 +76,9 @@ const MediumListItem = (props) => {
     }
     return null;
   };
+
+  const ratios = ratiosPropsFor('MD', imageRatio);
+
   return (
     <article className="container-fluid medium-promo" key={id}>
       <div className="row med-promo-padding-bottom">
@@ -88,23 +93,23 @@ const MediumListItem = (props) => {
                   // todo: get the proper alt tag for this image
                   // 16:9 aspect for medium
                   alt={itemTitle}
-                  smallWidth={274}
-                  smallHeight={154}
-                  mediumWidth={274}
-                  mediumHeight={154}
-                  largeWidth={400}
-                  largeHeight={225}
+                  smallWidth={ratios.smallWidth}
+                  smallHeight={ratios.smallHeight}
+                  mediumWidth={ratios.mediumWidth}
+                  mediumHeight={ratios.mediumHeight}
+                  largeWidth={ratios.largeWidth}
+                  largeHeight={ratios.largeHeight}
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                 />
               ) : (
                 <Image
-                  smallWidth={274}
-                  smallHeight={154}
-                  mediumWidth={274}
-                  mediumHeight={154}
-                  largeWidth={400}
-                  largeHeight={225}
+                  smallWidth={ratios.smallWidth}
+                  smallHeight={ratios.smallHeight}
+                  mediumWidth={ratios.mediumWidth}
+                  mediumHeight={ratios.mediumHeight}
+                  largeWidth={ratios.largeWidth}
+                  largeHeight={ratios.largeHeight}
                   alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
                   url={targetFallbackImage}
                   breakpoints={getProperties(arcSite)?.breakpoints}

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -3,12 +3,12 @@ import { Image } from '@wpmedia/engine-theme-sdk';
 import ArticleDate from '@wpmedia/date-block';
 import Byline from '@wpmedia/byline-block';
 import Overline from '@wpmedia/overline-block';
+import { ratiosFor } from '@wpmedia/resizer-image-block';
 import getProperties from 'fusion:properties';
 
 import Title from './title';
 import DescriptionText from './description-text';
 import checkObjectEmpty from '../shared/checkObjectEmpty';
-import { ratiosPropsFor } from '../shared/helper';
 
 const VerticalOverlineImageStoryItem = (props) => {
   const {
@@ -97,7 +97,7 @@ const VerticalOverlineImageStoryItem = (props) => {
     return null;
   };
 
-  const ratios = ratiosPropsFor('XL', imageRatio);
+  const ratios = ratiosFor('XL', imageRatio);
 
   return (
     <article className="container-fluid xl-large-promo" key={id}>

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -8,6 +8,7 @@ import getProperties from 'fusion:properties';
 import Title from './title';
 import DescriptionText from './description-text';
 import checkObjectEmpty from '../shared/checkObjectEmpty';
+import { ratiosPropsFor } from '../shared/helper';
 
 const VerticalOverlineImageStoryItem = (props) => {
   const {
@@ -28,6 +29,7 @@ const VerticalOverlineImageStoryItem = (props) => {
     customFields,
     targetFallbackImage,
     placeholderResizedImageOptions,
+    imageRatio,
   } = props;
   const showSeparator = by && by.length !== 0 && customFields.showDateXL;
 
@@ -95,6 +97,8 @@ const VerticalOverlineImageStoryItem = (props) => {
     return null;
   };
 
+  const ratios = ratiosPropsFor('XL', imageRatio);
+
   return (
     <article className="container-fluid xl-large-promo" key={id}>
       <div className="row xl-promo-padding-bottom">
@@ -111,25 +115,24 @@ const VerticalOverlineImageStoryItem = (props) => {
                 url={imageURL}
                 // todo: get the proper alt tag for this image
                 alt={itemTitle}
-                // xl aspect ratio of 4:3
-                smallWidth={400}
-                smallHeight={300}
-                mediumWidth={600}
-                mediumHeight={450}
-                largeWidth={800}
-                largeHeight={600}
+                smallWidth={ratios.smallWidth}
+                smallHeight={ratios.smallHeight}
+                mediumWidth={ratios.mediumWidth}
+                mediumHeight={ratios.mediumHeight}
+                largeWidth={ratios.largeWidth}
+                largeHeight={ratios.largeHeight}
                 breakpoints={getProperties(arcSite)?.breakpoints}
                 resizerURL={getProperties(arcSite)?.resizerURL}
               />
             </a>
           ) : (
             <Image
-              smallWidth={400}
-              smallHeight={300}
-              mediumWidth={600}
-              mediumHeight={450}
-              largeWidth={800}
-              largeHeight={600}
+              smallWidth={ratios.smallWidth}
+              smallHeight={ratios.smallHeight}
+              mediumWidth={ratios.mediumWidth}
+              mediumHeight={ratios.mediumHeight}
+              largeWidth={ratios.largeWidth}
+              largeHeight={ratios.largeHeight}
               alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
               url={targetFallbackImage}
               breakpoints={getProperties(arcSite)?.breakpoints}

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -5,7 +5,10 @@ import { useContent } from 'fusion:content';
 import Consumer from 'fusion:consumer';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
-import { extractResizedParams } from '@wpmedia/resizer-image-block';
+import {
+  extractResizedParams,
+  imageRatioCustomField,
+} from '@wpmedia/resizer-image-block';
 import getProperties from 'fusion:properties';
 import {
   EXTRA_LARGE,
@@ -14,7 +17,6 @@ import {
   SMALL,
 } from './shared/storySizeConstants';
 import StoryItemContainer from './_children/story-item-container';
-import { imageRatioProps } from './shared/helper';
 
 // start styles
 import '@wpmedia/shared-styles/scss/_small-promo.scss';
@@ -244,7 +246,7 @@ TopTableListWrapper.propTypes = {
         group: 'Extra Large story settings',
       },
     ),
-    ...imageRatioProps('imageRatioXL', 'Extra Large story settings', '4:3'),
+    ...imageRatioCustomField('imageRatioXL', 'Extra Large story settings', '4:3'),
 
     showOverlineLG: PropTypes.bool.tag({
       label: 'Show overline',
@@ -276,7 +278,7 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Large story settings',
     }),
-    ...imageRatioProps('imageRatioLG', 'Large story settings', '4:3'),
+    ...imageRatioCustomField('imageRatioLG', 'Large story settings', '4:3'),
 
     showHeadlineMD: PropTypes.bool.tag({
       label: 'Show headline',
@@ -303,7 +305,7 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Medium story settings',
     }),
-    ...imageRatioProps('imageRatioMD', 'Medium story settings', '16:9'),
+    ...imageRatioCustomField('imageRatioMD', 'Medium story settings', '16:9'),
 
     showHeadlineSM: PropTypes.bool.tag(
       {
@@ -319,7 +321,7 @@ TopTableListWrapper.propTypes = {
         group: 'Small story settings',
       },
     ),
-    ...imageRatioProps('imageRatioSM', 'Small story settings', '3:2'),
+    ...imageRatioCustomField('imageRatioSM', 'Small story settings', '3:2'),
   }),
 };
 

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -14,6 +14,7 @@ import {
   SMALL,
 } from './shared/storySizeConstants';
 import StoryItemContainer from './_children/story-item-container';
+import { imageRatioProps } from './shared/helper';
 
 // start styles
 import '@wpmedia/shared-styles/scss/_small-promo.scss';
@@ -243,6 +244,7 @@ TopTableListWrapper.propTypes = {
         group: 'Extra Large story settings',
       },
     ),
+    ...imageRatioProps('imageRatioXL', 'Extra Large story settings', '4:3'),
 
     showOverlineLG: PropTypes.bool.tag({
       label: 'Show overline',
@@ -274,6 +276,7 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Large story settings',
     }),
+    ...imageRatioProps('imageRatioLG', 'Large story settings', '4:3'),
 
     showHeadlineMD: PropTypes.bool.tag({
       label: 'Show headline',
@@ -300,6 +303,7 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Medium story settings',
     }),
+    ...imageRatioProps('imageRatioMD', 'Medium story settings', '16:9'),
 
     showHeadlineSM: PropTypes.bool.tag(
       {
@@ -315,6 +319,7 @@ TopTableListWrapper.propTypes = {
         group: 'Small story settings',
       },
     ),
+    ...imageRatioProps('imageRatioSM', 'Small story settings', '3:2'),
   }),
 };
 

--- a/blocks/top-table-list-block/features/top-table-list/default.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.test.jsx
@@ -114,3 +114,262 @@ describe('top table list', () => {
     expect(wrapper.find('.top-table-list-container').children().length).toBe(1);
   });
 });
+
+describe('default ratios', () => {
+  beforeAll(() => {
+    jest.mock('fusion:content', () => ({
+      useContent: jest.fn(() => ({
+        content_elements: [{
+          _id: 'kjdfh',
+          promo_items: {
+            basic: {
+              type: 'image',
+              url: 'url',
+              resized_params: {
+                '377x283': '',
+                '377x251': '',
+                '377x212': '',
+                '400x225': '',
+                '400x267': '',
+                '400x300': '',
+                '800x600': '',
+                '800x533': '',
+                '800x450': '',
+              },
+            },
+          },
+          headlines: {
+            basic: 'Basic Headline',
+          },
+          description: {
+            basic: 'Basic description',
+          },
+          credits: {
+            by: ['Bob Woodward'],
+          },
+          websites: {
+            'the-sun': {
+              website_url: 'url',
+            },
+          },
+        }],
+      })),
+    }));
+
+    jest.mock('fusion:properties', () => (jest.fn(() => ({
+      fallbackImage: 'placeholder.jpg',
+      resizerURL: 'resizer',
+    }))));
+  });
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it('must have a default 4:3 ratio for XL', () => {
+    const xlConfig = {
+      extraLarge: 1,
+      showImageXL: true,
+      showHeadlineXL: true,
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(600);
+  });
+
+  it('must have a default 4:3 ratio for LG', () => {
+    const xlConfig = {
+      large: 1,
+      showImageLG: true,
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(283);
+  });
+
+  it('must have a default 16:9 ratio for MD', () => {
+    const xlConfig = {
+      medium: 1,
+      showImageMD: true,
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(225);
+  });
+
+  it('must have a default 3:2 ratio for SM', () => {
+    const xlConfig = {
+      small: 1,
+      showImageSM: true,
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(267);
+  });
+
+  it('XL can be changed to 16:9', () => {
+    const xlConfig = {
+      extraLarge: 1,
+      showImageXL: true,
+      showHeadlineXL: true,
+      imageRatioXL: '16:9',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(450);
+  });
+
+  it('XL can be changed to 4:3', () => {
+    const xlConfig = {
+      extraLarge: 1,
+      showImageXL: true,
+      showHeadlineXL: true,
+      imageRatioXL: '4:3',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(600);
+  });
+
+  it('XL can be changed to 3:2', () => {
+    const xlConfig = {
+      extraLarge: 1,
+      showImageXL: true,
+      showHeadlineXL: true,
+      imageRatioXL: '3:2',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(533);
+  });
+
+  it('LG can be changed to 16:9', () => {
+    const xlConfig = {
+      large: 1,
+      showImageLG: true,
+      imageRatioLG: '16:9',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(212);
+  });
+
+  it('LG can be changed to 4:3', () => {
+    const xlConfig = {
+      large: 1,
+      showImageLG: true,
+      imageRatioLG: '4:3',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(283);
+  });
+
+  it('LG can be changed to 3:2', () => {
+    const xlConfig = {
+      large: 1,
+      showImageLG: true,
+      imageRatioLG: '3:2',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(251);
+  });
+
+  it('MD can be changed to 16:9', () => {
+    const xlConfig = {
+      medium: 1,
+      showImageMD: true,
+      imageRatioMD: '16:9',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(225);
+  });
+
+  it('MD can be changed to 4:3', () => {
+    const xlConfig = {
+      medium: 1,
+      showImageMD: true,
+      imageRatioMD: '4:3',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(300);
+  });
+
+  it('MD can be changed to 3:2', () => {
+    const xlConfig = {
+      medium: 1,
+      showImageMD: true,
+      imageRatioMD: '3:2',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(267);
+  });
+
+  it('SM can be changed to 16:9', () => {
+    const xlConfig = {
+      small: 1,
+      showImageSM: true,
+      imageRatioSM: '16:9',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(225);
+  });
+
+  it('SM can be changed to 4:3', () => {
+    const xlConfig = {
+      small: 1,
+      showImageSM: true,
+      imageRatioSM: '4:3',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(300);
+  });
+
+  it('SM can be changed to 3:2', () => {
+    const xlConfig = {
+      small: 1,
+      showImageSM: true,
+      imageRatioSM: '3:2',
+    };
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
+
+    expect(ttl.find('img').prop('height')).toBe(267);
+  });
+});

--- a/blocks/top-table-list-block/features/top-table-list/shared/helper.js
+++ b/blocks/top-table-list-block/features/top-table-list/shared/helper.js
@@ -1,0 +1,88 @@
+import PropTypes from 'prop-types';
+
+const imageRatioLabels = {
+  '16:9': '16:9',
+  '3:2': '3:2',
+  '4:3': '4:3',
+};
+
+const imageRatiosKeys = Object.keys(imageRatioLabels);
+
+/**
+ * Helper to create imageRatio properties to be used on CustomFields
+ *
+ * @param element Base name of the element.
+ * @param group Group to witch the element belong to
+ * @param defaultValue Default value to use for this property
+ *
+ * @return A property object to be use on CustomFields
+ */
+export const imageRatioProps = (element, group, defaultValue) => {
+  const elementTextProp = {
+    [`${element}`]: PropTypes.oneOf(imageRatiosKeys).tag({
+      labels: imageRatioLabels,
+      name: 'Image ratio',
+      defaultValue,
+      group,
+    }),
+  };
+  return { ...elementTextProp };
+};
+
+const sizes = {
+  XL: {
+    options: [
+      { kind: 'small', width: 400 },
+      { kind: 'medium', width: 600 },
+      { kind: 'large', width: 800 },
+    ],
+    defaultRatio: '4:3',
+  },
+  LG: {
+    options: [
+      { kind: 'small', width: 274 },
+      { kind: 'medium', width: 274 },
+      { kind: 'large', width: 377 },
+    ],
+    defaultRatio: '4:3',
+  },
+  MD: {
+    options: [
+      { kind: 'small', width: 274 },
+      { kind: 'medium', width: 274 },
+      { kind: 'large', width: 400 },
+    ],
+    defaultRatio: '16:9',
+  },
+  SM: {
+    options: [
+      { kind: 'small', width: 274 },
+      { kind: 'medium', width: 274 },
+      { kind: 'large', width: 400 },
+    ],
+    defaultRatio: '3:2',
+  },
+};
+const ratios = {
+  '4:3': 0.75,
+  '3:2': 0.6668,
+  '16:9': 0.5625,
+};
+
+/**
+ * Helper to return the image sizes properties according to a ratio
+ *
+ * @param ratioValue Ratio to use for the calc
+ *
+ * @return an object with all the sizes
+ */
+export const ratiosPropsFor = (size, ratioValue) => {
+  const { options, defaultRatio } = sizes[size];
+  const ratio = ratios[ratioValue] || ratios[defaultRatio];
+
+  return options.reduce((acc, ele) => {
+    acc[`${ele.kind}Width`] = ele.width;
+    acc[`${ele.kind}Height`] = Math.round(ele.width * ratio);
+    return acc;
+  }, {});
+};

--- a/blocks/top-table-list-block/package.json
+++ b/blocks/top-table-list-block/package.json
@@ -29,6 +29,7 @@
     "@wpmedia/overline-block": "latest",
     "@wpmedia/placeholder-image-block": "latest",
     "@wpmedia/shared-styles": "latest",
+    "@wpmedia/resizer-image-block": "latest",
     "styled-components": "^4.4.0"
   },
   "scripts": {


### PR DESCRIPTION
[PEN-1113](https://arcpublishing.atlassian.net/browse/PEN-1113)

# What does this implement or fix?
- move shared code to `image-resizer-block`
- refactor top-table-list ratios code
- wrote tests for `image-resizer-block` and `top-table-list-block`

# How was this tested?

- test written for each case
- visually on PB on all-blocks, homepage and a new blank page

# Dependencies or Side Effects

- none