### PR TITLE
Video player breaking tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5324,8 +5324,8 @@
     "@wpmedia/article-body-block": {
       "version": "file:blocks/article-body-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/video-player-block": "^5.2.0",
         "react-oembed-container": "^0.3.0",
         "styled-components": "^4.4.0"
@@ -5333,8 +5333,7 @@
       "dependencies": {
         "@wpmedia/video-player-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/video-player-block/5.2.0/3ff0c567fb5e9e559bac196403077b98d45afdd9d961e69ebeeed0b4516ac9d1",
-          "integrity": "sha512-Bskz9mGGec00Kco16007/egAx2alaqnADEdMR7e23WnLK5yT41NypWJaBqSC4SqC2Scx94Yp8zCcKxlhhks+KQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8",
             "react-oembed-container": "^0.3.0",
@@ -5353,46 +5352,44 @@
     "@wpmedia/article-tag-block": {
       "version": "file:blocks/article-tag-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "styled-components": "^4.4.0"
       }
     },
     "@wpmedia/byline-block": {
       "version": "file:blocks/byline-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "styled-components": "^4.4.0"
       }
     },
     "@wpmedia/date-block": {
       "version": "file:blocks/date-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "styled-components": "^4.4.0"
       }
     },
     "@wpmedia/default-output-block": {
       "version": "file:blocks/default-output-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8"
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0"
       },
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "bundled": true,
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
         },
         "@babel/generator": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+          "bundled": true,
           "requires": {
             "@babel/types": "^7.10.5",
             "jsesc": "^2.5.1",
@@ -5401,16 +5398,14 @@
         },
         "@babel/helper-annotate-as-pure": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-          "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+          "bundled": true,
           "requires": {
             "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-function-name": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "bundled": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.10.4",
             "@babel/template": "^7.10.4",
@@ -5419,37 +5414,32 @@
         },
         "@babel/helper-get-function-arity": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "bundled": true,
           "requires": {
             "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-module-imports": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+          "bundled": true,
           "requires": {
             "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-split-export-declaration": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-          "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+          "bundled": true,
           "requires": {
             "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-validator-identifier": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+          "bundled": true
         },
         "@babel/highlight": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "bundled": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "chalk": "^2.0.0",
@@ -5458,21 +5448,18 @@
         },
         "@babel/parser": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
+          "bundled": true
         },
         "@babel/runtime": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
-          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+          "bundled": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "@babel/template": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "bundled": true,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/parser": "^7.10.4",
@@ -5481,8 +5468,7 @@
         },
         "@babel/traverse": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+          "bundled": true,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/generator": "^7.10.5",
@@ -5497,8 +5483,7 @@
         },
         "@babel/types": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+          "bundled": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -5507,26 +5492,22 @@
         },
         "@emotion/is-prop-valid": {
           "version": "0.8.8",
-          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+          "bundled": true,
           "requires": {
             "@emotion/memoize": "0.7.4"
           }
         },
         "@emotion/memoize": {
           "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+          "bundled": true
         },
         "@emotion/unitless": {
           "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-          "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+          "bundled": true
         },
         "@wpmedia/engine-theme-sdk": {
           "version": "2.1.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.1.0/8fad8e96d2a403f707c1c54fc7f47551a0782510e3694ceaf71a149d85bf0751",
-          "integrity": "sha512-ovfTL2IhQgMLCjRxbdXOwABXMsSRVBMRHZL4SRNXGk4RhjbuQA/de61sMeyNGim8/JOmS2ZV3VJ8HmwiPsTXvA==",
+          "bundled": true,
           "requires": {
             "dom-parser": "^0.1.6",
             "is-react": "^1.3.3",
@@ -5543,21 +5524,18 @@
         },
         "@wpmedia/news-theme-css": {
           "version": "2.1.8",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/2.1.8/704c3bef6c5a7225ce819fbbb9a7270474ef78c414c6db016ff5a77c6c21563f",
-          "integrity": "sha512-f6OnKjPTAp2lQEmkLO+hBIfZNmTUo5glRLLFyRfkoFYDAgRQxzzDVNZgVPfqhsyGd0vszF06xXDFJQFNmMzdyQ=="
+          "bundled": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "bundled": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "babel-plugin-styled-components": {
           "version": "1.10.7",
-          "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz",
-          "integrity": "sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==",
+          "bundled": true,
           "requires": {
             "@babel/helper-annotate-as-pure": "^7.0.0",
             "@babel/helper-module-imports": "^7.0.0",
@@ -5567,18 +5545,15 @@
         },
         "babel-plugin-syntax-jsx": {
           "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-          "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+          "bundled": true
         },
         "camelize": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-          "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+          "bundled": true
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "bundled": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -5587,8 +5562,7 @@
         },
         "cipher-base": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-          "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+          "bundled": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -5596,26 +5570,22 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "bundled": true,
           "requires": {
             "color-name": "1.1.3"
           }
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "bundled": true
         },
         "css-color-keywords": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-          "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+          "bundled": true
         },
         "css-to-react-native": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
