### PR TITLE
PEN-1196 add lines between promo blocks

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -38,84 +38,87 @@ const ExtraLargeManualPromo = ({ customFields }) => {
   });
 
   return (customFields.linkURL ? (
-    <article className="container-fluid xl-large-promo">
-      <div className="row xl-promo-padding-bottom">
-        {(customFields.showHeadline || customFields.showDescription
-          || customFields.showOverline)
-        && (
-          <div className="col-sm-xl-12 flex-col">
-            {(customFields.showOverline && customFields.overline && customFields.overlineURL)
-            && (
-              <OverlineLink
-                href={customFields.overlineURL}
-                primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-                className="overline"
-              >
-                {customFields.overline}
-              </OverlineLink>
-            )}
-            {((customFields.showOverline && customFields.overline) && !customFields.overlineURL)
-            && (
-              <OverlineHeader
-                primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-                className="overline"
-              >
-                {customFields.overline}
-              </OverlineHeader>
-            )}
-            {(customFields.showHeadline && customFields.headline)
-            && (
-              <a
-                href={customFields.linkURL}
-                className="xl-promo-headline"
-                title={customFields.headline}
-                target={customFields.newTab ? '_blank' : '_self'}
-                rel={customFields.newTab ? 'noreferrer' : ''}
-              >
-                <HeadlineText
-                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
-                  className="xl-promo-headline"
+    <>
+      <article className="container-fluid xl-large-promo xl-large-manual-promo">
+        <div className="row">
+          {(customFields.showHeadline || customFields.showDescription
+            || customFields.showOverline)
+          && (
+            <div className="col-sm-xl-12 flex-col">
+              {(customFields.showOverline && customFields.overline && customFields.overlineURL)
+              && (
+                <OverlineLink
+                  href={customFields.overlineURL}
+                  primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+                  className="overline"
                 >
-                  {customFields.headline}
-                </HeadlineText>
-              </a>
-            )}
-            {(customFields.showImage && customFields.imageURL)
-            && (
-              <a
-                href={customFields.linkURL}
-                title={customFields.headline}
-                target={customFields.newTab ? '_blank' : '_self'}
-                rel={customFields.newTab ? 'noreferrer' : ''}
-              >
-                <Image
-                  url={customFields.imageURL}
-                  alt={customFields.headline}
-                  smallWidth={400}
-                  smallHeight={300}
-                  mediumWidth={600}
-                  mediumHeight={450}
-                  largeWidth={800}
-                  largeHeight={600}
-                  breakpoints={getProperties(arcSite)?.breakpoints}
-                  resizerURL={getProperties(arcSite)?.resizerURL}
-                  resizedImageOptions={resizedImageOptions}
-                />
-              </a>
-            )}
-            {(customFields.showDescription && customFields.description)
-            && (
-              <DescriptionText
-                secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
-                className="description-text"
-              >
-                {customFields.description}
-              </DescriptionText>
-            )}
-          </div>
-        )}
-      </div>
-    </article>
+                  {customFields.overline}
+                </OverlineLink>
+              )}
+              {((customFields.showOverline && customFields.overline) && !customFields.overlineURL)
+              && (
+                <OverlineHeader
+                  primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+                  className="overline"
+                >
+                  {customFields.overline}
+                </OverlineHeader>
+              )}
+              {(customFields.showHeadline && customFields.headline)
+              && (
+                <a
+                  href={customFields.linkURL}
+                  className="xl-promo-headline"
+                  title={customFields.headline}
+                  target={customFields.newTab ? '_blank' : '_self'}
+                  rel={customFields.newTab ? 'noreferrer' : ''}
+                >
+                  <HeadlineText
+                    primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+                    className="xl-promo-headline"
+                  >
+                    {customFields.headline}
+                  </HeadlineText>
+                </a>
+              )}
+              {(customFields.showImage && customFields.imageURL)
+              && (
+                <a
+                  href={customFields.linkURL}
+                  title={customFields.headline}
+                  target={customFields.newTab ? '_blank' : '_self'}
+                  rel={customFields.newTab ? 'noreferrer' : ''}
+                >
+                  <Image
+                    url={customFields.imageURL}
+                    alt={customFields.headline}
+                    smallWidth={400}
+                    smallHeight={300}
+                    mediumWidth={600}
+                    mediumHeight={450}
+                    largeWidth={800}
+                    largeHeight={600}
+                    breakpoints={getProperties(arcSite)?.breakpoints}
+                    resizerURL={getProperties(arcSite)?.resizerURL}
+                    resizedImageOptions={resizedImageOptions}
+                  />
+                </a>
+              )}
+              {(customFields.showDescription && customFields.description)
+              && (
+                <DescriptionText
+                  secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
+                  className="description-text"
+                >
+                  {customFields.description}
+                </DescriptionText>
+              )}
+            </div>
+          )}
+        </div>
+      </article>
+      <hr />
+    </>
   ) : null);
 };
 

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
@@ -66,4 +66,9 @@ describe('the extra large promo feature', () => {
     const wrapper = mount(<ExtraLargeManualPromo customFields={noImgConfig} />);
     expect(wrapper.find('Image')).toHaveLength(0);
   });
