### PR TITLE
PEN-926 show promo elements results list and block

### DIFF
--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -11,6 +11,7 @@ import getTranslatedPhrases from 'fusion:intl';
 
 import { Image } from '@wpmedia/engine-theme-sdk';
 import { extractResizedParams } from '@wpmedia/resizer-image-block';
+import { resolveDefaultPromoElements } from './helpers';
 
 // shared with search results list
 // to modify, go to the shared styles block
@@ -139,12 +140,14 @@ class ResultsList extends Component {
   render() {
     const {
       arcSite,
+      customFields,
     } = this.props;
     const {
       resultList: { content_elements: contentElements = [] } = {}, seeMore,
       placeholderResizedImageOptions,
     } = this.state;
     const targetFallbackImage = this.getFallbackImageURL();
+    const promoElements = resolveDefaultPromoElements(customFields);
 
     return (
       <div className="results-list-container">
@@ -166,78 +169,90 @@ class ResultsList extends Component {
           const url = websites[arcSite].website_url;
           return (
             <div className="list-item" key={`result-card-${url}`}>
-              <div className="results-list--image-container">
-                <a
-                  href={url}
-                  title={headlineText}
-                >
-                  {extractImage(promoItems) ? (
-                    <Image
-                      // results list is 16:9 by default
-                      resizedImageOptions={extractResizedParams(element)}
-                      url={extractImage(element.promo_items)}
-                      alt={headlineText}
-                      smallWidth={158}
-                      smallHeight={89}
-                      mediumWidth={274}
-                      mediumHeight={154}
-                      largeWidth={274}
-                      largeHeight={154}
-                      breakpoints={getProperties(arcSite)?.breakpoints}
-                      resizerURL={getProperties(arcSite)?.resizerURL}
-                    />
-                  ) : (
-                    <Image
-                      smallWidth={158}
-                      smallHeight={89}
-                      mediumWidth={274}
-                      mediumHeight={154}
-                      largeWidth={274}
-                      largeHeight={154}
-                      alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-                      url={targetFallbackImage}
-                      breakpoints={getProperties(arcSite)?.breakpoints}
-                      resizedImageOptions={placeholderResizedImageOptions}
-                      resizerURL={getProperties(arcSite)?.resizerURL}
-
-                    />
-                  )}
-                </a>
-              </div>
-              <div className="results-list--headline-container">
-                <a
-                  href={url}
-                  title={headlineText}
-                >
-                  <HeadlineText
-                    primaryFont={getThemeStyle(this.arcSite)['primary-font-family']}
-                    className="headline-text"
-                  >
-                    {headlineText}
-                  </HeadlineText>
-                </a>
-              </div>
-              <div className="results-list--description-author-container">
-                {descriptionText && (
+              { promoElements.showImage && (
+                <div className="results-list--image-container">
                   <a
                     href={url}
                     title={headlineText}
                   >
-                    <DescriptionText
-                      secondaryFont={getThemeStyle(this.arcSite)['secondary-font-family']}
-                      className="description-text"
-                    >
-                      {descriptionText}
-                    </DescriptionText>
+                    {extractImage(promoItems) ? (
+                      <Image
+                        // results list is 16:9 by default
+                        resizedImageOptions={extractResizedParams(element)}
+                        url={extractImage(element.promo_items)}
+                        alt={headlineText}
+                        smallWidth={158}
+                        smallHeight={89}
+                        mediumWidth={274}
+                        mediumHeight={154}
+                        largeWidth={274}
+                        largeHeight={154}
+                        breakpoints={getProperties(arcSite)?.breakpoints}
+                        resizerURL={getProperties(arcSite)?.resizerURL}
+                      />
+                    ) : (
+                      <Image
+                        smallWidth={158}
+                        smallHeight={89}
+                        mediumWidth={274}
+                        mediumHeight={154}
+                        largeWidth={274}
+                        largeHeight={154}
+                        alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
+                        url={targetFallbackImage}
+                        breakpoints={getProperties(arcSite)?.breakpoints}
+                        resizedImageOptions={placeholderResizedImageOptions}
+                        resizerURL={getProperties(arcSite)?.resizerURL}
+
+                      />
+                    )}
                   </a>
-                )}
-                <div className="results-list--author-date">
-                  <Byline story={element} stylesFor="list" />
-                  {/* The Separator will only be shown if there is at least one author name */}
-                  { showSeparator && <p className="dot-separator">&#9679;</p> }
-                  <ArticleDate classNames="story-date" date={displayDate} />
                 </div>
-              </div>
+              )}
+              { promoElements.showHeadline && (
+                <div className="results-list--headline-container">
+                  <a
+                    href={url}
+                    title={headlineText}
+                  >
+                    <HeadlineText
+                      primaryFont={getThemeStyle(this.arcSite)['primary-font-family']}
+                      className="headline-text"
+                    >
+                      {headlineText}
+                    </HeadlineText>
+                  </a>
+                </div>
+              )}
+              { (
+                promoElements.showDescription
+                  || promoElements.showDate
+                  || promoElements.showByline
+              ) && (
+                <div className="results-list--description-author-container">
+                  {promoElements.showDescription && descriptionText && (
+                    <a
+                      href={url}
+                      title={headlineText}
+                    >
+                      <DescriptionText
+                        secondaryFont={getThemeStyle(this.arcSite)['secondary-font-family']}
+                        className="description-text"
+                      >
+                        {descriptionText}
+                      </DescriptionText>
+                    </a>
+                  )}
+                  { (promoElements.showDate || promoElements.showByline) && (
+                    <div className="results-list--author-date">
+                      { promoElements.showByline && <Byline story={element} stylesFor="list" /> }
+                      {/* The Separator will only be shown if there is at least one author name */}
+                      { promoElements.showByline && showSeparator && promoElements.showDate && <p className="dot-separator">&#9679;</p> }
+                      { promoElements.showDate && <ArticleDate classNames="story-date" date={displayDate} /> }
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           );
         })}
@@ -267,7 +282,45 @@ ResultsList.label = 'Results List – Arc Block';
 
 ResultsList.propTypes = {
   customFields: PropTypes.shape({
-    listContentConfig: PropTypes.contentConfig('ans-feed'),
+    listContentConfig: PropTypes.contentConfig('ans-feed').tag({
+      group: 'Configure Content',
+      label: 'Display Content Info',
+    }),
+    showHeadline: PropTypes.bool.tag(
+      {
+        label: 'Show headline',
+        defaultValue: true,
+        group: 'Show promo elements',
+      },
+    ),
+    showImage: PropTypes.bool.tag(
+      {
+        label: 'Show image',
+        defaultValue: true,
+        group: 'Show promo elements',
+      },
+    ),
+    showDescription: PropTypes.bool.tag(
+      {
+        label: 'Show description',
+        defaultValue: true,
+        group: 'Show promo elements',
+      },
+    ),
+    showByline: PropTypes.bool.tag(
+      {
+        label: 'Show byline',
+        defaultValue: true,
+        group: 'Show promo elements',
+      },
+    ),
+    showDate: PropTypes.bool.tag(
+      {
+        label: 'Show date',
+        defaultValue: true,
+        group: 'Show promo elements',
+      },
+    ),
   }),
 };
 

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -78,10 +78,9 @@ describe('The results list', () => {
         expect(wrapper.find('.list-item').length).toEqual(1);
       });
 
-      // todo: add this back when engine theme sdk used
-      // it('should render one image wrapped in an anchor tag', () => {
-      //   expect(wrapper.find('.list-item').find('a').find('Image').length).toEqual(1);
-      // });
+      it('should render one image wrapped in an anchor tag', () => {
+        expect(wrapper.find('.list-item').find('a').find('Image').length).toEqual(1);
+      });
 
       it('should render an anchor and an image with the correct url', () => {
         expect(wrapper.find('.list-item').find('a').first()
@@ -199,6 +198,193 @@ describe('The results list', () => {
       expect(wrapper.find('.results-list-container').length).toEqual(1);
       expect(wrapper.find('.list-item').length).toEqual(1);
       expect(wrapper.find('.results-list-container').childAt(0).hasClass('list-item')).toEqual(true);
+    });
+  });
+
+  describe('when all promo items disabled', () => {
+    const listContentConfig = {
+      contentConfigValues: {
+        offset: '0',
+        query: 'type: story',
+        size: '30',
+      },
+      contentService: 'story-feed-query',
+      showByline: false,
+      showDate: false,
+      showDescription: false,
+      showHeadline: false,
+      showImage: false,
+    };
+    const { default: ResultsList } = require('./default');
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    ResultsList.prototype.fetchStories = jest.fn().mockReturnValue({});
+
+    const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+
+    wrapper.setState({ resultList: oneListItem }, () => {
+      wrapper.update();
+
+      it('should not render promor elements', () => {
+        expect(wrapper.find('.results-list-container').length).toEqual(1);
+        expect(wrapper.find('.results-list-container').find('.list-item').children().length).toEqual(0);
+      });
+    });
+  });
+
+  describe('when only headline enabled', () => {
+    const listContentConfig = {
+      contentConfigValues: {
+        offset: '0',
+        query: 'type: story',
+        size: '30',
+      },
+      contentService: 'story-feed-query',
+      showHeadline: true,
+      showImage: false,
+      showDescription: false,
+      showByline: false,
+      showDate: false,
+    };
+    const { default: ResultsList } = require('./default');
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    ResultsList.prototype.fetchStories = jest.fn().mockReturnValue({});
+    const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+    wrapper.setState({ resultList: oneListItem }, () => {
+      wrapper.update();
+
+      it('should render only headline', () => {
+        expect(wrapper.find('.results-list-container').length).toEqual(1);
+        const item = wrapper.find('.results-list-container').find('.list-item');
+        expect(item.length).toEqual(1);
+        expect(item.children().length).toEqual(1);
+        expect(item.find('.results-list--headline-container').length).toEqual(1);
+      });
+    });
+  });
+
+  describe('when only image enabled', () => {
+    const listContentConfig = {
+      contentConfigValues: {
+        offset: '0',
+        query: 'type: story',
+        size: '30',
+      },
+      contentService: 'story-feed-query',
+      showHeadline: false,
+      showImage: true,
+      showDescription: false,
+      showByline: false,
+      showDate: false,
+    };
+    const { default: ResultsList } = require('./default');
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+    wrapper.setState({ resultList: oneListItem }, () => {
+      wrapper.update();
+
+      it('should render only image', () => {
+        expect(wrapper.find('.results-list-container').length).toEqual(1);
+        const item = wrapper.find('.results-list-container').find('.list-item');
+        expect(item.length).toEqual(1);
+        expect(item.children().length).toEqual(1);
+        expect(item.find('.results-list--image-container').length).toEqual(1);
+      });
+    });
+  });
+
+  describe('when only description enabled', () => {
+    const listContentConfig = {
+      contentConfigValues: {
+        offset: '0',
+        query: 'type: story',
+        size: '30',
+      },
+      contentService: 'story-feed-query',
+      showHeadline: false,
+      showImage: false,
+      showDescription: true,
+      showByline: false,
+      showDate: false,
+    };
+    const { default: ResultsList } = require('./default');
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+    wrapper.setState({ resultList: oneListItem }, () => {
+      wrapper.update();
+
+      it('should render only description', () => {
+        expect(wrapper.find('.results-list-container').length).toEqual(1);
+        const item = wrapper.find('.results-list-container').find('.list-item');
+        expect(item.length).toEqual(1);
+        expect(item.children().length).toEqual(1);
+        expect(item.find('.results-list--description-author-container').length).toEqual(1);
+      });
+    });
+  });
+
+  describe('when only byline enabled', () => {
+    const listContentConfig = {
+      contentConfigValues: {
+        offset: '0',
+        query: 'type: story',
+        size: '30',
+      },
+      contentService: 'story-feed-query',
+      showHeadline: false,
+      showImage: false,
+      showDescription: false,
+      showByline: true,
+      showDate: false,
+    };
+    const { default: ResultsList } = require('./default');
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+    wrapper.setState({ resultList: oneListItem }, () => {
+      wrapper.update();
+
+      it('should render only byline', () => {
+        expect(wrapper.find('.results-list-container').length).toEqual(1);
+        const item = wrapper.find('.results-list-container').find('.list-item');
+        expect(item.length).toEqual(1);
+        expect(item.children().length).toEqual(1);
+        expect(item.find('.results-list--description-author-container').length).toEqual(1);
+        expect(item.find('.results-list--description-author-container').children().length).toEqual(1);
+        expect(item.find('.results-list--author-date').length).toEqual(1);
+        expect(item.find('.results-list--author-date').find('Byline').length).toEqual(1);
+      });
+    });
+  });
+
+  describe('when only byline date', () => {
+    const listContentConfig = {
+      contentConfigValues: {
+        offset: '0',
+        query: 'type: story',
+        size: '30',
+      },
+      contentService: 'story-feed-query',
+      showHeadline: false,
+      showImage: false,
+      showDescription: false,
+      showByline: false,
+      showDate: true,
+    };
+    const { default: ResultsList } = require('./default');
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+    wrapper.setState({ resultList: oneListItem }, () => {
+      wrapper.update();
+
+      it('should render only date', () => {
+        expect(wrapper.find('.results-list-container').length).toEqual(1);
+        const item = wrapper.find('.results-list-container').find('.list-item');
+        expect(item.length).toEqual(1);
+        expect(item.children().length).toEqual(1);
+        expect(item.find('.results-list--description-author-container').length).toEqual(1);
+        expect(item.find('.results-list--description-author-container').children().length).toEqual(1);
+        expect(item.find('.results-list--author-date').length).toEqual(1);
+        expect(item.find('.results-list--author-date').find('ArticleDate').length).toEqual(1);
+      });
     });
   });
 

--- a/blocks/results-list-block/features/results-list/helpers.jsx
+++ b/blocks/results-list-block/features/results-list/helpers.jsx
@@ -1,0 +1,21 @@
+const resolveDefaultPromoElements = (customFields = {}) => {
+  const fields = {
+    showHeadline: true,
+    showImage: true,
+    showDescription: true,
+    showByline: true,
+    showDate: true,
+  };
+  const fieldKeys = Object.keys(fields);
+  return fieldKeys.reduce((acc, key) => {
+    if (typeof customFields[key] === 'undefined') {
+      acc[key] = fields[key];
+    } else {
+      acc[key] = customFields[key];
+    }
+    return acc;
+  }, fields);
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { resolveDefaultPromoElements };

--- a/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
@@ -2,17 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Consumer from 'fusion:consumer';
-import Byline from '@wpmedia/byline-block';
-import ArticleDate from '@wpmedia/date-block';
 import getThemeStyle from 'fusion:themes';
-import { Image } from '@wpmedia/engine-theme-sdk';
-import { extractResizedParams } from '@wpmedia/resizer-image-block';
 
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 import SearchIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/SearchIcon';
-import { HeadlineText, DescriptionText } from './styled-components';
-import { extractImage } from './helpers';
+import SearchResult from './search-result';
 
 // shared with results list
 // to modify, go to the shared styles block
@@ -126,8 +121,9 @@ class CustomSearchResultsList extends React.Component {
       placeholderResizedImageOptions,
     } = this.state;
     const targetFallbackImage = this.getFallbackImageURL();
-
     const { arcSite } = this.props;
+    const { promoElements } = this.props;
+
     return (
       <div>
         <div className="search-container">
@@ -161,91 +157,16 @@ class CustomSearchResultsList extends React.Component {
         </div>
         <div className="results-list-container">
           {
-            data && data.length > 0 && data.map((element) => {
-              const {
-                description: { basic: descriptionText } = {},
-                headlines: { basic: headlineText } = {},
-                display_date: displayDate,
-                credits: { by } = {},
-                promo_items: promoItems,
-                websites,
-              } = element;
-              if (!websites[arcSite]) {
-                return null;
-              }
-              const url = websites[arcSite].website_url;
-              const resizedImageOptions = extractResizedParams(element);
-              const showSeparator = by && by.length !== 0;
-              return (
-                <div className="list-item" key={`result-card-${url}`}>
-                  <div className="results-list--image-container">
-                    <a
-                      href={url}
-                      title={headlineText}
-                      className="list-anchor"
-                    >
-                      {extractImage(promoItems) ? (
-                        <Image
-                          url={extractImage(promoItems)}
-                          alt={headlineText}
-                          smallWidth={274}
-                          smallHeight={154}
-                          mediumWidth={274}
-                          mediumHeight={154}
-                          largeWidth={274}
-                          largeHeight={154}
-                          resizedImageOptions={resizedImageOptions}
-                          resizerURL={getProperties(arcSite)?.resizerURL}
-                          breakpoints={getProperties(arcSite)?.breakpoints}
-                        />
-                      ) : (
-                        <Image
-                          smallWidth={274}
-                          smallHeight={154}
-                          mediumWidth={274}
-                          mediumHeight={154}
-                          largeWidth={274}
-                          largeHeight={154}
-                          alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-                          url={targetFallbackImage}
-                          breakpoints={getProperties(arcSite)?.breakpoints}
-                          resizedImageOptions={placeholderResizedImageOptions}
-                          resizerURL={getProperties(arcSite)?.resizerURL}
-                        />
-                      )}
-                    </a>
-                  </div>
-                  <div className="results-list--headline-container">
-                    <a
-                      href={url}
-                      title={headlineText}
-                      className="list-anchor"
-                    >
-                      <HeadlineText
-                        primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-                        className="headline-text"
-                      >
-                        {headlineText}
-                      </HeadlineText>
-                    </a>
-                  </div>
-                  <div className="results-list--description-author-container">
-                    <DescriptionText
-                      secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
-                      className="description-text"
-                    >
-                      {descriptionText}
-                    </DescriptionText>
-                    <div className="results-list--author-date">
-                      <Byline story={element} stylesFor="list" />
-                      {/* The Separator will only be shown if there is at least one author name */}
-                      { showSeparator && <p className="dot-separator">&#9679;</p> }
-                      <ArticleDate classNames="story-date" date={displayDate} />
-                    </div>
-                  </div>
-                </div>
-              );
-            })
+            data && data.length > 0 && data.map((element) => (
+              <SearchResult
+                key={`result-card-${element._id}`}
+                element={element}
+                arcSite={arcSite}
+                targetFallbackImage={targetFallbackImage}
+                placeholderResizedImageOptions={placeholderResizedImageOptions}
+                promoElements={promoElements}
+              />
+            ))
           }
           {
             !!(data && data.length > 0 && data.length < totalHits) && (

--- a/blocks/search-results-list-block/features/search-results-list/_children/custom-content.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/custom-content.test.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import getThemeStyle from 'fusion:themes';
-import mockData, { oneListItem, LineItemWithOutDescription, withoutByline } from '../mock-data';
+import mockData from '../mock-data';
 
 const mockReturnData = mockData;
 
@@ -102,25 +102,8 @@ describe('The search results list', () => {
       wrapper.update();
       expect(wrapper.find('.results-list-container').length).toEqual(1);
       expect(wrapper.find('SearchResult').length).toEqual(28);
-      // expect(wrapper.find('.results-list-container').childAt(0).hasClass('list-item')).toEqual(true);
     });
   });
-
-  // describe('renders one list item correctly when list of authors is missing', () => {
-  //   const { default: SearchResultsList } = require('./custom-content');
-  //   SearchResultsList.prototype.fetchContent = jest.fn().mockReturnValue(withoutByline);
-  //   const wrapper = shallow(<SearchResultsList arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-  //   wrapper.setState({ resultList: withoutByline }, () => {
-  //     wrapper.update();
-  //     it('should render one parent wrapper', () => {
-  //       expect(wrapper.find('.results-list-container').length).toEqual(1);
-  //     });
-  //
-  //     it('should render a separator', () => {
-  //       expect(wrapper.find('.list-item').find('.dot-separator').length).toEqual(0);
-  //     });
-  //   });
-  // });
 
   describe('renders a button to display more stories', () => {
     const { default: SearchResultsList } = require('./custom-content');

--- a/blocks/search-results-list-block/features/search-results-list/_children/custom-content.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/custom-content.test.jsx
@@ -31,6 +31,14 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
 }));
 
+const fullPromoElements = {
+  showHeadline: true,
+  showImage: true,
+  showDescription: true,
+  showByline: true,
+  showDate: true,
+};
+
 describe('The search results list', () => {
   describe('renders a search bar', () => {
     const { default: SearchResultsList } = require('./custom-content');
@@ -89,115 +97,30 @@ describe('The search results list', () => {
   it('should render a list of stories', () => {
     const { default: SearchResultsList } = require('./custom-content');
     SearchResultsList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
-    const wrapper = shallow(<SearchResultsList arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+    const wrapper = shallow(<SearchResultsList arcSite="the-sun" promoElements={fullPromoElements} deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: mockData }, () => {
       wrapper.update();
       expect(wrapper.find('.results-list-container').length).toEqual(1);
-      expect(wrapper.find('.list-item').length).toEqual(28);
-      expect(wrapper.find('.results-list-container').childAt(0).hasClass('list-item')).toEqual(true);
+      expect(wrapper.find('SearchResult').length).toEqual(28);
+      // expect(wrapper.find('.results-list-container').childAt(0).hasClass('list-item')).toEqual(true);
     });
   });
 
-  describe('renders one list item correctly', () => {
-    const { default: SearchResultsList } = require('./custom-content');
-    SearchResultsList.prototype.fetchContent = jest.fn().mockReturnValue(oneListItem);
-    const wrapper = shallow(<SearchResultsList arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ resultList: oneListItem }, () => {
-      it('should have one parent wrapper', () => {
-        expect(wrapper.find('.results-list-container').length).toEqual(1);
-      });
-
-      it('should render one list item as its child', () => {
-        expect(wrapper.find('.results-list-container').childAt(0).hasClass('list-item')).toEqual(true);
-        expect(wrapper.find('.list-item').length).toEqual(1);
-      });
-
-      it('should render one image wrapped in an anchor tag', () => {
-        expect(wrapper.find('.list-item').find('.list-anchor').length).toEqual(2);
-        expect(wrapper.find('.list-item').find('.list-anchor').find('Image').length).toEqual(1);
-      });
-
-      it('should render an anchor and an image with the correct url', () => {
-        expect(wrapper.find('.list-item').find('.list-anchor').at(0).find('a')
-          .prop('href')).toEqual('/arts/2019/12/18/article-with-a-youtube-embed-in-it/');
-      });
-
-      it('should render a parent for headline and a description', () => {
-        expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
-      });
-
-      it('should render a headline and a description', () => {
-        expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
-        expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').length).toEqual(1);
-        expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.headline-text').length).toEqual(1);
-        expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.headline-text')
-          .text()).toEqual('Article with a YouTube embed in it');
-        expect(wrapper.find('.list-item').find('.results-list--description-author-container').find('.description-text')
-          .text()).toEqual('Test article for YouTube responsiveness');
-      });
-
-      it('should render an author and a publish date section', () => {
-        expect(wrapper.find('.list-item').find('.results-list--author-date').length).toEqual(1);
-      });
-
-      it('should render a byline', () => {
-        expect(wrapper.find('.list-item').find('.results-list--author-date').find('Byline').length).toEqual(1);
-      });
-
-      it('should render a separator', () => {
-        expect(wrapper.find('.list-item').find('.dot-separator').length).toEqual(1);
-      });
-
-      it('should render a publish date', () => {
-        expect(wrapper.find('.list-item').find('.results-list--author-date').find('ArticleDate').length).toEqual(1);
-      });
-    });
-  });
-
-  describe('renders one list item correctly when description is missing', () => {
-    const { default: SearchResultsList } = require('./custom-content');
-    SearchResultsList.prototype.fetchContent = jest.fn()
-      .mockReturnValue(LineItemWithOutDescription);
-    const wrapper = shallow(<SearchResultsList arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ resultList: LineItemWithOutDescription }, () => {
-      wrapper.update();
-      it('should render one parent wrapper', () => {
-        expect(wrapper.find('.results-list-container').length).toEqual(1);
-      });
-
-      it('should render a parent for headline and a description', () => {
-        expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
-      });
-
-      it('should render a headline', () => {
-        expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
-        expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').length).toEqual(1);
-        expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.headline-text').length).toEqual(1);
-        expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.headline-text')
-          .text()).toEqual('Article with a YouTube embed in it');
-      });
-
-      it('should not render a description', () => {
-        expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.description-text').length).toEqual(0);
-      });
-    });
-  });
-
-  describe('renders one list item correctly when list of authors is missing', () => {
-    const { default: SearchResultsList } = require('./custom-content');
-    SearchResultsList.prototype.fetchContent = jest.fn().mockReturnValue(withoutByline);
-    const wrapper = shallow(<SearchResultsList arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ resultList: withoutByline }, () => {
-      wrapper.update();
-      it('should render one parent wrapper', () => {
-        expect(wrapper.find('.results-list-container').length).toEqual(1);
-      });
-
-      it('should render a separator', () => {
-        expect(wrapper.find('.list-item').find('.dot-separator').length).toEqual(0);
-      });
-    });
-  });
+  // describe('renders one list item correctly when list of authors is missing', () => {
+  //   const { default: SearchResultsList } = require('./custom-content');
+  //   SearchResultsList.prototype.fetchContent = jest.fn().mockReturnValue(withoutByline);
+  //   const wrapper = shallow(<SearchResultsList arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+  //   wrapper.setState({ resultList: withoutByline }, () => {
+  //     wrapper.update();
+  //     it('should render one parent wrapper', () => {
+  //       expect(wrapper.find('.results-list-container').length).toEqual(1);
+  //     });
+  //
+  //     it('should render a separator', () => {
+  //       expect(wrapper.find('.list-item').find('.dot-separator').length).toEqual(0);
+  //     });
+  //   });
+  // });
 
   describe('renders a button to display more stories', () => {
     const { default: SearchResultsList } = require('./custom-content');

--- a/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 import Consumer from 'fusion:consumer';
-import Byline from '@wpmedia/byline-block';
-import ArticleDate from '@wpmedia/date-block';
 import getThemeStyle from 'fusion:themes';
-import { Image } from '@wpmedia/engine-theme-sdk';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 import SearchIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/SearchIcon';
 import { extractResizedParams } from '@wpmedia/resizer-image-block';
 
-import { HeadlineText, DescriptionText } from './styled-components';
+import SearchResult from './search-result';
 import { extractImage } from './helpers';
 import '@wpmedia/shared-styles/scss/_results-list.scss';
 import '@wpmedia/shared-styles/scss/_results-list-desktop.scss';
@@ -128,6 +125,7 @@ class GlobalSearchResultsList extends React.Component {
 
     const targetFallbackImage = this.getFallbackImageURL();
     const results = moreStories || data;
+    const { promoElements } = this.props;
 
     return (
       <div>
@@ -165,88 +163,20 @@ class GlobalSearchResultsList extends React.Component {
         <div className="results-list-container">
           {
             results && results.length > 0 && results.map((element) => {
-              const {
-                description: { basic: descriptionText } = {},
-                headlines: { basic: headlineText } = {},
-                display_date: displayDate,
-                credits: { by } = {},
-                promo_items: promoItems,
-                websites,
-              } = element;
-              const showSeparator = by && by.length !== 0;
-              if (!websites[arcSite]) {
-                return null;
-              }
-              const url = websites[arcSite].website_url;
-              return (
-                <div className="list-item" key={`result-card-${url}`}>
-                  <div className="results-list--image-container">
-                    <a
-                      href={url}
-                      title={headlineText}
-                      className="list-anchor"
-                    >
-                      {extractImage(promoItems) ? (
-                        <Image
-                          resizedImageOptions={extractResizedParams(element)}
-                          url={extractImage(promoItems)}
-                          alt={headlineText}
-                          smallWidth={274}
-                          smallHeight={154}
-                          mediumWidth={274}
-                          mediumHeight={154}
-                          largeWidth={274}
-                          largeHeight={154}
-                          breakpoints={getProperties(arcSite)?.breakpoints}
-                          resizerURL={getProperties(arcSite)?.resizerURL}
-                        />
-                      ) : (
-                        <Image
-                          smallWidth={274}
-                          smallHeight={154}
-                          mediumWidth={274}
-                          mediumHeight={154}
-                          largeWidth={274}
-                          largeHeight={154}
-                          alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-                          url={targetFallbackImage}
-                          breakpoints={getProperties(arcSite)?.breakpoints}
-                          resizedImageOptions={placeholderResizedImageOptions}
-                          resizerURL={getProperties(arcSite)?.resizerURL}
+              const resizedImageOptions = extractImage(element.promoItems)
+                ? extractResizedParams(element)
+                : placeholderResizedImageOptions;
 
-                        />
-                      )}
-                    </a>
-                  </div>
-                  <div className="results-list--headline-container">
-                    <a
-                      href={url}
-                      title={headlineText}
-                      className="list-anchor"
-                    >
-                      <HeadlineText
-                        primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-                        className="headline-text"
-                      >
-                        {headlineText}
-                      </HeadlineText>
-                    </a>
-                  </div>
-                  <div className="results-list--description-author-container">
-                    <DescriptionText
-                      secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
-                      className="description-text"
-                    >
-                      {descriptionText}
-                    </DescriptionText>
-                    <div className="results-list--author-date">
-                      <Byline story={element} stylesFor="list" />
-                      {/* The Separator will only be shown if there is at least one author name */}
-                      { showSeparator && <p className="dot-separator">&#9679;</p> }
-                      <ArticleDate classNames="story-date" date={displayDate} />
-                    </div>
-                  </div>
-                </div>
+              return (
+                <SearchResult
+                  key={`result-card-${element._id}`}
+                  element={element}
+                  arcSite={arcSite}
+                  targetFallbackImage={targetFallbackImage}
+                  placeholderResizedImageOptions={placeholderResizedImageOptions}
+                  resizedImageOptions={resizedImageOptions}
+                  promoElements={promoElements}
+                />
               );
             })
           }

--- a/blocks/search-results-list-block/features/search-results-list/_children/global-content.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/global-content.test.jsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 // import getThemeStyle from 'fusion:themes';
 // import getTranslatedPhrases from 'fusion:intl';
 // import getProperties from 'fusion:properties';
-import mockData, { oneListItem, LineItemWithOutDescription, withoutByline } from '../mock-data';
+import mockData, { oneListItem } from '../mock-data';
 
 jest.mock('fusion:themes', () => ({
   __esModule: true,
@@ -100,21 +100,7 @@ describe('The search results list', () => {
     const wrapper = shallow(<SearchResultsList globalContent={mockData} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     expect(wrapper.find('.results-list-container').length).toEqual(1);
     expect(wrapper.find('SearchResult').length).toEqual(28);
-    // expect(wrapper.find('.results-list-container').childAt(0).hasClass('list-item')).toEqual(true);
   });
-
-  // describe('renders one list item correctly when list of authors is missing', () => {
-  //   const { default: SearchResultsList } = require('./global-content');
-  //   SearchResultsList.prototype.fetchContent = jest.fn();
-  //   const wrapper = shallow(<SearchResultsList globalContent={withoutByline} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-  //   it('should render one parent wrapper', () => {
-  //     expect(wrapper.find('.results-list-container').length).toEqual(1);
-  //   });
-  //
-  //   it('should render a separator', () => {
-  //     expect(wrapper.find('.list-item').find('.dot-separator').length).toEqual(0);
-  //   });
-  // });
 
   describe('renders a button to display more stories', () => {
     it('should render a button to display more stories', () => {

--- a/blocks/search-results-list-block/features/search-results-list/_children/global-content.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/global-content.test.jsx
@@ -99,101 +99,22 @@ describe('The search results list', () => {
     SearchResultsList.prototype.fetchContent = jest.fn();
     const wrapper = shallow(<SearchResultsList globalContent={mockData} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     expect(wrapper.find('.results-list-container').length).toEqual(1);
-    expect(wrapper.find('.list-item').length).toEqual(28);
-    expect(wrapper.find('.results-list-container').childAt(0).hasClass('list-item')).toEqual(true);
+    expect(wrapper.find('SearchResult').length).toEqual(28);
+    // expect(wrapper.find('.results-list-container').childAt(0).hasClass('list-item')).toEqual(true);
   });
 
-  describe('renders one list item correctly', () => {
-    const { default: SearchResultsList } = require('./global-content');
-    SearchResultsList.prototype.fetchContent = jest.fn();
-    const wrapper = shallow(<SearchResultsList globalContent={oneListItem} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-    it('should have one parent wrapper', () => {
-      expect(wrapper.find('.results-list-container').length).toEqual(1);
-    });
-
-    it('should render one list item as its child', () => {
-      expect(wrapper.find('.results-list-container').childAt(0).hasClass('list-item')).toEqual(true);
-      expect(wrapper.find('.list-item').length).toEqual(1);
-    });
-
-    it('should render one image wrapped in an anchor tag', () => {
-      expect(wrapper.find('.list-item').find('.list-anchor').length).toEqual(2);
-      expect(wrapper.find('.list-item').find('.list-anchor').find('Image').length).toEqual(1);
-    });
-
-    it('should render an anchor and an image with the correct url', () => {
-      expect(wrapper.find('.list-item').find('.list-anchor').at(0).find('a')
-        .prop('href')).toEqual('/arts/2019/12/18/article-with-a-youtube-embed-in-it/');
-    });
-
-    it('should render a parent for headline and a description', () => {
-      expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
-    });
-
-    it('should render a headline and a description', () => {
-      expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').length).toEqual(1);
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.headline-text').length).toEqual(1);
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.headline-text')
-        .text()).toEqual('Article with a YouTube embed in it');
-      expect(wrapper.find('.list-item').find('.results-list--description-author-container').find('.description-text')
-        .text()).toEqual('Test article for YouTube responsiveness');
-    });
-
-    it('should render an author and a publish date section', () => {
-      expect(wrapper.find('.list-item').find('.results-list--author-date').length).toEqual(1);
-    });
-
-    it('should render a byline', () => {
-      expect(wrapper.find('.list-item').find('.results-list--author-date').find('Byline').length).toEqual(1);
-    });
-
-    it('should render a separator', () => {
-      expect(wrapper.find('.list-item').find('.dot-separator').length).toEqual(1);
-    });
-
-    it('should render a publish date', () => {
-      expect(wrapper.find('.list-item').find('.results-list--author-date').find('ArticleDate').length).toEqual(1);
-    });
-  });
-
-  describe('renders one list item correctly when description is missing', () => {
-    const { default: SearchResultsList } = require('./global-content');
-    SearchResultsList.prototype.fetchContent = jest.fn();
-    const wrapper = shallow(<SearchResultsList globalContent={LineItemWithOutDescription} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-    it('should render one parent wrapper', () => {
-      expect(wrapper.find('.results-list-container').length).toEqual(1);
-    });
-
-    it('should render a parent for headline and a description', () => {
-      expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
-    });
-
-    it('should render a headline', () => {
-      expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').length).toEqual(1);
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.headline-text').length).toEqual(1);
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.headline-text')
-        .text()).toEqual('Article with a YouTube embed in it');
-    });
-
-    it('should not render a description', () => {
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.description-text').length).toEqual(0);
-    });
-  });
-
-  describe('renders one list item correctly when list of authors is missing', () => {
-    const { default: SearchResultsList } = require('./global-content');
-    SearchResultsList.prototype.fetchContent = jest.fn();
-    const wrapper = shallow(<SearchResultsList globalContent={withoutByline} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-    it('should render one parent wrapper', () => {
-      expect(wrapper.find('.results-list-container').length).toEqual(1);
-    });
-
-    it('should render a separator', () => {
-      expect(wrapper.find('.list-item').find('.dot-separator').length).toEqual(0);
-    });
-  });
+  // describe('renders one list item correctly when list of authors is missing', () => {
+  //   const { default: SearchResultsList } = require('./global-content');
+  //   SearchResultsList.prototype.fetchContent = jest.fn();
+  //   const wrapper = shallow(<SearchResultsList globalContent={withoutByline} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+  //   it('should render one parent wrapper', () => {
+  //     expect(wrapper.find('.results-list-container').length).toEqual(1);
+  //   });
+  //
+  //   it('should render a separator', () => {
+  //     expect(wrapper.find('.list-item').find('.dot-separator').length).toEqual(0);
+  //   });
+  // });
 
   describe('renders a button to display more stories', () => {
     it('should render a button to display more stories', () => {

--- a/blocks/search-results-list-block/features/search-results-list/_children/helpers.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/helpers.jsx
@@ -11,4 +11,23 @@ const constructHref = (websiteUrl, arcSite) => {
 
 const extractImage = (promo) => promo && promo.basic && promo.basic.type === 'image' && promo.basic.url;
 
-export { constructHref, extractImage };
+const resolveDefaultPromoElements = (customFields = {}) => {
+  const fields = {
+    showHeadline: true,
+    showImage: true,
+    showDescription: true,
+    showByline: true,
+    showDate: true,
+  };
+  const fieldKeys = Object.keys(fields);
+  return fieldKeys.reduce((acc, key) => {
+    if (typeof customFields[key] === 'undefined') {
+      acc[key] = fields[key];
+    } else {
+      acc[key] = customFields[key];
+    }
+    return acc;
+  }, fields);
+};
+
+export { constructHref, extractImage, resolveDefaultPromoElements };

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import Byline from '@wpmedia/byline-block';
+import ArticleDate from '@wpmedia/date-block';
+import { extractResizedParams } from '@wpmedia/resizer-image-block';
+import { Image } from '@wpmedia/engine-theme-sdk';
+import getThemeStyle from 'fusion:themes';
+
+import getProperties from 'fusion:properties';
+import { HeadlineText, DescriptionText } from './styled-components';
+import { extractImage } from './helpers';
+
+const SearchResult = ({
+  element,
+  arcSite,
+  targetFallbackImage,
+  placeholderResizedImageOptions,
+  promoElements = {},
+}) => {
+  const {
+    description: { basic: descriptionText } = {},
+    headlines: { basic: headlineText } = {},
+    display_date: displayDate,
+    credits: { by } = {},
+    promo_items: promoItems,
+    websites,
+  } = element;
+
+  if (!websites[arcSite]) {
+    return null;
+  }
+
+  const url = websites[arcSite].website_url;
+  const resizedImageOptions = extractResizedParams(element);
+  const showSeparator = by && by.length !== 0;
+  const {
+    showHeadline,
+    showImage,
+    showDescription,
+    showByline,
+    showDate,
+  } = promoElements;
+
+  return (
+    <div className="list-item" key={`result-card-${url}`}>
+      { showImage && (
+        <div className="results-list--image-container">
+          <a
+            href={url}
+            title={headlineText}
+            className="list-anchor"
+          >
+            {extractImage(promoItems) ? (
+              <Image
+                url={extractImage(promoItems)}
+                alt={headlineText}
+                smallWidth={274}
+                smallHeight={154}
+                mediumWidth={274}
+                mediumHeight={154}
+                largeWidth={274}
+                largeHeight={154}
+                resizedImageOptions={resizedImageOptions}
+                resizerURL={getProperties(arcSite)?.resizerURL}
+                breakpoints={getProperties(arcSite)?.breakpoints}
+              />
+            ) : (
+              <Image
+                smallWidth={274}
+                smallHeight={154}
+                mediumWidth={274}
+                mediumHeight={154}
+                largeWidth={274}
+                largeHeight={154}
+                alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
+                url={targetFallbackImage}
+                breakpoints={getProperties(arcSite)?.breakpoints}
+                resizedImageOptions={placeholderResizedImageOptions}
+                resizerURL={getProperties(arcSite)?.resizerURL}
+              />
+            )}
+          </a>
+        </div>
+      )}
+      { showHeadline && (
+        <div className="results-list--headline-container">
+          <a
+            href={url}
+            title={headlineText}
+            className="list-anchor"
+          >
+            <HeadlineText
+              primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+              className="headline-text"
+            >
+              {headlineText}
+            </HeadlineText>
+          </a>
+        </div>
+      )}
+      { (showDescription || showDate || showByline) && (
+        <div className="results-list--description-author-container">
+          { showDescription && (
+            <DescriptionText
+              secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
+              className="description-text"
+            >
+              {descriptionText}
+            </DescriptionText>
+          )}
+          { (showDate || showByline) && (
+            <div className="results-list--author-date">
+              { showByline && <Byline story={element} stylesFor="list" /> }
+              { showByline && showSeparator && showDate && <p className="dot-separator">&#9679;</p> }
+              { showDate && <ArticleDate classNames="story-date" date={displayDate} /> }
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SearchResult;

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.test.jsx
@@ -1,0 +1,282 @@
+/* eslint-disable prefer-arrow-callback, react/jsx-props-no-spreading  */
+import React from 'react';
+import { mount } from 'enzyme';
+// import getThemeStyle from 'fusion:themes';
+import { oneListItem, LineItemWithOutDescription } from '../mock-data';
+import SearchResult from './search-result';
+
+jest.mock('fusion:themes', () => jest.fn(() => ({})));
+jest.mock('fusion:properties', () => (jest.fn(() => ({
+  fallbackImage: 'placeholder.jpg',
+  resizerURL: 'http://example.com',
+}))));
+
+describe('The search results', () => {
+  describe('renders one list item correctly', () => {
+    const element = oneListItem.data[0];
+    if (element?.['promo_items']?.basic) {
+      element.promo_items.basic.resized_params = { '274x154': '' };
+    }
+    const fullElements = {
+      showHeadline: true,
+      showImage: true,
+      showDescription: true,
+      showByline: true,
+      showDate: true,
+    };
+
+    const wrapper = mount(
+      <SearchResult
+        element={element}
+        arcSite="the-sun"
+        targetFallbackImage="/resource/example.jpg"
+        placeholderResizedImageOptions={{}}
+        promoElements={fullElements}
+      />,
+    );
+
+    it('should render one list item as its child', () => {
+      expect(wrapper.find('.list-item').length).toEqual(1);
+    });
+
+    it('should render one image wrapped in an anchor tag', () => {
+      expect(wrapper.find('.list-item').find('.list-anchor').length).toEqual(2);
+      expect(wrapper.find('.list-item').find('.list-anchor').find('Image').length).toEqual(1);
+    });
+
+    it('should render an anchor and an image with the correct url', () => {
+      expect(wrapper.find('.list-item').find('.list-anchor').at(0).find('a')
+        .prop('href')).toEqual('/arts/2019/12/18/article-with-a-youtube-embed-in-it/');
+    });
+
+    it('should render a parent for headline and a description', () => {
+      expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
+    });
+
+    it('should render a headline and a description', () => {
+      expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
+      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').length).toEqual(1);
+      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('h2.headline-text').length).toEqual(1);
+      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('h2.headline-text')
+        .text()).toEqual('Article with a YouTube embed in it');
+      expect(wrapper.find('.list-item').find('.results-list--description-author-container').find('p.description-text')
+        .text()).toEqual('Test article for YouTube responsiveness');
+    });
+
+    it('should render an author and a publish date section', () => {
+      expect(wrapper.find('.list-item').find('.results-list--author-date').length).toEqual(1);
+    });
+
+    it('should render a byline', () => {
+      expect(wrapper.find('.list-item').find('.results-list--author-date').find('ArticleByline').length).toEqual(1);
+    });
+
+    it('should render a separator', () => {
+      expect(wrapper.find('.list-item').find('.dot-separator').length).toEqual(1);
+    });
+
+    it('should render a publish date', () => {
+      expect(wrapper.find('.list-item').find('.results-list--author-date').find('ArticleDate').length).toEqual(1);
+    });
+  });
+
+  describe('renders one list item correctly when description is missing', () => {
+    const element = LineItemWithOutDescription.data[0];
+    if (element?.['promo_items']?.basic) {
+      element.promo_items.basic.resized_params = { '274x154': '' };
+    }
+    const fullElements = {
+      showHeadline: true,
+      showImage: true,
+      showDescription: true,
+      showByline: true,
+      showDate: true,
+    };
+
+    const wrapper = mount(
+      <SearchResult
+        element={element}
+        arcSite="the-sun"
+        targetFallbackImage="/resource/example.jpg"
+        placeholderResizedImageOptions={{}}
+        promoElements={fullElements}
+      />,
+    );
+
+    it('should render a parent for headline and a description', () => {
+      expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
+    });
+
+    it('should render a headline', () => {
+      expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
+      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').length).toEqual(1);
+      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('h2.headline-text').length).toEqual(1);
+      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('h2.headline-text')
+        .text()).toEqual('Article with a YouTube embed in it');
+    });
+
+    it('should not render a description', () => {
+      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('p.description-text').length).toEqual(0);
+    });
+  });
+
+  describe('renders results items on demand', () => {
+    const element = oneListItem.data[0];
+    if (element?.['promo_items']?.basic) {
+      element.promo_items.basic.resized_params = { '274x154': '' };
+    }
+
+    it('should not render promo elements', () => {
+      const promoElements = {
+        showHeadline: false,
+        showImage: false,
+        showDescription: false,
+        showByline: false,
+        showDate: false,
+      };
+
+      const wrapper = mount(
+        <SearchResult
+          element={element}
+          arcSite="the-sun"
+          targetFallbackImage="/resource/example.jpg"
+          placeholderResizedImageOptions={{}}
+          promoElements={promoElements}
+        />,
+      );
+
+      expect(wrapper.find('.list-item').length).toEqual(1);
+      expect(wrapper.find('.list-item').children().length).toEqual(0);
+    });
+
+    it('should render only headline', () => {
+      const promoElements = {
+        showHeadline: true,
+        showImage: false,
+        showDescription: false,
+        showByline: false,
+        showDate: false,
+      };
+
+      const wrapper = mount(
+        <SearchResult
+          element={element}
+          arcSite="the-sun"
+          targetFallbackImage="/resource/example.jpg"
+          placeholderResizedImageOptions={{}}
+          promoElements={promoElements}
+        />,
+      );
+
+      const headline = wrapper.find('.list-item').find('.results-list--headline-container');
+      expect(headline.length).toEqual(1);
+      expect(headline.find('.list-anchor').length).toEqual(1);
+      expect(headline.find('.list-anchor').prop('title')).toEqual('Article with a YouTube embed in it');
+      expect(headline.find('h2.headline-text').length).toEqual(1);
+      expect(headline.text()).toEqual('Article with a YouTube embed in it');
+    });
+
+    it('should render only image', () => {
+      const promoElements = {
+        showHeadline: false,
+        showImage: true,
+        showDescription: false,
+        showByline: false,
+        showDate: false,
+      };
+
+      const wrapper = mount(
+        <SearchResult
+          element={element}
+          arcSite="the-sun"
+          targetFallbackImage="/resource/example.jpg"
+          placeholderResizedImageOptions={{}}
+          promoElements={promoElements}
+        />,
+      );
+
+      const image = wrapper.find('.list-item').find('.results-list--image-container');
+      expect(image.length).toEqual(1);
+      expect(image.find('.list-anchor').length).toEqual(1);
+      expect(image.find('.list-anchor').prop('title')).toEqual('Article with a YouTube embed in it');
+      expect(image.find('Image').length).toEqual(1);
+      expect(image.find('Image').prop('alt')).toEqual('Article with a YouTube embed in it');
+    });
+
+    it('should render only description', () => {
+      const promoElements = {
+        showHeadline: false,
+        showImage: false,
+        showDescription: true,
+        showByline: false,
+        showDate: false,
+      };
+
+      const wrapper = mount(
+        <SearchResult
+          element={element}
+          arcSite="the-sun"
+          targetFallbackImage="/resource/example.jpg"
+          placeholderResizedImageOptions={{}}
+          promoElements={promoElements}
+        />,
+      );
+
+      const desc = wrapper.find('.list-item').find('.results-list--description-author-container');
+      expect(desc.length).toEqual(1);
+      expect(desc.find('p.description-text').length).toEqual(1);
+      expect(desc.find('p.description-text').text()).toEqual('Test article for YouTube responsiveness');
+      // check missing internal items
+    });
+
+    it('should render only byline', () => {
+      const promoElements = {
+        showHeadline: false,
+        showImage: false,
+        showDescription: false,
+        showByline: true,
+        showDate: false,
+      };
+
+      const wrapper = mount(
+        <SearchResult
+          element={element}
+          arcSite="the-sun"
+          targetFallbackImage="/resource/example.jpg"
+          placeholderResizedImageOptions={{}}
+          promoElements={promoElements}
+        />,
+      );
+
+      const desc = wrapper.find('.list-item').find('.results-list--description-author-container');
+      expect(desc.length).toEqual(1);
+      expect(desc.find('ArticleByline').length).toEqual(1);
+      // check internal items
+    });
+
+    it('should render only date', () => {
+      const promoElements = {
+        showHeadline: false,
+        showImage: false,
+        showDescription: false,
+        showByline: false,
+        showDate: true,
+      };
+
+      const wrapper = mount(
+        <SearchResult
+          element={element}
+          arcSite="the-sun"
+          targetFallbackImage="/resource/example.jpg"
+          placeholderResizedImageOptions={{}}
+          promoElements={promoElements}
+        />,
+      );
+
+      const desc = wrapper.find('.list-item').find('.results-list--description-author-container');
+      expect(desc.length).toEqual(1);
+      expect(desc.find('ArticleDate').length).toEqual(1);
+      // check internal items
+    });
+  });
+});

--- a/blocks/search-results-list-block/features/search-results-list/default.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/default.jsx
@@ -3,20 +3,39 @@ import PropTypes from 'prop-types';
 import { useAppContext } from 'fusion:context';
 import CustomSearchResultsList from './_children/custom-content';
 import GlobalContentSearch from './_children/global-content';
+import { resolveDefaultPromoElements } from './_children/helpers';
 
 const SearchResultsListContainer = (
   {
-    customFields: {
-      inheritGlobalContent = true,
-    } = {},
+    customFields = {},
     customSearchAction = null,
   } = {},
 ) => {
   const { arcSite } = useAppContext();
-  if (inheritGlobalContent) {
-    return <GlobalContentSearch arcSite={arcSite} customSearchAction={customSearchAction} />;
+  const { inheritGlobalContent } = customFields;
+  let showGlobalContent;
+
+  if (typeof inheritGlobalContent === 'undefined') {
+    showGlobalContent = (typeof searchContentConfig === 'undefined');
+  } else {
+    showGlobalContent = inheritGlobalContent;
   }
-  return <CustomSearchResultsList arcSite={arcSite} />;
+
+  if (showGlobalContent) {
+    return (
+      <GlobalContentSearch
+        arcSite={arcSite}
+        customSearchAction={customSearchAction}
+        promoElements={resolveDefaultPromoElements(customFields)}
+      />
+    );
+  }
+  return (
+    <CustomSearchResultsList
+      arcSite={arcSite}
+      promoElements={resolveDefaultPromoElements(customFields)}
+    />
+  );
 };
 
 SearchResultsListContainer.label = 'Search Results List – Arc Block';
@@ -30,6 +49,41 @@ SearchResultsListContainer.propTypes = {
     inheritGlobalContent: PropTypes.bool.tag({
       group: 'Configure Content',
     }),
+    showHeadline: PropTypes.bool.tag(
+      {
+        label: 'Show headline',
+        defaultValue: true,
+        group: 'Show promo elements',
+      },
+    ),
+    showImage: PropTypes.bool.tag(
+      {
+        label: 'Show image',
+        defaultValue: true,
+        group: 'Show promo elements',
+      },
+    ),
+    showDescription: PropTypes.bool.tag(
+      {
+        label: 'Show description',
+        defaultValue: true,
+        group: 'Show promo elements',
+      },
+    ),
+    showByline: PropTypes.bool.tag(
+      {
+        label: 'Show byline',
+        defaultValue: true,
+        group: 'Show promo elements',
+      },
+    ),
+    showDate: PropTypes.bool.tag(
+      {
+        label: 'Show date',
+        defaultValue: true,
+        group: 'Show promo elements',
+      },
+    ),
   }),
 };
 

--- a/blocks/search-results-list-block/features/search-results-list/default.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/default.test.jsx
@@ -17,6 +17,14 @@ jest.mock('fusion:properties', () => (jest.fn(() => ({
   fallbackImage: 'placeholder.jpg',
 }))));
 
+const defaultPromos = {
+  showByline: true,
+  showDate: true,
+  showDescription: true,
+  showHeadline: true,
+  showImage: true,
+};
+
 describe('the search results list feature block', () => {
   describe('when it is configured to inherit global content', () => {
     it('should render the global content search results list', () => {
@@ -32,38 +40,53 @@ describe('the search results list feature block', () => {
   });
 
   describe('when it is configured to NOT inherit global content', () => {
-    it('should render the global content search results list', () => {
-      const { default: SearchResultsListContainer } = require('./default');
+    const { default: SearchResultsListContainer } = require('./default');
 
-      const wrapper = shallow(
-        <SearchResultsListContainer
-          customFields={{ inheritGlobalContent: false, sectionContentConfig: {} }}
-          deployment={jest.fn((path) => path)}
-        />,
-      );
+    const wrapper = shallow(
+      <SearchResultsListContainer
+        customFields={{ inheritGlobalContent: false, sectionContentConfig: {} }}
+        deployment={jest.fn((path) => path)}
+      />,
+    );
+
+    it('should render the global content search results list', () => {
       expect(wrapper.is('CustomContentSearchResultsList')).toBeTruthy();
+    });
+
+    it('should render all promo items', () => {
+      expect(wrapper.find('CustomContentSearchResultsList').prop('promoElements')).toEqual(defaultPromos);
     });
   });
 
   describe('when customFields is empty', () => {
+    const { default: SearchResultsListContainer } = require('./default');
+    const wrapper = shallow(<SearchResultsListContainer
+      customFields={{}}
+      deployment={jest.fn((path) => path)}
+    />);
+
     it('should render the global content search results list', () => {
-      const { default: SearchResultsListContainer } = require('./default');
-      const wrapper = shallow(<SearchResultsListContainer
-        customFields={{}}
-        deployment={jest.fn((path) => path)}
-      />);
       expect(wrapper.is('GlobalContentSearchResultsList')).toBeTruthy();
+    });
+
+    it('should render all promo items', () => {
+      expect(wrapper.find('GlobalContentSearchResultsList').prop('promoElements')).toEqual(defaultPromos);
     });
   });
 
   describe('when customFields is missing', () => {
+    const { default: SearchResultsListContainer } = require('./default');
+    const wrapper = shallow(<SearchResultsListContainer
+      customFields={undefined}
+      deployment={jest.fn((path) => path)}
+    />);
+
     it('should render the global content search results list', () => {
-      const { default: SearchResultsListContainer } = require('./default');
-      const wrapper = shallow(<SearchResultsListContainer
-        customFields={undefined}
-        deployment={jest.fn((path) => path)}
-      />);
       expect(wrapper.is('GlobalContentSearchResultsList')).toBeTruthy();
+    });
+
+    it('should render all promo items', () => {
+      expect(wrapper.find('GlobalContentSearchResultsList').prop('promoElements')).toEqual(defaultPromos);
     });
   });
 });


### PR DESCRIPTION
[PEN-926](https://arcpublishing.atlassian.net/browse/PEN-926)

# What does this implement or fix?
- enable to select what promo items to show on the search result and result list blocks

# How was this tested?
- tests written
- visually on PB editor to check the blocks already on the pages

# Show Effect Of Changes

## Before

### Result List without promo blocks
![resultList_without_promoItems](https://user-images.githubusercontent.com/9757/87477173-12714680-c5fe-11ea-87bf-b4d47ad6c2ed.png)

### Search Result list without promo blocks
![resultList_without_promoItems](https://user-images.githubusercontent.com/9757/87477542-a8a56c80-c5fe-11ea-9f3a-0b14beca1b69.png)

## After

### Result List with promo blocks
![Screenshot from 2020-07-14 18-18-42](https://user-images.githubusercontent.com/9757/87477455-83b0f980-c5fe-11ea-902a-df48bc457178.png)

### Search Result list with promo blocks
![searchResult_with_promoItems](https://user-images.githubusercontent.com/9757/87477574-b824b580-c5fe-11ea-96de-08780cff12a3.png)

### Search Result already placed on an page and showing all elements by default
![searcResult_already_placed](https://user-images.githubusercontent.com/9757/87477623-cc68b280-c5fe-11ea-8104-8f64fc6c68e2.png)

# Dependencies or Side Effects

- none