-          "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+          "bundled": true,
           "requires": {
             "camelize": "^1.0.0",
             "css-color-keywords": "^1.0.0",
@@ -5624,118 +5594,98 @@
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "bundled": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "dom-parser": {
           "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/dom-parser/-/dom-parser-0.1.6.tgz",
-          "integrity": "sha512-3nVRKbLEwmGfghLoeT1dxlK/0votalnOfasP+8VCHYDfDuCETY4LeMblfOeqww6XZk2ymZ1Uewy/hVad6Dy3yw=="
+          "bundled": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "bundled": true
         },
         "exenv": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-          "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+          "bundled": true
         },
         "globals": {
           "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+          "bundled": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "bundled": true
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+          "bundled": true
         },
         "is-react": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/is-react/-/is-react-1.4.0.tgz",
-          "integrity": "sha512-6MfKyatgJfuvvKPPKvdaEnFlvdbwhAma4jiTOjxp9uL8oTKo9uKw9U/vTvMB2jiYkPoXBvK2QSUGI5m4egJsgw==",
+          "bundled": true,
           "requires": {
             "react": "^16.13.1"
           }
         },
         "is-what": {
           "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.10.0.tgz",
-          "integrity": "sha512-U4RYCXNOmATQHlOPlOCHCfXyKEFIPqvyaKDqYRuLbD6EYKcTTfc3YXkAYjzOVxO3zt34L+Wh2feIyWrYiZ7kng=="
+          "bundled": true
         },
         "js-tokens": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+          "bundled": true
         },
         "jsesc": {
           "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+          "bundled": true
         },
         "lodash": {
           "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+          "bundled": true
         },
         "loose-envify": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "bundled": true,
           "requires": {
             "js-tokens": "^3.0.0 || ^4.0.0"
           }
         },
         "memoize-one": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-          "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+          "bundled": true
         },
         "merge-anything": {
           "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.4.tgz",
-          "integrity": "sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==",
+          "bundled": true,
           "requires": {
             "is-what": "^3.3.1"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+          "bundled": true
         },
         "polished": {
           "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.5.tgz",
-          "integrity": "sha512-VwhC9MlhW7O5dg/z7k32dabcAFW1VI2+7fSe8cE/kXcfL7mVdoa5UxciYGW2sJU78ldDLT6+ROEKIZKFNTnUXQ==",
+          "bundled": true,
           "requires": {
             "@babel/runtime": "^7.9.2"
           }
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+          "bundled": true
         },
         "prop-types": {
           "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "bundled": true,
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
@@ -5744,8 +5694,7 @@
         },
         "react": {
           "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-          "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+          "bundled": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
@@ -5754,8 +5703,7 @@
         },
         "react-dom": {
           "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-          "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+          "bundled": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
@@ -5765,18 +5713,15 @@
         },
         "react-is": {
           "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "bundled": true
         },
         "react-lifecycles-compat": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-          "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+          "bundled": true
         },
         "react-modal": {
           "version": "3.11.2",
-          "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.2.tgz",
-          "integrity": "sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==",
+          "bundled": true,
           "requires": {
             "exenv": "^1.2.0",
             "prop-types": "^15.5.10",
@@ -5786,26 +5731,22 @@
         },
         "react-swipeable": {
           "version": "5.5.1",
-          "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-5.5.1.tgz",
-          "integrity": "sha512-EQObuU3Qg3JdX3WxOn5reZvOSCpU4fwpUAs+NlXSN3y+qtsO2r8VGkVnOQzmByt3BSYj9EWYdUOUfi7vaMdZZw==",
+          "bundled": true,
           "requires": {
             "prop-types": "^15.6.2"
           }
         },
         "regenerator-runtime": {
           "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+          "bundled": true
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "bundled": true
         },
         "scheduler": {
           "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "bundled": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
@@ -5813,13 +5754,11 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "bundled": true
         },
         "styled-components": {
           "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.4.1.tgz",
-          "integrity": "sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==",
+          "bundled": true,
           "requires": {
             "@babel/helper-module-imports": "^7.0.0",
             "@babel/traverse": "^7.0.0",
@@ -5838,26 +5777,22 @@
         },
         "stylis": {
           "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-          "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
+          "bundled": true
         },
         "stylis-rule-sheet": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-          "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
+          "bundled": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "bundled": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
         },
         "thumbor-lite": {
           "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/thumbor-lite/-/thumbor-lite-0.1.8.tgz",
-          "integrity": "sha512-8C0Ohi2vi0/JVdhRVzNEhtF3MptFp3r9Br0nU3rjor3m5zhGL6QtGJZPV42NJ/e8qyVisZtr0d/Ew4mBz5w4OQ==",
+          "bundled": true,
           "requires": {
             "cipher-base": "^1.0.4",
             "inherits": "^2.0.4",
@@ -5866,18 +5801,15 @@
         },
         "timezone": {
           "version": "1.0.23",
-          "resolved": "https://registry.npmjs.org/timezone/-/timezone-1.0.23.tgz",
-          "integrity": "sha512-yhQgk6qmSLB+TF8HGmApZAVI5bfzR1CoKUGr+WMZWmx75ED1uDewAZA8QMGCQ70TEv4GmM8pDB9jrHuxdaQ1PA=="
+          "bundled": true
         },
         "to-fast-properties": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+          "bundled": true
         },
         "warning": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "bundled": true,
           "requires": {
             "loose-envify": "^1.0.0"
           }
@@ -5905,23 +5837,22 @@
     "@wpmedia/event-tester-block": {
       "version": "file:blocks/event-tester-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10"
+        "@wpmedia/engine-theme-sdk": "^2.2.0"
       }
     },
     "@wpmedia/extra-large-manual-promo-block": {
       "version": "file:blocks/extra-large-manual-promo-block",
       "requires": {
         "@arc-fusion/prop-types": "^0.1.5",
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/shared-styles": "^5.2.0",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/shared-styles": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/shared-styles/5.2.0/f7a94010969176c97f8a3de325699939c0c6e1bde0c14b31a2f47ce7ec5ddf43",
-          "integrity": "sha512-qUhnRmbZ65cmrTH4zH5f/kO7idJlm51x7eCt7ATbODj6LX6cEAGZUrLfvrC/kNQwqdOPS21TyqwZvsj+VXUXIQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -5940,9 +5871,9 @@
       "requires": {
         "@wpmedia/byline-block": "^5.2.0",
         "@wpmedia/date-block": "^5.2.0",
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
         "@wpmedia/global-phrases-block": "^5.2.0",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/overline-block": "^5.2.0",
         "@wpmedia/shared-styles": "^5.2.0",
         "styled-components": "^4.4.0"
@@ -5950,8 +5881,7 @@
       "dependencies": {
         "@wpmedia/byline-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/byline-block/5.2.0/b8f3ef4c4dfc9e16435d6ad58af27ed9ccd4c6958f9611f6340b1f741c605854",
-          "integrity": "sha512-kfGU1Yx9sOoLbC0ph6btb8DCQWDjnrs6yGpyDZMGpuww6OUkCHcGD87qwvR/XVDSPjzi466k8EK2PJ+VSRHE6g==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8",
             "styled-components": "^4.4.0"
@@ -5966,8 +5896,7 @@
         },
         "@wpmedia/date-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/date-block/5.2.0/c8fcf1b6078010db3e16eb6eef59bf6d19553383538e356554ca9d7e85fff004",
-          "integrity": "sha512-uPtBaEUt6VozAmsDa1gKjZOmwhmkNIruPVIdu0Jrb1lTqal+Rop6J9BAy9hylBFsohI1nKd7dDKgMcl/opL5TA==",
+          "bundled": true,
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.1.0",
             "@wpmedia/news-theme-css": "^2.1.8",
@@ -5983,13 +5912,11 @@
         },
         "@wpmedia/global-phrases-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/global-phrases-block/5.2.0/bf433b4873107e0b8332fc67a5e5cbb060103db9811604aad85a72322affd038",
-          "integrity": "sha512-gN6LWEe5ECCRKcRyll3+FRhQSaIJm+sKU+BwJ/Ge+5tV5zAJF22mxn5UQjCL/BFyqB09fsyaDo4GxdFZ4kHpZg=="
+          "bundled": true
         },
         "@wpmedia/overline-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/overline-block/5.2.0/8e82623b1747eecec4f7f867826698daa7ad58282417aa4b0fe01b1faa06de6e",
-          "integrity": "sha512-CdWLYwV1int57BnDzBtci65N1lkiHWnu2aSczp4QRahAea12FsdzvFBN9f2OEKzTa1jRaoAZyHk3COatIrRoQg==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6003,8 +5930,7 @@
         },
         "@wpmedia/shared-styles": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/shared-styles/5.2.0/f7a94010969176c97f8a3de325699939c0c6e1bde0c14b31a2f47ce7ec5ddf43",