+
+  it('should have one line separator', () => {
+    const wrapper = mount(<ExtraLargeManualPromo customFields={config} />);
+    expect(wrapper.find('ExtraLargeManualPromo > hr')).toHaveLength(1);
+  });
 });

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -39,87 +39,90 @@ const LargeManualPromo = ({ customFields }) => {
   });
 
   return customFields.linkURL ? (
-    <article className="container-fluid large-promo">
-      <div className="row lg-promo-padding-bottom">
-        {(customFields.showImage && customFields.imageURL)
-        && (
-          <div className="col-sm-12 col-md-xl-6">
-            <a
-              href={customFields.linkURL}
-              title={customFields.headline}
-              target={customFields.newTab ? '_blank' : '_self'}
-              rel={customFields.newTab ? 'noreferrer noopener' : ''}
-            >
-              <Image
-                url={customFields.imageURL}
-                alt={customFields.headline}
-                // large promo has 4:3
-                smallWidth={274}
-                smallHeight={206}
-                mediumWidth={274}
-                mediumHeight={206}
-                largeWidth={377}
-                largeHeight={283}
-                breakpoints={getProperties(arcSite)?.breakpoints}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-                resizedImageOptions={resizedImageOptions}
-              />
-            </a>
-          </div>
-        )}
-        {(customFields.showHeadline || customFields.showDescription
-          || customFields.showOverline)
-        && (
-          <div className={textClass}>
-            {(customFields.showOverline && customFields.overline && customFields.overlineURL)
-            && (
-              <OverlineLink
-                href={customFields.overlineURL}
-                primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-                className="overline"
-              >
-                {customFields.overline}
-              </OverlineLink>
-            )}
-            {((customFields.showOverline && customFields.overline) && !customFields.overlineURL)
-            && (
-              <OverlineHeader
-                primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-                className="overline"
-              >
-                {customFields.overline}
-              </OverlineHeader>
-            )}
-            {(customFields.showHeadline && customFields.headline)
-            && (
+    <>
+      <article className="container-fluid large-promo">
+        <div className="row lg-promo-padding-bottom">
+          {(customFields.showImage && customFields.imageURL)
+          && (
+            <div className="col-sm-12 col-md-xl-6">
               <a
                 href={customFields.linkURL}
-                className="lg-promo-headline"
                 title={customFields.headline}
                 target={customFields.newTab ? '_blank' : '_self'}
-                rel={customFields.newTab ? 'noreferrer' : ''}
+                rel={customFields.newTab ? 'noreferrer noopener' : ''}
               >
-                <HeadlineText
-                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
-                  className="lg-promo-headline"
-                >
-                  {customFields.headline}
-                </HeadlineText>
+                <Image
+                  url={customFields.imageURL}
+                  alt={customFields.headline}
+                  // large promo has 4:3
+                  smallWidth={274}
+                  smallHeight={206}
+                  mediumWidth={274}
+                  mediumHeight={206}
+                  largeWidth={377}
+                  largeHeight={283}
+                  breakpoints={getProperties(arcSite)?.breakpoints}
+                  resizerURL={getProperties(arcSite)?.resizerURL}
+                  resizedImageOptions={resizedImageOptions}
+                />
               </a>
-            )}
-            {(customFields.showDescription && customFields.description)
-            && (
-              <DescriptionText
-                secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
-                className="description-text"
-              >
-                {customFields.description}
-              </DescriptionText>
-            )}
-          </div>
-        )}
-      </div>
-    </article>
+            </div>
+          )}
+          {(customFields.showHeadline || customFields.showDescription
+            || customFields.showOverline)
+          && (
+            <div className={textClass}>
+              {(customFields.showOverline && customFields.overline && customFields.overlineURL)
+              && (
+                <OverlineLink
+                  href={customFields.overlineURL}
+                  primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+                  className="overline"
+                >
+                  {customFields.overline}
+                </OverlineLink>
+              )}
+              {((customFields.showOverline && customFields.overline) && !customFields.overlineURL)
+              && (
+                <OverlineHeader
+                  primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+                  className="overline"
+                >
+                  {customFields.overline}
+                </OverlineHeader>
+              )}
+              {(customFields.showHeadline && customFields.headline)
+              && (
+                <a
+                  href={customFields.linkURL}
+                  className="lg-promo-headline"
+                  title={customFields.headline}
+                  target={customFields.newTab ? '_blank' : '_self'}
+                  rel={customFields.newTab ? 'noreferrer' : ''}
+                >
+                  <HeadlineText
+                    primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+                    className="lg-promo-headline"
+                  >
+                    {customFields.headline}
+                  </HeadlineText>
+                </a>
+              )}
+              {(customFields.showDescription && customFields.description)
+              && (
+                <DescriptionText
+                  secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
+                  className="description-text"
+                >
+                  {customFields.description}
+                </DescriptionText>
+              )}
+            </div>
+          )}
+        </div>
+      </article>
+      <hr />
+    </>
   ) : null;
 };
 

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
@@ -113,4 +113,9 @@ describe('the large promo feature', () => {
     const wrapper = mount(<LargeManualPromo customFields={noHeadlineConfig} />);
     expect(wrapper.find('a')).toHaveLength(1);
   });
