### PR TITLE
PEN-1181 fix overline display

### DIFF
--- a/blocks/overline-block/features/overline/default.jsx
+++ b/blocks/overline-block/features/overline/default.jsx
@@ -13,12 +13,40 @@ const StyledLink = styled.a`
   text-decoration: none;
 `;
 
-function fixTrailingSlash(item) {
-  let fixedItem = item;
-  if (fixedItem[fixedItem.length - 1] !== '/') {
-    fixedItem += '/';
+const StyledText = styled.span`
+  font-family: ${(props) => props.primaryFont};
+  font-weight: bold;
+  text-decoration: none;
+`;
+
+function getLocation(uri) {
+  let url;
+  if (typeof window === 'undefined') {
+    url = new URL(uri, 'http://example.com');
+  } else {
+    url = document.createElement('a');
+    // IE doesn't populate all link properties when setting .href with a relative URL,
+    // however .href will return an absolute URL which then can be used on itself
+    // to populate these additional fields.
+    url.href = uri;
+    if (url.host === '') {
+      url.href = `${url.href}`;
+    }
   }
-  return fixedItem;
+  return url;
+}
+
+function fixTrailingSlash(item) {
+  const url = getLocation(item);
+
+  if (url.hash || url.search || url.pathname.match(/\./)) {
+    return item;
+  }
+
+  if (item[item.length - 1] !== '/') {
+    return `${item}/`;
+  }
+  return item;
 }
 
 const Overline = (props) => {
@@ -46,8 +74,8 @@ const Overline = (props) => {
   const [text, url] = shouldUseProps ? [customText, customUrl] : useGlobalContent;
   const edit = editable ? { ...editableContent(content, text) } : {};
 
-  return text
-    ? (
+  if (url) {
+    return (
       <StyledLink
         href={fixTrailingSlash(url)}
         primaryFont={getThemeStyle(arcSite)['primary-font-family']}
@@ -57,8 +85,23 @@ const Overline = (props) => {
       >
         {text}
       </StyledLink>
-    )
-    : null;
+    );
+  }
+
+  if (text) {
+    return (
+      <StyledText
+        primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+        className="overline"
+        {...edit}
+        suppressContentEditableWarning
+      >
+        {text}
+      </StyledText>
+    );
+  }
+
+  return null;
 };
 
 Overline.label = 'Overline – Arc Block';

--- a/blocks/overline-block/features/overline/default.test.jsx
+++ b/blocks/overline-block/features/overline/default.test.jsx
@@ -84,6 +84,63 @@ describe('overline feature for default output type', () => {
       });
     });
 
+    describe('when label.basic.url is missing', () => {
+      beforeEach(() => {
+        const labelObj = {
+          label: { basic: { display: true, text: 'EXCLUSIVE' } },
+        };
+        const contextObjWithLabel = {
+          ...mockContextObj,
+          globalContent: {
+            ...labelObj,
+            ...mockContextObj.globalContent,
+          },
+        };
+        useFusionContext.mockImplementation(() => contextObjWithLabel);
+      });
+
+      it('should display the label name instead of the website section name', () => {
+        const wrapper = shallow(<Overline />);
+
+        expect(wrapper.text()).toMatch('EXCLUSIVE');
+      });
+
+      it('should render as text', () => {
+        const wrapper = shallow(<Overline />);
+
+        expect(wrapper.at(0).prop('className')).toEqual('overline');
+        expect(wrapper.at(0).prop('href')).toBeFalsy();
+      });
+    });
+
+    describe('when label.basic.url is empty', () => {
+      beforeEach(() => {
+        const labelObj = {
+          label: { basic: { display: true, text: 'EXCLUSIVE', url: '' } },
+        };
+        const contextObjWithLabel = {
+          ...mockContextObj,
+          globalContent: {
+            ...labelObj,
+            ...mockContextObj.globalContent,
+          },
+        };
+        useFusionContext.mockImplementation(() => contextObjWithLabel);
+      });
+
+      it('should display the label name instead of the website section name', () => {
+        const wrapper = shallow(<Overline />);
+        expect(wrapper.text()).toMatch('EXCLUSIVE');
+      });
+
+      it('should render as text', () => {
+        const wrapper = shallow(<Overline />);
+
+        expect(wrapper.at(0).prop('className')).toEqual('overline');
+        expect(wrapper.at(0).prop('href')).toBeFalsy();
+      });
+    });
+
     describe('when label.basic.display is NOT true', () => {
       beforeEach(() => {
         const labelObj = {
@@ -126,8 +183,8 @@ describe('overline feature for default output type', () => {
     });
   });
 
-  describe('when a link is not missing a trailing slash', () => {
-    beforeEach(() => {
+  describe('when a link is rendered', () => {
+    it('should not add a slash at the end of the link if already has one', () => {
       const mockTrailingSlash = {
         arcSite: 'site',
         globalContent: {
@@ -142,11 +199,69 @@ describe('overline feature for default output type', () => {
         },
       };
       useFusionContext.mockImplementation(() => mockTrailingSlash);
-    });
-    it('should not add a slash at the end of the link', () => {
       const wrapper = shallow(<Overline />);
 
       expect(wrapper.at(0).prop('href')).toStrictEqual('/test/');
+    });
+
+    it('should add a slash at the end of the link', () => {
+      const mockTrailingSlash = {
+        arcSite: 'site',
+        globalContent: {
+          websites: {
+            site: {
+              website_section: {
+                _id: '/test',
+                name: 'Test',
+              },
+            },
+          },
+        },
+      };
+      useFusionContext.mockImplementation(() => mockTrailingSlash);
+      const wrapper = shallow(<Overline />);
+
+      expect(wrapper.at(0).prop('href')).toStrictEqual('/test/');
+    });
+
+    it('should not add a slash at the end of the link with query params', () => {
+      const mockTrailingSlash = {
+        arcSite: 'site',
+        globalContent: {
+          websites: {
+            site: {
+              website_section: {
+                _id: '/test?query=a',
+                name: 'Test',
+              },
+            },
+          },
+        },
+      };
+      useFusionContext.mockImplementation(() => mockTrailingSlash);
+      const wrapper = shallow(<Overline />);
+
+      expect(wrapper.at(0).prop('href')).toStrictEqual('/test?query=a');
+    });
+
+    it('should not add a slash at the end of the link with hash params', () => {
+      const mockTrailingSlash = {
+        arcSite: 'site',
+        globalContent: {
+          websites: {
+            site: {
+              website_section: {
+                _id: '/test/page#section',
+                name: 'Test',
+              },
+            },
+          },
+        },
+      };
+      useFusionContext.mockImplementation(() => mockTrailingSlash);
+      const wrapper = shallow(<Overline />);
+
+      expect(wrapper.at(0).prop('href')).toStrictEqual('/test/page#section');
     });
   });
 });


### PR DESCRIPTION
[PEN-1181](https://arcpublishing.atlassian.net/browse/PEN-1181)

# What does this implement or fix?
- display when labels.basic do not have url or is empty
- fix url generation

# How was this tested?
- test written
- visually on PB with the stories on the ticket

# Dependencies or Side Effects

- none
