### PR TITLE
PEN-975 remove scripts between head body

### DIFF
--- a/blocks/author-content-source-block/sources/author-api.test.js
+++ b/blocks/author-content-source-block/sources/author-api.test.js
@@ -2,7 +2,6 @@ import getProperties from 'fusion:properties';
 
 import contentSource from './author-api';
 
-
 describe('the author api content source block', () => {
   it('should use the proper param types', () => {
     expect(contentSource.params).toEqual({

--- a/blocks/default-output-block/output-types/__tests__/default.text.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.text.jsx
@@ -43,11 +43,23 @@ describe('the default output type', () => {
     });
 
     it('should have script tags', () => {
-      expect(wrapper.find('script').length).toBe(4);
+      expect(wrapper.find('script').length).toBe(3);
     });
 
     it('should have link tags', () => {
       expect(wrapper.find('link').length).toBe(2);
+    });
+  });
+
+  describe('root html layout', () => {
+    const wrapper = shallow(<DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} />);
+
+    it('html must have only have head and body tags', () => {
+      const html = wrapper.find('html');
+      expect(html.length).toBe(1);
+      expect(html.children().length).toBe(2);
+      expect(html.children('head').length).toBe(1);
+      expect(html.children('body').length).toBe(1);
     });
   });
 });

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -98,16 +98,15 @@ const SampleOutputType = ({
         <Libs />
         <CssLinks />
         <link rel="icon" type="image/x-icon" href={deployment(`${contextPath}/resources/favicon.ico`)} />
+        <script
+          src={powaBoot}
+          async
+          data-powa-script
+          data-loaded-via="powa-manifest"
+        />
+        <link rel="preload" as="script" href={powaDrive} />
+        {googleFonts()}
       </head>
-      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-58927291-1" />
-      <script
-        src={powaBoot}
-        async
-        data-powa-script
-        data-loaded-via="powa-manifest"
-      />
-      <link rel="preload" as="script" href={powaDrive} />
-      {googleFonts()}
       <body>
         {gtmID
           ? (


### PR DESCRIPTION
[PEN-975](https://arcpublishing.atlassian.net/browse/PEN-975)

# What does this implement or fix?

- move code between head and body tags to inside head
- the hard coded tag from Google Analytics was removed.  GTM can be use to add it on each site, or a new keyword must be defined on blocks.json to be able to insert it.

# How was this tested?

- test written

# Dependencies or Side Effects

- none