+
+  it('should have one line separator', () => {
+    const wrapper = mount(<LargeManualPromo customFields={config} />);
+    expect(wrapper.find('LargeManualPromo > hr')).toHaveLength(1);
+  });
 });

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -31,67 +31,70 @@ const MediumManualPromo = ({ customFields }) => {
   const textClass = customFields.showImage ? 'col-sm-12 col-md-xl-8 flex-col' : 'col-sm-xl-12 flex-col';
 
   return customFields.linkURL ? (
-    <article className="container-fluid medium-promo">
-      <div className="row med-promo-padding-bottom">
-        {(customFields.showImage && customFields.imageURL)
-        && (
-          <div className="col-sm-12 col-md-xl-4">
-            <a
-              href={customFields.linkURL}
-              title={customFields.headline}
-              target={customFields.newTab ? '_blank' : '_self'}
-              rel={customFields.newTab ? 'noreferrer noopener' : ''}
-            >
-              <Image
-                // medium is 16:9
-                url={customFields.imageURL}
-                alt={customFields.headline}
-                smallWidth={274}
-                smallHeight={154}
-                mediumWidth={274}
-                mediumHeight={154}
-                largeWidth={400}
-                largeHeight={225}
-                breakpoints={breakpoints}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-                resizedImageOptions={resizedImageOptions}
-              />
-            </a>
-          </div>
-        )}
-        {(customFields.showHeadline || customFields.showDescription)
-        && (
-          <div className={textClass}>
-            {(customFields.showHeadline && customFields.headline)
-            && (
+    <>
+      <article className="container-fluid medium-promo">
+        <div className="row med-promo-padding-bottom">
+          {(customFields.showImage && customFields.imageURL)
+          && (
+            <div className="col-sm-12 col-md-xl-4">
               <a
                 href={customFields.linkURL}
-                className="md-promo-headline"
                 title={customFields.headline}
                 target={customFields.newTab ? '_blank' : '_self'}
-                rel={customFields.newTab ? 'noreferrer' : ''}
+                rel={customFields.newTab ? 'noreferrer noopener' : ''}
               >
-                <HeadlineText
-                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
-                  className="md-promo-headline"
-                >
-                  {customFields.headline}
-                </HeadlineText>
+                <Image
+                  // medium is 16:9
+                  url={customFields.imageURL}
+                  alt={customFields.headline}
+                  smallWidth={274}
+                  smallHeight={154}
+                  mediumWidth={274}
+                  mediumHeight={154}
+                  largeWidth={400}
+                  largeHeight={225}
+                  breakpoints={breakpoints}
+                  resizerURL={getProperties(arcSite)?.resizerURL}
+                  resizedImageOptions={resizedImageOptions}
+                />
               </a>
-            )}
-            {(customFields.showDescription && customFields.description)
-            && (
-              <DescriptionText
-                secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
-                className="description-text"
-              >
-                {customFields.description}
-              </DescriptionText>
-            )}
-          </div>
-        )}
-      </div>
-    </article>
+            </div>
+          )}
+          {(customFields.showHeadline || customFields.showDescription)
+          && (
+            <div className={textClass}>
+              {(customFields.showHeadline && customFields.headline)
+              && (
+                <a
+                  href={customFields.linkURL}
+                  className="md-promo-headline"
+                  title={customFields.headline}
+                  target={customFields.newTab ? '_blank' : '_self'}
+                  rel={customFields.newTab ? 'noreferrer' : ''}
+                >
+                  <HeadlineText
+                    primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+                    className="md-promo-headline"
+                  >
+                    {customFields.headline}
+                  </HeadlineText>
+                </a>
+              )}
+              {(customFields.showDescription && customFields.description)
+              && (
+                <DescriptionText
+                  secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
+                  className="description-text"
+                >
+                  {customFields.description}
+                </DescriptionText>
+              )}
+            </div>
+          )}
+        </div>
+      </article>
+      <hr />
+    </>
   ) : null;
 };
 

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
@@ -100,4 +100,9 @@ describe('the medium promo feature', () => {
     const wrapper = mount(<MediumManualPromo customFields={noHeadlineConfig} />);
     expect(wrapper.find('a')).toHaveLength(1);
   });
