### PR TITLE
PEN-798 change image ratio promo blocks

### DIFF
--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -13,7 +13,11 @@ import Overline from '@wpmedia/overline-block';
 import { Image } from '@wpmedia/engine-theme-sdk';
 import '@wpmedia/shared-styles/scss/_extra-large-promo.scss';
 import PlaceholderImage from '@wpmedia/placeholder-image-block';
-import { extractResizedParams } from '@wpmedia/resizer-image-block';
+import {
+  extractResizedParams,
+  imageRatioCustomField,
+  ratiosFor,
+} from '@wpmedia/resizer-image-block';
 
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
@@ -133,6 +137,8 @@ const ExtraLargePromo = ({ customFields }) => {
     return null;
   };
 
+  const ratios = ratiosFor('XL', customFields.imageRatio);
+
   return content && (
     <article className="container-fluid xl-large-promo">
       <div className="row xl-promo-padding-bottom">
@@ -154,12 +160,12 @@ const ExtraLargePromo = ({ customFields }) => {
                       url={customFields.imageOverrideURL
                         ? customFields.imageOverrideURL : extractImage(content.promo_items)}
                       alt={content && content.headlines ? content.headlines.basic : ''}
-                      smallWidth={400}
-                      smallHeight={300}
-                      mediumWidth={600}
-                      mediumHeight={450}
-                      largeWidth={800}
-                      largeHeight={600}
+                      smallWidth={ratios.smallWidth}
+                      smallHeight={ratios.smallHeight}
+                      mediumWidth={ratios.mediumWidth}
+                      mediumHeight={ratios.mediumHeight}
+                      largeWidth={ratios.largeWidth}
+                      largeHeight={ratios.largeHeight}
                       breakpoints={getProperties(arcSite)?.breakpoints}
                       resizerURL={getProperties(arcSite)?.resizerURL}
                       resizedImageOptions={extractResizedParams(content)}
@@ -168,12 +174,12 @@ const ExtraLargePromo = ({ customFields }) => {
                   )
                   : (
                     <PlaceholderImage
-                      smallWidth={400}
-                      smallHeight={300}
-                      mediumWidth={600}
-                      mediumHeight={450}
-                      largeWidth={800}
-                      largeHeight={600}
+                      smallWidth={ratios.smallWidth}
+                      smallHeight={ratios.smallHeight}
+                      mediumWidth={ratios.mediumWidth}
+                      mediumHeight={ratios.mediumHeight}
+                      largeWidth={ratios.largeWidth}
+                      largeHeight={ratios.largeHeight}
                     />
                   )}
               </a>
@@ -244,6 +250,7 @@ ExtraLargePromo.propTypes = {
       label: 'Image URL',
       group: 'Image',
     }),
+    ...imageRatioCustomField('imageRatio', 'Art', '4:3'),
   }),
 };
 

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -79,4 +79,31 @@ describe('the extra large promo feature', () => {
     const wrapper = mount(<ExtraLargePromo customFields={noImgConfig} />);
     expect(wrapper.find('Image')).toHaveLength(0);
   });
+
+  it('should have by default an 4:3 image ratio', () => {
+    const wrapper = mount(<ExtraLargePromo customFields={config} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(600);
+  });
+
+  it('should accept a 16:9 ratio', () => {
+    const myConfig = { ...config, imageRatio: '16:9' };
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(450);
+  });
+
+  it('should accept a 3:2 ratio', () => {
+    const myConfig = { ...config, imageRatio: '3:2' };
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(533);
+  });
+
+  it('should accept a 4:3 ratio', () => {
+    const myConfig = { ...config, imageRatio: '4:3' };
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(600);
+  });
 });

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -13,7 +13,11 @@ import Overline from '@wpmedia/overline-block';
 import { Image } from '@wpmedia/engine-theme-sdk';
 import '@wpmedia/shared-styles/scss/_large-promo.scss';
 import PlaceholderImage from '@wpmedia/placeholder-image-block';