-          "integrity": "sha512-qUhnRmbZ65cmrTH4zH5f/kO7idJlm51x7eCt7ATbODj6LX6cEAGZUrLfvrC/kNQwqdOPS21TyqwZvsj+VXUXIQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6021,16 +5947,15 @@
     "@wpmedia/header-nav-block": {
       "version": "file:blocks/header-nav-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/shared-styles": "^5.2.0",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/shared-styles": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/shared-styles/5.2.0/f7a94010969176c97f8a3de325699939c0c6e1bde0c14b31a2f47ce7ec5ddf43",
-          "integrity": "sha512-qUhnRmbZ65cmrTH4zH5f/kO7idJlm51x7eCt7ATbODj6LX6cEAGZUrLfvrC/kNQwqdOPS21TyqwZvsj+VXUXIQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6047,24 +5972,23 @@
     "@wpmedia/headline-block": {
       "version": "file:blocks/headline-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "styled-components": "^4.4.0"
       }
     },
     "@wpmedia/large-manual-promo-block": {
       "version": "file:blocks/large-manual-promo-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/shared-styles": "^5.2.0",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/shared-styles": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/shared-styles/5.2.0/f7a94010969176c97f8a3de325699939c0c6e1bde0c14b31a2f47ce7ec5ddf43",
-          "integrity": "sha512-qUhnRmbZ65cmrTH4zH5f/kO7idJlm51x7eCt7ATbODj6LX6cEAGZUrLfvrC/kNQwqdOPS21TyqwZvsj+VXUXIQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6083,8 +6007,8 @@
       "requires": {
         "@wpmedia/byline-block": "^5.2.0",
         "@wpmedia/date-block": "^5.2.0",
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/overline-block": "^5.2.0",
         "@wpmedia/shared-styles": "^5.2.0",
         "styled-components": "^4.4.0"
@@ -6092,8 +6016,7 @@
       "dependencies": {
         "@wpmedia/byline-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/byline-block/5.2.0/b8f3ef4c4dfc9e16435d6ad58af27ed9ccd4c6958f9611f6340b1f741c605854",
-          "integrity": "sha512-kfGU1Yx9sOoLbC0ph6btb8DCQWDjnrs6yGpyDZMGpuww6OUkCHcGD87qwvR/XVDSPjzi466k8EK2PJ+VSRHE6g==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8",
             "styled-components": "^4.4.0"
@@ -6108,8 +6031,7 @@
         },
         "@wpmedia/date-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/date-block/5.2.0/c8fcf1b6078010db3e16eb6eef59bf6d19553383538e356554ca9d7e85fff004",
-          "integrity": "sha512-uPtBaEUt6VozAmsDa1gKjZOmwhmkNIruPVIdu0Jrb1lTqal+Rop6J9BAy9hylBFsohI1nKd7dDKgMcl/opL5TA==",
+          "bundled": true,
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.1.0",
             "@wpmedia/news-theme-css": "^2.1.8",
@@ -6125,8 +6047,7 @@
         },
         "@wpmedia/overline-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/overline-block/5.2.0/8e82623b1747eecec4f7f867826698daa7ad58282417aa4b0fe01b1faa06de6e",
-          "integrity": "sha512-CdWLYwV1int57BnDzBtci65N1lkiHWnu2aSczp4QRahAea12FsdzvFBN9f2OEKzTa1jRaoAZyHk3COatIrRoQg==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6140,8 +6061,7 @@
         },
         "@wpmedia/shared-styles": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/shared-styles/5.2.0/f7a94010969176c97f8a3de325699939c0c6e1bde0c14b31a2f47ce7ec5ddf43",
