### PR TITLE
PEN-1137: Public Block Packages

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,10 @@
-UNLICENSED
+Shield: [![CC BY-NC-ND 4.0][cc-by-shield]][cc-by-nc-nd]
+
+This work is licensed under a
+[Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License][cc-by-nc-nd].
+
+[![CC BY-NC-ND 4.0][cc-by-image]][cc-by-nc-nd]
+
+[cc-by-nc-nd]: https://creativecommons.org/licenses/by-nc-nd/4.0/
+[cc-by-image]: https://licensebuttons.net/l/by-nc-nd/3.0/88x31.png
+[cc-by-shield]: https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ The structure of blocks is largely incompatible with what lerna generates in thi
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The structure of blocks is largely incompatible with what lerna generates in thi
   "description": "Fusion News Theme header nav block",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -100,7 +100,7 @@ The structure of blocks is largely incompatible with what lerna generates in thi
     "layouts"
   ],
   "publishConfig": {
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/README.md
+++ b/README.md
@@ -206,4 +206,13 @@ Notes:
 
 ## License
 
-TODO
+Shield: [![CC BY-NC-ND 4.0][cc-by-shield]][cc-by-nc-nd]
+
+This work is licensed under a
+[Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License][cc-by-nc-nd].
+
+[![CC BY-NC-ND 4.0][cc-by-image]][cc-by-nc-nd]
+
+[cc-by-nc-nd]: https://creativecommons.org/licenses/by-nc-nd/4.0/
+[cc-by-image]: https://licensebuttons.net/l/by-nc-nd/3.0/88x31.png
+[cc-by-shield]: https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg

--- a/blocks/a11y-testing-block/package.json
+++ b/blocks/a11y-testing-block/package.json
@@ -10,7 +10,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/a11y-testing-block/package.json
+++ b/blocks/a11y-testing-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme A11y Testing block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/alert-bar-block/package.json
+++ b/blocks/alert-bar-block/package.json
@@ -10,7 +10,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/alert-bar-block/package.json
+++ b/blocks/alert-bar-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme alert bar block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/alert-bar-content-source-block/package.json
+++ b/blocks/alert-bar-content-source-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme collections content API content source block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/alert-bar-content-source-block/package.json
+++ b/blocks/alert-bar-content-source-block/package.json
@@ -10,7 +10,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/article-body-block/package.json
+++ b/blocks/article-body-block/package.json
@@ -13,7 +13,8 @@
     "chains"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/article-body-block/package.json
+++ b/blocks/article-body-block/package.json
@@ -7,14 +7,13 @@
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "chains"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/article-tag-block/package.json
+++ b/blocks/article-tag-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/article-tag-block/package.json
+++ b/blocks/article-tag-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion Article Tag block",
   "author": "Rohit Gande <rohit.gande@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/author-bio-block/package.json
+++ b/blocks/author-bio-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/author-bio-block/package.json
+++ b/blocks/author-bio-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme byline block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/author-content-source-block/package.json
+++ b/blocks/author-content-source-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme author API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/author-content-source-block/package.json
+++ b/blocks/author-content-source-block/package.json
@@ -10,7 +10,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/byline-block/package.json
+++ b/blocks/byline-block/package.json
@@ -14,7 +14,8 @@
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/byline-block/package.json
+++ b/blocks/byline-block/package.json
@@ -7,15 +7,14 @@
     "Jack Howard <jack.howard@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/card-list-block/package.json
+++ b/blocks/card-list-block/package.json
@@ -10,7 +10,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/card-list-block/package.json
+++ b/blocks/card-list-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion themes card list block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/collections-content-source-block/package.json
+++ b/blocks/collections-content-source-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme collections content API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/collections-content-source-block/package.json
+++ b/blocks/collections-content-source-block/package.json
@@ -10,7 +10,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/content-api-source-block/package.json
+++ b/blocks/content-api-source-block/package.json
@@ -7,14 +7,13 @@
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/content-api-source-block/package.json
+++ b/blocks/content-api-source-block/package.json
@@ -13,7 +13,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/date-block/package.json
+++ b/blocks/date-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/date-block/package.json
+++ b/blocks/date-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme date block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/default-output-block/package.json
+++ b/blocks/default-output-block/package.json
@@ -14,7 +14,8 @@
     "output-types"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/default-output-block/package.json
+++ b/blocks/default-output-block/package.json
@@ -8,14 +8,13 @@
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "output-types"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/double-chain-block/package.json
+++ b/blocks/double-chain-block/package.json
@@ -13,7 +13,8 @@
     "chains"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/double-chain-block/package.json
+++ b/blocks/double-chain-block/package.json
@@ -7,14 +7,13 @@
     "Jack Howard <jack.howard@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "chains"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/event-tester-block/package.json
+++ b/blocks/event-tester-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/event-tester-block/package.json
+++ b/blocks/event-tester-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme event tester-block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/extra-large-manual-promo-block/package.json
+++ b/blocks/extra-large-manual-promo-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/extra-large-manual-promo-block/package.json
+++ b/blocks/extra-large-manual-promo-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme Extra Large Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/extra-large-promo-block/package.json
+++ b/blocks/extra-large-promo-block/package.json
@@ -13,7 +13,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/extra-large-promo-block/package.json
+++ b/blocks/extra-large-promo-block/package.json
@@ -7,14 +7,13 @@
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/footer-block/package.json
+++ b/blocks/footer-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/footer-block/package.json
+++ b/blocks/footer-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme footer block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/full-author-bio-block/package.json
+++ b/blocks/full-author-bio-block/package.json
@@ -11,7 +11,8 @@
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/full-author-bio-block/package.json
+++ b/blocks/full-author-bio-block/package.json
@@ -4,15 +4,14 @@
   "description": "Fusion News Theme full author bio block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/gallery-block/package.json
+++ b/blocks/gallery-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme gallery block",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/gallery-block/package.json
+++ b/blocks/gallery-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/global-phrases-block/package.json
+++ b/blocks/global-phrases-block/package.json
@@ -10,8 +10,7 @@
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/global-phrases-block/package.json
+++ b/blocks/global-phrases-block/package.json
@@ -10,7 +10,8 @@
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/header-block/package.json
+++ b/blocks/header-block/package.json
@@ -10,7 +10,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/header-block/package.json
+++ b/blocks/header-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion themes header block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/header-nav-block/package.json
+++ b/blocks/header-nav-block/package.json
@@ -16,7 +16,8 @@
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/header-nav-block/package.json
+++ b/blocks/header-nav-block/package.json
@@ -7,7 +7,7 @@
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -16,8 +16,7 @@
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/header-nav-chain-block/package.json
+++ b/blocks/header-nav-chain-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme header nav chain block",
   "author": "Sean Shannon <sean.shannon@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -13,8 +13,7 @@
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/header-nav-chain-block/package.json
+++ b/blocks/header-nav-chain-block/package.json
@@ -13,7 +13,8 @@
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/headline-block/package.json
+++ b/blocks/headline-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/headline-block/package.json
+++ b/blocks/headline-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme headline block",
   "author": "Brent Miller <brent.miller@washport.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/htmlbox-block/package.json
+++ b/blocks/htmlbox-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/htmlbox-block/package.json
+++ b/blocks/htmlbox-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme HTMLBox block",
   "author": "Rohit Gande <rohit.gande@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/large-manual-promo-block/package.json
+++ b/blocks/large-manual-promo-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/large-manual-promo-block/package.json
+++ b/blocks/large-manual-promo-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme Large Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/large-promo-block/package.json
+++ b/blocks/large-promo-block/package.json
@@ -13,7 +13,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/large-promo-block/package.json
+++ b/blocks/large-promo-block/package.json
@@ -7,14 +7,13 @@
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/lead-art-block/package.json
+++ b/blocks/lead-art-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/lead-art-block/package.json
+++ b/blocks/lead-art-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme lead art block",
   "author": "Brent Miller <brent.miller@washport.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/links-bar-block/package.json
+++ b/blocks/links-bar-block/package.json
@@ -7,14 +7,13 @@
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/links-bar-block/package.json
+++ b/blocks/links-bar-block/package.json
@@ -13,7 +13,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/masthead-block/package.json
+++ b/blocks/masthead-block/package.json
@@ -10,7 +10,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",

--- a/blocks/masthead-block/package.json
+++ b/blocks/masthead-block/package.json
@@ -4,14 +4,13 @@
   "description": "Masthead – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",

--- a/blocks/medium-manual-promo-block/package.json
+++ b/blocks/medium-manual-promo-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/medium-manual-promo-block/package.json
+++ b/blocks/medium-manual-promo-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme Medium Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme Medium Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/numbered-list-block/package.json
+++ b/blocks/numbered-list-block/package.json
@@ -14,7 +14,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/numbered-list-block/package.json
+++ b/blocks/numbered-list-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme numbered list block",
   "author": "Rohit Gande <rohit.gande@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "contributors": [
     "Jack Howard <jack.howard@washpost.com>",
@@ -14,8 +14,7 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/overline-block/package.json
+++ b/blocks/overline-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/overline-block/package.json
+++ b/blocks/overline-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion themes block containing an overline block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/placeholder-image-block/package.json
+++ b/blocks/placeholder-image-block/package.json
@@ -8,8 +8,7 @@
   },
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",
@@ -23,7 +22,7 @@
     "thumbor"
   ],
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0"
   },