-import { extractResizedParams } from '@wpmedia/resizer-image-block';
+import {
+  extractResizedParams,
+  imageRatioCustomField,
+  ratiosFor,
+} from '@wpmedia/resizer-image-block';
 
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
@@ -135,6 +139,8 @@ const LargePromo = ({ customFields }) => {
     return null;
   };
 
+  const ratios = ratiosFor('LG', customFields.imageRatio);
+
   return content ? (
     <article className="container-fluid large-promo">
       <div className="row lg-promo-padding-bottom">
@@ -152,13 +158,13 @@ const LargePromo = ({ customFields }) => {
                       url={customFields.imageOverrideURL
                         ? customFields.imageOverrideURL : extractImage(content.promo_items)}
                       alt={content && content.headlines ? content.headlines.basic : ''}
-                // large is 4:3 aspect ratio
-                      smallWidth={274}
-                      smallHeight={206}
-                      mediumWidth={274}
-                      mediumHeight={206}
-                      largeWidth={377}
-                      largeHeight={283}
+                      // large is 4:3 aspect ratio
+                      smallWidth={ratios.smallWidth}
+                      smallHeight={ratios.smallHeight}
+                      mediumWidth={ratios.mediumWidth}
+                      mediumHeight={ratios.mediumHeight}
+                      largeWidth={ratios.largeWidth}
+                      largeHeight={ratios.largeHeight}
                       breakpoints={getProperties(arcSite)?.breakpoints}
                       resizerURL={getProperties(arcSite)?.resizerURL}
                       resizedImageOptions={extractResizedParams(content)}
@@ -167,12 +173,12 @@ const LargePromo = ({ customFields }) => {
                   )
                   : (
                     <PlaceholderImage
-                      smallWidth={274}
-                      smallHeight={206}
-                      mediumWidth={274}
-                      mediumHeight={206}
-                      largeWidth={377}
-                      largeHeight={283}
+                      smallWidth={ratios.smallWidth}
+                      smallHeight={ratios.smallHeight}
+                      mediumWidth={ratios.mediumWidth}
+                      mediumHeight={ratios.mediumHeight}
+                      largeWidth={ratios.largeWidth}
+                      largeHeight={ratios.largeHeight}
                     />
                   )
 }
@@ -237,6 +243,7 @@ LargePromo.propTypes = {
       label: 'Image URL',
       group: 'Image',
     }),
+    ...imageRatioCustomField('imageRatio', 'Art', '4:3'),
   }),
 
 };

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -104,4 +104,31 @@ describe('the large promo feature', () => {
     const wrapper = mount(<LargePromo customFields={noHeadlineConfig} />);
     expect(wrapper.find('a')).toHaveLength(1);
   });