-          "integrity": "sha512-qUhnRmbZ65cmrTH4zH5f/kO7idJlm51x7eCt7ATbODj6LX6cEAGZUrLfvrC/kNQwqdOPS21TyqwZvsj+VXUXIQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6158,16 +6078,15 @@
     "@wpmedia/lead-art-block": {
       "version": "file:blocks/lead-art-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/video-player-block": "^5.2.0",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/video-player-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/video-player-block/5.2.0/3ff0c567fb5e9e559bac196403077b98d45afdd9d961e69ebeeed0b4516ac9d1",
-          "integrity": "sha512-Bskz9mGGec00Kco16007/egAx2alaqnADEdMR7e23WnLK5yT41NypWJaBqSC4SqC2Scx94Yp8zCcKxlhhks+KQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8",
             "react-oembed-container": "^0.3.0",
@@ -6186,24 +6105,23 @@
     "@wpmedia/links-bar-block": {
       "version": "file:blocks/links-bar-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "styled-components": "^4.4.0"
       }
     },
     "@wpmedia/medium-manual-promo-block": {
       "version": "file:blocks/medium-manual-promo-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/shared-styles": "^5.2.0",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/shared-styles": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/shared-styles/5.2.0/f7a94010969176c97f8a3de325699939c0c6e1bde0c14b31a2f47ce7ec5ddf43",
-          "integrity": "sha512-qUhnRmbZ65cmrTH4zH5f/kO7idJlm51x7eCt7ATbODj6LX6cEAGZUrLfvrC/kNQwqdOPS21TyqwZvsj+VXUXIQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6222,16 +6140,15 @@
       "requires": {
         "@wpmedia/byline-block": "^5.2.0",
         "@wpmedia/date-block": "^5.2.0",
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/shared-styles": "^5.2.0",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/byline-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/byline-block/5.2.0/b8f3ef4c4dfc9e16435d6ad58af27ed9ccd4c6958f9611f6340b1f741c605854",
-          "integrity": "sha512-kfGU1Yx9sOoLbC0ph6btb8DCQWDjnrs6yGpyDZMGpuww6OUkCHcGD87qwvR/XVDSPjzi466k8EK2PJ+VSRHE6g==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8",
             "styled-components": "^4.4.0"
@@ -6246,8 +6163,7 @@
         },
         "@wpmedia/date-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/date-block/5.2.0/c8fcf1b6078010db3e16eb6eef59bf6d19553383538e356554ca9d7e85fff004",
-          "integrity": "sha512-uPtBaEUt6VozAmsDa1gKjZOmwhmkNIruPVIdu0Jrb1lTqal+Rop6J9BAy9hylBFsohI1nKd7dDKgMcl/opL5TA==",
+          "bundled": true,
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.1.0",
             "@wpmedia/news-theme-css": "^2.1.8",
@@ -6263,8 +6179,7 @@
         },
         "@wpmedia/shared-styles": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/shared-styles/5.2.0/f7a94010969176c97f8a3de325699939c0c6e1bde0c14b31a2f47ce7ec5ddf43",