+
+  it('should have one line separator', () => {
+    const wrapper = mount(<MediumManualPromo customFields={config} />);
+    expect(wrapper.find('MediumManualPromo > hr')).toHaveLength(1);
+  });
 });

--- a/blocks/shared-styles/scss/_extra-large-promo.scss
+++ b/blocks/shared-styles/scss/_extra-large-promo.scss
@@ -77,3 +77,9 @@
     flex-direction: column;
   }
 }
+
+.xl-large-manual-promo {
+  .description-text {
+    margin-bottom: 0;
+  }
+}

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -23,55 +23,58 @@ const SmallManualPromo = ({ customFields }) => {
   const headlineClass = customFields.showImage ? 'col-sm-xl-8' : 'col-sm-xl-12 no-image-padding';
 
   return customFields.linkURL ? (
-    <article className="container-fluid small-promo">
-      <div className="row sm-promo-padding-btm">
-        {(customFields.showHeadline && customFields.headline)
-        && (
-          <div className={headlineClass}>
-            <a
-              href={customFields.linkURL}
-              className="sm-promo-headline"
-              title={customFields.headline}
-              target={customFields.newTab ? '_blank' : '_self'}
-              rel={customFields.newTab ? 'noreferrer noopener' : ''}
-            >
-              <HeadlineText
-                primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+    <>
+      <article className="container-fluid small-promo">
+        <div className="row sm-promo-padding-btm">
+          {(customFields.showHeadline && customFields.headline)
+          && (
+            <div className={headlineClass}>
+              <a
+                href={customFields.linkURL}
                 className="sm-promo-headline"
+                title={customFields.headline}
+                target={customFields.newTab ? '_blank' : '_self'}
+                rel={customFields.newTab ? 'noreferrer noopener' : ''}
               >
-                {customFields.headline}
-              </HeadlineText>
-            </a>
-          </div>
-        )}
-        {(customFields.showImage && customFields.imageURL)
-        && (
-          <div className="col-sm-xl-4 right-aligned-container">
-            <a
-              href={customFields.linkURL}
-              title={customFields.headline}
-              target={customFields.newTab ? '_blank' : '_self'}
-              rel={customFields.newTab ? 'noreferrer noopener' : ''}
-            >
-              <Image
-                url={customFields.imageURL}
-                alt={customFields.headline}
-                // small should be 3:2 aspect ratio
-                smallWidth={105}
-                smallHeight={70}
-                mediumWidth={105}
-                mediumHeight={70}
-                largeWidth={105}
-                largeHeight={70}
-                breakpoints={getProperties(arcSite)?.breakpoints}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-                resizedImageOptions={resizedImageOptions}
-              />
-            </a>
-          </div>
-        )}
-      </div>
-    </article>
+                <HeadlineText
+                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+                  className="sm-promo-headline"
+                >
+                  {customFields.headline}
+                </HeadlineText>
+              </a>
+            </div>
+          )}
+          {(customFields.showImage && customFields.imageURL)
+          && (
+            <div className="col-sm-xl-4 right-aligned-container">
+              <a
+                href={customFields.linkURL}
+                title={customFields.headline}
+                target={customFields.newTab ? '_blank' : '_self'}
+                rel={customFields.newTab ? 'noreferrer noopener' : ''}
+              >
+                <Image
+                  url={customFields.imageURL}
+                  alt={customFields.headline}
+                  // small should be 3:2 aspect ratio
+                  smallWidth={105}
+                  smallHeight={70}
+                  mediumWidth={105}
+                  mediumHeight={70}
+                  largeWidth={105}
+                  largeHeight={70}
+                  breakpoints={getProperties(arcSite)?.breakpoints}
+                  resizerURL={getProperties(arcSite)?.resizerURL}
+                  resizedImageOptions={resizedImageOptions}
+                />
+              </a>
+            </div>
+          )}
+        </div>
+      </article>
+      <hr />
+    </>
   ) : null;
 };
 

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
@@ -92,4 +92,9 @@ describe('the small promo feature', () => {
     const wrapper = mount(<SmallManualPromo customFields={noHeadlineConfig} />);
     expect(wrapper.find('a')).toHaveLength(1);
   });
