### PR TITLE
PEN-1196 bump news-theme-css version

### DIFF
--- a/blocks/article-body-block/package.json
+++ b/blocks/article-body-block/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/video-player-block": "latest",
     "react-oembed-container": "^0.3.0",
     "styled-components": "^4.4.0"

--- a/blocks/article-tag-block/package.json
+++ b/blocks/article-tag-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/author-bio-block/package.json
+++ b/blocks/author-bio-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/byline-block/package.json
+++ b/blocks/byline-block/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/card-list-block/package.json
+++ b/blocks/card-list-block/package.json
@@ -26,7 +26,7 @@
     "@wpmedia/byline-block": "latest",
     "@wpmedia/date-block": "latest",
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/date-block/package.json
+++ b/blocks/date-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/default-output-block/package.json
+++ b/blocks/default-output-block/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8"
+    "@wpmedia/news-theme-css": "^2.1.13"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"
 }

--- a/blocks/double-chain-block/package.json
+++ b/blocks/double-chain-block/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8"
+    "@wpmedia/news-theme-css": "^2.1.13"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/blocks/extra-large-manual-promo-block/package.json
+++ b/blocks/extra-large-manual-promo-block/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/extra-large-promo-block/package.json
+++ b/blocks/extra-large-promo-block/package.json
@@ -30,7 +30,7 @@
     "@wpmedia/date-block": "latest",
     "@wpmedia/engine-theme-sdk": "^2.2.0",
     "@wpmedia/global-phrases-block": "latest",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/overline-block": "latest",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"

--- a/blocks/footer-block/package.json
+++ b/blocks/footer-block/package.json
@@ -28,7 +28,7 @@
     "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/engine-theme-sdk": "^2.2.0",
     "@wpmedia/links-bar-block": "latest",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/full-author-bio-block/package.json
+++ b/blocks/full-author-bio-block/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "bugs": {

--- a/blocks/gallery-block/package.json
+++ b/blocks/gallery-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8"
+    "@wpmedia/news-theme-css": "^2.1.13"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"
 }

--- a/blocks/header-block/package.json
+++ b/blocks/header-block/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8"
+    "@wpmedia/news-theme-css": "^2.1.13"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"

--- a/blocks/header-nav-block/package.json
+++ b/blocks/header-nav-block/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/header-nav-chain-block/package.json
+++ b/blocks/header-nav-chain-block/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/headline-block/package.json
+++ b/blocks/headline-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/htmlbox-block/package.json
+++ b/blocks/htmlbox-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "b80023124aed777cfa92f1215bf4ccc2b7b65868"

--- a/blocks/large-manual-promo-block/package.json
+++ b/blocks/large-manual-promo-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/large-promo-block/package.json
+++ b/blocks/large-promo-block/package.json
@@ -29,7 +29,7 @@
     "@wpmedia/byline-block": "latest",
     "@wpmedia/date-block": "latest",
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/overline-block": "latest",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"

--- a/blocks/lead-art-block/package.json
+++ b/blocks/lead-art-block/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/video-player-block": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/links-bar-block/package.json
+++ b/blocks/links-bar-block/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "b80023124aed777cfa92f1215bf4ccc2b7b65868"

--- a/blocks/masthead-block/package.json
+++ b/blocks/masthead-block/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^5.0.1"
   },
   "scripts": {

--- a/blocks/medium-manual-promo-block/package.json
+++ b/blocks/medium-manual-promo-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -28,7 +28,7 @@
     "@wpmedia/byline-block": "latest",
     "@wpmedia/date-block": "latest",
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/numbered-list-block/package.json
+++ b/blocks/numbered-list-block/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "b80023124aed777cfa92f1215bf4ccc2b7b65868"

--- a/blocks/overline-block/package.json
+++ b/blocks/overline-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8"
+    "@wpmedia/news-theme-css": "^2.1.13"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"

--- a/blocks/results-list-block/package.json
+++ b/blocks/results-list-block/package.json
@@ -32,7 +32,7 @@
     "@wpmedia/date-block": "latest",
     "@wpmedia/engine-theme-sdk": "^2.2.0",
     "@wpmedia/global-phrases-block": "latest",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/right-rail-advanced-block/package.json
+++ b/blocks/right-rail-advanced-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/right-rail-block/package.json
+++ b/blocks/right-rail-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/section-title-block/package.json
+++ b/blocks/section-title-block/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8"
+    "@wpmedia/news-theme-css": "^2.1.13"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"

--- a/blocks/share-bar-block/package.json
+++ b/blocks/share-bar-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/shared-styles/package.json
+++ b/blocks/shared-styles/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8"
+    "@wpmedia/news-theme-css": "^2.1.13"
   },
   "scripts": {},
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/simple-list-block/package.json
+++ b/blocks/simple-list-block/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "scripts": {

--- a/blocks/site-hierarchy-content-block/package.json
+++ b/blocks/site-hierarchy-content-block/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/small-manual-promo-block/package.json
+++ b/blocks/small-manual-promo-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/small-promo-block/package.json
+++ b/blocks/small-promo-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/subheadline-block/package.json
+++ b/blocks/subheadline-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "styled-components": "^4.4.0"
   },
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/tag-title-block/package.json
+++ b/blocks/tag-title-block/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8"
+    "@wpmedia/news-theme-css": "^2.1.13"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"

--- a/blocks/top-table-list-block/package.json
+++ b/blocks/top-table-list-block/package.json
@@ -25,7 +25,7 @@
     "@wpmedia/byline-block": "latest",
     "@wpmedia/date-block": "latest",
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "@wpmedia/overline-block": "latest",
     "@wpmedia/placeholder-image-block": "latest",
     "@wpmedia/resizer-image-block": "latest",

--- a/blocks/video-player-block/package.json
+++ b/blocks/video-player-block/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "^2.1.8",
+    "@wpmedia/news-theme-css": "^2.1.13",
     "react-oembed-container": "^0.3.0",
     "styled-components": "^4.4.0"
   },


### PR DESCRIPTION
[PEN-1196](https://arcpublishing.atlassian.net/browse/PEN-1196)

# What does this implement or fix?
- bump news-theme-css version on blocks to match the beta version published

# How was this tested?
- no need

# Dependencies or Side Effects

- this work is to be able to test the work on https://github.com/WPMedia/news-theme-css/pull/21
- cssFramework key on blocks.json must be updated to use `news-theme-css@beta`
