### PR TITLE
PEN-1211 breaking news banner didnt disappear

### DIFF
--- a/blocks/a11y-testing-block/features/a11y-testing/styled.js
+++ b/blocks/a11y-testing-block/features/a11y-testing/styled.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import styled from 'styled-components';
 
-
 export const AllyControl = styled.button`
     width:100px;
     height: 60px;
@@ -12,29 +11,29 @@ export const AllyControl = styled.button`
     justify-content:center;
     align-items: center;
     border: 0;
-    
+
     cursor: pointer;
-    
+
     &.topleft {
         top:0;
         left:0;
     }
-    
+
     &.topright {
         top:0;
-        right:0;    
+        right:0;
     }
-    
+
     &.bottomleft {
         bottom:0;
-        left:0;    
+        left:0;
     }
-    
+
     &.bottomright {
         bottom:0;
-        right:0;     
-    }        
-    
+        right:0;
+    }
+
     img {
         width: 55px;
         height:auto;
@@ -56,15 +55,15 @@ export const AllyContainer = styled.div`
     display: flex;
     flex-direction: column;
     transition: all 1s ease;
-    
+
     &.ally-panel-active {
         right: 0;
     }
-    
+
     * {
         box-sizing: border-box;
     }
-    
+
    .header {
         width: 100%;
         padding: 5px 10px;
@@ -110,13 +109,13 @@ export const AllyContainer = styled.div`
         background-color: transparent;
         cursor: pointer;
     }
-    
+
     .alert {
         color: red;
         padding: 15px;
         background: #F5F5F5
     }
-    
+
     .alert h2 {
         font-size: 24px;
         line-height: 30px;
@@ -133,7 +132,7 @@ export const AllyContainer = styled.div`
         align-items: center;
         height: 100%
     }
-    
+
     section.allyInnerContainer .reportContainer {
         width: 100%;
         padding: 15px;
@@ -151,7 +150,7 @@ export const AllyContainer = styled.div`
         background-color: rgba(244, 215, 201, .37);
         border-left: 4px solid #d93025;
     }
