### PR TITLE
PEN-1190 navigation link trailing slash

### DIFF
--- a/blocks/header-nav-block/features/navigation/_children/section-nav.jsx
+++ b/blocks/header-nav-block/features/navigation/_children/section-nav.jsx
@@ -3,12 +3,34 @@ import ChevronRight from '@wpmedia/engine-theme-sdk/dist/es/components/icons/Che
 
 function hasChildren(node) { return node.children && node.children.length > 0; }
 
-function fixTrailingSlash(item) {
-  let fixedItem = item;
-  if (fixedItem[fixedItem.length - 1] !== '/') {
-    fixedItem += '/';
+function getLocation(uri) {
+  let url;
+  if (typeof window === 'undefined') {
+    url = new URL(uri, 'http://example.com');
+  } else {
+    url = document.createElement('a');
+    // IE doesn't populate all link properties when setting .href with a relative URL,
+    // however .href will return an absolute URL which then can be used on itself
+    // to populate these additional fields.
+    url.href = uri;
+    if (url.host === '') {
+      url.href = `${url.href}`;
+    }
   }
-  return fixedItem;
+  return url;
+}
+
+function fixTrailingSlash(item) {
+  const url = getLocation(item);
+
+  if (url.hash || url.search || url.pathname.match(/\./)) {
+    return item;
+  }
+
+  if (item[item.length - 1] !== '/') {
+    return `${item}/`;
+  }
+  return item;
 }
 
 const Link = ({ href, name, child }) => {

--- a/blocks/header-nav-block/features/navigation/_children/section-nav.test.jsx
+++ b/blocks/header-nav-block/features/navigation/_children/section-nav.test.jsx
@@ -69,7 +69,7 @@ describe('the SectionNav component', () => {
     expect(wrapper.find('li.section-item')).toHaveLength(numActiveItems);
   });
 
-  it.only('should render the text for a section node correctly', () => {
+  it('should render the text for a section node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
     expect(wrapper.find('li.section-item > Link').at(0)).toIncludeText('Sports');
@@ -78,7 +78,7 @@ describe('the SectionNav component', () => {
   it('should render the href for a section node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
-    expect(wrapper.find('li.section-item > Link').at(0)).toHaveProp('href', '/sports/');
+    expect(wrapper.find('li.section-item > Link > a').at(0)).toHaveProp('href', '/sports/');
   });
 
   it('should render the text for a link node correctly', () => {
@@ -90,14 +90,14 @@ describe('the SectionNav component', () => {
   it('should render the href for a link node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
-    expect(wrapper.find('li.section-item > Link').at(1)).toHaveProp('href', '/entertainment/');
+    expect(wrapper.find('li.section-item > Link > a').at(1)).toHaveProp('href', '/entertainment/');
   });
 
   describe('when a section has child nodes', () => {
     it('should render a .submenu-caret element inside the anchor tag', () => {
       const wrapper = mount(<SectionNav sections={items} />);
 
-      expect(wrapper.find('li.section-item > Link > span.submenu-caret').at(0)).toHaveLength(1);
+      expect(wrapper.find('li.section-item > Link > a > span.submenu-caret').at(0)).toHaveLength(1);
     });
 
     it('should render a .subsection-container', () => {
@@ -123,14 +123,14 @@ describe('the SectionNav component', () => {
     it('should render the href for a subsection link node correctly', () => {
       const wrapper = mount(<SectionNav sections={items} />);
 
-      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > Link').at(0)).toHaveProp('href', '/basketball/');
+      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > Link > a').at(0)).toHaveProp('href', '/basketball/');
     });
 
     it('should render target and rel attribute for external links', () => {
       const wrapper = mount(<SectionNav sections={items} />);
 
-      expect(wrapper.find('li.section-item > Link').at(1)).toHaveProp('target', '/_blank/');
-      expect(wrapper.find('li.section-item > Link').at(1)).toHaveProp('rel', '/noopener noreferrer/');
+      expect(wrapper.find('li.section-item > Link > a').at(2)).toHaveProp('target', '_blank');
+      expect(wrapper.find('li.section-item > Link > a').at(2)).toHaveProp('rel', 'noopener noreferrer');
     });
   });
 

--- a/blocks/header-nav-block/features/navigation/_children/section-nav.test.jsx
+++ b/blocks/header-nav-block/features/navigation/_children/section-nav.test.jsx
@@ -41,6 +41,36 @@ const items = [
     url: 'http://washingtonpost.com/entertainment/',
   },
   {
+    _id: 'query',
+    node_type: 'link',
+    display_name: 'External with query',
+    url: 'http://washingtonpost.com/entertainment/?test=2&foo=bar',
+  },
+  {
+    _id: 'query2',
+    node_type: 'link',
+    display_name: 'internal with query',
+    url: '/entertainment/?test=1',
+  },
+  {
+    _id: 'link3',
+    node_type: 'link',
+    display_name: 'with page name',
+    url: 'https://example.com/category/page.html',
+  },
+  {
+    _id: 'hash',
+    node_type: 'link',
+    display_name: 'internal with hash',
+    url: '/entertainment/page#myhash',
+  },
+  {
+    _id: 'mail',
+    node_type: 'link',
+    display_name: 'mail link',
+    url: 'mailto:readers@washpost.com',
+  },
+  {
     _id: '/some-inactive-section',
     inactive: true,
     node_type: 'section',
@@ -91,6 +121,16 @@ describe('the SectionNav component', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
     expect(wrapper.find('li.section-item > Link > a').at(1)).toHaveProp('href', '/entertainment/');
+  });
+
+  it('should render the href for a link without a final slash if has a query parameter', () => {
+    const wrapper = mount(<SectionNav sections={items} />);
+
+    expect(wrapper.find('li.section-item > Link > a').at(3)).toHaveProp('href', 'http://washingtonpost.com/entertainment/?test=2&foo=bar');
+    expect(wrapper.find('li.section-item > Link > a').at(4)).toHaveProp('href', '/entertainment/?test=1');
+    expect(wrapper.find('li.section-item > Link > a').at(5)).toHaveProp('href', 'https://example.com/category/page.html');
+    expect(wrapper.find('li.section-item > Link > a').at(6)).toHaveProp('href', '/entertainment/page#myhash');
+    expect(wrapper.find('li.section-item > Link > a').at(7)).toHaveProp('href', 'mailto:readers@washpost.com');
   });
 
   describe('when a section has child nodes', () => {

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
@@ -3,12 +3,34 @@ import ChevronRight from '@wpmedia/engine-theme-sdk/dist/es/components/icons/Che
 
 function hasChildren(node) { return node.children && node.children.length > 0; }
 
-function fixTrailingSlash(item) {
-  let fixedItem = item;
-  if (fixedItem[fixedItem.length - 1] !== '/') {
-    fixedItem += '/';
+function getLocation(uri) {
+  let url;
+  if (typeof window !== 'undefined') {
+    url = new URL(uri, 'http://example.com');
+  } else {
+    url = document.createElement('a');
+    // IE doesn't populate all link properties when setting .href with a relative URL,
+    // however .href will return an absolute URL which then can be used on itself
+    // to populate these additional fields.
+    url.href = uri;
+    if (url.host === '') {
+      url.href = `${url.href}`;
+    }
   }
-  return fixedItem;
+  return url;
+}
+
+function fixTrailingSlash(item) {
+  const url = getLocation(item);
+
+  if (url.hash || url.search || url.pathname.match(/\./)) {
+    return item;
+  }
+
+  if (item[item.length - 1] !== '/') {
+    return `${item}/`;
+  }
+  return item;
 }
 
 const Link = ({ href, name, child }) => {

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
@@ -69,16 +69,16 @@ describe('the SectionNav component', () => {
     expect(wrapper.find('li.section-item')).toHaveLength(numActiveItems);
   });
 
-  it.only('should render the text for a section node correctly', () => {
+  it('should render the text for a section node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
-    expect(wrapper.find('li.section-item > Link').at(0)).toIncludeText('Sports');
+    expect(wrapper.find('li.section-item > Link > a').at(0)).toIncludeText('Sports');
   });
 
   it('should render the href for a section node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
-    expect(wrapper.find('li.section-item > Link').at(0)).toHaveProp('href', '/sports/');
+    expect(wrapper.find('li.section-item > Link > a').at(0)).toHaveProp('href', '/sports/');
   });
 
   it('should render the text for a link node correctly', () => {
@@ -90,14 +90,14 @@ describe('the SectionNav component', () => {
   it('should render the href for a link node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
-    expect(wrapper.find('li.section-item > Link').at(1)).toHaveProp('href', '/entertainment/');
+    expect(wrapper.find('li.section-item > Link > a').at(1)).toHaveProp('href', '/entertainment/');
   });
 
   describe('when a section has child nodes', () => {
     it('should render a .submenu-caret element inside the anchor tag', () => {
       const wrapper = mount(<SectionNav sections={items} />);
 
-      expect(wrapper.find('li.section-item > Link > span.submenu-caret').at(0)).toHaveLength(1);
+      expect(wrapper.find('li.section-item > Link > a > span.submenu-caret').at(0)).toHaveLength(1);
     });
 
     it('should render a .subsection-container', () => {
@@ -123,14 +123,14 @@ describe('the SectionNav component', () => {
     it('should render the href for a subsection link node correctly', () => {
       const wrapper = mount(<SectionNav sections={items} />);
 
-      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > Link').at(0)).toHaveProp('href', '/basketball/');
+      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > Link > a').at(0)).toHaveProp('href', '/basketball/');
     });
 
     it('should render target and rel attribute for external links', () => {
       const wrapper = mount(<SectionNav sections={items} />);
 
-      expect(wrapper.find('li.section-item > Link').at(1)).toHaveProp('target', '/_blank/');
-      expect(wrapper.find('li.section-item > Link').at(1)).toHaveProp('rel', '/noopener noreferrer/');
+      expect(wrapper.find('li.section-item > Link > a').at(2)).toHaveProp('target', '_blank');
+      expect(wrapper.find('li.section-item > Link > a').at(2)).toHaveProp('rel', 'noopener noreferrer');
     });
   });
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
@@ -41,6 +41,36 @@ const items = [
     url: 'http://washingtonpost.com/entertainment/',
   },
   {
+    _id: 'query',
+    node_type: 'link',
+    display_name: 'External with query',
+    url: 'http://washingtonpost.com/entertainment/?test=2&foo=bar',
+  },
+  {
+    _id: 'query2',
+    node_type: 'link',
+    display_name: 'internal with query',
+    url: '/entertainment/?test=1',
+  },
+  {
+    _id: 'link3',
+    node_type: 'link',
+    display_name: 'with page name',
+    url: 'https://example.com/category/page.html',
+  },
+  {
+    _id: 'hash',
+    node_type: 'link',
+    display_name: 'internal with hash',
+    url: '/entertainment/page#myhash',
+  },
+  {
+    _id: 'mail',
+    node_type: 'link',
+    display_name: 'mail link',
+    url: 'mailto:readers@washpost.com',
+  },
+  {
     _id: '/some-inactive-section',
     inactive: true,
     node_type: 'section',
@@ -91,6 +121,16 @@ describe('the SectionNav component', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
     expect(wrapper.find('li.section-item > Link > a').at(1)).toHaveProp('href', '/entertainment/');
+  });
+
+  it('should render the href for a link without a final slash if has a query parameter', () => {
+    const wrapper = mount(<SectionNav sections={items} />);
+
+    expect(wrapper.find('li.section-item > Link > a').at(3)).toHaveProp('href', 'http://washingtonpost.com/entertainment/?test=2&foo=bar');
+    expect(wrapper.find('li.section-item > Link > a').at(4)).toHaveProp('href', '/entertainment/?test=1');
+    expect(wrapper.find('li.section-item > Link > a').at(5)).toHaveProp('href', 'https://example.com/category/page.html');
+    expect(wrapper.find('li.section-item > Link > a').at(6)).toHaveProp('href', '/entertainment/page#myhash');
+    expect(wrapper.find('li.section-item > Link > a').at(7)).toHaveProp('href', 'mailto:readers@washpost.com');
   });
 
   describe('when a section has child nodes', () => {

--- a/blocks/links-bar-block/features/links-bar/_children/link.jsx
+++ b/blocks/links-bar-block/features/links-bar/_children/link.jsx
@@ -1,12 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function fixTrailingSlash(item) {
-  let fixedItem = item;
-  if (fixedItem[fixedItem.length - 1] !== '/') {
-    fixedItem += '/';
+function getLocation(uri) {
+  let url;
+  if (typeof window !== 'undefined') {
+    url = new URL(uri, 'http://example.com');
+  } else {
+    url = document.createElement('a');
+    // IE doesn't populate all link properties when setting .href with a relative URL,
+    // however .href will return an absolute URL which then can be used on itself
+    // to populate these additional fields.
+    url.href = uri;
+    if (url.host === '') {
+      url.href = `${url.href}`;
+    }
   }
-  return fixedItem;
+  return url;
+}
+
+function fixTrailingSlash(item) {
+  const url = getLocation(item);
+
+  if (url.hash || url.search || url.pathname.match(/\./)) {
+    return item;
+  }
+
+  if (item[item.length - 1] !== '/') {
+    return `${item}/`;
+  }
+  return item;
 }
 
 const Link = ({ href, name, showSeparator }) => {

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -114,4 +114,54 @@ describe('the links bar feature for the default output type', () => {
       expect(wrapper.find('[href="/testurl/"]').length).toBe(2);
     });
   });
+
+  describe('when a link has query parameters', () => {
+    it('should not add a slash at the end of a internal link', () => {
+      const { default: Link } = require('./_children/link');
+      const wrapper = mount(<Link href="/testurl/?query=home" name="test" />);
+
+      expect(wrapper.props().href).toBe('/testurl/?query=home');
+      expect(wrapper.find('[href="/testurl/?query=home"]').length).toBe(2);
+    });
+  });
+
+  describe('when a link has query parameters', () => {
+    it('should not add a slash at the end of a external link', () => {
+      const { default: Link } = require('./_children/link');
+      const wrapper = mount(<Link href="http://example.com/testurl/?query=home" name="test" />);
+
+      expect(wrapper.props().href).toBe('http://example.com/testurl/?query=home');
+      expect(wrapper.find('[href="http://example.com/testurl/?query=home"]').length).toBe(2);
+    });
+  });
+
+  describe('when a link is to a page', () => {
+    it('should not add a slash at the end of the link', () => {
+      const { default: Link } = require('./_children/link');
+      const wrapper = mount(<Link href="https://example.com/category/page.html" name="test" />);
+
+      expect(wrapper.props().href).toBe('https://example.com/category/page.html');
+      expect(wrapper.find('[href="https://example.com/category/page.html"]').length).toBe(2);
+    });
+  });
+
+  describe('when a link has a hash', () => {
+    it('should not add a slash at the end of the link', () => {
+      const { default: Link } = require('./_children/link');
+      const wrapper = mount(<Link href="/category/page#myhash" name="test" />);
+
+      expect(wrapper.props().href).toBe('/category/page#myhash');
+      expect(wrapper.find('[href="/category/page#myhash"]').length).toBe(2);
+    });
+  });
+
+  describe('when a link has a mail', () => {
+    it('should not add a slash at the end of the link', () => {
+      const { default: Link } = require('./_children/link');
+      const wrapper = mount(<Link href="mailto:readers@washpost.com" name="test" />);
+
+      expect(wrapper.props().href).toBe('mailto:readers@washpost.com');
+      expect(wrapper.find('[href="mailto:readers@washpost.com"]').length).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
[PEN-1190](https://arcpublishing.atlassian.net/browse/PEN-1190)

# What does this implement or fix?
- fix link generation on header nav bar and links bar, was adding a final '/' character on some urls

# How was this tested?
- tests written

# Show Effect Of Changes

## Before
![Screenshot from 2020-07-23 11-47-09](https://user-images.githubusercontent.com/9757/88301796-76b99780-ccdb-11ea-91a8-159e6a5fd514.png)
![Screenshot from 2020-07-23 11-47-15](https://user-images.githubusercontent.com/9757/88301805-78835b00-ccdb-11ea-98c9-0ae8e641d579.png)


## After

![Screenshot from 2020-07-23 11-57-26](https://user-images.githubusercontent.com/9757/88302013-b6807f00-ccdb-11ea-8347-49b76aad2374.png)
![Screenshot from 2020-07-23 11-57-29](https://user-images.githubusercontent.com/9757/88302044-c009e700-ccdb-11ea-8e4b-9cda4c0ea914.png)


# Dependencies or Side Effects

- none
