### PR TITLE
PEN-1196 rework blocks spacing

### DIFF
--- a/blocks/card-list-block/features/card-list/card-list.scss
+++ b/blocks/card-list-block/features/card-list/card-list.scss
@@ -1,6 +1,23 @@
 .card-list-container {
-  @include block-margin-bottom;
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 2px 2px 0 rgba(0, 0, 0, 0.12), 0 1px 3px 0 rgba(0, 0, 0, 0.14);
+
+  hr {
+    margin-left: 16px;
+    margin-right: 16px;
+  }
+
+  .simple-results-list-container {
+    @include container-vertial-spacing;
+    @include container-hr-separator;
+
+    > *:last-child {
+      padding-bottom: map-get($spacers, 'lg');
+
+      @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
+        padding-bottom: map-get($spacers, 'md');
+      }
+    }
+  }
 }
 
 #card-list--link-container img {
@@ -16,6 +33,7 @@
   font-size: 20px;
   font-weight: bold;
   line-height: 24px;
+  margin-bottom: 0 !important;
   padding: 11px 0 11px 16px;
 }
 
@@ -39,7 +57,8 @@
 }
 
 .author-date {
-  padding: 16px;
+  // top, horizontal, botom
+  padding: 16px 16px 0;
 
   .dot-separator {
     color: $ui-primary-font-color;
@@ -71,14 +90,9 @@
 }
 
 .card-list-item {
-  box-shadow: inset 0 -1px 0 0 $ui-light-gray;
   display: flex;
   justify-content: space-between;
-  padding: 16px;
-
-  &:last-child {
-    box-shadow: none;
-  }
+  padding: 0 16px;
 
   .list-item-number {
     color: $ui-primary-font-color;

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -131,7 +131,7 @@ class CardList extends React.Component {
                   : ''
               }
               <div
-                className={`list-item-simple ${contentElements.length > 1 ? 'list-item-simple--divider' : ''}`}
+                className="list-item-simple"
                 key={`result-card-${contentElements[0].websites[arcSite].website_url}`}
               >
                 <a
@@ -211,62 +211,65 @@ class CardList extends React.Component {
                   } = element;
                   const url = element.websites[arcSite].website_url;
                   return (
-                    <div
-                      className="card-list-item"
-                      key={`result-card-${url}`}
-                      type="1"
-                    >
-                      <a
-                        href={websiteUrl}
-                        className="headline-list-anchor"
+                    <React.Fragment key={`result-card-${url}`}>
+                      <hr />
+                      <div
+                        className="card-list-item"
+                        key={`result-card-${url}`}
+                        type="1"
                       >
-                        <HeadlineText
-                          primaryFont={getThemeStyle(this.arcSite)['primary-font-family']}
-                          className="headline-text"
+                        <a
+                          href={websiteUrl}
+                          className="headline-list-anchor"
                         >
-                          {headlineText}
-                        </HeadlineText>
-                      </a>
-                      <a
-                        href={url}
-                        className="list-anchor-image"
-                      >
-                        {
-                          extractImage(element.promo_items)
-                            ? (
-                              <Image
-                                url={extractImage(element.promo_items)}
-                                alt={headlineText}
-                                // small, matches numbered list, is 3:2 aspect ratio
-                                smallWidth={105}
-                                smallHeight={70}
-                                mediumWidth={105}
-                                mediumHeight={70}
-                                largeWidth={274}
-                                largeHeight={183}
-                                resizedImageOptions={extractResizedParams(element)}
-                                breakpoints={getProperties(arcSite)?.breakpoints}
-                                resizerURL={getProperties(arcSite)?.resizerURL}
-                              />
-                            )
-                            : (
-                              <Image
-                                smallWidth={105}
-                                smallHeight={70}
-                                mediumWidth={105}
-                                mediumHeight={70}
-                                largeWidth={274}
-                                largeHeight={183}
-                                alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-                                url={targetFallbackImage}
-                                breakpoints={getProperties(arcSite)?.breakpoints}
-                                resizedImageOptions={placeholderResizedImageOptions}
-                                resizerURL={getProperties(arcSite)?.resizerURL}
-                              />
-                            )
-                        }
-                      </a>
-                    </div>
+                          <HeadlineText
+                            primaryFont={getThemeStyle(this.arcSite)['primary-font-family']}
+                            className="headline-text"
+                          >
+                            {headlineText}
+                          </HeadlineText>
+                        </a>
+                        <a
+                          href={url}
+                          className="list-anchor-image"
+                        >
+                          {
+                            extractImage(element.promo_items)
+                              ? (
+                                <Image
+                                  url={extractImage(element.promo_items)}
+                                  alt={headlineText}
+                                  // small, matches numbered list, is 3:2 aspect ratio
+                                  smallWidth={105}
+                                  smallHeight={70}
+                                  mediumWidth={105}
+                                  mediumHeight={70}
+                                  largeWidth={274}
+                                  largeHeight={183}
+                                  resizedImageOptions={extractResizedParams(element)}
+                                  breakpoints={getProperties(arcSite)?.breakpoints}
+                                  resizerURL={getProperties(arcSite)?.resizerURL}
+                                />
+                              )
+                              : (
+                                <Image
+                                  smallWidth={105}
+                                  smallHeight={70}
+                                  mediumWidth={105}
+                                  mediumHeight={70}
+                                  largeWidth={274}
+                                  largeHeight={183}
+                                  alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
+                                  url={targetFallbackImage}
+                                  breakpoints={getProperties(arcSite)?.breakpoints}
+                                  resizedImageOptions={placeholderResizedImageOptions}
+                                  resizerURL={getProperties(arcSite)?.resizerURL}
+                                />
+                              )
+                          }
+                        </a>
+                      </div>
+                    </React.Fragment>
                   );
                 })
               }

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -194,7 +194,7 @@ describe('Card list', () => {
       });
 
       it('should add the line divider when have multiple items', () => {
-        expect(wrapper.find('.list-item-simple--divider').length).toEqual(1);
+        expect(wrapper.find('hr').length).toEqual(27);
       });
     });
   });

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -123,7 +123,7 @@ const SampleOutputType = ({
               />
             </noscript>
           ) : null}
-        <div id="fusion-app">
+        <div id="fusion-app" className="layout-section">
           {children}
         </div>
         <Fusion />

