### PR TITLE
PEN-1128 gallery inherit global content behavior

### DIFF
--- a/blocks/article-body-block/chains/article-body/_children/heading.jsx
+++ b/blocks/article-body-block/chains/article-body/_children/heading.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 
-
 const Heading = ({ element, primaryColor }) => {
   const defaultHeaderLevel = 2;
   const HeadingLevel = `h${element.level ? element.level : defaultHeaderLevel}`;

--- a/blocks/article-body-block/chains/article-body/_children/html.test.jsx
+++ b/blocks/article-body-block/chains/article-body/_children/html.test.jsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/blocks/article-body-block/chains/article-body/_children/table.jsx
+++ b/blocks/article-body-block/chains/article-body/_children/table.jsx
@@ -26,7 +26,6 @@ const Table = ({ element }) => {
     return <tr key={keys}>{cells}</tr>;
   });
 
-
   return (
     <div className="table-wrapper">
       <table>

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -290,7 +290,6 @@ describe('article-body chain', () => {
     });
   });
 
-
   describe('when it is initalized with no customFields in editor', () => {
     afterEach(() => {
       jest.resetModules();

--- a/blocks/author-bio-block/features/author-bio/default.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.jsx
@@ -24,7 +24,6 @@ import getProperties from 'fusion:properties';
 
 import constructSocialURL from './shared/constructSocialURL';
 
-
 import './author-bio.scss';
 
 /*

--- a/blocks/author-bio-block/features/author-bio/default.test.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.test.jsx
@@ -9,7 +9,6 @@ jest.mock('fusion:themes', () => (jest.fn(() => ({
   'primary-color': 'blue',
 }))));
 
-
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
   EnvelopeIcon: () => <svg>EnvelopeIcon</svg>,
@@ -617,7 +616,6 @@ describe('Given the list of author(s) from the article', () => {
       useFusionContext: jest.fn(() => ({ globalContent: {} })),
     }));
     const { default: AuthorBio } = require('./default');
-
 
     const wrapper = mount(<AuthorBio />);
     expect(wrapper).toBeEmptyRender();

--- a/blocks/byline-block/features/byline/default.jsx
+++ b/blocks/byline-block/features/byline/default.jsx
@@ -19,7 +19,6 @@ const BylineSection = styled.section`
 `}
 `;
 
-
 const By = styled.span`
   ${({ stylesFor }) => stylesFor === 'list' && `
     color: #3B3B3B;
@@ -27,13 +26,11 @@ const By = styled.span`
   `}
 `;
 
-
 const BylineNames = styled.span`
   ${({ stylesFor }) => stylesFor === 'list' && `
     color: #434343;
   `}
 `;
-
 
 @Consumer
 class ArticleByline extends Component {

--- a/blocks/byline-block/features/byline/default.test.jsx
+++ b/blocks/byline-block/features/byline/default.test.jsx
@@ -99,7 +99,6 @@ describe('Given the display time from ANS, it should convert to the proper timez
     expect(wrapper.find('span').at(1).prop('dangerouslySetInnerHTML')).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim</a>, <a href="/author/joe-grosspietsch">Joe Grosspietsch</a>, <a href="/author/brent-miller">Brent Miller</a> and <a href="/author/sara-carothers">Sara Carothers</a>' });
   });
 
-
   it('should return 4 authors complete with url and bylines', () => {
     const { default: ArticleByline } = require('./default');
     const credits = {
@@ -154,7 +153,6 @@ describe('Given the display time from ANS, it should convert to the proper timez
       useFusionContext: jest.fn(() => ({ globalContent: {} })),
     }));
     const { default: ArticleByline } = require('./default');
-
 
     expect(() => {
       mount(<ArticleByline />);

--- a/blocks/collections-content-source-block/sources/content-api-collections.test.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.test.js
@@ -56,7 +56,6 @@ describe('the collections content source block', () => {
     });
   });
 
-
   describe('when a size is provided', () => {
     it('should build the correct url without a size', () => {
       const url = contentSource.resolve({

--- a/blocks/date-block/features/date/default.test.jsx
+++ b/blocks/date-block/features/date/default.test.jsx
@@ -1,7 +1,6 @@
 const React = require('react');
 const { render } = require('enzyme');
 
-
 jest.mock('fusion:properties', () => jest.fn(() => (
   {
     dateLocalization: {
@@ -12,7 +11,6 @@ jest.mock('fusion:properties', () => jest.fn(() => (
     },
   }
 )));
-
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   localizeDateTime: jest.fn(() => new Date().toDateString()),

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -133,5 +133,4 @@ const SampleOutputType = ({
   );
 };
 
-
 export default SampleOutputType;

--- a/blocks/event-tester-block/features/event-tester/default.jsx
+++ b/blocks/event-tester-block/features/event-tester/default.jsx
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { EventEmitter } from '@wpmedia/engine-theme-sdk';
 import './event.scss';
 
-
 /**
  * @file EventTester is a React Class Component
  * @summary Used for testing the event emitter.  When new events are created, they should be

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 import ExtraLargeManualPromo from './default';
 
-
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
 }));

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -17,7 +17,15 @@ const GalleryFeature = (
   const { arcSite } = useFusionContext();
   const { locale = 'en' } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
-  if (inheritGlobalContent) {
+
+  let globalContent;
+  if (inheritGlobalContent === undefined) {
+    globalContent = (galleryContentConfig === undefined);
+  } else {
+    globalContent = inheritGlobalContent;
+  }
+
+  if (globalContent) {
     return <GlobalContentGallery phrases={phrases} />;
   }
 

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -18,14 +18,14 @@ const GalleryFeature = (
   const { locale = 'en' } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
 
-  let globalContent;
-  if (inheritGlobalContent === undefined) {
-    globalContent = (galleryContentConfig === undefined);
+  let showGlobalContent;
+  if (typeof inheritGlobalContent === 'undefined') {
+    showGlobalContent = (typeof galleryContentConfig === 'undefined');
   } else {
-    globalContent = inheritGlobalContent;
+    showGlobalContent = inheritGlobalContent;
   }
 
-  if (globalContent) {
+  if (showGlobalContent) {
     return <GlobalContentGallery phrases={phrases} />;
   }
 

--- a/blocks/gallery-block/features/gallery/default.test.jsx
+++ b/blocks/gallery-block/features/gallery/default.test.jsx
@@ -21,7 +21,6 @@ jest.mock('prop-types', () => ({
   contentConfig: () => {},
 }));
 
-
 describe('the gallery feature block', () => {
   describe('when it is configured to inherit global content', () => {
     it('should render the global content gallery', () => {
@@ -33,7 +32,7 @@ describe('the gallery feature block', () => {
   });
 
   describe('when it is configured to NOT inherit global content', () => {
-    it('should render the global content gallery', () => {
+    it('should render the custom content gallery', () => {
       const { default: GalleryFeature } = require('./default');
 
       const wrapper = shallow(
@@ -51,11 +50,21 @@ describe('the gallery feature block', () => {
     });
   });
 
+  describe('when is only configured the content source', () => {
+    it('should render a custom content callery', () => {
+      const { default: GalleryFeature } = require('./default');
+      const wrapper = shallow(
+        <GalleryFeature customFields={{ galleryContentConfig: {} }} />,
+      );
+      expect(wrapper.is('CustomContentGallery')).toBeTruthy();
+    });
+  });
+
   describe('when customfields is empty', () => {
     it('should render the global content gallery', () => {
       const { default: GalleryFeature } = require('./default');
       const wrapper = shallow(<GalleryFeature customFields={{}} />);
-      expect(wrapper.is('CustomContentGallery')).toBeTruthy();
+      expect(wrapper.is('GlobalContentGallery')).toBeTruthy();
     });
   });
 
@@ -63,7 +72,7 @@ describe('the gallery feature block', () => {
     it('should render the global content gallery', () => {
       const { default: GalleryFeature } = require('./default');
       const wrapper = shallow(<GalleryFeature customFields={undefined} />);
-      expect(wrapper.is('CustomContentGallery')).toBeTruthy();
+      expect(wrapper.is('GlobalContentGallery')).toBeTruthy();
     });
   });
 
@@ -71,7 +80,7 @@ describe('the gallery feature block', () => {
     it('should render the global content gallery', () => {
       const { default: GalleryFeature } = require('./default');
       const wrapper = shallow(
-        <GalleryFeature customFields={{ inheritGlobalContent: true, galleryContentConfig: {} }} />,
+        <GalleryFeature />,
       );
       expect(wrapper.is('GlobalContentGallery')).toBeTruthy();
     });

--- a/blocks/header-nav-block/features/navigation/default.test.jsx
+++ b/blocks/header-nav-block/features/navigation/default.test.jsx
@@ -85,7 +85,6 @@ describe('the header navigation feature for the default output type', () => {
     });
   });
 
-
   describe('when the nav color is set to "dark"', () => {
     it('should set the "dark" class on the component', () => {
       getProperties.mockImplementation(() => ({ navColor: 'dark' }));

--- a/blocks/headline-block/index.story.jsx
+++ b/blocks/headline-block/index.story.jsx
@@ -23,7 +23,6 @@ export const longHeadline = () => (
   <Headline fusionContext={data} />
 );
 
-
 export const customHeadline = () => {
   const headline = text('Headline', 'Man Bites Dog');
   const newData = () => ({

--- a/blocks/htmlbox-block/features/htmlbox/default.test.jsx
+++ b/blocks/htmlbox-block/features/htmlbox/default.test.jsx
@@ -1,7 +1,6 @@
 const React = require('react');
 const { mount } = require('enzyme');
 
-
 describe('the htmlbox block', () => {
   it('should render the embedded iframe', () => {
     const { default: HTMLBox } = require('./default');

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 import LargeManualPromo from './default';
 
-
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
 }));

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -13,7 +13,6 @@ import {
 import './leadart.scss';
 import FullscreenIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/FullscreenIcon';
 
-
 const LeadArtWrapperDiv = styled.div`
   figcaption {
     font-family: ${(props) => props.primaryFont};

--- a/blocks/masthead-block/features/masthead-block/default.jsx
+++ b/blocks/masthead-block/features/masthead-block/default.jsx
@@ -59,7 +59,6 @@ const Masthead = (props) => {
   );
 };
 
-
 Masthead.label = 'Masthead – Arc Block';
 
 Masthead.propTypes = {

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -39,7 +39,6 @@ class NumberedList extends Component {
     this.primaryFont = getThemeStyle(this.arcSite)['primary-font-family'];
   }
 
-
   getFallbackImageURL() {
     const { arcSite, deployment, contextPath } = this.props;
     let targetFallbackImage = getProperties(arcSite).fallbackImage;
@@ -164,7 +163,6 @@ class NumberedList extends Component {
     );
   }
 }
-
 
 NumberedList.propTypes = {
   customFields: PropTypes.shape({

--- a/blocks/quad-chain-block/chains/quad-chain/default.test.jsx
+++ b/blocks/quad-chain-block/chains/quad-chain/default.test.jsx
@@ -41,7 +41,6 @@ describe('the quad chain block', () => {
       </Chain>,
     );
 
-
     const columnOne = component.find('.row').children().at(0);
     const columnTwo = component.find('.row').children().at(1);
 

--- a/blocks/resizer-image-block/galleryResizeData.js
+++ b/blocks/resizer-image-block/galleryResizeData.js
@@ -844,5 +844,4 @@ const galleryResizeData = {
   created_date: '2020-05-21T18:09:59.840Z',
 };
 
-
 export default galleryResizeData;

--- a/blocks/resizer-image-block/index.js
+++ b/blocks/resizer-image-block/index.js
@@ -113,7 +113,6 @@ export const getResizerParams = (
   return output;
 };
 
-
 const resizeImage = (image, resizerURL) => {
   if ((image.type && image.type !== 'image') || !image.url) {
     throw new Error('Not a valid image object');
@@ -240,7 +239,6 @@ export const extractResizedParams = (storyObject) => {
 
   return [];
 };
-
 
 // top level for transforming data
 // takes in content source story data via ans

--- a/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
@@ -70,7 +70,6 @@ class CustomSearchResultsList extends React.Component {
     }
   }
 
-
   fetchStories(additionalStoryAmount) {
     const { customFields: { searchContentConfig } } = this.props;
     const { value, storedList } = this.state;

--- a/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
@@ -17,7 +17,6 @@ import '@wpmedia/shared-styles/scss/_results-list-desktop.scss';
 import '@wpmedia/shared-styles/scss/_results-list-mobile.scss';
 import './search-results-list.scss';
 
-
 const StyledInput = styled.input`
   font-family: ${(props) => props.primaryFont};
 `;

--- a/blocks/search-results-list-block/features/search-results-list/_children/styled-components.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/styled-components.test.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { HeadlineText, DescriptionText } from './styled-components';
 
-
 describe('the HeadlineText', () => {
   it('renders correctly', () => {
     const tree = renderer

--- a/blocks/search-results-list-block/features/search-results-list/default.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/default.jsx
@@ -19,7 +19,6 @@ const SearchResultsListContainer = (
   return <CustomSearchResultsList arcSite={arcSite} />;
 };
 
-
 SearchResultsListContainer.label = 'Search Results List – Arc Block';
 
 SearchResultsListContainer.propTypes = {

--- a/blocks/section-title-block/features/section-title/_children/custom-content.test.jsx
+++ b/blocks/section-title-block/features/section-title/_children/custom-content.test.jsx
@@ -7,7 +7,6 @@ jest.mock('fusion:content', () => ({
   useContent: jest.fn(() => (mockNestedChildren)),
 }));
 
-
 describe('the custom content section title', () => {
   it('should call useContent with the expected content config values', () => {
     const { default: CustomContentSectionTitle } = require('./custom-content');

--- a/blocks/section-title-block/features/section-title/default.jsx
+++ b/blocks/section-title-block/features/section-title/default.jsx
@@ -18,7 +18,6 @@ const SectionTitleContainer = (
   return <CustomContentSectionTitle contentConfig={sectionContentConfig} />;
 };
 
-
 SectionTitleContainer.label = 'Section Title – Arc Block';
 
 SectionTitleContainer.propTypes = {

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
@@ -31,14 +31,12 @@ const config = {
   showImageSM: true,
 };
 
-
 jest.mock('fusion:context', () => ({
   useFusionContext: jest.fn(() => ({
     arcSite: 'the-sun',
     globalContent: {},
   })),
 }));
-
 
 jest.mock('fusion:content', () => ({
   useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
@@ -57,7 +57,6 @@ describe('medium list item', () => {
       customFields={config}
     />);
 
-
     // placeholder
     // expect(wrapper.find('.top-table-med-image-placeholder').length).toBe(0);
 

--- a/blocks/top-table-list-block/features/top-table-list/default.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.test.jsx
@@ -276,7 +276,6 @@ describe('top table list overline rules', () => {
       })),
     }));
 
-
     const wrapper = mount(
       <TopTableList customFields={localConfig} arcSite="" deployment={jest.fn((path) => path)} />,
     );


### PR DESCRIPTION
[PEN-1128](https://arcpublishing.atlassian.net/browse/PEN-1128)

# What does this implement or fix?
- fix an render issue when the gallery was in a template with global content

# How was this tested?
- tests added/fixed
- visually in PB with pages and templates
- screen record added to the ticket

# Dependencies or Side Effects
- none
