### PR TITLE
PEN-1180 fix byline display

### DIFF
--- a/blocks/byline-block/features/byline/default.jsx
+++ b/blocks/byline-block/features/byline/default.jsx
@@ -55,22 +55,22 @@ class ArticleByline extends Component {
 
     const authors = by.length > 0 && by.map((author) => {
       if (author.type === 'author') {
-        const hasName = Object.prototype.hasOwnProperty.call(author, 'name');
+        /* eslint-disable-next-line camelcase */
+        const authorName = author?.additional_properties?.original?.byline || author?.name;
         const hasURL = Object.prototype.hasOwnProperty.call(author, 'url');
 
         // If the author has a url to their bio page, return an anchor tag to the bio.
         // If not, just return the string.
-        if (hasName) {
-          return (hasURL) ? `<a href="${author.url}">${author.name}</a>` : author.name;
+        if (authorName) {
+          return (hasURL) ? `<a href="${author.url}">${authorName}</a>` : authorName;
         }
         // Those without name will not be included in the byline
       }
 
       return null;
-    });
+    }).filter((author) => author != null);
 
-    const numAuthors = authors.length && authors.every((element) => element !== null)
-      ? authors.length : 0;
+    const numAuthors = authors.length;
     // This will be an innerHTML to accommodate potential multiple anchor tags within the section
     // Leave it empty so that if there's no author with listed name it would just return '' string
     // note: default is empty string with one space

