### PR TITLE
PEN-996 update twitter metadata

### DIFF
--- a/blocks/author-content-source-block/sources/author-api.test.js
+++ b/blocks/author-content-source-block/sources/author-api.test.js
@@ -2,7 +2,6 @@ import getProperties from 'fusion:properties';
 
 import contentSource from './author-api';
 
-
 describe('the author api content source block', () => {
   it('should use the proper param types', () => {
     expect(contentSource.params).toEqual({

--- a/blocks/default-output-block/output-types/__tests__/default.text.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.text.jsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import getProperties from 'fusion:properties';
+import { MetaData } from '@wpmedia/engine-theme-sdk';
 import DefaultOutputType from '../default';
 
 jest.mock('fusion:context', () => ({
@@ -22,7 +23,7 @@ jest.mock('react-dom/server', () => ({
 
 getProperties.mockImplementation(() => ({
   websiteName: 'The Sun',
-  twitterSite: 'https://www.twitter.com/the-sun',
+  twitterUsername: 'thesun',
   dangerouslyInjectJS: [],
 }));
 
@@ -48,6 +49,14 @@ describe('the default output type', () => {
 
     it('should have link tags', () => {
       expect(wrapper.find('link').length).toBe(2);
+    });
+
+    it('should have a MedataData component', () => {
+      expect(wrapper.find(MetaData).length).toBe(1);
+    });
+
+    it('MedataData should receive twitterUsername', () => {
+      expect(wrapper.find(MetaData).prop('twitterUsername')).toEqual('thesun');
     });
   });
 });

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -25,7 +25,7 @@ const SampleOutputType = ({
 }) => {
   const { globalContent: gc, arcSite } = useFusionContext();
   const {
-    websiteName, twitterSite, gtmID, dangerouslyInjectJS = [], fontUrl, resizerURL,
+    websiteName, twitterUsername, gtmID, dangerouslyInjectJS = [], fontUrl, resizerURL,
   } = getProperties(arcSite);
 
   const googleFonts = () => {
@@ -83,7 +83,7 @@ const SampleOutputType = ({
           metaValue={metaValue}
           globalContent={gc}
           websiteName={websiteName}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           resizerURL={resizerURL}
         />
 


### PR DESCRIPTION
[PEN-996](https://arcpublishing.atlassian.net/browse/PEN-996)

# What does this implement or fix?
- updated the twitter property name used to get the twitter handle from the site properties

# How was this tested?
- tests written

# Dependencies or Side Effects

- verify that blocks.json is using `twitterUsername` as property for the twitter handle
- this PR works with another one from `engine-theme-sdk` [PEN-996 update twitter metatada](https://github.com/WPMedia/engine-theme-sdk/pull/60)