--- a/blocks/double-chain-block/chains/double-chain/default.jsx
+++ b/blocks/double-chain-block/chains/double-chain/default.jsx
@@ -11,12 +11,12 @@ const DoubleChain = ({ children, customFields }) => {
     // check column one length not negative
     if (columnOneLength > 0) {
       return (
-        <div className="container-fluid double-chain">
-          <div className="row">
-            <div className="col-sm-12 col-md-xl-6 ie-flex-100-percent-sm column-1 reduce-internal-row-col-gap">
+        <div className="container-fluid double-chain chain-container">
+          <div className="row wrap-bottom">
+            <div className="col-sm-12 col-md-xl-6 ie-flex-100-percent-sm column-1 reduce-internal-row-col-gap chain-col">
               {children.slice(0, columnOneLength)}
             </div>
-            <div className="col-sm-12 col-md-xl-6 ie-flex-100-percent-sm column-2 reduce-internal-row-col-gap">
+            <div className="col-sm-12 col-md-xl-6 ie-flex-100-percent-sm column-2 reduce-internal-row-col-gap chain-col">
               {children.slice(columnOneLength)}
             </div>
           </div>

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -140,59 +140,62 @@ const ExtraLargePromo = ({ customFields }) => {
   const ratios = ratiosFor('XL', customFields.imageRatio);
 
   return content && (
-    <article className="container-fluid xl-large-promo">
-      <div className="row xl-promo-padding-bottom">
-        {(customFields.showHeadline || customFields.showDescription
-          || customFields.showByline || customFields.showDate)
-        && (
-          <div className="col-sm-xl-12 flex-col">
-            {overlineTmpl()}
-            {headlineTmpl()}
-            {customFields.showImage
-            && (
-              <a
-                href={content.website_url}
-                title={content && content.headlines ? content.headlines.basic : ''}
-              >
-                {customFields.imageOverrideURL || extractImage(content.promo_items)
-                  ? (
-                    <Image
-                      url={customFields.imageOverrideURL
-                        ? customFields.imageOverrideURL : extractImage(content.promo_items)}
-                      alt={content && content.headlines ? content.headlines.basic : ''}
-                      smallWidth={ratios.smallWidth}
-                      smallHeight={ratios.smallHeight}
-                      mediumWidth={ratios.mediumWidth}
-                      mediumHeight={ratios.mediumHeight}
-                      largeWidth={ratios.largeWidth}
-                      largeHeight={ratios.largeHeight}
-                      breakpoints={getProperties(arcSite)?.breakpoints}
-                      resizerURL={getProperties(arcSite)?.resizerURL}
-                      resizedImageOptions={extractResizedParams(content)}
-                      // todo: this should have resized params
-                    />
-                  )
-                  : (
-                    <PlaceholderImage
-                      smallWidth={ratios.smallWidth}
-                      smallHeight={ratios.smallHeight}
-                      mediumWidth={ratios.mediumWidth}
-                      mediumHeight={ratios.mediumHeight}
-                      largeWidth={ratios.largeWidth}
-                      largeHeight={ratios.largeHeight}
-                    />
-                  )}
-              </a>
-            )}
-            {descriptionTmpl()}
-            <div className="article-meta">
-              {byLineTmpl()}
-              {dateTmpl()}
+    <>
+      <article className="container-fluid xl-large-promo">
+        <div className="row">
+          {(customFields.showHeadline || customFields.showDescription
+            || customFields.showByline || customFields.showDate)
+          && (
+            <div className="col-sm-xl-12 flex-col">
+              {overlineTmpl()}
+              {headlineTmpl()}
+              {customFields.showImage
+              && (
+                <a
+                  href={content.website_url}
+                  title={content && content.headlines ? content.headlines.basic : ''}
+                >
+                  {customFields.imageOverrideURL || extractImage(content.promo_items)
+                    ? (
+                      <Image
+                        url={customFields.imageOverrideURL
+                          ? customFields.imageOverrideURL : extractImage(content.promo_items)}
+                        alt={content && content.headlines ? content.headlines.basic : ''}
+                        smallWidth={ratios.smallWidth}
+                        smallHeight={ratios.smallHeight}
+                        mediumWidth={ratios.mediumWidth}
+                        mediumHeight={ratios.mediumHeight}
+                        largeWidth={ratios.largeWidth}
+                        largeHeight={ratios.largeHeight}
+                        breakpoints={getProperties(arcSite)?.breakpoints}
+                        resizerURL={getProperties(arcSite)?.resizerURL}
+                        resizedImageOptions={extractResizedParams(content)}
+                        // todo: this should have resized params
+                      />
+                    )
+                    : (
+                      <PlaceholderImage
+                        smallWidth={ratios.smallWidth}
+                        smallHeight={ratios.smallHeight}
+                        mediumWidth={ratios.mediumWidth}
+                        mediumHeight={ratios.mediumHeight}
+                        largeWidth={ratios.largeWidth}
+                        largeHeight={ratios.largeHeight}
+                      />
+                    )}
+                </a>
+              )}
+              {descriptionTmpl()}
+              <div className="article-meta">
+                {byLineTmpl()}
+                {dateTmpl()}
+              </div>
             </div>
-          </div>
-        )}
-      </div>
-    </article>
+          )}
+        </div>
+      </article>
+      <hr />
+    </>
   );
 };
 

--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -91,7 +91,7 @@ const Footer = ({ customFields: { navigationConfig } }) => {
   );
 
   return (
-    <div className="container">
+    <div className="container layout-section">
       <div className="section-separator">
         <section className="footer-header">
           <div className="footer-row">

--- a/blocks/header-block/features/header/default.jsx
+++ b/blocks/header-block/features/header/default.jsx
@@ -37,14 +37,14 @@ class Header extends React.Component {
     this.state = { };
   }
 
-  getHeader(text, removeBottomPadding) {
+  getHeader(text) {
     const { arcSite, customFields: { size } = {} } = this.props;
     switch (size) {
       case 'Extra Large':
         return (
           <ExtraLargeHeader
             primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-            className={`header-block ${removeBottomPadding ? 'no-bottom-margin' : ''}`}
+            className="header-block"
           >
             {text}
           </ExtraLargeHeader>
@@ -53,7 +53,7 @@ class Header extends React.Component {
         return (
           <LargeHeader
             primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-            className={`header-block ${removeBottomPadding ? 'no-bottom-margin' : ''}`}
+            className="header-block"
           >
             {text}
           </LargeHeader>
@@ -62,7 +62,7 @@ class Header extends React.Component {
         return (
           <MediumHeader
             primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-            className={`header-block ${removeBottomPadding ? 'no-bottom-margin' : ''}`}
+            className="header-block"
           >
             {text}
           </MediumHeader>
@@ -71,7 +71,7 @@ class Header extends React.Component {
         return (
           <SmallHeader
             primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-            className={`header-block ${removeBottomPadding ? 'no-bottom-margin' : ''}`}
+            className="header-block"
           >
             {text}
           </SmallHeader>
@@ -80,7 +80,7 @@ class Header extends React.Component {
         return (
           <MediumHeader
             primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-            className={`header-block ${removeBottomPadding ? 'no-bottom-margin' : ''}`}
+            className="header-block"
           >
             {text}
           </MediumHeader>
@@ -89,8 +89,8 @@ class Header extends React.Component {
   }
 
   render() {
-    const { customFields: { text = '', removeBottomPadding = false } } = this.props;
-    return this.getHeader(text, removeBottomPadding);
+    const { customFields: { text = '' } } = this.props;
+    return this.getHeader(text);
   }
 }
 
@@ -98,12 +98,6 @@ Header.propTypes = {
   customFields: PropTypes.shape({
     text: PropTypes.string,
     size: PropTypes.oneOf(['Extra Large', 'Large', 'Medium', 'Small']),
-    removeBottomPadding: PropTypes.bool.tag(
-      {
-        label: 'Remove bottom padding',
-        defaultValue: false,
-      },
-    ),
   }),
 };
 

--- a/blocks/header-block/features/header/default.test.jsx
+++ b/blocks/header-block/features/header/default.test.jsx
@@ -11,7 +11,6 @@ describe('The header block', () => {
     const customFields = {
       text: 'Header',
       size: 'Extra Large',
-      removeBottomPadding: false,
     };
     const wrapper = shallow(<Header customFields={customFields} />);
 
@@ -25,20 +24,7 @@ describe('The header block', () => {
     });
 
     it('should have the appropriate class', () => {
-      expect(wrapper).toHaveProp('className', 'header-block ');
-    });
-  });
-
-  describe('when bottom margin is removed by user', () => {
-    const customFields = {
-      text: 'Header',
-      size: 'Extra Large',
-      removeBottomPadding: true,
-    };
-    const wrapper = shallow(<Header customFields={customFields} />);
-
-    it('should have the appropriate class', () => {
-      expect(wrapper).toHaveProp('className', 'header-block no-bottom-margin');
+      expect(wrapper).toHaveProp('className', 'header-block');
     });
   });
 

--- a/blocks/header-block/features/header/header.scss
+++ b/blocks/header-block/features/header/header.scss
@@ -1,9 +1,4 @@
 .header-block {
   color: $ui-primary-font-color;
   font-weight: bold;
-  margin-bottom: map-get($spacers, 'md');
-
-  &.no-bottom-margin {
-    margin-bottom: 0;
-  }
 }

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -142,64 +142,67 @@ const LargePromo = ({ customFields }) => {
   const ratios = ratiosFor('LG', customFields.imageRatio);
 
   return content ? (
-    <article className="container-fluid large-promo">
-      <div className="row lg-promo-padding-bottom">
-        {customFields.showImage
-        && (
-          <div className="col-sm-12 col-md-xl-6">
-            <a
-              href={content.website_url}
-              title={content && content.headlines ? content.headlines.basic : ''}
-            >
-              {
-                customFields.imageOverrideURL || extractImage(content.promo_items)
-                  ? (
-                    <Image
-                      url={customFields.imageOverrideURL
-                        ? customFields.imageOverrideURL : extractImage(content.promo_items)}
-                      alt={content && content.headlines ? content.headlines.basic : ''}
-                      // large is 4:3 aspect ratio
-                      smallWidth={ratios.smallWidth}
-                      smallHeight={ratios.smallHeight}
-                      mediumWidth={ratios.mediumWidth}
-                      mediumHeight={ratios.mediumHeight}
-                      largeWidth={ratios.largeWidth}
-                      largeHeight={ratios.largeHeight}
-                      breakpoints={getProperties(arcSite)?.breakpoints}
-                      resizerURL={getProperties(arcSite)?.resizerURL}
-                      resizedImageOptions={extractResizedParams(content)}
-                      // todo: should have resized params
-                    />
-                  )
-                  : (
-                    <PlaceholderImage
-                      smallWidth={ratios.smallWidth}
-                      smallHeight={ratios.smallHeight}
-                      mediumWidth={ratios.mediumWidth}
-                      mediumHeight={ratios.mediumHeight}
-                      largeWidth={ratios.largeWidth}
-                      largeHeight={ratios.largeHeight}
-                    />
-                  )
-}
-            </a>
-          </div>
-        )}
-        {(customFields.showHeadline || customFields.showDescription
-          || customFields.showByline || customFields.showDate)
-        && (
-          <div className={textClass}>
-            {overlineTmpl()}
-            {headlineTmpl()}
-            {descriptionTmpl()}
-            <div className="article-meta">
-              {byLineTmpl()}
-              {dateTmpl()}
+    <>
+      <article className="container-fluid large-promo">
+        <div className="row">
+          {customFields.showImage
+          && (
+            <div className="col-sm-12 col-md-xl-6">
+              <a
+                href={content.website_url}
+                title={content && content.headlines ? content.headlines.basic : ''}
+              >
+                {
+                  customFields.imageOverrideURL || extractImage(content.promo_items)
+                    ? (
+                      <Image
+                        url={customFields.imageOverrideURL
+                          ? customFields.imageOverrideURL : extractImage(content.promo_items)}
+                        alt={content && content.headlines ? content.headlines.basic : ''}
+                        // large is 4:3 aspect ratio
+                        smallWidth={ratios.smallWidth}
+                        smallHeight={ratios.smallHeight}
+                        mediumWidth={ratios.mediumWidth}
+                        mediumHeight={ratios.mediumHeight}
+                        largeWidth={ratios.largeWidth}
+                        largeHeight={ratios.largeHeight}
+                        breakpoints={getProperties(arcSite)?.breakpoints}
+                        resizerURL={getProperties(arcSite)?.resizerURL}
+                        resizedImageOptions={extractResizedParams(content)}
+                        // todo: should have resized params
+                      />
+                    )
+                    : (
+                      <PlaceholderImage
+                        smallWidth={ratios.smallWidth}
+                        smallHeight={ratios.smallHeight}
+                        mediumWidth={ratios.mediumWidth}
+                        mediumHeight={ratios.mediumHeight}
+                        largeWidth={ratios.largeWidth}
+                        largeHeight={ratios.largeHeight}
+                      />
+                    )
+  }
+              </a>
             </div>
-          </div>
-        )}
-      </div>
-    </article>
+          )}
+          {(customFields.showHeadline || customFields.showDescription
+            || customFields.showByline || customFields.showDate)
+          && (
+            <div className={textClass}>
+              {overlineTmpl()}
+              {headlineTmpl()}
+              {descriptionTmpl()}
+              <div className="article-meta">
+                {byLineTmpl()}
+                {dateTmpl()}
+              </div>
+            </div>
+          )}
+        </div>
+      </article>
+      <hr />
+    </>
   ) : null;
 };
 

--- a/blocks/links-bar-block/features/links-bar/default.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.jsx
@@ -30,33 +30,36 @@ const LinksBar = ({ customFields: { navigationConfig = {} } }) => {
   );
 
   return (
-    <nav key={id} className="links-bar">
-      {menuItems && menuItems.map((item, index) => (
-        <LinkBarSpan
-          className="links-menu"
-          key={item._id}
-          primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-        >
-          {
-            item.node_type === 'link'
-              ? (
-                <Link
-                  href={item.url}
-                  name={item.display_name}
-                  showSeparator={content.children.length !== index + 1 && showSeparator}
-                />
-              )
-              : (
-                <Link
-                  href={item._id}
-                  name={item.name}
-                  showSeparator={content.children.length !== index + 1 && showSeparator}
-                />
-              )
-          }
-        </LinkBarSpan>
-      ))}
-    </nav>
+    <>
+      <nav key={id} className="links-bar">
+        {menuItems && menuItems.map((item, index) => (
+          <LinkBarSpan
+            className="links-menu"
+            key={item._id}
+            primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+          >
+            {
+              item.node_type === 'link'
+                ? (
+                  <Link
+                    href={item.url}
+                    name={item.display_name}
+                    showSeparator={content.children.length !== index + 1 && showSeparator}
+                  />
+                )
+                : (
+                  <Link
+                    href={item._id}
+                    name={item.name}
+                    showSeparator={content.children.length !== index + 1 && showSeparator}
+                  />
+                )
+            }
+          </LinkBarSpan>
+        ))}
+      </nav>
+      <hr />
+    </>
   );
 };
 

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -35,7 +35,7 @@ describe('the links bar feature for the default output type', () => {
     }));
     const wrapper = shallow(<LinksBar customFields={{ navigationConfig: 'links' }} />);
 
-    expect(wrapper.at(0).type()).toBe('nav');
+    expect(wrapper.children().at(0).type()).toBe('nav');
   });
 
   it('should contain the equal number of links between input and output', () => {

--- a/blocks/links-bar-block/features/links-bar/links-bar.scss
+++ b/blocks/links-bar-block/features/links-bar/links-bar.scss
@@ -1,12 +1,9 @@
 .links-bar {
   @include block-margin-bottom;
   align-items: center;
-  box-shadow: inset 0 -1px 0 0 $ui-light-gray;
-  height: calculateRem(60px);
   text-align: left;
   width: 100%;
   @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-    height: calculateRem(40px);
     text-align: center;
   }
 

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -113,62 +113,65 @@ const MediumPromo = ({ customFields }) => {
   const ratios = ratiosFor('MD', customFields.imageRatio);
 
   return content ? (
-    <article className="container-fluid medium-promo">
-      <div className="row med-promo-padding-bottom">
-        {customFields.showImage
-        && (
-          <div className="col-sm-12 col-md-xl-4">
-            <a
-              href={content.website_url}
-              title={content && content.headlines ? content.headlines.basic : ''}
-            >
-              {
-                customFields.imageOverrideURL || extractImage(content.promo_items)
-                  ? (
-                    <Image
-                      url={customFields.imageOverrideURL
-                        ? customFields.imageOverrideURL : extractImage(content.promo_items)}
-                      alt={content && content.headlines ? content.headlines.basic : ''}
-                      // medium is 16:9
-                      smallWidth={ratios.smallWidth}
-                      smallHeight={ratios.smallHeight}
-                      mediumWidth={ratios.mediumWidth}
-                      mediumHeight={ratios.mediumHeight}
-                      largeWidth={ratios.largeWidth}
-                      largeHeight={ratios.largeHeight}
-                      breakpoints={getProperties(arcSite)?.breakpoints}
-                      resizerURL={getProperties(arcSite)?.resizerURL}
-                      resizedImageOptions={extractResizedParams(content)}
-                    />
-                  )
-                  : (
-                    <PlaceholderImage
-                      smallWidth={ratios.smallWidth}
-                      smallHeight={ratios.smallHeight}
-                      mediumWidth={ratios.mediumWidth}
-                      mediumHeight={ratios.mediumHeight}
-                      largeWidth={ratios.largeWidth}
-                      largeHeight={ratios.largeHeight}
-                    />
-                  )
-                }
-            </a>
-          </div>
-        )}
-        {(customFields.showHeadline || customFields.showDescription
-          || customFields.showByline || customFields.showDate)
-        && (
-          <div className={textClass}>
-            {headlineTmpl()}
-            {descriptionTmpl()}
-            <div className="article-meta">
-              {byLineTmpl()}
-              {dateTmpl()}
+    <>
+      <article className="container-fluid medium-promo">
+        <div className="row med-promo-padding-bottom">
+          {customFields.showImage
+          && (
+            <div className="col-sm-12 col-md-xl-4">
+              <a
+                href={content.website_url}
+                title={content && content.headlines ? content.headlines.basic : ''}
+              >
+                {
+                  customFields.imageOverrideURL || extractImage(content.promo_items)
+                    ? (
+                      <Image
+                        url={customFields.imageOverrideURL
+                          ? customFields.imageOverrideURL : extractImage(content.promo_items)}
+                        alt={content && content.headlines ? content.headlines.basic : ''}
+                        // medium is 16:9
+                        smallWidth={ratios.smallWidth}
+                        smallHeight={ratios.smallHeight}
+                        mediumWidth={ratios.mediumWidth}
+                        mediumHeight={ratios.mediumHeight}
+                        largeWidth={ratios.largeWidth}
+                        largeHeight={ratios.largeHeight}
+                        breakpoints={getProperties(arcSite)?.breakpoints}
+                        resizerURL={getProperties(arcSite)?.resizerURL}
+                        resizedImageOptions={extractResizedParams(content)}
+                      />
+                    )
+                    : (
+                      <PlaceholderImage
+                        smallWidth={ratios.smallWidth}
+                        smallHeight={ratios.smallHeight}
+                        mediumWidth={ratios.mediumWidth}
+                        mediumHeight={ratios.mediumHeight}
+                        largeWidth={ratios.largeWidth}
+                        largeHeight={ratios.largeHeight}
+                      />
+                    )
+                  }
+              </a>
             </div>
-          </div>
-        )}
-      </div>
-    </article>
+          )}
+          {(customFields.showHeadline || customFields.showDescription
+            || customFields.showByline || customFields.showDate)
+          && (
+            <div className={textClass}>
+              {headlineTmpl()}
+              {descriptionTmpl()}
+              <div className="article-meta">
+                {byLineTmpl()}
+                {dateTmpl()}
+              </div>
+            </div>
+          )}
+        </div>
+      </article>
+      <hr />
+    </>
   ) : null;
 };
 

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -91,7 +91,7 @@ class NumberedList extends Component {
     const targetFallbackImage = this.getFallbackImageURL();
 
     return (
-      <div className="numbered-list-container">
+      <div className="numbered-list-container layout-section">
         {(title !== '' && contentElements && contentElements.length) ? (
           <Title className="list-title" primaryFont={this.primaryFont}>
             {title}
@@ -110,58 +110,61 @@ class NumberedList extends Component {
           const url = websites[arcSite].website_url;
 
           return (
-            <div className="numbered-list-item" key={`result-card-${url}`} type="1">
-              {showHeadline
-              && (
-              <a
-                href={url}
-                title={headlineText}
-                className="headline-list-anchor"
-              >
-                <Number secondaryFont={getThemeStyle(this.arcSite)['secondary-font-family']} className="list-item-number">{i + 1}</Number>
-                <HeadlineText primaryFont={getThemeStyle(this.arcSite)['primary-font-family']} className="headline-text">{headlineText}</HeadlineText>
-              </a>
-              )}
-              {showImage
-              && (
-              <a
-                href={url}
-                title={headlineText}
-                className="list-anchor-image"
-              >
-                {extractImage(promoItems) ? (
-                  <Image
-                    resizedImageOptions={extractResizedParams(element)}
-                    url={extractImage(promoItems)}
-                    alt={headlineText}
-                    // small, including numbered list, is 3:2 aspect ratio
-                    smallWidth={105}
-                    smallHeight={70}
-                    mediumWidth={105}
-                    mediumHeight={70}
-                    largeWidth={274}
-                    largeHeight={183}
-                    breakpoints={getProperties(arcSite)?.breakpoints}
-                    resizerURL={getProperties(arcSite)?.resizerURL}
-                  />
-                ) : (
-                  <Image
-                    smallWidth={105}
-                    smallHeight={70}
-                    mediumWidth={105}
-                    mediumHeight={70}
-                    largeWidth={274}
-                    largeHeight={183}
-                    alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-                    url={targetFallbackImage}
-                    breakpoints={getProperties(arcSite)?.breakpoints}
-                    resizedImageOptions={placeholderResizedImageOptions}
-                    resizerURL={getProperties(arcSite)?.resizerURL}
-                  />
+            <React.Fragment key={`result-card-${url}`}>
+              <div className="numbered-list-item" key={`result-card-${url}`} type="1">
+                {showHeadline
+                && (
+                <a
+                  href={url}
+                  title={headlineText}
+                  className="headline-list-anchor"
+                >
+                  <Number secondaryFont={getThemeStyle(this.arcSite)['secondary-font-family']} className="list-item-number">{i + 1}</Number>
+                  <HeadlineText primaryFont={getThemeStyle(this.arcSite)['primary-font-family']} className="headline-text">{headlineText}</HeadlineText>
+                </a>
                 )}
-              </a>
-              )}
-            </div>
+                {showImage
+                && (
+                <a
+                  href={url}
+                  title={headlineText}
+                  className="list-anchor-image"
+                >
+                  {extractImage(promoItems) ? (
+                    <Image
+                      resizedImageOptions={extractResizedParams(element)}
+                      url={extractImage(promoItems)}
+                      alt={headlineText}
+                      // small, including numbered list, is 3:2 aspect ratio
+                      smallWidth={105}
+                      smallHeight={70}
+                      mediumWidth={105}
+                      mediumHeight={70}
+                      largeWidth={274}
+                      largeHeight={183}
+                      breakpoints={getProperties(arcSite)?.breakpoints}
+                      resizerURL={getProperties(arcSite)?.resizerURL}
+                    />
+                  ) : (
+                    <Image
+                      smallWidth={105}
+                      smallHeight={70}
+                      mediumWidth={105}
+                      mediumHeight={70}
+                      largeWidth={274}
+                      largeHeight={183}
+                      alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
+                      url={targetFallbackImage}
+                      breakpoints={getProperties(arcSite)?.breakpoints}
+                      resizedImageOptions={placeholderResizedImageOptions}
+                      resizerURL={getProperties(arcSite)?.resizerURL}
+                    />
+                  )}
+                </a>
+                )}
+              </div>
+              <hr />
+            </React.Fragment>
           );
         }) : null}
       </div>

--- a/blocks/numbered-list-block/features/numbered-list/default.test.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.test.jsx
@@ -92,12 +92,12 @@ describe('The numbered-list-block', () => {
       wrapper.setState({ resultList: mockData }, () => {
         wrapper.update();
         expect(wrapper.find('.numbered-list-container').length).toEqual(1);
-        expect(wrapper.find('.numbered-list-container').childAt(3).type()).toEqual('div');
-        expect(wrapper.find('.numbered-list-container').childAt(3).find('.list-anchor-image').length).toEqual(1);
-        const placeholderImage = wrapper.find('.numbered-list-container').childAt(3).find('.list-anchor-image').children();
+        expect(wrapper.find('.numbered-list-container').childAt(4).type()).toEqual('div');
+        expect(wrapper.find('.numbered-list-container').childAt(4).find('.list-anchor-image').length).toEqual(1);
+        const placeholderImage = wrapper.find('.numbered-list-container').childAt(4).find('.list-anchor-image').children();
         // the placeholder component is mocked globally in jest mocks with this alt tag
         expect(placeholderImage.html()).toEqual('<img alt="test"/>');
-        expect(wrapper.find('.numbered-list-container').childAt(3).find('.headline-list-anchor').find('.headline-text')
+        expect(wrapper.find('.numbered-list-container').childAt(6).find('.headline-list-anchor').find('.headline-text')
           .text()).toEqual('Story with video as the Lead Art');
       });
     });

--- a/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
+++ b/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
@@ -1,6 +1,4 @@
 .numbered-list-container {
-  @include block-margin-bottom;
-
   .list-title {
     color: $ui-primary-font-color;
     font-size: calculateRem(20px);
@@ -10,10 +8,8 @@
 }
 
 .numbered-list-item {
-  box-shadow: inset 0 -1px 0 0 $ui-light-gray;
   display: flex;
   justify-content: space-between;
-  padding: map-get($spacers, 'sm') 0 map-get($spacers, 'sm') 0;
 
   .list-item-number {
     color: $ui-dark-secondary-color;

--- a/blocks/quad-chain-block/chains/quad-chain/default.jsx
+++ b/blocks/quad-chain-block/chains/quad-chain/default.jsx
@@ -18,18 +18,18 @@ const QuadChain = ({ children, customFields }) => {
       const endOfColumnThreeIndex = endOfColumnTwoIndex + columnThreeLength;
 
       return (
-        <div className="container-fluid">
-          <div className="row">
-            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap">
+        <div className="container-fluid chain-container">
+          <div className="row wrap-bottom">
+            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap chain-col">
               {children.slice(0, columnOneLength)}
             </div>
-            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap">
+            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap chain-col">
               {children.slice(columnOneLength, endOfColumnTwoIndex)}
             </div>
-            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap">
+            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap chain-col">
               {children.slice(endOfColumnTwoIndex, endOfColumnThreeIndex)}
             </div>
-            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap">
+            <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap chain-col">
               {children.slice(endOfColumnThreeIndex)}
             </div>
           </div>

--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
@@ -52,7 +52,7 @@ const RightRailAdvancedLayout = ({ children }) => {
   const mobileTabletLayout = (
     <>
       <div className="row">
-        <div className="col-sm-md-12 col-lg-xl-8 left-article-section ie-flex-100-percent-sm">
+        <div className="col-sm-md-12 col-lg-xl-8 left-article-section ie-flex-100-percent-sm layout-section">
           {/* Main Content Area */}
           {rightRailTop}
           {main}
@@ -67,12 +67,12 @@ const RightRailAdvancedLayout = ({ children }) => {
   const desktopLayout = (
     <>
       <div className="row">
-        <div className="col-sm-md-12 col-lg-xl-8 left-article-section ie-flex-100-percent-sm">
+        <div className="col-sm-md-12 col-lg-xl-8 left-article-section ie-flex-100-percent-sm layout-section">
           {/* Main Content Area */}
           {main}
           {main2}
         </div>
-        <aside className="col-sm-md-12 col-lg-xl-4 right-article-section ie-flex-100-percent-sm">
+        <aside className="col-sm-md-12 col-lg-xl-4 right-article-section ie-flex-100-percent-sm layout-section">
           {/* Right Rail Content Area */}
           {rightRailTop}
           {rightRailMiddle}
@@ -86,16 +86,16 @@ const RightRailAdvancedLayout = ({ children }) => {
     <>
       <header className="page-header">{navigation}</header>
       <section role="main" className="main">
-        <div className="container">
+        <div className="container layout-section">
           <div className="row">
-            <div className="col-sm-xl-12 fullwidth-section horizontal-borders">
+            <div className="col-sm-xl-12 layout-section wrap-bottom">
               {fullwidth1}
             </div>
           </div>
           {isDesktop ? desktopLayout : mobileTabletLayout }
           {featureList['7'] > 0 && (
             <div className="row">
-              <div className="col-sm-xl-12">
+              <div className="col-sm-xl-12 layout-section wrap-bottom">
                 {fullWidth2}
               </div>
             </div>

--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
@@ -17,20 +17,11 @@ body {
 
   .main {
     flex-grow: 1;
-    padding-bottom: calculateRem(56px);
-    padding-top: 54px;
+    padding-top: calc(56px + #{map-get($spacers, 'lg')});
     width: 100%;
 
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding-bottom: calculateRem(52px);
-    }
-
-    @media screen and (min-width: map-get($grid-breakpoints, 'lg')) {
-      padding-bottom: calculateRem(64px);
-    }
-
-    @media screen and (min-width: map-get($grid-breakpoints, 'xl')) {
-      padding-bottom: calculateRem(56px);
+      padding-top: calc(56px + #{map-get($spacers, 'md')});
     }
 
     @media screen and (max-width: 95rem) and (min-width: 90rem) {
@@ -38,22 +29,6 @@ body {
         margin-left: 5%;
         margin-right: 5%;
       }
-    }
-  }
-
-  .fullwidth-section {
-    padding: map-get($spacers, 'lg') 0 map-get($spacers, 'md');
-
-    &.horizontal-borders {
-      border-bottom: 1px solid $border-rule-color;
-
-      &:empty {
-        border: none;
-      }
-    }
-
-    @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding: map-get($spacers, 'lg') 0;
     }
   }
 
@@ -68,17 +43,4 @@ body {
   .right-article-section {
     padding: 0;
   }
-
-  .section-padding {
-    padding: map-get($spacers, 'sm');
-
-    @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding: map-get($spacers, 'md');
-    }
-
-    @media screen and (min-width: map-get($grid-breakpoints, 'lg')) {
-      padding: map-get($spacers, 'ld');
-    }
-  }
-
 }

--- a/blocks/right-rail-block/layouts/right-rail/default.jsx
+++ b/blocks/right-rail-block/layouts/right-rail/default.jsx
@@ -22,25 +22,25 @@ const RightRailLayout = ({ children }) => {
     <>
       <header className="page-header">{navigation}</header>
       <section role="main" className="main">
-        <div className="container">
+        <div className="container layout-section">
           <div className="row">
-            <div className="col-sm-xl-12 fullwidth-section horizontal-borders">
+            <div className="col-sm-xl-12 layout-section wrap-bottom">
               {fullWidth1}
             </div>
           </div>
 
           <div className="row">
-            <div className="col-sm-md-12 col-lg-xl-8 left-article-section ie-flex-100-percent-sm">
+            <div className="col-sm-md-12 col-lg-xl-8 left-article-section ie-flex-100-percent-sm layout-section">
               {main}
             </div>
-            <aside className="col-sm-md-12 col-lg-xl-4 right-article-section ie-flex-100-percent-sm">
+            <aside className="col-sm-md-12 col-lg-xl-4 right-article-section ie-flex-100-percent-sm layout-section wrap-bottom">
               {rightRail}
             </aside>
           </div>
 
           {featureList['4'] > 0 && (
             <div className="row">
-              <div className="col-sm-xl-12">
+              <div className="col-sm-xl-12 layout-section wrap-bottom">
                 {fullWidth2}
               </div>
             </div>

--- a/blocks/right-rail-block/layouts/right-rail/default.scss
+++ b/blocks/right-rail-block/layouts/right-rail/default.scss
@@ -17,20 +17,11 @@ body {
 
   .main {
     flex-grow: 1;
-    padding-bottom: calculateRem(56px);
-    padding-top: 54px;
+    padding-top: calc(56px + #{map-get($spacers, 'lg')});
     width: 100%;
 
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding-bottom: calculateRem(52px);
-    }
-
-    @media screen and (min-width: map-get($grid-breakpoints, 'lg')) {
-      padding-bottom: calculateRem(64px);
-    }
-
-    @media screen and (min-width: map-get($grid-breakpoints, 'xl')) {
-      padding-bottom: calculateRem(56px);
+      padding-top: calc(56px + #{map-get($spacers, 'md')});
     }
 
     @media screen and (max-width: 95rem) and (min-width: 90rem) {
@@ -38,22 +29,6 @@ body {
         margin-left: 5%;
         margin-right: 5%;
       }
-    }
-  }
-
-  .fullwidth-section {
-    padding: map-get($spacers, 'lg') 0 map-get($spacers, 'md');
-
-    &.horizontal-borders {
-      border-bottom: 1px solid $border-rule-color;
-
-      &:empty {
-        border: none;
-      }
-    }
-
-    @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding: map-get($spacers, 'lg') 0;
     }
   }
 
@@ -68,17 +43,4 @@ body {
   .right-article-section {
     padding: 0;
   }
-
-  .section-padding {
-    padding: map-get($spacers, 'sm');
-
-    @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding: map-get($spacers, 'md');
-    }
-
-    @media screen and (min-width: map-get($grid-breakpoints, 'lg')) {
-      padding: map-get($spacers, 'ld');
-    }
-  }
-
 }

--- a/blocks/shared-styles/scss/_extra-large-promo.scss
+++ b/blocks/shared-styles/scss/_extra-large-promo.scss
@@ -1,11 +1,5 @@
 .xl-large-promo {
-  @include block-margin-bottom;
-  box-shadow: inset 0 -1px 0 0 $ui-light-gray;
   color: $ui-primary-font-color;
-
-  .xl-promo-padding-bottom {
-    padding-bottom: map-get($spacers, 'md');
-  }
 
   a {
     color: $ui-primary-font-color;

--- a/blocks/shared-styles/scss/_large-promo.scss
+++ b/blocks/shared-styles/scss/_large-promo.scss
@@ -1,14 +1,8 @@
 .large-promo {
-  @include block-margin-bottom;
-  box-shadow: inset 0 -1px 0 0 $ui-light-gray;
   color: $ui-primary-font-color;
 
   a {
     color: $ui-primary-font-color;
-  }
-
-  .lg-promo-padding-bottom {
-    padding-bottom: map-get($spacers, 'md');
   }
 
   .overline {

--- a/blocks/shared-styles/scss/_medium-promo.scss
+++ b/blocks/shared-styles/scss/_medium-promo.scss
@@ -1,14 +1,8 @@
 .medium-promo {
-  @include block-margin-bottom;
-  box-shadow: inset 0 -1px 0 0 $ui-light-gray;
   color: $ui-primary-font-color;
 
   a {
     color: $ui-primary-font-color;
-  }
-
-  .med-promo-padding-bottom {
-    padding-bottom: map-get($spacers, 'md');
   }
 
   .md-promo-headline {

--- a/blocks/shared-styles/scss/_small-promo.scss
+++ b/blocks/shared-styles/scss/_small-promo.scss
@@ -1,7 +1,5 @@
 .small-promo {
-  box-shadow: inset 0 -1px 0 0 $ui-light-gray;
   color: $ui-primary-font-color;
-  margin-bottom: 0;
   margin-top: 0;
 
   a {
@@ -24,13 +22,6 @@
   img {
     height: auto;
     max-width: 100%;
-  }
-
-  .sm-promo-padding-btm {
-    margin-bottom: 0;
-    margin-top: 0;
-    padding-bottom: map-get($spacers, 'md');
-    padding-top: map-get($spacers, 'md');
   }
 }
 

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -113,7 +113,7 @@ const SimpleList = (props) => {
   }) || {};
 
   return (
-    <div key={id} className="list-container">
+    <div key={id} className="list-container layout-section">
       <Title className="list-title" primaryFont={primaryFont}>
         {title}
       </Title>
@@ -121,21 +121,24 @@ const SimpleList = (props) => {
         contentElements.reduce(unserializeStory(arcSite), []).map(({
           id: listItemId, itemTitle, imageURL, websiteURL, resizedImageOptions,
         }) => (
-          <StoryItem
-            key={listItemId}
-            id={listItemId}
-            itemTitle={itemTitle}
-            imageURL={imageURL}
-            primaryFont={primaryFont}
-            websiteURL={websiteURL}
-            websiteDomain={websiteDomain}
-            showHeadline={showHeadline}
-            showImage={showImage}
-            resizedImageOptions={resizedImageOptions}
-            placeholderResizedImageOptions={placeholderResizedImageOptions}
-            targetFallbackImage={targetFallbackImage}
-            arcSite={arcSite}
-          />
+          <React.Fragment key={listItemId}>
+            <StoryItem
+              key={listItemId}
+              id={listItemId}
+              itemTitle={itemTitle}
+              imageURL={imageURL}
+              primaryFont={primaryFont}
+              websiteURL={websiteURL}
+              websiteDomain={websiteDomain}
+              showHeadline={showHeadline}
+              showImage={showImage}
+              resizedImageOptions={resizedImageOptions}
+              placeholderResizedImageOptions={placeholderResizedImageOptions}
+              targetFallbackImage={targetFallbackImage}
+              arcSite={arcSite}
+            />
+            <hr />
+          </React.Fragment>
         ))
       }
     </div>

--- a/blocks/simple-list-block/features/simple-list/simple-list.scss
+++ b/blocks/simple-list-block/features/simple-list/simple-list.scss
@@ -1,5 +1,4 @@
 .list-container {
-  @include block-margin-bottom;
   padding-left: 0;
   padding-right: 0;
   padding-top: 0;
@@ -12,11 +11,9 @@
   }
 
   .list-item-simple {
-    box-shadow: inset 0 -1px 0 0 $ui-light-gray;
     display: flex;
     justify-content: flex-start;
     min-height: 72px;
-    padding: map-get($spacers, 'sm') 0 map-get($spacers, 'sm') 0;
 
     .simple-list-anchor {
       flex: 0 0 33%;

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -38,67 +38,70 @@ const SmallPromo = ({ customFields }) => {
   const ratios = ratiosFor('SM', customFields.imageRatio);
 
   return content ? (
-    <article className="container-fluid small-promo">
-      <div className="row sm-promo-padding-btm">
-        {customFields.showHeadline
-        && (
-          <div className={headlineClass}>
-            <a
-              href={content.website_url}
-              className="sm-promo-headline"
-              title={content && content.headlines ? content.headlines.basic : ''}
-            >
-              <HeadlineText
-                primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+    <>
+      <article className="container-fluid small-promo">
+        <div className="row">
+          {customFields.showHeadline
+          && (
+            <div className={headlineClass}>
+              <a
+                href={content.website_url}
                 className="sm-promo-headline"
-                {...editableContent(content, 'headlines.basic')}
-                suppressContentEditableWarning
+                title={content && content.headlines ? content.headlines.basic : ''}
               >
-                {content && content.headlines ? content.headlines.basic : ''}
-              </HeadlineText>
-            </a>
-          </div>
-        )}
-        {customFields.showImage
-        && (
-          <div className="col-sm-xl-4">
-            <a
-              href={content.website_url}
-              title={content && content.headlines ? content.headlines.basic : ''}
-            >
-              {customFields.imageOverrideURL || extractImage(content.promo_items)
-                ? (
-                  <Image
-                    url={customFields.imageOverrideURL
-                      ? customFields.imageOverrideURL : extractImage(content.promo_items)}
-                    alt={content && content.headlines ? content.headlines.basic : ''}
-                    // small should be 3:2 aspect ratio
-                    smallWidth={ratios.smallWidth}
-                    smallHeight={ratios.smallHeight}
-                    mediumWidth={ratios.mediumWidth}
-                    mediumHeight={ratios.mediumHeight}
-                    largeWidth={ratios.largeWidth}
-                    largeHeight={ratios.largeHeight}
-                    breakpoints={getProperties(arcSite)?.breakpoints}
-                    resizerURL={getProperties(arcSite)?.resizerURL}
-                    resizedImageOptions={extractResizedParams(content)}
-                  />
-                )
-                : (
-                  <PlaceholderImage
-                    smallWidth={ratios.smallWidth}
-                    smallHeight={ratios.smallHeight}
-                    mediumWidth={ratios.mediumWidth}
-                    mediumHeight={ratios.mediumHeight}
-                    largeWidth={ratios.largeWidth}
-                    largeHeight={ratios.largeHeight}
-                  />
-                )}
-            </a>
-          </div>
-        )}
-      </div>
-    </article>
+                <HeadlineText
+                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+                  className="sm-promo-headline"
+                  {...editableContent(content, 'headlines.basic')}
+                  suppressContentEditableWarning
+                >
+                  {content && content.headlines ? content.headlines.basic : ''}
+                </HeadlineText>
+              </a>
+            </div>
+          )}
+          {customFields.showImage
+          && (
+            <div className="col-sm-xl-4">
+              <a
+                href={content.website_url}
+                title={content && content.headlines ? content.headlines.basic : ''}
+              >
+                {customFields.imageOverrideURL || extractImage(content.promo_items)
+                  ? (
+                    <Image
+                      url={customFields.imageOverrideURL
+                        ? customFields.imageOverrideURL : extractImage(content.promo_items)}
+                      alt={content && content.headlines ? content.headlines.basic : ''}
+                      // small should be 3:2 aspect ratio
+                      smallWidth={ratios.smallWidth}
+                      smallHeight={ratios.smallHeight}
+                      mediumWidth={ratios.mediumWidth}
+                      mediumHeight={ratios.mediumHeight}
+                      largeWidth={ratios.largeWidth}
+                      largeHeight={ratios.largeHeight}
+                      breakpoints={getProperties(arcSite)?.breakpoints}
+                      resizerURL={getProperties(arcSite)?.resizerURL}
+                      resizedImageOptions={extractResizedParams(content)}
+                    />
+                  )
+                  : (
+                    <PlaceholderImage
+                      smallWidth={ratios.smallWidth}
+                      smallHeight={ratios.smallHeight}
+                      mediumWidth={ratios.mediumWidth}
+                      mediumHeight={ratios.mediumHeight}
+                      largeWidth={ratios.largeWidth}
+                      largeHeight={ratios.largeHeight}
+                    />
+                  )}
+              </a>
+            </div>
+          )}
+        </div>
+      </article>
+      <hr />
+    </>
   ) : null;
 };
 

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -165,7 +165,7 @@ const TopTableList = (props) => {
   }, []);
 
   return (
-    <div key={id} className={`top-table-list-container ${small > 0 ? 'box-shadow-bottom' : ''}`}>
+    <div key={id} className="top-table-list-container layout-section">
       {siteContent.map(unserializeStory(arcSite)).map((itemObject, index) => {
         const {
           id: itemId,
@@ -208,6 +208,7 @@ const TopTableList = (props) => {
           />
         );
       })}
+      { small > 0 && <hr /> }
     </div>
   );
 };

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -1,18 +1,4 @@
 .top-table-list-container {
-  &.box-shadow-bottom {
-    box-shadow: none;
-    @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      box-shadow: inset 0 -1px 0 0 $ui-light-gray;
-    }
-  }
-
-  .small-promo,
-  .medium-promo,
-  .large-promo,
-  .xl-large-promo {
-    margin-bottom: 0;
-  }
-
   .small-promo {
     @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
       .row.sm-promo-padding-btm {

--- a/blocks/triple-chain-block/chains/triple-chain/default.jsx
+++ b/blocks/triple-chain-block/chains/triple-chain/default.jsx
@@ -15,15 +15,15 @@ const TripleChain = ({ children, customFields }) => {
       const endOfColumnTwoIndex = columnOneLength + columnTwoLength;
 
       return (
-        <div className="container-fluid">
-          <div className="row">
-            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm reduce-internal-row-col-gap">
+        <div className="container-fluid triple-chain chain-container">
+          <div className="row wrap-bottom">
+            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm reduce-internal-row-col-gap chain-col">
               {children.slice(0, columnOneLength)}
             </div>
-            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm reduce-internal-row-col-gap">
+            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm reduce-internal-row-col-gap chain-col">
               {children.slice(columnOneLength, endOfColumnTwoIndex)}
             </div>
-            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm reduce-internal-row-col-gap">
+            <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm reduce-internal-row-col-gap chain-col">
               {children.slice(endOfColumnTwoIndex)}
             </div>
           </div>


### PR DESCRIPTION
[PEN-1196](https://arcpublishing.atlassian.net/browse/PEN-1196)

# What does this implement or fix?
- rework the spacing between blocks to be handled by the container instead of individually by each block

# How was this tested?
- test updated with the changes
- visually with different pages and layouts

# Show Effect Of Changes
### each element inside a container is spaced with the same rules
![2020_0722_163819](https://user-images.githubusercontent.com/9757/88220816-e4ad8280-cc39-11ea-895b-7558f0eb273c.png)

### each element in a chain is spaced with the same rules
![2020_0722_164218](https://user-images.githubusercontent.com/9757/88221118-600f3400-cc3a-11ea-8286-644f5b030559.png)

# Dependencies or Side Effects

- need css framework to be on this same branch name or updated with this PR https://github.com/WPMedia/news-theme-css/pull/21
