### PR TITLE
Update tests to reduce warnings

### DIFF
--- a/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
@@ -69,8 +69,9 @@ describe('the full author bio block', () => {
 
     it('should render a p', () => {
       const wrapper = mount(<FullAuthorBio />);
-
-      expect(wrapper.find('.author-content > p')).toHaveClassName('author-bio');
+      const bio = wrapper.find('.author-content > p');
+      expect(bio).toHaveClassName('author-bio');
+      expect(bio.text()).toMatch('She works on Arc Themes');
     });
 
     it('should render a photo', () => {
@@ -93,6 +94,7 @@ describe('the full author bio block', () => {
               byline: 'Jane Da Doe',
               role: 'Senior Product Manager',
               image: 'https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg',
+              resized_params: { '158x158': '' },
               email: 'jane@doe.com',
               facebook: 'https://facebook.com/janedoe',
               rss: 'somersslink',
@@ -107,8 +109,43 @@ describe('the full author bio block', () => {
 
     it('should render a short bio', () => {
       const wrapper = mount(<FullAuthorBio />);
+      const bio = wrapper.find('.author-content > p');
+      expect(bio).toHaveClassName('author-bio');
+      expect(bio.text()).toMatch('short bio');
+    });
+  });
 
-      expect(wrapper.find('.author-content > p')).toHaveClassName('author-bio');
+  describe('when there is only a long bio', () => {
+    beforeEach(() => {
+      useFusionContext.mockImplementation(() => ({
+        arcSite: 'no-site',
+        globalContent: {
+          authors: [
+            {
+              _id: 'janedoe',
+              firstName: 'Jane',
+              lastName: 'Doe',
+              byline: 'Jane Da Doe',
+              role: 'Senior Product Manager',
+              image: 'https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg',
+              resized_params: { '158x158': '' },
+              email: 'jane@doe.com',
+              facebook: 'https://facebook.com/janedoe',
+              rss: 'somersslink',
+              twitter: 'janedoe',
+              longBio: 'Jane Doe is a senior product manager for Arc Publishing. This is a Long bio. ',
+              instagram: 'janedoe',
+            },
+          ],
+        },
+      }));
+    });
+
+    it('should render a short bio', () => {
+      const wrapper = mount(<FullAuthorBio />);
+      const bio = wrapper.find('.author-content > p');
+      expect(bio).toHaveClassName('author-bio');
+      expect(bio.text()).toMatch('Long bio');
     });
   });
 


### PR DESCRIPTION
cherry-picked from @kascote's #393 

before: 

blocks/full-author-bio-block/features/full-author-bio/default.test.jsx (6.373s)
  ● Console

    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:100
      no resized options found for url: https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg.
    console.error node_modules/@wpmedia/engine-theme-sdk/dist/cjs/components/Image/index.js:101
      Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.

 PASS  blocks/simple-list-block/features/simple-list/default.test.jsx (6.695s)

after: 

 PASS  blocks/full-author-bio-block/features/full-author-bio/default.test.jsx (8.637s)
 PASS  blocks/default-output-block/output-types/__tests__/default.text.jsx