--- a/blocks/placeholder-image-block/package.json
+++ b/blocks/placeholder-image-block/package.json
@@ -8,7 +8,8 @@
   },
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/quad-chain-block/package.json
+++ b/blocks/quad-chain-block/package.json
@@ -4,7 +4,7 @@
   "description": "Quad Chain – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "chains"
@@ -14,8 +14,7 @@
     "containers"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/quad-chain-block/package.json
+++ b/blocks/quad-chain-block/package.json
@@ -14,7 +14,8 @@
     "containers"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/resizer-image-block/package.json
+++ b/blocks/resizer-image-block/package.json
@@ -12,7 +12,8 @@
     "directory": "blocks/resizer-image-block"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "keywords": [
     "thumbor",

--- a/blocks/resizer-image-block/package.json
+++ b/blocks/resizer-image-block/package.json
@@ -12,8 +12,7 @@
     "directory": "blocks/resizer-image-block"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "keywords": [
     "thumbor",
@@ -23,7 +22,7 @@
     "images"
   ],
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
   },

--- a/blocks/resizer-image-content-source-block/package.json
+++ b/blocks/resizer-image-content-source-block/package.json
@@ -12,7 +12,8 @@
     "directory": "blocks/resizer-image-content-source-block"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
   "files": [

--- a/blocks/resizer-image-content-source-block/package.json
+++ b/blocks/resizer-image-content-source-block/package.json
@@ -12,8 +12,7 @@
     "directory": "blocks/resizer-image-content-source-block"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
   "files": [
@@ -27,7 +26,7 @@
     "images"
   ],
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77",
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0"

--- a/blocks/results-list-block/package.json
+++ b/blocks/results-list-block/package.json
@@ -8,15 +8,14 @@
     "Jack Howard <jack.howard@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/results-list-block/package.json
+++ b/blocks/results-list-block/package.json
@@ -15,7 +15,8 @@
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/right-rail-advanced-block/package.json
+++ b/blocks/right-rail-advanced-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/right-rail-advanced-block/package.json
+++ b/blocks/right-rail-advanced-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion themes block containing an advanced right-rail layout.",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/right-rail-block/package.json
+++ b/blocks/right-rail-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/right-rail-block/package.json
+++ b/blocks/right-rail-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion themes block containing a right-rail layout.",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/search-content-source-block/package.json
+++ b/blocks/search-content-source-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme search API content source block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/search-content-source-block/package.json
+++ b/blocks/search-content-source-block/package.json
@@ -10,7 +10,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/search-results-list-block/package.json
+++ b/blocks/search-results-list-block/package.json
@@ -11,7 +11,8 @@
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/search-results-list-block/package.json
+++ b/blocks/search-results-list-block/package.json
@@ -4,15 +4,14 @@
   "description": "Fusion News Theme search results list block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
     "intl.json"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/section-title-block/package.json
+++ b/blocks/section-title-block/package.json
@@ -10,7 +10,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/section-title-block/package.json
+++ b/blocks/section-title-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme section title block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/share-bar-block/package.json
+++ b/blocks/share-bar-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/share-bar-block/package.json
+++ b/blocks/share-bar-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme share bar block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/shared-styles/package.json
+++ b/blocks/shared-styles/package.json
@@ -10,7 +10,8 @@
     "scss"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/shared-styles/package.json
+++ b/blocks/shared-styles/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme Shared Styles",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "scss"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/simple-list-block/package.json
+++ b/blocks/simple-list-block/package.json
@@ -7,14 +7,13 @@
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/simple-list-block/package.json
+++ b/blocks/simple-list-block/package.json
@@ -13,7 +13,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/single-chain-block/package.json
+++ b/blocks/single-chain-block/package.json
@@ -10,7 +10,8 @@
     "chains"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/single-chain-block/package.json
+++ b/blocks/single-chain-block/package.json
@@ -4,14 +4,13 @@
   "description": "Single Chain – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "chains"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/site-hierarchy-content-block/package.json
+++ b/blocks/site-hierarchy-content-block/package.json
@@ -7,7 +7,7 @@
     "Jack Howard <jack.howard@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "directories": {
     "lib": "lib",
@@ -17,8 +17,7 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/site-hierarchy-content-block/package.json
+++ b/blocks/site-hierarchy-content-block/package.json
@@ -17,7 +17,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/small-manual-promo-block/package.json
+++ b/blocks/small-manual-promo-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/small-manual-promo-block/package.json
+++ b/blocks/small-manual-promo-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme Small Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/small-promo-block/package.json
+++ b/blocks/small-promo-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/small-promo-block/package.json
+++ b/blocks/small-promo-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme Small Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/story-feed-author-content-source-block/package.json
+++ b/blocks/story-feed-author-content-source-block/package.json
@@ -10,7 +10,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/story-feed-author-content-source-block/package.json
+++ b/blocks/story-feed-author-content-source-block/package.json
@@ -4,14 +4,13 @@
   "description": "Content source block for story feed queries by author",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/story-feed-query-content-source-block/package.json
+++ b/blocks/story-feed-query-content-source-block/package.json
@@ -10,7 +10,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/story-feed-query-content-source-block/package.json
+++ b/blocks/story-feed-query-content-source-block/package.json
@@ -4,14 +4,13 @@
   "description": "Content source block for story feed queries by Elasticsearch queries",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/story-feed-sections-content-source-block/package.json
+++ b/blocks/story-feed-sections-content-source-block/package.json
@@ -10,7 +10,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/story-feed-sections-content-source-block/package.json
+++ b/blocks/story-feed-sections-content-source-block/package.json
@@ -4,14 +4,13 @@
   "description": "Content source block for story feed queries by section",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -4,14 +4,13 @@
   "description": "Content source block for story feed queries by tag",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -10,7 +10,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/subheadline-block/package.json
+++ b/blocks/subheadline-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme sub-headline block",
   "author": "Brent Miller <brent.miller@washport.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"    
   },
   "repository": {
     "type": "git",

--- a/blocks/subheadline-block/package.json
+++ b/blocks/subheadline-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"    
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public" 
   },
   "repository": {
     "type": "git",

--- a/blocks/tag-title-block/package.json
+++ b/blocks/tag-title-block/package.json
@@ -10,7 +10,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/tag-title-block/package.json
+++ b/blocks/tag-title-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion themes block containing a tag title block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/tags-content-source-block/package.json
+++ b/blocks/tags-content-source-block/package.json
@@ -10,7 +10,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/tags-content-source-block/package.json
+++ b/blocks/tags-content-source-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme tags API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/text-output-block/package.json
+++ b/blocks/text-output-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme text output type",
   "author": "nelson fernandez <nelson.fernandez@washport.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "output-types"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/text-output-block/package.json
+++ b/blocks/text-output-block/package.json
@@ -10,7 +10,8 @@
     "output-types"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/textfile-block/package.json
+++ b/blocks/textfile-block/package.json
@@ -10,7 +10,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/textfile-block/package.json
+++ b/blocks/textfile-block/package.json
@@ -4,14 +4,13 @@
   "description": "Fusion News Theme text file block",
   "author": "nelson fernandez <nelson.fernandez@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/top-table-list-block/package.json
+++ b/blocks/top-table-list-block/package.json
@@ -7,14 +7,13 @@
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/top-table-list-block/package.json
+++ b/blocks/top-table-list-block/package.json
@@ -13,7 +13,8 @@
     "features"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/triple-chain-block/package.json
+++ b/blocks/triple-chain-block/package.json
@@ -10,7 +10,8 @@
     "chains"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/triple-chain-block/package.json
+++ b/blocks/triple-chain-block/package.json
@@ -4,14 +4,13 @@
   "description": "Triple Chain – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "chains"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/unpublished-content-source-block/package.json
+++ b/blocks/unpublished-content-source-block/package.json
@@ -13,7 +13,8 @@
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/unpublished-content-source-block/package.json
+++ b/blocks/unpublished-content-source-block/package.json
@@ -7,14 +7,13 @@
     "Jack Howard <jack.howard@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "sources"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/blocks/video-player-block/package.json
+++ b/blocks/video-player-block/package.json
@@ -12,7 +12,8 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/blocks/video-player-block/package.json
+++ b/blocks/video-player-block/package.json
@@ -4,7 +4,7 @@
   "description": "Fusion News Theme video player block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
     "features",
@@ -12,8 +12,7 @@
     "layouts"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "fusion-news-theme-blocks",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
       "pre-push": "npm run test:coverage && npm run lint"
     }
   },
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND",
   "devDependencies": {
     "@arc-fusion/prop-types": "^0.1.5",
     "@babel/core": "^7.10.2",


### PR DESCRIPTION
[PEN-1137](https://arcpublishing.atlassian.net/browse/PEN-1137)

# What does this implement or fix?
- Removes restricted publishing config
- Adds a license to the repo
- Adds CC-NC-ND license to each package

# How was this tested?

Will test by installing blocks without a `.npmrc` once the repo becomes public

# Dependencies or Side Effects

- This PR will be required to make the blocks repo public. 
- Since we are not making other dependencies like engine theme SDK or news theme css public yet, we will rely on having Luke's personal Github token, but it isn't publicly readable.
