### PR TITLE
Added some optimizations for reducing canary build times

### DIFF
--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -14,14 +14,21 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+      - name: Cache NPM files
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
           node-version: '12'
           registry-url: 'https://npm.pkg.github.com'
-      - run: npm install
+      - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
-      - run: npx lerna publish 0.0.0-$(git rev-parse --short HEAD) --force-publish --no-git-tag-version --no-push --dist-tag canary --yes
+      - run: npx lerna publish 0.0.0-$(git rev-parse --short HEAD) --no-git-tag-version --no-push --dist-tag canary --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This does 3 things that should speed up our canary builds:
- Caching NPM files ([We're caching `~/.npm` instead of `node_modules` because that's what's recommended.](https://github.com/actions/cache/blob/main/examples.md#node---npm))
- `npm ci` instead of `npm install`
- Removing `--force-publish` from our publish command to reduce the number of packages being published.

No, I haven't tested this and I won't test this.