-          "integrity": "sha512-qUhnRmbZ65cmrTH4zH5f/kO7idJlm51x7eCt7ATbODj6LX6cEAGZUrLfvrC/kNQwqdOPS21TyqwZvsj+VXUXIQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6286,28 +6201,28 @@
     "@wpmedia/numbered-list-block": {
       "version": "file:blocks/numbered-list-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "styled-components": "^4.4.0"
       }
     },
     "@wpmedia/overline-block": {
       "version": "file:blocks/overline-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8"
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0"
       }
     },
     "@wpmedia/placeholder-image-block": {
       "version": "file:blocks/placeholder-image-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10"
+        "@wpmedia/engine-theme-sdk": "^2.2.0"
       }
     },
     "@wpmedia/resizer-image-block": {
       "version": "file:blocks/resizer-image-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
         "thumbor-lite": "^0.1.8"
       }
     },
@@ -6316,17 +6231,16 @@
       "requires": {
         "@wpmedia/byline-block": "^5.2.0",
         "@wpmedia/date-block": "^5.2.0",
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
         "@wpmedia/global-phrases-block": "^5.2.0",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/shared-styles": "^5.2.0",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/byline-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/byline-block/5.2.0/b8f3ef4c4dfc9e16435d6ad58af27ed9ccd4c6958f9611f6340b1f741c605854",
-          "integrity": "sha512-kfGU1Yx9sOoLbC0ph6btb8DCQWDjnrs6yGpyDZMGpuww6OUkCHcGD87qwvR/XVDSPjzi466k8EK2PJ+VSRHE6g==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8",
             "styled-components": "^4.4.0"
@@ -6341,8 +6255,7 @@
         },
         "@wpmedia/date-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/date-block/5.2.0/c8fcf1b6078010db3e16eb6eef59bf6d19553383538e356554ca9d7e85fff004",
