### PR TITLE
PEN-1175 text file output type and text block

### DIFF
--- a/blocks/text-output-block/CHANGELOG.md
+++ b/blocks/text-output-block/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [5.2.0](https://github.com/WPMedia/fusion-news-theme-blocks/compare/v5.2.0-beta.0...v5.2.0) (2020-07-09)
+
+Initial version

--- a/blocks/text-output-block/README.md
+++ b/blocks/text-output-block/README.md
@@ -1,0 +1,12 @@
+# `@wpmedia/text-output-block`
+
+Fusion News Theme text output type
+
+## Usage
+
+```
+import textOutputBlock from '@wpmedia/text-output-block';
+```
+
+Any child feature component that support this output type (`text`) will be rendered.
+Can check `@wpmedia/textfile-block` for a reference implementation.

--- a/blocks/text-output-block/index.js
+++ b/blocks/text-output-block/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/blocks/text-output-block/jest.config.js
+++ b/blocks/text-output-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require('../../jest/jest.config.base');
+
+module.exports = {
+  ...base,
+};

--- a/blocks/text-output-block/output-types/text.jsx
+++ b/blocks/text-output-block/output-types/text.jsx
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+
+const TextOutputType = (props) => props.children;
+
+TextOutputType.contentType = 'text/plain';
+TextOutputType.fallback = false;
+
+TextOutputType.propTypes = {
+  children: PropTypes.node,
+};
+
+export default TextOutputType;

--- a/blocks/text-output-block/output-types/text.test.jsx
+++ b/blocks/text-output-block/output-types/text.test.jsx
@@ -1,0 +1,26 @@
+/**
+ * this is for mocking node env
+ * will not have window attribute, testing ssr
+ * https://jestjs.io/docs/en/configuration.html#testenvironment-string
+ * @jest-environment node
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import TextOutputType from './text';
+
+describe('the text output type', () => {
+  it('should render', () => {
+    const wrapper = shallow(<TextOutputType />);
+    expect(wrapper).toBeDefined();
+  });
+
+  describe('renders a page', () => {
+    const wrapper = shallow(
+      <TextOutputType>hello world</TextOutputType>,
+    );
+
+    it('should render the childs plain', () => {
+      expect(wrapper.text()).toEqual('hello world');
+    });
+  });
+});

--- a/blocks/text-output-block/package-lock.json
+++ b/blocks/text-output-block/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wpmedia/text-output-block",
+  "version": "5.2.0",
+  "lockfileVersion": 1
+}

--- a/blocks/text-output-block/package.json
+++ b/blocks/text-output-block/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wpmedia/text-output-block",
+  "version": "5.2.0",
+  "description": "Fusion News Theme text output type",
+  "author": "nelson fernandez <nelson.fernandez@washport.com>",
+  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "license": "UNLICENSED",
+  "main": "index.js",
+  "files": [
+    "output-types"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "directory": "blocks/text-output-block"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "lint": "eslint --ext js --ext jsx output-types"
+  }
+}

--- a/blocks/textfile-block/CHANGELOG.md
+++ b/blocks/textfile-block/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [5.2.0](https://github.com/WPMedia/fusion-news-theme-blocks/compare/v5.2.0-beta.0...v5.2.0) (2020-07-09)
+
+Initial version

--- a/blocks/textfile-block/README.md
+++ b/blocks/textfile-block/README.md
@@ -1,0 +1,16 @@
+# `@wpmedia/textfile-block`
+
+Text File block for Fusion News Theme
+This block offers a convenient way to render text files such as `ads.txt` or `robots.txt`. It must be used with `text` output type only, if other output type is selected, it will render nothing.
+
+## Usage
+
+The content of the custom field `Text` is the data to be rendered on the page.
+Be sure to use the page output type `text` or nothing will render. 
+
+## Production
+
+Before go live, open a ticket with ACS (Arc Customer Service) asking to have a redirect added:
+```
+rewrite ^/robots.txt$ /robots.txt?outputType=text? last;
+```

--- a/blocks/textfile-block/features/textfile/text.jsx
+++ b/blocks/textfile-block/features/textfile/text.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Textfile = ({ customFields }) => {
+  const { Text = '' } = customFields || {};
+  return (
+    <>{ Text }</>
+  );
+};
+
+Textfile.label = 'Text File – Arc Block';
+
+Textfile.propTypes = {
+  customFields: PropTypes.shape({
+    // eslint-disable-next-line react/no-typos
+    Text: PropTypes.richtext,
+  }),
+};
+
+export default Textfile;

--- a/blocks/textfile-block/features/textfile/text.test.jsx
+++ b/blocks/textfile-block/features/textfile/text.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import TextFile from './text';
+
+const simple = 'User-agent: *\nAllow: /\n\nSitemap: http://www.example.com/sitemap.xml';
+
+describe('the textfile block', () => {
+  it('should render the simple text', () => {
+    const wrapper = mount(<TextFile customFields={{ Text: simple }} />);
+    expect(wrapper.html()).toEqual(simple);
+  });
+
+  it('should not render anything when no data is given', () => {
+    const wrapper = mount(<TextFile />);
+    expect(wrapper.find(TextFile).children()).toHaveLength(0);
+  });
+
+  it('should not render anything when Text missing', () => {
+    const wrapper = mount(<TextFile customFields={{}} />);
+    expect(wrapper.find(TextFile).children()).toHaveLength(0);
+  });
+
+  it('should not render anything when Text is empty', () => {
+    const wrapper = mount(<TextFile customFields={{ Text: '' }} />);
+    expect(wrapper.find(TextFile).children()).toHaveLength(0);
+  });
+});

--- a/blocks/textfile-block/index.js
+++ b/blocks/textfile-block/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/blocks/textfile-block/index.story.jsx
+++ b/blocks/textfile-block/index.story.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Text from './features/textfile/text';
+
+export default {
+  component: Text,
+  title: 'Text File',
+  decorators: [
+    (storyFn) => (<pre>{storyFn()}</pre>),
+  ],
+};
+
+export const output = () => (
+  <Text customFields={{ Text: 'User-agent: *\nAllow: /\n\nSitemap: http://www.example.com/sitemap.xml' }} />
+);

--- a/blocks/textfile-block/jest.config.js
+++ b/blocks/textfile-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require('../../jest/jest.config.base');
+
+module.exports = {
+  ...base,
+};

--- a/blocks/textfile-block/package.json
+++ b/blocks/textfile-block/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wpmedia/textfile-block",
+  "version": "5.2.0",
+  "description": "Fusion News Theme text file block",
+  "author": "nelson fernandez <nelson.fernandez@washpost.com>",
+  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "license": "UNLICENSED",
+  "main": "index.js",
+  "files": [
+    "features"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "directory": "blocks/textfile-block"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "lint": "eslint --ext js --ext jsx features"
+  }
+}


### PR DESCRIPTION
[PEN-1175](https://arcpublishing.atlassian.net/browse/PEN-1175)

# What does this implement or fix?
- a new output type named `text` to render raw text.
- a new block named `textfile` to configure the text to be rendered.

# How was this tested?
- tests written

# Show Effect Of Changes

### Text File Block
![Screenshot from 2020-07-09 20-56-19](https://user-images.githubusercontent.com/9757/87101902-b2a62480-c226-11ea-87a3-ada0c5fbc519.png)

### Text output type
![Screenshot from 2020-07-09 20-51-49](https://user-images.githubusercontent.com/9757/87101911-b76ad880-c226-11ea-88e5-10382c7de5c9.png)

# Dependencies or Side Effects

- none