+
+  it('should have by default an 4:3 image ratio', () => {
+    const wrapper = mount(<LargePromo customFields={config} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(283);
+  });
+
+  it('should accept a 16:9 ratio', () => {
+    const myConfig = { ...config, imageRatio: '16:9' };
+    const wrapper = mount(<LargePromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(212);
+  });
+
+  it('should accept a 3:2 ratio', () => {
+    const myConfig = { ...config, imageRatio: '3:2' };
+    const wrapper = mount(<LargePromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(251);
+  });
+
+  it('should accept a 4:3 ratio', () => {
+    const myConfig = { ...config, imageRatio: '4:3' };
+    const wrapper = mount(<LargePromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(283);
+  });
 });

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -12,7 +12,11 @@ import ArticleDate from '@wpmedia/date-block';
 import '@wpmedia/shared-styles/scss/_medium-promo.scss';
 import { Image } from '@wpmedia/engine-theme-sdk';
 import PlaceholderImage from '@wpmedia/placeholder-image-block';
-import { extractResizedParams } from '@wpmedia/resizer-image-block';
+import {
+  extractResizedParams,
+  imageRatioCustomField,
+  ratiosFor,
+} from '@wpmedia/resizer-image-block';
 
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
@@ -106,6 +110,8 @@ const MediumPromo = ({ customFields }) => {
     return null;
   };
 
+  const ratios = ratiosFor('MD', customFields.imageRatio);
+
   return content ? (
     <article className="container-fluid medium-promo">
       <div className="row med-promo-padding-bottom">
@@ -124,12 +130,12 @@ const MediumPromo = ({ customFields }) => {
                         ? customFields.imageOverrideURL : extractImage(content.promo_items)}
                       alt={content && content.headlines ? content.headlines.basic : ''}
                       // medium is 16:9
-                      smallWidth={274}
-                      smallHeight={154}
-                      mediumWidth={274}
-                      mediumHeight={154}
-                      largeWidth={400}
-                      largeHeight={225}
+                      smallWidth={ratios.smallWidth}
+                      smallHeight={ratios.smallHeight}
+                      mediumWidth={ratios.mediumWidth}
+                      mediumHeight={ratios.mediumHeight}
+                      largeWidth={ratios.largeWidth}
+                      largeHeight={ratios.largeHeight}
                       breakpoints={getProperties(arcSite)?.breakpoints}
                       resizerURL={getProperties(arcSite)?.resizerURL}
                       resizedImageOptions={extractResizedParams(content)}
@@ -137,12 +143,12 @@ const MediumPromo = ({ customFields }) => {
                   )
                   : (
                     <PlaceholderImage
-                      smallWidth={274}
-                      smallHeight={154}
-                      mediumWidth={274}
-                      mediumHeight={154}
-                      largeWidth={400}
-                      largeHeight={225}
+                      smallWidth={ratios.smallWidth}
+                      smallHeight={ratios.smallHeight}
+                      mediumWidth={ratios.mediumWidth}
+                      mediumHeight={ratios.mediumHeight}
+                      largeWidth={ratios.largeWidth}
+                      largeHeight={ratios.largeHeight}
                     />
                   )
                 }
@@ -201,6 +207,7 @@ MediumPromo.propTypes = {
       label: 'Image URL',
       group: 'Image',
     }),
+    ...imageRatioCustomField('imageRatio', 'Art', '16:9'),
   }),
 };
 

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -99,4 +99,31 @@ describe('the medium promo feature', () => {
     const wrapper = mount(<MediumPromo customFields={noHeadlineConfig} />);
     expect(wrapper.find('a')).toHaveLength(1);
   });