-          "integrity": "sha512-uPtBaEUt6VozAmsDa1gKjZOmwhmkNIruPVIdu0Jrb1lTqal+Rop6J9BAy9hylBFsohI1nKd7dDKgMcl/opL5TA==",
+          "bundled": true,
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.1.0",
             "@wpmedia/news-theme-css": "^2.1.8",
@@ -6358,13 +6271,11 @@
         },
         "@wpmedia/global-phrases-block": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/global-phrases-block/5.2.0/bf433b4873107e0b8332fc67a5e5cbb060103db9811604aad85a72322affd038",
-          "integrity": "sha512-gN6LWEe5ECCRKcRyll3+FRhQSaIJm+sKU+BwJ/Ge+5tV5zAJF22mxn5UQjCL/BFyqB09fsyaDo4GxdFZ4kHpZg=="
+          "bundled": true
         },
         "@wpmedia/shared-styles": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/shared-styles/5.2.0/f7a94010969176c97f8a3de325699939c0c6e1bde0c14b31a2f47ce7ec5ddf43",
-          "integrity": "sha512-qUhnRmbZ65cmrTH4zH5f/kO7idJlm51x7eCt7ATbODj6LX6cEAGZUrLfvrC/kNQwqdOPS21TyqwZvsj+VXUXIQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6381,39 +6292,38 @@
     "@wpmedia/right-rail-advanced-block": {
       "version": "file:blocks/right-rail-advanced-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "styled-components": "^4.4.0"
       }
     },
     "@wpmedia/right-rail-block": {
       "version": "file:blocks/right-rail-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "styled-components": "^4.4.0"
       }
     },
     "@wpmedia/shared-styles": {
       "version": "file:blocks/shared-styles",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8"
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0"
       }
     },
     "@wpmedia/small-manual-promo-block": {
       "version": "file:blocks/small-manual-promo-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/shared-styles": "^5.2.0",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/shared-styles": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/shared-styles/5.2.0/f7a94010969176c97f8a3de325699939c0c6e1bde0c14b31a2f47ce7ec5ddf43",
-          "integrity": "sha512-qUhnRmbZ65cmrTH4zH5f/kO7idJlm51x7eCt7ATbODj6LX6cEAGZUrLfvrC/kNQwqdOPS21TyqwZvsj+VXUXIQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6430,16 +6340,15 @@
     "@wpmedia/small-promo-block": {
       "version": "file:blocks/small-promo-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "@wpmedia/shared-styles": "^5.2.0",
         "styled-components": "^4.4.0"
       },
       "dependencies": {
         "@wpmedia/shared-styles": {
           "version": "5.2.0",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/shared-styles/5.2.0/f7a94010969176c97f8a3de325699939c0c6e1bde0c14b31a2f47ce7ec5ddf43",
-          "integrity": "sha512-qUhnRmbZ65cmrTH4zH5f/kO7idJlm51x7eCt7ATbODj6LX6cEAGZUrLfvrC/kNQwqdOPS21TyqwZvsj+VXUXIQ==",
+          "bundled": true,
           "requires": {
             "@wpmedia/news-theme-css": "^2.1.8"
           },
@@ -6456,9 +6365,42 @@
     "@wpmedia/subheadline-block": {
       "version": "file:blocks/subheadline-block",
       "requires": {
-        "@wpmedia/engine-theme-sdk": "^2.0.1-beta.10",
-        "@wpmedia/news-theme-css": "^2.1.8",
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
         "styled-components": "^4.4.0"
+      }
+    },
+    "@wpmedia/video-player-block": {
+      "version": "file:blocks/video-player-block",
+      "requires": {
+        "@wpmedia/engine-theme-sdk": "^2.2.0",
+        "@wpmedia/news-theme-css": "^3.0.0",
+        "react-oembed-container": "^0.3.0",
+        "styled-components": "^4.4.0"
+      },
+      "dependencies": {
+        "@wpmedia/engine-theme-sdk": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "dom-parser": "^0.1.6",
+            "is-react": "^1.3.3",
+            "lazy-child": "^0.2.0",
+            "polished": "^3.4.4",
+            "prop-types": "^15.7.2",
+            "react": "^16.12.0",
+            "react-dom": "^16.12.0",
+            "react-modal": "^3.11.1",
+            "react-swipeable": "^5.5.0",
+            "styled-components": "^4.4.1",
+            "thumbor-lite": "^0.1.6",
+            "timezone": "^1.0.23"
+          }
+        },
+        "@wpmedia/news-theme-css": {
+          "version": "3.0.2",
+          "bundled": true
+        }
       }
     },
     "@xtuc/ieee754": {
@@ -8611,8 +8553,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
           "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "to-regex-range": {
           "version": "5.0.1",
@@ -12594,8 +12535,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12619,15 +12559,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12644,22 +12582,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -12790,8 +12725,7 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -12805,7 +12739,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12822,7 +12755,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12831,15 +12763,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12860,7 +12790,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -12959,8 +12888,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -12974,7 +12902,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -13070,8 +12997,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -13113,7 +13039,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13135,7 +13060,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -13184,15 +13108,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -16295,6 +16217,15 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
+    },
+    "lazy-child": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/lazy-child/-/lazy-child-0.2.0.tgz",
+      "integrity": "sha512-QOlhECVjMLIS2FNujfZqPXnWBYpd54sv0k4YDgwuPb16CZMMPC5QxNfN/rH0SpfSe3sktK0l6qrOgtScV7eqWQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "react-peekaboo": "^0.3.0"
+      }
     },
     "lazy-universal-dotenv": {
       "version": "3.0.1",
@@ -20404,6 +20335,15 @@
       "integrity": "sha512-TnnbXcZNyweth85SUPY7t4cr0EL0D28MhxZ2zLD5pQd/2xVuiFzj+yNadY+w20akCxwZqdHl/PhDEFls5lb/3A==",
       "requires": {
         "prop-types": "^15.6.0"
+      }
+    },
+    "react-peekaboo": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/react-peekaboo/-/react-peekaboo-0.3.0.tgz",
+      "integrity": "sha512-Vae3BZ6aBCqAD4F7nWwX0Q8GWHb15p8hgfLiKtp3XF8/iyWhx+9na4Kz15lvoOR12+V7sdYv3BCNv3rG5gK2uA==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "lodash.throttle": "^4.1.1"
       }
     },
     "react-popper": {
@@ -24984,8 +24924,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@wpmedia/small-manual-promo-block": "file:blocks/small-manual-promo-block",
     "@wpmedia/small-promo-block": "file:blocks/small-promo-block",
     "@wpmedia/subheadline-block": "file:blocks/subheadline-block",
+    "@wpmedia/video-player-block": "file:blocks/video-player-block",
     "@wpmedia/a11y-testing-block": "file:blocks/a11y-testing-block"
   },
   "jest": {


### PR DESCRIPTION
Getting dependency issue with video player. I guess it should be included in top-level package.json. 

Steps: 

- Clear block node modules `npx lerna clean`
- Clear top-level node_modules `rm -rf node_modules`
- Install top-level node_modules `npm i`
- Run tests `npm t`


```

  ● article-body chain › Render raw html correctly › should render raw html

    Cannot find module '@wpmedia/video-player-block' from 'default.jsx'

    However, Jest was able to find:
        './default.jsx'
        './default.test.jsx'

    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'json', 'jsx', 'ts', 'tsx', 'node'].

    See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string

       6 | import getProperties from 'fusion:properties';
       7 | import getTranslatedPhrases from 'fusion:intl';
    >  8 | import VideoPlayer from '@wpmedia/video-player-block';
         | ^
       9 | import {
      10 |   Gallery, ImageMetadata, Image,
      11 | } from '@wpmedia/engine-theme-sdk';

      at Resolver.resolveModule (../../node_modules/jest-resolve/build/index.js:259:17)
      at Object.<anonymous> (chains/article-body/default.jsx:8:1)

  ● article-body chain › Render raw html correctly › should not render raw html

    Cannot find module '@wpmedia/video-player-block' from 'default.jsx'

    However, Jest was able to find:
        './default.jsx'
        './default.test.jsx'

    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'json', 'jsx', 'ts', 'tsx', 'node'].

    See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string

       6 | import getProperties from 'fusion:properties';
       7 | import getTranslatedPhrases from 'fusion:intl';
    >  8 | import VideoPlayer from '@wpmedia/video-player-block';
         | ^
       9 | import {
      10 |   Gallery, ImageMetadata, Image,
      11 | } from '@wpmedia/engine-theme-sdk';

      at Resolver.resolveModule (../../node_modules/jest-resolve/build/index.js:259:17)
      at Object.<anonymous> (chains/article-body/default.jsx:8:1)

  ● article-body chain › Render interstital link correctly › should render interstitial link

    Cannot find module '@wpmedia/video-player-block' from 'default.jsx'

    However, Jest was able to find:
        './default.jsx'
        './default.test.jsx'

    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'json', 'jsx', 'ts', 'tsx', 'node'].

    See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string

       6 | import getProperties from 'fusion:properties';
       7 | import getTranslatedPhrases from 'fusion:intl';
    >  8 | import VideoPlayer from '@wpmedia/video-player-block';
         | ^
       9 | import {
      10 |   Gallery, ImageMetadata, Image,
      11 | } from '@wpmedia/engine-theme-sdk';

      at Resolver.resolveModule (../../node_modules/jest-resolve/build/index.js:259:17)
      at Object.<anonymous> (chains/article-body/default.jsx:8:1)

  ● article-body chain › Render interstital link correctly › should not render interstitial link

    Cannot find module '@wpmedia/video-player-block' from 'default.jsx'

    However, Jest was able to find:
        './default.jsx'
        './default.test.jsx'

    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'json', 'jsx', 'ts', 'tsx', 'node'].

    See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string

       6 | import getProperties from 'fusion:properties';
       7 | import getTranslatedPhrases from 'fusion:intl';
    >  8 | import VideoPlayer from '@wpmedia/video-player-block';
         | ^
       9 | import {
      10 |   Gallery, ImageMetadata, Image,
      11 | } from '@wpmedia/engine-theme-sdk';

      at Resolver.resolveModule (../../node_modules/jest-resolve/build/index.js:259:17)
      at Object.<anonymous> (chains/article-body/default.jsx:8:1)

  ● article-body chain › Render image correctly › should render image with figcaption and author

    Cannot find module '@wpmedia/video-player-block' from 'default.jsx'

    However, Jest was able to find:
        './default.jsx'
        './default.test.jsx'

    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'json', 'jsx', 'ts', 'tsx', 'node'].

    See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string

       6 | import getProperties from 'fusion:properties';
       7 | import getTranslatedPhrases from 'fusion:intl';
    >  8 | import VideoPlayer from '@wpmedia/video-player-block';
         | ^
       9 | import {
      10 |   Gallery, ImageMetadata, Image,
      11 | } from '@wpmedia/engine-theme-sdk';

      at Resolver.resolveModule (../../node_modules/jest-resolve/build/index.js:259:17)
      at Object.<anonymous> (chains/article-body/default.jsx:8:1)

  ● article-body chain › Render image correctly › should not render image with figcaption and author

    Cannot find module '@wpmedia/video-player-block' from 'default.jsx'

    However, Jest was able to find:
        './default.jsx'
        './default.test.jsx'

    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'json', 'jsx', 'ts', 'tsx', 'node'].

    See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string

       6 | import getProperties from 'fusion:properties';
       7 | import getTranslatedPhrases from 'fusion:intl';
    >  8 | import VideoPlayer from '@wpmedia/video-player-block';
         | ^
       9 | import {
      10 |   Gallery, ImageMetadata, Image,
      11 | } from '@wpmedia/engine-theme-sdk';

      at Resolver.resolveModule (../../node_modules/jest-resolve/build/index.js:259:17)
      at Object.<anonymous> (chains/article-body/default.jsx:8:1)


Test Suites: 1 failed, 1 skipped, 82 passed, 83 of 84 total
Tests:       23 failed, 3 skipped, 662 passed, 688 total
Snapshots:   2 passed, 2 total
Time:        22.871s, estimated 26s
Ran all test suites in 54 projects.
npm ERR! Test failed.  See above for more details.