### PR TITLE
PEN-954 reduce padding top section layouts

### DIFF
--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
@@ -53,6 +53,7 @@ body {
     }
 
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
+      /* top | horizontal | bottom */
       padding: 0 0 map-get($spacers, 'lg');
     }
   }

--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
@@ -42,7 +42,7 @@ body {
   }
 
   .fullwidth-section {
-    padding: map-get($spacers, 'lg') 0 map-get($spacers, 'md');
+    padding: map-get($spacers, 'sm') 0 map-get($spacers, 'md');
 
     &.horizontal-borders {
       border-bottom: 1px solid $border-rule-color;
@@ -53,7 +53,7 @@ body {
     }
 
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding: map-get($spacers, 'lg') 0;
+      padding: 0 0 map-get($spacers, 'lg');
     }
   }
 

--- a/blocks/right-rail-block/layouts/right-rail/default.scss
+++ b/blocks/right-rail-block/layouts/right-rail/default.scss
@@ -53,6 +53,7 @@ body {
     }
 
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
+      /* top | horizontal | bottom */
       padding: 0 0 map-get($spacers, 'lg');
     }
   }

--- a/blocks/right-rail-block/layouts/right-rail/default.scss
+++ b/blocks/right-rail-block/layouts/right-rail/default.scss
@@ -42,7 +42,7 @@ body {
   }
 
   .fullwidth-section {
-    padding: map-get($spacers, 'lg') 0 map-get($spacers, 'md');
+    padding: map-get($spacers, 'sm') 0 map-get($spacers, 'md');
 
     &.horizontal-borders {
       border-bottom: 1px solid $border-rule-color;
@@ -53,7 +53,7 @@ body {
     }
 
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding: map-get($spacers, 'lg') 0;
+      padding: 0 0 map-get($spacers, 'lg');
     }
   }
 


### PR DESCRIPTION
[PEN-954](https://arcpublishing.atlassian.net/browse/PEN-954)

# What does this implement or fix?
- remove/reduce the top padding on head section

# How was this tested?
visually on PB using the home page template and right-rail-block and right-rail-advanced-block

# Show Effect Of Changes

## Before
desktop inside layout
![rr_desktop](https://user-images.githubusercontent.com/9757/87564006-426c2880-c696-11ea-81aa-7fd2e6c423b9.png)

desktop full width
![rr_desktop_fw](https://user-images.githubusercontent.com/9757/87564019-45ffaf80-c696-11ea-9248-139290e9dd55.png)

mobile inside layout
![rr_mobile](https://user-images.githubusercontent.com/9757/87564186-7d6e5c00-c696-11ea-8c08-ed386f6d94ed.png)

mobile full width
![rr_mobile_fw](https://user-images.githubusercontent.com/9757/87564234-8a8b4b00-c696-11ea-8bfe-353517829aee.png)


## After
desktop inside layout
![rr_desktop_reduced](https://user-images.githubusercontent.com/9757/87564348-a8f14680-c696-11ea-9b42-def51e3af8a1.png)

desktop full width
![rr_desktop_fw_reduced](https://user-images.githubusercontent.com/9757/87564375-b1498180-c696-11ea-9bb9-10f97bcc5e8b.png)

mobile inside layout
![rr_mobile_reduced](https://user-images.githubusercontent.com/9757/87564417-c0c8ca80-c696-11ea-90f3-acee32002abe.png)

mobile full width
![rr_mobile_fw_reduced](https://user-images.githubusercontent.com/9757/87564434-c58d7e80-c696-11ea-8c18-6281542e5a5a.png)

![2020_0715_120309](https://user-images.githubusercontent.com/9757/87564525-e48c1080-c696-11ea-870c-a91d60360eb4.png)
![2020_0715_115753](https://user-images.githubusercontent.com/9757/87564528-e655d400-c696-11ea-81cf-2aa7386ece3e.png)


# Dependencies or Side Effects

- none