-    
+
     section.allyInnerContainer .reportContainer .report h2 {
         font-size: 22px;
         font-weight: 700;
@@ -214,13 +213,13 @@ export const AllyContainer = styled.div`
     section.allyInnerContainer .reportContainer .report ul li {
         margin-left: 25px;
     }
-    
+
     section.allyInnerContainer .reportContainer .report pre{
         width: 100%;
         overflow-y: scroll;
     }
-    
+
     .a11yHighlight {
         border: 4px solid red;
-    }        
+    }
 `;

--- a/blocks/alert-bar-content-source-block/sources/alert-bar-collections.js
+++ b/blocks/alert-bar-content-source-block/sources/alert-bar-collections.js
@@ -4,7 +4,17 @@ const resolve = (key = {}) => {
   return `content/v4/collections?content_alias=alert-bar${site ? `&website=${site}` : ''}&from=0&size=1&published=true`;
 };
 
+// when a collection as a unpublished elements, the content_elements has a
+// reference to the data without being expanded, and need to be removed
 export default {
   ttl: 120,
   resolve,
+  transform: (data) => {
+    const source = data;
+    const elements = source.content_elements.reduce((acc, ele) => (
+      (!ele.referent) ? acc.concat(ele) : acc
+    ), []);
+    source.content_elements = elements;
+    return source;
+  },
 };

--- a/blocks/alert-bar-content-source-block/sources/alert-bar-collections.test.js
+++ b/blocks/alert-bar-content-source-block/sources/alert-bar-collections.test.js
@@ -1,5 +1,9 @@
 import contentSource from './alert-bar-collections';
 
+import mockCollection from './mockCollection';
+import mockCollectionEmpty from './mockCollectionEmpty';
+import mockCollectionUnpublishedStory from './mockCollectionUnpublishedStory';
+
 describe('the collections content source block', () => {
   describe('when a website param is provided', () => {
     it('should build the correct url', () => {
@@ -10,11 +14,39 @@ describe('the collections content source block', () => {
       expect(url).toEqual('content/v4/collections?content_alias=alert-bar&website=the-sun&from=0&size=1&published=true');
     });
   });
+
   describe('when a website param is not provided', () => {
     it('should build the url without the website', () => {
       const url = contentSource.resolve({});
 
       expect(url).toEqual('content/v4/collections?content_alias=alert-bar&from=0&size=1&published=true');
+    });
+
+    it('should build the url without parameters', () => {
+      const url = contentSource.resolve();
+
+      expect(url).toEqual('content/v4/collections?content_alias=alert-bar&from=0&size=1&published=true');
+    });
+  });
+
+  describe('when a collection is empty', () => {
+    it('should return an empty content_elements', () => {
+      const content = contentSource.transform(mockCollectionEmpty);
+      expect(content.content_elements.length).toBe(0);
+    });
+  });
+
+  describe('when a collection has data', () => {
+    it('should return an one item on content_elements', () => {
+      const content = contentSource.transform(mockCollection);
+      expect(content.content_elements.length).toBe(1);
+    });
+  });
+
+  describe('when a collection has unpublished content', () => {
+    it('should return an empty content_elements', () => {
+      const content = contentSource.transform(mockCollectionUnpublishedStory);
+      expect(content.content_elements.length).toBe(0);
     });
   });
 });

--- a/blocks/alert-bar-content-source-block/sources/mockCollection.js
+++ b/blocks/alert-bar-content-source-block/sources/mockCollection.js
@@ -1,0 +1,342 @@
+const alertBar = {
+  _id: 'VTKOTRJXEVATHG7MELTPZ2RIBU',
+  headlines: {
+    basic: 'Alert Bar – The Sun',
+  },
+  type: 'collection',
+  version: '0.7.0',
+  canonical_website: 'the-sun',
+  content_elements: [{
+    _id: 'X3UX64DV6ZGP3DBXDTR7OEFKWA',
+    type: 'story',
+    version: '0.10.5',
+    canonical_url: '/news/2020/04/15/7-questions-about-traveling-to-australia-during-catastrophic-fires-answered/',
+    headlines: {
+      basic: '7 questions about traveling to Australia during catastrophic fires, answered',
+      mobile: '',
+      native: '',
+      print: '',
+      tablet: '',
+      web: '',
+      meta_title: '',
+    },
+    ubheadlines: {
+      basic: 'The country is urging travelers to come visit areas that are not fighting the blaze',
+    },
+    description: {
+      basic: 'Apocalyptic images have been coming out of Australia as fires rage. But the country is urging travelers to come visit areas that are not fighting the blaze.',
+    },
+    language: '',
+    label: {},
+    taxonomy: {},
+    promo_items: {
+      basic: {
+        _id: 'DPD3743AIBHAPLN5YRJBLWZ5RI',
+        additional_properties: {
+          fullSizeResizeUrl: '/photo/resize/FlWZJc0rz3mgQYtppOvF4J3N7UQ=/arc-anglerfish-arc2-prod-corecomponents/public/DPD3743AIBHAPLN5YRJBLWZ5RI.png',
+          galleries: [],
+          ingestionMethod: 'manual',
+          keywords: [],
+          mime_type: 'application/octet-stream',
+          originalName: 'Screen Shot 2020-01-30 at 6.20.27 PM.png',
+          originalUrl: 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/DPD3743AIBHAPLN5YRJBLWZ5RI.png',
+          owner: 'sara.carothers@washpost.com',
+          proxyUrl: '/photo/resize/FlWZJc0rz3mgQYtppOvF4J3N7UQ=/arc-anglerfish-arc2-prod-corecomponents/public/DPD3743AIBHAPLN5YRJBLWZ5RI.png',
+          published: true,
+          resizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/FlWZJc0rz3mgQYtppOvF4J3N7UQ=/arc-anglerfish-arc2-prod-corecomponents/public/DPD3743AIBHAPLN5YRJBLWZ5RI.png',
+          restricted: false,
+          thumbnailResizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/-vkqXXU_kDq7qIpkiJKISSOkKUQ=/300x0/arc-anglerfish-arc2-prod-corecomponents/public/DPD3743AIBHAPLN5YRJBLWZ5RI.png',
+          version: 1,
+          template_id: 297,
+        },
+        address: {},
+        caption: 'A Rural Fire Service firefighter views a flank of a fire in Tumburumba, Australia.',
+        created_date: '2020-01-30T23:36:44Z',
+        credits: {
+          affiliation: [{
+            name: 'Getty Images',
+            type: 'author',
+          }],
+          by: [{
+            byline: 'Sam Mooy (custom credit)',
+            name: 'Sam Mooy',
+            type: 'author',
+          }],
+        },
+        height: 712,
+        image_type: 'photograph',
+        last_updated_date: '2020-01-30T23:36:50Z',
+        licensable: false,
+        owner: {
+          id: 'corecomponents',
+        },
+        source: {
+          edit_url: 'https://corecomponents.arcpublishing.com/photo/DPD3743AIBHAPLN5YRJBLWZ5RI',
+          system: 'photo center',
+        },
+        status: '',
+        taxonomy: {
+          associated_tasks: [],
+        },
+        type: 'image',
+        url: 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/DPD3743AIBHAPLN5YRJBLWZ5RI.png',
+        version: '0.10.3',
+        width: 1073,
+        syndication: {
+          external_distribution: '',
+          search: '',
+        },
+      },
+    },
+    distributor: {
+      name: 'corecomponents',
+      category: 'staff',
+      subcategory: '',
+    },
+    canonical_website: 'the-sun',
+    display_date: '2020-01-30T17:37:12.780Z',
+    credits: {
+      by: [{
+        _id: 'saracarothers',
+        type: 'author',
+        version: '0.5.8',
+        name: 'Sara Carothers',
+        image: {
+          url: 'https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg',
+          version: '0.5.8',
+        },
+        description: 'Sara Carothers is a senior product manager for Arc Publishing. This is a short bio. ',
+        url: '/author/sara-carothers/',
+        slug: 'sara-carothers',
+        social_links: [{
+          site: 'email',
+          url: 'sara.carothers@washpost.com',
+        }, {
+          site: 'twitter',
+          url: 'sLcarothers',
+        }, {
+          site: 'instagram',
+          url: 'scarothers',
+        }],
+        socialLinks: [{
+          site: 'email',
+          url: 'sara.carothers@washpost.com',
+          deprecated: true,
+          deprecation_msg: 'Please use social_links.',
+        }, {
+          site: 'twitter',
+          url: 'sLcarothers',
+          deprecated: true,
+          deprecation_msg: 'Please use social_links.',
+        }, {
+          site: 'instagram',
+          url: 'scarothers',
+          deprecated: true,
+          deprecation_msg: 'Please use social_links.',
+        }],
+        additional_properties: {
+          original: {
+            _id: 'saracarothers',
+            firstName: 'Sara',
+            lastName: 'Carothers',
+            secondLastName: '',
+            byline: 'Sara Lynn Carothers',
+            role: 'Senior Product Manager',
+            image: 'https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg',
+            email: 'sara.carothers@washpost.com',
+            affiliations: '',
+            education: [],
+            awards: [],
+            books: [],
+            podcasts: [],
+            twitter: 'sLcarothers',
+            bio_page: '/author/sara-carothers/',
+            bio: 'Sara Carothers is a senior product manager for Arc Publishing. This is a short bio. ',
+            longBio: 'Sara Carothers is a senior product manager for Arc Publishing. She works on Arc Themes and PageBuilder Fusion. This is a long bio. \n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. \n\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n',
+            slug: 'sara-carothers',
+            instagram: 'scarothers',
+            native_app_rendering: false,
+            fuzzy_match: false,
+            contributor: false,
+            status: true,
+            last_updated_date: '2020-03-04T18:20:55.600Z',
+            type: 'author',
+          },
+        },
+      }],
+    },
+    subtype: 'right-rail-template',
+    websites: {
+      dagen: {
+        website_section: {
+          _id: '/kultur',
+          _website: 'dagen',
+          type: 'section',
+          version: '0.6.0',
+          name: 'Kultur',
+          path: '/kultur',
+          parent_id: '/',
+          parent: {
+            default: '/',
+          },
+          additional_properties: {
+            original: {
+              _id: '/kultur',
+              metadata: {
+                metadata_title: 'Kultur - Dagen Kultur',
+                metadata_description: 'Kulturartiklar från Dagen, Sveriges största dagstidning på kristen grund',
+                content_code: 'premium',
+              },
+              _website: 'dagen',
+              name: 'Kultur',
+              order: {
+                footer: 2001,
+              },
+              parent: {
+                default: '/',
+                footer: '/familj',
+                hamburgermenu: '/',
+              },
+              ancestors: {
+                default: [],
+                footer: ['/', '/familj'],
+                hamburgermenu: [],
+              },
+              inactive: false,
+              node_type: 'section',
+            },
+          },
+          _website_section_id: 'dagen./kultur',
+        },
+        website_url: '/news/2020/04/15/7-questions-about-traveling-to-australia-during-catastrophic-fires-answered/',
+      },
+      'the-sun': {
+        website_section: {
+          _id: '/news',
+          _website: 'the-sun',
+          type: 'section',
+          version: '0.6.0',
+          name: 'News',
+          description: null,
+          path: '/news',
+          parent_id: '/',
+          parent: {
+            default: '/',
+          },
+          additional_properties: {
+            original: {
+              _id: '/news',
+              site: {
+                site_tagline: null,
+                pagebuilder_path_for_native_apps: null,
+                site_description: null,
+                site_url: null,
+                site_keywords: null,
+                site_title: null,
+                site_about: null,
+              },
+              social: {
+                rss: null,
+                twitter: null,
+                instagram: null,
+                facebook: null,
+              },
+              navigation: {
+                nav_title: null,
+              },
+              site_topper: {
+                site_logo_image: null,
+              },
+              name: 'News',
+              _website: 'the-sun',
+              parent: {
+                default: '/',
+                footer: null,
+                hamburgermenu: '/',
+              },
+              ancestors: {
+                default: [],
+                footer: [],
+                hamburgermenu: [],
+              },
+              _admin: {
+                alias_ids: ['/news'],
+              },
+              inactive: false,
+              node_type: 'section',
+              order: {},
+            },
+          },
+          _website_section_id: 'the-sun./news',
+        },
+        website_url: '/news/2020/04/15/7-questions-about-traveling-to-australia-during-catastrophic-fires-answered/',
+      },
+      'the-gazette': {
+        website_section: {
+          _id: '/news',
+          _website: 'the-gazette',
+          type: 'section',
+          version: '0.6.0',
+          name: 'News',
+          path: '/news',
+          parent_id: '/',
+          parent: {
+            default: '/',
+          },
+          additional_properties: {
+            original: {
+              _id: '/news',
+              metadata: {
+                metadata_title: 'News and latest updates from The Gazette',
+                metadata_description: 'This is the description for the News section',
+              },
+              _website: 'the-gazette',
+              name: 'News',
+              order: {
+                default: 1006,
+                hamburgermenu: 1002,
+                'links-bar': 1006,
+              },
+              parent: {
+                default: '/',
+                hamburgermenu: '/',
+                'links-bar': '/',
+              },
+              ancestors: {
+                default: [],
+                hamburgermenu: [],
+                'links-bar': ['/'],
+              },
+              inactive: false,
+              node_type: 'section',
+            },
+          },
+        },
+        website_url: '/news/2020/04/15/7-questions-about-traveling-to-australia-during-catastrophic-fires-answered/',
+      },
+    },
+    publish_date: '2020-04-17T15:09:27.028Z',
+  }],
+  description: {
+    basic: 'Alert Bar collection for The Sun website. If a story is added to this collection, it will appear in the Alert Bar Block on a Theme website until it is removed from this collection. ',
+  },
+  content_aliases: ['alert-bar'],
+  owner: {
+    id: 'corecomponents',
+  },
+  revision: {
+    branch: 'default',
+    published: true,
+  },
+  publishing: {
+    scheduled_operations: {
+      publish_edition: [],
+      unpublish_edition: [],
+    },
+  },
+  last_updated_date: '1970-01-01T00:00:00.000Z',
+  created_date: '1970-01-01T00:00:00.000Z',
+  website: 'the-sun',
+};
+
+export default alertBar;

--- a/blocks/alert-bar-content-source-block/sources/mockCollectionEmpty.js
+++ b/blocks/alert-bar-content-source-block/sources/mockCollectionEmpty.js
@@ -1,0 +1,32 @@
+const dataEmpty = {
+  _id: 'VTKOTRJXEVATHG7MELTPZ2RIBU',
+  headlines: {
+    basic: 'Alert Bar – The Sun',
+  },
+  type: 'collection',
+  version: '0.7.0',
+  canonical_website: 'the-sun',
+  content_elements: [],
+  description: {
+    basic: 'Alert Bar collection for The Sun website. If a story is added to this collection, it will appear in the Alert Bar Block on a Theme website until it is removed from this collection. ',
+  },
+  content_aliases: ['alert-bar'],
+  owner: {
+    id: 'corecomponents',
+  },
+  revision: {
+    branch: 'default',
+    published: true,
+  },
+  publishing: {
+    scheduled_operations: {
+      publish_edition: [],
+      unpublish_edition: [],
+    },
+  },
+  last_updated_date: '1970-01-01T00:00:00.000Z',
+  created_date: '1970-01-01T00:00:00.000Z',
+  website: 'the-sun',
+};
+
+export default dataEmpty;

--- a/blocks/alert-bar-content-source-block/sources/mockCollectionUnpublishedStory.js
+++ b/blocks/alert-bar-content-source-block/sources/mockCollectionUnpublishedStory.js
@@ -1,4 +1,3 @@
-
 const CollectionWithUnpublishedStory = {
   _id: 'VTKOTRJXEVATHG7MELTPZ2RIBU',
   headlines: {

--- a/blocks/alert-bar-content-source-block/sources/mockCollectionUnpublishedStory.js
+++ b/blocks/alert-bar-content-source-block/sources/mockCollectionUnpublishedStory.js
@@ -1,0 +1,39 @@
+
+const CollectionWithUnpublishedStory = {
+  _id: 'VTKOTRJXEVATHG7MELTPZ2RIBU',
+  headlines: {
+    basic: 'Alert Bar – The Sun',
+  },
+  type: 'collection',
+  version: '0.7.0',
+  canonical_website: 'the-sun',
+  content_elements: [{
+    referent: {
+      id: 'GKCW5R7J6BHWHFTG436KWQESVA',
+      type: 'story',
+    },
+    type: 'promo_reference',
+  }],
+  description: {
+    basic: 'Alert Bar collection for The Sun website. If a story is added to this collection, it will appear in the Alert Bar Block on a Theme website until it is removed from this collection. ',
+  },
+  content_aliases: ['alert-bar'],
+  owner: {
+    id: 'corecomponents',
+  },
+  revision: {
+    branch: 'default',
+    published: true,
+  },
+  publishing: {
+    scheduled_operations: {
+      publish_edition: [],
+      unpublish_edition: [],
+    },
+  },
+  last_updated_date: '1970-01-01T00:00:00.000Z',
+  created_date: '1970-01-01T00:00:00.000Z',
+  website: 'the-sun',
+};
+
+export default CollectionWithUnpublishedStory;

--- a/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
@@ -76,7 +76,7 @@ describe('the full author bio block', () => {
     it('should render a photo', () => {
       const wrapper = mount(<FullAuthorBio />);
 
-      expect(wrapper.find('img').props().src === '').toEqual(false);
+      expect(wrapper.find('Image').props().src === '').toEqual(false);
     });
   });
 

--- a/blocks/top-table-list-block/features/top-table-list/default.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.test.jsx
@@ -446,7 +446,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(600);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(600);
   });
 
   it('must have a default 4:3 ratio for LG', () => {
@@ -458,7 +458,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(283);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(283);
   });
 
   it('must have a default 16:9 ratio for MD', () => {
@@ -470,7 +470,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(225);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(225);
   });
 
   it('must have a default 3:2 ratio for SM', () => {
@@ -482,7 +482,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(267);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(267);
   });
 
   it('XL can be changed to 16:9', () => {
@@ -496,7 +496,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(450);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(450);
   });
 
   it('XL can be changed to 4:3', () => {
@@ -510,7 +510,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(600);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(600);
   });
 
   it('XL can be changed to 3:2', () => {
@@ -524,7 +524,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(533);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(533);
   });
 
   it('LG can be changed to 16:9', () => {
@@ -537,7 +537,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(212);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(212);
   });
 
   it('LG can be changed to 4:3', () => {
@@ -550,7 +550,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(283);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(283);
   });
 
   it('LG can be changed to 3:2', () => {
@@ -563,7 +563,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(251);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(251);
   });
 
   it('MD can be changed to 16:9', () => {
@@ -576,7 +576,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(225);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(225);
   });
 
   it('MD can be changed to 4:3', () => {
@@ -589,7 +589,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(300);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(300);
   });
 
   it('MD can be changed to 3:2', () => {
@@ -602,7 +602,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(267);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(267);
   });
 
   it('SM can be changed to 16:9', () => {
@@ -615,7 +615,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(225);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(225);
   });
 
   it('SM can be changed to 4:3', () => {
@@ -628,7 +628,7 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(300);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(300);
   });
 
   it('SM can be changed to 3:2', () => {
@@ -641,6 +641,6 @@ describe('default ratios', () => {
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const ttl = mount(<TopTableList customFields={xlConfig} arcSite="" deployment={jest.fn((path) => path)} />);
 
-    expect(ttl.find('img').prop('height')).toBe(267);
+    expect(ttl.find('Image').prop('largeHeight')).toBe(267);
   });
 });


### PR DESCRIPTION
[PEN-1211](https://arcpublishing.atlassian.net/browse/PEN-1211)

# What does this implement or fix?
- remove non expanded content elements from collection (unpublished stories)

# How was this tested?

- tests written

# Show Effect Of Changes

## Before
![2020_0724_125630](https://user-images.githubusercontent.com/9757/88420454-4ea26500-cdbd-11ea-8335-e8498722c20f.png)

## After
![2020_0727_112059](https://user-images.githubusercontent.com/9757/88553182-5c452e00-cffb-11ea-807e-e52b71bec310.png)


# Dependencies or Side Effects

- none
