### PR TITLE
Rename fusionContext with hooks prefix for clarity

### DIFF
--- a/blocks/headline-block/features/headline/default.jsx
+++ b/blocks/headline-block/features/headline/default.jsx
@@ -8,8 +8,8 @@ const HeadlineHeader = styled.h1`
   font-family: ${(props) => props.primaryFont};
 `;
 
-const Headline = ({ fusionContext = useFusionContext }) => {
-  const { globalContent: content, arcSite } = fusionContext();
+const Headline = ({ useInjectedFusionContext = useFusionContext }) => {
+  const { globalContent: content, arcSite } = useInjectedFusionContext();
 
   return (
     !!(content && content.headlines && content.headlines.basic) && (

--- a/blocks/headline-block/index.story.jsx
+++ b/blocks/headline-block/index.story.jsx
@@ -20,7 +20,7 @@ const data = () => ({
 });
 
 export const longHeadline = () => (
-  <Headline fusionContext={data} />
+  <Headline useInjectedFusionContext={data} />
 );
 
 export const customHeadline = () => {
@@ -34,6 +34,6 @@ export const customHeadline = () => {
   });
 
   return (
-    <Headline fusionContext={newData} />
+    <Headline useInjectedFusionContext={newData} />
   );
 };

--- a/blocks/share-bar-block/features/share-bar/default.jsx
+++ b/blocks/share-bar-block/features/share-bar/default.jsx
@@ -70,7 +70,7 @@ function getLogoComponent(type) {
   }
 }
 
-const ShareBar = ({ fusionContext = useFusionContext }) => {
+const ShareBar = ({ useInjectedFusionContext = useFusionContext }) => {
   const {
     customFields,
     globalContent: {
@@ -78,7 +78,7 @@ const ShareBar = ({ fusionContext = useFusionContext }) => {
       website_url: websiteUrl = '',
     } = {},
     arcSite,
-  } = fusionContext();
+  } = useInjectedFusionContext();
 
   const {
     websiteDomain,

--- a/blocks/share-bar-block/index.story.mdx
+++ b/blocks/share-bar-block/index.story.mdx
@@ -1,6 +1,6 @@
-import ShareBar from './features/share-bar/default';
-import data from './helper';
-import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import ShareBar from "./features/share-bar/default";
+import data from "./helper";
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 
 <Meta title="Share Bar" component={ShareBar} />
 
@@ -17,7 +17,7 @@ import ShareBar from '@wpmedia/share-bar-block';
 
 ...
     <ShareBar
-        fusionContext={{
+        useInjectedFusionContext={{
             customFields: {
                 email: false,
                 facebook: true,
@@ -40,16 +40,16 @@ import ShareBar from '@wpmedia/share-bar-block';
 
 ```
 
-
-
 ## Props
+
 <Props of={ShareBar} />
 
 ## Stories
 
 ** Custom ShareBar **
+
 <Preview>
-    <Story name="Custom ShareBar">
-        <ShareBar fusionContext={data} />
-    </Story>
+  <Story name="Custom ShareBar">
+    <ShareBar useInjectedFusionContext={data} />
+  </Story>
 </Preview>

--- a/stories/aaaIntro.stories.mdx
+++ b/stories/aaaIntro.stories.mdx
@@ -55,7 +55,7 @@ const data = () => ({
   },
 });
 
-  <ShareBar fusionContext={data} />
+  <ShareBar useInjectedFusionContext={data} />
 ```
 
 


### PR DESCRIPTION
re: https://github.com/WPMedia/fusion-news-theme-blocks/wiki/Technical-Grooming-(June-25,-2020)#dependency-injection-and-hooks and discussion with @jgrosspietsch 

# What does this implement or fix?
- Improves clarity of injected hooks 

# How was this tested?

Ran storybook. Minimal effect as vars were just renamed 

<img width="839" alt="Screen Shot 2020-07-10 at 4 09 55 PM" src="https://user-images.githubusercontent.com/5950956/87203511-5e538100-c2c8-11ea-9237-d62583491d12.png">

Otherwise, explain how to test this change.

- Run storybook

# Dependencies or Side Effects

Examples of dependencies or side effects are:
- None