+
+  it('should have one line separator', () => {
+    const wrapper = mount(<SmallManualPromo customFields={config} />);
+    expect(wrapper.find('SmallManualPromo > hr')).toHaveLength(1);
+  });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -100,60 +100,63 @@ const HorizontalOverlineImageStoryItem = (props) => {
   const ratios = ratiosFor('LG', imageRatio);
 
   return (
-    <article key={id} className="container-fluid large-promo">
-      <div className="row lg-promo-padding-bottom">
-        {customFields.showImageLG
-        && (
-        <div className="col-sm-12 col-md-xl-6">
-          {imageURL !== '' ? (
-            <a href={websiteURL} title={itemTitle}>
+    <>
+      <article key={id} className="container-fluid large-promo">
+        <div className="row lg-promo-padding-bottom">
+          {customFields.showImageLG
+          && (
+          <div className="col-sm-12 col-md-xl-6">
+            {imageURL !== '' ? (
+              <a href={websiteURL} title={itemTitle}>
+                <Image
+                  resizedImageOptions={resizedImageOptions}
+                  url={imageURL}
+                  // todo: get the proper alt tag for this image
+                  alt={itemTitle}
+                  smallWidth={ratios.smallWidth}
+                  smallHeight={ratios.smallHeight}
+                  mediumWidth={ratios.mediumWidth}
+                  mediumHeight={ratios.mediumHeight}
+                  largeWidth={ratios.largeWidth}
+                  largeHeight={ratios.largeHeight}
+                  breakpoints={getProperties(arcSite)?.breakpoints}
+                  resizerURL={getProperties(arcSite)?.resizerURL}
+                />
+              </a>
+            ) : (
               <Image
-                resizedImageOptions={resizedImageOptions}
-                url={imageURL}
-                // todo: get the proper alt tag for this image
-                alt={itemTitle}
                 smallWidth={ratios.smallWidth}
                 smallHeight={ratios.smallHeight}
                 mediumWidth={ratios.mediumWidth}
                 mediumHeight={ratios.mediumHeight}
                 largeWidth={ratios.largeWidth}
                 largeHeight={ratios.largeHeight}
+                alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
+                url={targetFallbackImage}
                 breakpoints={getProperties(arcSite)?.breakpoints}
+                resizedImageOptions={placeholderResizedImageOptions}
                 resizerURL={getProperties(arcSite)?.resizerURL}
               />
-            </a>
-          ) : (
-            <Image
-              smallWidth={ratios.smallWidth}
-              smallHeight={ratios.smallHeight}
-              mediumWidth={ratios.mediumWidth}
-              mediumHeight={ratios.mediumHeight}
-              largeWidth={ratios.largeWidth}
-              largeHeight={ratios.largeHeight}
-              alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-              url={targetFallbackImage}
-              breakpoints={getProperties(arcSite)?.breakpoints}
-              resizedImageOptions={placeholderResizedImageOptions}
-              resizerURL={getProperties(arcSite)?.resizerURL}
-            />
+            )}
+          </div>
+          )}
+          {(customFields.showHeadlineLG || customFields.showDescriptionLG
+              || customFields.showBylineLG || customFields.showDateLG)
+          && (
+          <div className={textClass}>
+            {overlineTmpl()}
+            {headlineTmpl()}
+            {descriptionTmpl()}
+            <div className="article-meta">
+              {byLineTmpl()}
+              {dateTmpl()}
+            </div>
+          </div>
           )}
         </div>
-        )}
-        {(customFields.showHeadlineLG || customFields.showDescriptionLG
-            || customFields.showBylineLG || customFields.showDateLG)
-        && (
-        <div className={textClass}>
-          {overlineTmpl()}
-          {headlineTmpl()}
-          {descriptionTmpl()}
-          <div className="article-meta">
-            {byLineTmpl()}
-            {dateTmpl()}
-          </div>
-        </div>
-        )}
-      </div>
-    </article>
+      </article>
+      <hr />
+    </>
   );
 };
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
@@ -87,6 +87,8 @@ describe('horizontal overline image story item', () => {
     expect(wrapper.find('a.lg-promo-headline').length).toBe(1);
     expect(wrapper.props().websiteURL).toBe('url');
     expect(wrapper.find('a.lg-promo-headline').props().href).toBe(websiteURL);
+
+    expect(wrapper.find('HorizontalOverlineImageStoryItem > hr').length).toBe(1);
   });
   it('renders with empty props with defaults', () => {
     jest.mock('fusion:context', () => ({
@@ -153,5 +155,7 @@ describe('horizontal overline image story item', () => {
 
     // finds default spacing for headline descriptions
     // expect(wrapper.find('.headline-description-spacing').length).toBe(1);
+
+    expect(wrapper.find('HorizontalOverlineImageStoryItem > hr').length).toBe(1);
   });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -22,9 +22,10 @@ const ItemTitleWithRightImage = (props) => {
   } = props;
 
   const ratios = ratiosFor('SM', imageRatio);
+  const promoClasses = 'container-fluid small-promo layout-section wrap-bottom';
 
   return (
-    <article key={id} className={`container-fluid small-promo ${paddingRight ? 'small-promo-padding' : ''}`}>
+    <article key={id} className={`${promoClasses} ${paddingRight ? 'small-promo-padding' : ''}`}>
       <div className="row sm-promo-padding-btm">
         {customFields.showHeadlineSM && itemTitle !== '' ? (
           <div className="col-sm-8 col-md-xl-8">
@@ -72,6 +73,7 @@ const ItemTitleWithRightImage = (props) => {
           </div>
           )}
       </div>
+      <hr />
     </article>
   );
 };

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({
   fallbackImage: 'placeholder.jpg',
+  resizerURL: 'http://example.com',
 }))));
 
 const config = {
@@ -28,7 +29,7 @@ const config = {
 };
 
 describe('item title with right image block', () => {
-  xit('renders title and image with full props', () => {
+  it('renders title and image with full props', () => {
     const imageURL = 'pic';
     const itemTitle = 'title';
     const primaryFont = 'arial';
@@ -43,6 +44,7 @@ describe('item title with right image block', () => {
         primaryFont={primaryFont}
         id={id}
         customFields={config}
+        resizedImageOptions={{ '400x267': '' }}
       />,
     );
 
@@ -52,6 +54,8 @@ describe('item title with right image block', () => {
     // placeholder
     // expect(wrapper.find('.simple-list-placeholder').length).toBe(0);
     // expect(wrapper.find('.simple-list-img').length).toBe(1);
+
+    expect(wrapper.find('ItemTitleWithRightImage > article > hr').length).toBe(1);
   });
   xit('renders neither title nor image with empty props, renders placeholder', () => {
     const imageURL = '';

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -81,61 +81,64 @@ const MediumListItem = (props) => {
   const ratios = ratiosFor('MD', imageRatio);
 
   return (
-    <article className="container-fluid medium-promo" key={id}>
-      <div className="row med-promo-padding-bottom">
-        {customFields.showImageMD
-          && (
-          <div className="col-sm-12 col-md-xl-4">
-            <a href={websiteURL} title={itemTitle}>
-              {imageURL !== '' ? (
-                <Image
-                  resizedImageOptions={resizedImageOptions}
-                  url={imageURL}
-                  // todo: get the proper alt tag for this image
-                  // 16:9 aspect for medium
-                  alt={itemTitle}
-                  smallWidth={ratios.smallWidth}
-                  smallHeight={ratios.smallHeight}
-                  mediumWidth={ratios.mediumWidth}
-                  mediumHeight={ratios.mediumHeight}
-                  largeWidth={ratios.largeWidth}
-                  largeHeight={ratios.largeHeight}
-                  breakpoints={getProperties(arcSite)?.breakpoints}
-                  resizerURL={getProperties(arcSite)?.resizerURL}
-                />
-              ) : (
-                <Image
-                  smallWidth={ratios.smallWidth}
-                  smallHeight={ratios.smallHeight}
-                  mediumWidth={ratios.mediumWidth}
-                  mediumHeight={ratios.mediumHeight}
-                  largeWidth={ratios.largeWidth}
-                  largeHeight={ratios.largeHeight}
-                  alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-                  url={targetFallbackImage}
-                  breakpoints={getProperties(arcSite)?.breakpoints}
-                  resizedImageOptions={placeholderResizedImageOptions}
-                  resizerURL={getProperties(arcSite)?.resizerURL}
+    <>
+      <article className="container-fluid medium-promo" key={id}>
+        <div className="row med-promo-padding-bottom">
+          {customFields.showImageMD
+            && (
+            <div className="col-sm-12 col-md-xl-4">
+              <a href={websiteURL} title={itemTitle}>
+                {imageURL !== '' ? (
+                  <Image
+                    resizedImageOptions={resizedImageOptions}
+                    url={imageURL}
+                    // todo: get the proper alt tag for this image
+                    // 16:9 aspect for medium
+                    alt={itemTitle}
+                    smallWidth={ratios.smallWidth}
+                    smallHeight={ratios.smallHeight}
+                    mediumWidth={ratios.mediumWidth}
+                    mediumHeight={ratios.mediumHeight}
+                    largeWidth={ratios.largeWidth}
+                    largeHeight={ratios.largeHeight}
+                    breakpoints={getProperties(arcSite)?.breakpoints}
+                    resizerURL={getProperties(arcSite)?.resizerURL}
+                  />
+                ) : (
+                  <Image
+                    smallWidth={ratios.smallWidth}
+                    smallHeight={ratios.smallHeight}
+                    mediumWidth={ratios.mediumWidth}
+                    mediumHeight={ratios.mediumHeight}
+                    largeWidth={ratios.largeWidth}
+                    largeHeight={ratios.largeHeight}
+                    alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
+                    url={targetFallbackImage}
+                    breakpoints={getProperties(arcSite)?.breakpoints}
+                    resizedImageOptions={placeholderResizedImageOptions}
+                    resizerURL={getProperties(arcSite)?.resizerURL}
 
-                />
-              )}
-            </a>
-          </div>
-          )}
-        {(customFields.showHeadlineMD || customFields.showDescriptionMD
-              || customFields.showBylineMD || customFields.showDateMD)
-          && (
-          <div className={textClass}>
-            {headlineTmpl()}
-            {descriptionTmpl()}
-            <div className="article-meta">
-              {byLineTmpl()}
-              {dateTmpl()}
+                  />
+                )}
+              </a>
             </div>
-          </div>
-          )}
-      </div>
-    </article>
+            )}
+          {(customFields.showHeadlineMD || customFields.showDescriptionMD
+                || customFields.showBylineMD || customFields.showDateMD)
+            && (
+            <div className={textClass}>
+              {headlineTmpl()}
+              {descriptionTmpl()}
+              <div className="article-meta">
+                {byLineTmpl()}
+                {dateTmpl()}
+              </div>
+            </div>
+            )}
+        </div>
+      </article>
+      <hr />
+    </>
   );
 };
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
@@ -31,7 +31,7 @@ const config = {
 
 describe('medium list item', () => {
   jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
-  xit('renders title and image with full props', () => {
+  it('renders title and image with full props', () => {
     const imageURL = 'pic';
     const constructedURL = 'url';
     const itemTitle = 'title';
@@ -60,13 +60,15 @@ describe('medium list item', () => {
     />);
 
     // placeholder
-    // expect(wrapper.find('.top-table-med-image-placeholder').length).toBe(0);
+    expect(wrapper.find('.top-table-med-image-placeholder').length).toBe(0);
 
     // doesn't find spacer
     // expect(wrapper.find('.headline-description-spacing').length).toBe(0);
 
     // finds description text
-    // expect(wrapper.find('p.description-text').text()).toBe(descriptionText);
+    expect(wrapper.find('p.description-text').text()).toBe(descriptionText);
+
+    expect(wrapper.find('MediumListItem > hr').length).toBe(1);
   });
 
   it('renders image placeholder with empty props', () => {
@@ -106,5 +108,7 @@ describe('medium list item', () => {
 
     // doesn't find a headline
     expect(wrapper.find('a.md-promo-headline').length).toBe(0);
+
+    expect(wrapper.find('MediumListItem > hr').length).toBe(1);
   });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -101,55 +101,58 @@ const VerticalOverlineImageStoryItem = (props) => {
   const ratios = ratiosFor('XL', imageRatio);
 
   return (
-    <article className="container-fluid xl-large-promo" key={id}>
-      <div className="row xl-promo-padding-bottom">
-        {(customFields.showHeadlineXL || customFields.showDescriptionXL
-            || customFields.showBylineXL || customFields.showDateXL)
-        && (
-        <div className="col-sm-xl-12 flex-col">
-          {overlineTmpl()}
-          {headlineTmpl()}
-          {customFields.showImageXL && imageURL !== '' ? (
-            <a href={websiteURL} title={itemTitle}>
+    <>
+      <article className="container-fluid xl-large-promo" key={id}>
+        <div className="row xl-promo-padding-bottom">
+          {(customFields.showHeadlineXL || customFields.showDescriptionXL
+              || customFields.showBylineXL || customFields.showDateXL)
+          && (
+          <div className="col-sm-xl-12 flex-col">
+            {overlineTmpl()}
+            {headlineTmpl()}
+            {customFields.showImageXL && imageURL !== '' ? (
+              <a href={websiteURL} title={itemTitle}>
+                <Image
+                  resizedImageOptions={resizedImageOptions}
+                  url={imageURL}
+                  // todo: get the proper alt tag for this image
+                  alt={itemTitle}
+                  smallWidth={ratios.smallWidth}
+                  smallHeight={ratios.smallHeight}
+                  mediumWidth={ratios.mediumWidth}
+                  mediumHeight={ratios.mediumHeight}
+                  largeWidth={ratios.largeWidth}
+                  largeHeight={ratios.largeHeight}
+                  breakpoints={getProperties(arcSite)?.breakpoints}
+                  resizerURL={getProperties(arcSite)?.resizerURL}
+                />
+              </a>
+            ) : (
               <Image
-                resizedImageOptions={resizedImageOptions}
-                url={imageURL}
-                // todo: get the proper alt tag for this image
-                alt={itemTitle}
                 smallWidth={ratios.smallWidth}
                 smallHeight={ratios.smallHeight}
                 mediumWidth={ratios.mediumWidth}
                 mediumHeight={ratios.mediumHeight}
                 largeWidth={ratios.largeWidth}
                 largeHeight={ratios.largeHeight}
+                alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
+                url={targetFallbackImage}
                 breakpoints={getProperties(arcSite)?.breakpoints}
+                resizedImageOptions={placeholderResizedImageOptions}
                 resizerURL={getProperties(arcSite)?.resizerURL}
               />
-            </a>
-          ) : (
-            <Image
-              smallWidth={ratios.smallWidth}
-              smallHeight={ratios.smallHeight}
-              mediumWidth={ratios.mediumWidth}
-              mediumHeight={ratios.mediumHeight}
-              largeWidth={ratios.largeWidth}
-              largeHeight={ratios.largeHeight}
-              alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-              url={targetFallbackImage}
-              breakpoints={getProperties(arcSite)?.breakpoints}
-              resizedImageOptions={placeholderResizedImageOptions}
-              resizerURL={getProperties(arcSite)?.resizerURL}
-            />
-          )}
-          {descriptionTmpl()}
-          <div className="article-meta">
-            {byLineTmpl()}
-            {dateTmpl()}
+            )}
+            {descriptionTmpl()}
+            <div className="article-meta">
+              {byLineTmpl()}
+              {dateTmpl()}
+            </div>
           </div>
+          )}
         </div>
-        )}
-      </div>
-    </article>
+      </article>
+      <hr />
+    </>
   );
 };
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
@@ -89,6 +89,8 @@ describe('vertical overline image story item', () => {
     expect(wrapper.find('a.xl-promo-headline').length).toBe(1);
     expect(wrapper.props().websiteURL).toBe('url');
     expect(wrapper.find('a.xl-promo-headline').props().href).toBe(websiteURL);
+
+    expect(wrapper.find('VerticalOverlineImageStoryItem > hr').length).toBe(1);
   });
   it('does not render image, overline and byline with empty props', () => {
     jest.mock('fusion:context', () => ({
@@ -155,5 +157,7 @@ describe('vertical overline image story item', () => {
     // finds overline
     expect(wrapper.find('a.overline').length).toBe(0);
     expect(wrapper.props().overlineText).toBe('');
+
+    expect(wrapper.find('VerticalOverlineImageStoryItem > hr').length).toBe(1);
   });
 });

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -165,7 +165,7 @@ const TopTableList = (props) => {
   }, []);
 
   return (
-    <div key={id} className="top-table-list-container layout-section">
+    <div key={id} className="top-table-list-container layout-section wrap-bottom">
       {siteContent.map(unserializeStory(arcSite)).map((itemObject, index) => {
         const {
           id: itemId,
@@ -208,7 +208,6 @@ const TopTableList = (props) => {
           />
         );
       })}
-      { small > 0 && <hr /> }
     </div>
   );
 };

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -11,7 +11,6 @@
       text-align: right;
     }
     @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      box-shadow: none;
       display: inline-block;
       width: calc((100% - #{map-get($spacers, 'md')}) / 2);
     }
@@ -25,6 +24,14 @@
         }
       }
     }
+
+    &.wrap-bottom {
+      margin-bottom: 0 !important;
+
+      @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
+        margin-bottom: inherit;
+      }
+    }
   }
 
   .small-promo-padding {
@@ -32,5 +39,9 @@
     @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
       padding-right: map-get($spacers, 'md');
     }
+  }
+
+  &.wrap-bottom {
+    margin-bottom: inherit !important;
   }
 }


### PR DESCRIPTION
[PEN-1196](https://arcpublishing.atlassian.net/browse/PEN-1196)

# What does this implement or fix?
- add lines between promo blocks in Top-Table list
- add lines to manual promo blocks

# How was this tested?
- test written
- visually on PB on different breakpoints

# Show Effect Of Changes

## Before
![2020_0803_191606](https://user-images.githubusercontent.com/9757/89232523-f558e380-d5bd-11ea-9323-33bbce5691fd.png)

## After

![2020_0803_191642](https://user-images.githubusercontent.com/9757/89232536-fc7ff180-d5bd-11ea-950f-fa7b75085bc6.png)

# Dependencies or Side Effects

- none