--- a/blocks/byline-block/features/byline/default.test.jsx
+++ b/blocks/byline-block/features/byline/default.test.jsx
@@ -26,7 +26,9 @@ describe('Given a single author', () => {
     const globalContent = { credits };
 
     const wrapper = mount(<ArticleByline globalContent={globalContent} />);
-    expect(wrapper.find('span').at(1).prop('dangerouslySetInnerHTML')).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim Byline</a>' });
+    expect(
+      wrapper.find('span').at(1).prop('dangerouslySetInnerHTML'),
+    ).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim Byline</a>' });
   });
 
   it("should fallback to author name if additional_properties doesn't exist", () => {
@@ -41,7 +43,9 @@ describe('Given a single author', () => {
     const globalContent = { credits };
 
     const wrapper = mount(<ArticleByline globalContent={globalContent} />);
-    expect(wrapper.find('span').at(1).prop('dangerouslySetInnerHTML')).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim</a>' });
+    expect(
+      wrapper.find('span').at(1).prop('dangerouslySetInnerHTML'),
+    ).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim</a>' });
   });
 
 
@@ -157,7 +161,9 @@ describe('Given an author list', () => {
     const globalContent = { credits };
 
     const wrapper = mount(<ArticleByline globalContent={globalContent} />);
-    expect(wrapper.find('span').at(1).prop('dangerouslySetInnerHTML')).toStrictEqual({ __html: '<a href="/author/sanghee-kim">SangHee Kim</a> and <a href="/author/sara-carothers">Sara Carothers</a>' });
+    expect(
+      wrapper.find('span').at(1).prop('dangerouslySetInnerHTML'),
+    ).toStrictEqual({ __html: '<a href="/author/sanghee-kim">SangHee Kim</a> and <a href="/author/sara-carothers">Sara Carothers</a>' });
   });
 
   it('should return three authors, oxford comma', () => {
@@ -182,7 +188,9 @@ describe('Given an author list', () => {
     const globalContent = { credits };
 
     const wrapper = mount(<ArticleByline globalContent={globalContent} />);
-    expect(wrapper.find('span').at(1).prop('dangerouslySetInnerHTML')).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim</a>, <a href="/author/joe-grosspietsch">Joe Grosspietsch</a> and <a href="/author/brent-miller">Brent Miller</a>' });
+    expect(
+      wrapper.find('span').at(1).prop('dangerouslySetInnerHTML'),
+    ).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim</a>, <a href="/author/joe-grosspietsch">Joe Grosspietsch</a> and <a href="/author/brent-miller">Brent Miller</a>' });
   });
 
   it('should return four authors, oxford comma', () => {
@@ -211,7 +219,9 @@ describe('Given an author list', () => {
     const globalContent = { credits };
 
     const wrapper = mount(<ArticleByline globalContent={globalContent} />);
-    expect(wrapper.find('span').at(1).prop('dangerouslySetInnerHTML')).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim</a>, <a href="/author/joe-grosspietsch">Joe Grosspietsch</a>, <a href="/author/brent-miller">Brent Miller</a> and <a href="/author/sara-carothers">Sara Carothers</a>' });
+    expect(
+      wrapper.find('span').at(1).prop('dangerouslySetInnerHTML'),
+    ).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim</a>, <a href="/author/joe-grosspietsch">Joe Grosspietsch</a>, <a href="/author/brent-miller">Brent Miller</a> and <a href="/author/sara-carothers">Sara Carothers</a>' });
   });
 
   it('should return 4 authors complete with url and bylines', () => {
@@ -269,7 +279,9 @@ describe('Given an author list', () => {
     const globalContent = { credits };
 
     const wrapper = mount(<ArticleByline globalContent={globalContent} />);
-    expect(wrapper.find('span').at(1).text().trim()).toEqual('SangHee Kim Byline, Joe Grosspietsch Byline, Brent Miller Byline and Sara Lynn Carothers');
+    expect(
+      wrapper.find('span').at(1).text().trim(),
+    ).toEqual('SangHee Kim Byline, Joe Grosspietsch Byline, Brent Miller Byline and Sara Lynn Carothers');
 
     wrapper.find('span').at(1).find('a').forEach((anchor, idx) => {
       expect(anchor.prop('href')).toEqual(credits.by[idx].url);

--- a/blocks/byline-block/features/byline/default.test.jsx
+++ b/blocks/byline-block/features/byline/default.test.jsx
@@ -9,7 +9,7 @@ jest.mock('fusion:intl', () => ({
 }));
 
 describe('Given a single author', () => {
-  it('should use additional_properties byline if exists', () => {
+  it('should use additional_properties byline if it exists', () => {
     const { default: ArticleByline } = require('./default');
     const credits = {
       by: [{
@@ -29,7 +29,7 @@ describe('Given a single author', () => {
     expect(wrapper.find('span').at(1).prop('dangerouslySetInnerHTML')).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim Byline</a>' });
   });
 
-  it('should fallback to author name if additional_properties doesnt exist', () => {
+  it("should fallback to author name if additional_properties doesn't exist", () => {
     const { default: ArticleByline } = require('./default');
     const credits = {
       by: [{
@@ -79,7 +79,7 @@ describe('Given a single author', () => {
     expect(wrapper.find('span').length).toBe(0);
   });
 
-  it('should not be a link if not have url', () => {
+  it('should not be a link if url is missing', () => {
     const { default: ArticleByline } = require('./default');
     const credits = {
       by: [
@@ -97,7 +97,7 @@ describe('Given a single author', () => {
     expect(wrapper.find('span').at(1).text().trim()).toEqual('SangHee Kim');
   });
 
-  it('should not be a link if not have url #2', () => {
+  it('should not be a link if url is missing #2', () => {
     const { default: ArticleByline } = require('./default');
     const credits = {
       by: [
@@ -114,7 +114,7 @@ describe('Given a single author', () => {
     expect(wrapper.find('span').at(1).text().trim()).toEqual('SangHee Kim');
   });
 
-  it('should not be a link if not have url #3', () => {
+  it('should not be a link if url is missing #3', () => {
     const { default: ArticleByline } = require('./default');
     const credits = {
       by: [

--- a/blocks/byline-block/features/byline/default.test.jsx
+++ b/blocks/byline-block/features/byline/default.test.jsx
@@ -8,8 +8,28 @@ jest.mock('fusion:intl', () => ({
   default: jest.fn((locale) => ({ t: jest.fn((phrase) => require('../../intl.json')[phrase][locale]) })),
 }));
 
-describe('Given the display time from ANS, it should convert to the proper timezone format we want', () => {
-  it('should return one author', () => {
+describe('Given a single author', () => {
+  it('should use additional_properties byline if exists', () => {
+    const { default: ArticleByline } = require('./default');
+    const credits = {
+      by: [{
+        type: 'author',
+        name: 'SangHee Kim',
+        url: '/author/sanghee-kim',
+        additional_properties: {
+          original: {
+            byline: 'SangHee Kim Byline',
+          },
+        },
+      }],
+    };
+    const globalContent = { credits };
+
+    const wrapper = mount(<ArticleByline globalContent={globalContent} />);
+    expect(wrapper.find('span').at(1).prop('dangerouslySetInnerHTML')).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim Byline</a>' });
+  });
+
+  it('should fallback to author name if additional_properties doesnt exist', () => {
     const { default: ArticleByline } = require('./default');
     const credits = {
       by: [{
@@ -24,6 +44,101 @@ describe('Given the display time from ANS, it should convert to the proper timez
     expect(wrapper.find('span').at(1).prop('dangerouslySetInnerHTML')).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim</a>' });
   });
 
+
+  it('should return nothing if type is not "author"', () => {
+    const { default: ArticleByline } = require('./default');
+    const credits = {
+      by: [
+        {
+          type: 'other',
+          name: 'SangHee Kim',
+          url: '/author/sanghee-kim',
+        },
+      ],
+    };
+    const globalContent = { credits };
+
+    const wrapper = mount(<ArticleByline globalContent={globalContent} />);
+    expect(wrapper.find('span').length).toBe(0);
+  });
+
+  it('should return nothing if name is missing', () => {
+    const { default: ArticleByline } = require('./default');
+    const credits = {
+      by: [
+        {
+          type: 'author',
+          name: '',
+          url: '/author/sanghee-kim',
+        },
+      ],
+    };
+    const globalContent = { credits };
+
+    const wrapper = mount(<ArticleByline globalContent={globalContent} />);
+    expect(wrapper.find('span').length).toBe(0);
+  });
+
+  it('should not be a link if not have url', () => {
+    const { default: ArticleByline } = require('./default');
+    const credits = {
+      by: [
+        {
+          type: 'author',
+          name: 'SangHee Kim',
+          url: '',
+        },
+      ],
+    };
+    const globalContent = { credits };
+
+    const wrapper = mount(<ArticleByline globalContent={globalContent} />);
+    expect(wrapper.find('span').at(1).find('a').length).toBe(0);
+    expect(wrapper.find('span').at(1).text().trim()).toEqual('SangHee Kim');
+  });
+
+  it('should not be a link if not have url #2', () => {
+    const { default: ArticleByline } = require('./default');
+    const credits = {
+      by: [
+        {
+          type: 'author',
+          name: 'SangHee Kim',
+        },
+      ],
+    };
+    const globalContent = { credits };
+
+    const wrapper = mount(<ArticleByline globalContent={globalContent} />);
+    expect(wrapper.find('span').at(1).find('a').length).toBe(0);
+    expect(wrapper.find('span').at(1).text().trim()).toEqual('SangHee Kim');
+  });
+
+  it('should not be a link if not have url #3', () => {
+    const { default: ArticleByline } = require('./default');
+    const credits = {
+      by: [
+        {
+          type: 'author',
+          name: 'SangHee Kim',
+          url: '',
+          additional_properties: {
+            original: {
+              byline: 'SangHee Kim Byline',
+            },
+          },
+        },
+      ],
+    };
+    const globalContent = { credits };
+
+    const wrapper = mount(<ArticleByline globalContent={globalContent} stylesFor="list" />);
+    expect(wrapper.find('span').at(1).find('a').length).toBe(0);
+    expect(wrapper.find('span').at(1).text().trim()).toEqual('SangHee Kim Byline');
+  });
+});
+
+describe('Given an author list', () => {
   it('should return two authors', () => {
     const { default: ArticleByline } = require('./default');
     const credits = {
@@ -139,13 +254,27 @@ describe('Given the display time from ANS, it should convert to the proper timez
               byline: 'Sara Lynn Carothers',
             },
           },
+        }, {
+          type: 'other',
+          name: 'John Doe',
+          url: '/author/john-doe',
+          additional_properties: {
+            original: {
+              byline: 'John Doe',
+            },
+          },
         },
       ],
     };
     const globalContent = { credits };
 
     const wrapper = mount(<ArticleByline globalContent={globalContent} />);
-    expect(wrapper.find('span').at(1).prop('dangerouslySetInnerHTML')).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim</a>, <a href="/author/joe-grosspietsch">Joe Grosspietsch</a>, <a href="/author/brent-miller">Brent Miller</a> and <a href="/author/sara-carothers">Sara Carothers</a>' });
+    expect(wrapper.find('span').at(1).text().trim()).toEqual('SangHee Kim Byline, Joe Grosspietsch Byline, Brent Miller Byline and Sara Lynn Carothers');
+
+    wrapper.find('span').at(1).find('a').forEach((anchor, idx) => {
+      expect(anchor.prop('href')).toEqual(credits.by[idx].url);
+      expect(anchor.text()).toEqual(credits.by[idx].additional_properties.original.byline);
+    });
   });
 
   it('should not throw by undefined error if empty global content object', () => {


### PR DESCRIPTION
[PEN-1180](https://arcpublishing.atlassian.net/browse/PEN-1180)

# What does this implement or fix?
- fix how the byline is rendered taking into account additional_properties.byline


# How was this tested?
- tests written

# Show Effect Of Changes

## Before
![2020_0731_150543](https://user-images.githubusercontent.com/9757/89064327-304de380-d340-11ea-8b28-7565209574c2.png)

## After
![2020_0731_150515](https://user-images.githubusercontent.com/9757/89064344-3643c480-d340-11ea-92e5-3f551414ab05.png)

# Dependencies or Side Effects

- none