+
+  it('should have by default an 16:9 image ratio', () => {
+    const wrapper = mount(<MediumPromo customFields={config} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(225);
+  });
+
+  it('should accept a 16:9 ratio', () => {
+    const myConfig = { ...config, imageRatio: '16:9' };
+    const wrapper = mount(<MediumPromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(225);
+  });
+
+  it('should accept a 3:2 ratio', () => {
+    const myConfig = { ...config, imageRatio: '3:2' };
+    const wrapper = mount(<MediumPromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(267);
+  });
+
+  it('should accept a 4:3 ratio', () => {
+    const myConfig = { ...config, imageRatio: '4:3' };
+    const wrapper = mount(<MediumPromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(300);
+  });
 });

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -10,7 +10,11 @@ import { useFusionContext } from 'fusion:context';
 import '@wpmedia/shared-styles/scss/_small-promo.scss';
 import { Image } from '@wpmedia/engine-theme-sdk';
 import PlaceholderImage from '@wpmedia/placeholder-image-block';
-import { extractResizedParams } from '@wpmedia/resizer-image-block';
+import {
+  extractResizedParams,
+  imageRatioCustomField,
+  ratiosFor,
+} from '@wpmedia/resizer-image-block';
 
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
@@ -30,6 +34,8 @@ const SmallPromo = ({ customFields }) => {
   const extractImage = (promo) => promo && promo.basic && promo.basic.type === 'image' && promo.basic.url;
 
   const headlineClass = customFields.showImage ? 'col-sm-xl-8' : 'col-sm-xl-12 no-image-padding';
+
+  const ratios = ratiosFor('SM', customFields.imageRatio);
 
   return content ? (
     <article className="container-fluid small-promo">
@@ -67,12 +73,12 @@ const SmallPromo = ({ customFields }) => {
                       ? customFields.imageOverrideURL : extractImage(content.promo_items)}
                     alt={content && content.headlines ? content.headlines.basic : ''}
                     // small should be 3:2 aspect ratio
-                    smallWidth={274}
-                    smallHeight={183}
-                    mediumWidth={274}
-                    mediumHeight={183}
-                    largeWidth={400}
-                    largeHeight={267}
+                    smallWidth={ratios.smallWidth}
+                    smallHeight={ratios.smallHeight}
+                    mediumWidth={ratios.mediumWidth}
+                    mediumHeight={ratios.mediumHeight}
+                    largeWidth={ratios.largeWidth}
+                    largeHeight={ratios.largeHeight}
                     breakpoints={getProperties(arcSite)?.breakpoints}
                     resizerURL={getProperties(arcSite)?.resizerURL}
                     resizedImageOptions={extractResizedParams(content)}
@@ -80,12 +86,12 @@ const SmallPromo = ({ customFields }) => {
                 )
                 : (
                   <PlaceholderImage
-                    smallWidth={274}
-                    smallHeight={183}
-                    mediumWidth={274}
-                    mediumHeight={183}
-                    largeWidth={400}
-                    largeHeight={267}
+                    smallWidth={ratios.smallWidth}
+                    smallHeight={ratios.smallHeight}
+                    mediumWidth={ratios.mediumWidth}
+                    mediumHeight={ratios.mediumHeight}
+                    largeWidth={ratios.largeWidth}
+                    largeHeight={ratios.largeHeight}
                   />
                 )}
             </a>
@@ -122,6 +128,7 @@ SmallPromo.propTypes = {
       label: 'Image URL',
       group: 'Image',
     }),
+    ...imageRatioCustomField('imageRatio', 'Art', '3:2'),
   }),
 };
 

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -99,4 +99,31 @@ describe('the small promo feature', () => {
     const wrapper = mount(<SmallPromo customFields={noHeadlineConfig} />);
     expect(wrapper.find('a')).toHaveLength(1);
   });
+
+  it('should have by default an 3:2 image ratio', () => {
+    const wrapper = mount(<SmallPromo customFields={config} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(267);
+  });
+
+  it('should accept a 16:9 ratio', () => {
+    const myConfig = { ...config, imageRatio: '16:9' };
+    const wrapper = mount(<SmallPromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(225);
+  });
+
+  it('should accept a 3:2 ratio', () => {
+    const myConfig = { ...config, imageRatio: '3:2' };
+    const wrapper = mount(<SmallPromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(267);
+  });
+
+  it('should accept a 4:3 ratio', () => {
+    const myConfig = { ...config, imageRatio: '4:3' };
+    const wrapper = mount(<SmallPromo customFields={myConfig} />);
+    const img = wrapper.find('Image');
+    expect(img.prop('largeHeight')).toBe(300);
+  });
 });


### PR DESCRIPTION
[PEN-798](https://arcpublishing.atlassian.net/browse/PEN-798)

# What does this implement or fix?
- implements image ratio on Extra Large promo blocks
- implements image ratio on Large promo blocks
- implements image ratio on Medium promo blocks
- implements image ratio on Small promo blocks

# How was this tested?

- new tests for each block
- blank page with all the blocks
- check all the already created pages that use the default image ratio

# Dependencies or Side Effects

- this ticket relay on work done on PEN-1113 that refactor the image ratio routines to the resizer-image-block
