### PR TITLE
PEN-1244 top table list small promos

### DIFF
--- a/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.jsx
@@ -105,7 +105,13 @@ const ConditionalStoryItem = (props) => {
           imageRatio={customFields.imageRatioMD}
         />
       );
-    case SMALL:
+    case SMALL: {
+      let hasPaddingRight = false;
+      if ((typeof customFields.storiesPerRowSM === 'undefined') || (customFields.storiesPerRowSM === 2)) {
+        hasPaddingRight = (
+          index - (storySizeMap.extraLarge + storySizeMap.large + storySizeMap.medium)
+        ) % 2 === 0;
+      }
       return (
         <ItemTitleWithRightImage
           primaryFont={primaryFont}
@@ -119,12 +125,11 @@ const ConditionalStoryItem = (props) => {
           placeholderResizedImageOptions={placeholderResizedImageOptions}
           targetFallbackImage={targetFallbackImage}
           arcSite={arcSite}
-          paddingRight={
-            (index - (storySizeMap.extraLarge + storySizeMap.large + storySizeMap.medium)) % 2 === 0
-          }
+          paddingRight={hasPaddingRight}
           imageRatio={customFields.imageRatioSM}
         />
       );
+    }
     default:
       // don't render if no size
       return null;

--- a/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.test.jsx
@@ -83,7 +83,7 @@ describe('conditional story item', () => {
     expect(wrapper.is('VerticalOverlineImageStoryItem')).toBeTruthy();
   });
 
-  it.only('renders a small component with padding if storiesPerRowSM is 2 and the position is even', () => {
+  it('renders a small component with padding if storiesPerRowSM is 2 and the position is even', () => {
     const { default: ConditionalStoryItem } = require('./conditional-story-item');
 
     const storySize = SMALL;
@@ -108,7 +108,7 @@ describe('conditional story item', () => {
     expect(wrapper.find('ItemWithRightImage').prop('paddingRight')).toBe(true);
   });
 
-  it.only('renders a small component with padding if storiesPerRowSM is undefined and the position is even', () => {
+  it('renders a small component with padding if storiesPerRowSM is undefined and the position is even', () => {
     const { default: ConditionalStoryItem } = require('./conditional-story-item');
 
     const storySize = SMALL;
@@ -132,7 +132,7 @@ describe('conditional story item', () => {
     expect(wrapper.find('ItemWithRightImage').prop('paddingRight')).toBe(true);
   });
 
-  it.only('renders a small component without padding if storiesPerRowSM is 1', () => {
+  it('renders a small component without padding if storiesPerRowSM is 1', () => {
     const { default: ConditionalStoryItem } = require('./conditional-story-item');
 
     const storySize = SMALL;

--- a/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.test.jsx
@@ -82,4 +82,77 @@ describe('conditional story item', () => {
 
     expect(wrapper.is('VerticalOverlineImageStoryItem')).toBeTruthy();
   });
+
+  it.only('renders a small component with padding if storiesPerRowSM is 2 and the position is even', () => {
+    const { default: ConditionalStoryItem } = require('./conditional-story-item');
+
+    const storySize = SMALL;
+    const setup = Object.assign(config, { storiesPerRowSM: 2 });
+    const storySizeMap = {
+      extraLarge: 0,
+      large: 0,
+      medium: 0,
+      small: 1,
+    };
+
+    const wrapper = shallow(
+      <ConditionalStoryItem
+        storySize={storySize}
+        customFields={setup}
+        index={2}
+        storySizeMap={storySizeMap}
+      />,
+    );
+
+    expect(wrapper.is('ItemWithRightImage')).toBeTruthy();
+    expect(wrapper.find('ItemWithRightImage').prop('paddingRight')).toBe(true);
+  });
+
+  it.only('renders a small component with padding if storiesPerRowSM is undefined and the position is even', () => {
+    const { default: ConditionalStoryItem } = require('./conditional-story-item');
+
+    const storySize = SMALL;
+    const storySizeMap = {
+      extraLarge: 0,
+      large: 0,
+      medium: 0,
+      small: 1,
+    };
+
+    const wrapper = shallow(
+      <ConditionalStoryItem
+        storySize={storySize}
+        customFields={config}
+        index={2}
+        storySizeMap={storySizeMap}
+      />,
+    );
+
+    expect(wrapper.is('ItemWithRightImage')).toBeTruthy();
+    expect(wrapper.find('ItemWithRightImage').prop('paddingRight')).toBe(true);
+  });
+
+  it.only('renders a small component without padding if storiesPerRowSM is 1', () => {
+    const { default: ConditionalStoryItem } = require('./conditional-story-item');
+
+    const storySize = SMALL;
+    const storySizeMap = {
+      extraLarge: 0,
+      large: 0,
+      medium: 0,
+      small: 1,
+    };
+
+    const wrapper = shallow(
+      <ConditionalStoryItem
+        storySize={storySize}
+        customFields={config}
+        index={1}
+        storySizeMap={storySizeMap}
+      />,
+    );
+
+    expect(wrapper.is('ItemWithRightImage')).toBeTruthy();
+    expect(wrapper.find('ItemWithRightImage').prop('paddingRight')).toBe(false);
+  });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -22,7 +22,8 @@ const ItemTitleWithRightImage = (props) => {
   } = props;
 
   const ratios = ratiosFor('SM', imageRatio);
-  const promoClasses = 'container-fluid small-promo layout-section wrap-bottom';
+  const onePerLine = customFields.storiesPerRowSM === 1;
+  const promoClasses = `container-fluid small-promo layout-section ${onePerLine ? 'small-promo-one' : 'wrap-bottom'}`;
 
   return (
     <article key={id} className={`${promoClasses} ${paddingRight ? 'small-promo-padding' : ''}`}>

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
@@ -82,3 +82,73 @@ describe('item title with right image block', () => {
     // expect(wrapper.find('.simple-list-img').length).toBe(0);
   });
 });
+
+describe('small promo display', () => {
+  it('when storiesPerRowSM is undefined must not add class small-promo-one', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        customFields={config}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
+
+    expect(wrapper.find('.small-promo-one').length).toBe(0);
+    expect(wrapper.find('article.wrap-bottom').length).toBe(1);
+  });
+
+  it('when storiesPerRowSM is 2 must not add class small-promo-one', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+    const setup = Object.assign(config, { storiesPerRowSM: 2 });
+
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        customFields={setup}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
+
+    expect(wrapper.find('.small-promo-one').length).toBe(0);
+    expect(wrapper.find('article.wrap-bottom').length).toBe(1);
+  });
+
+  it('when storiesPerRowSM is 1 must add class small-promo-one', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+    const setup = Object.assign(config, { storiesPerRowSM: 1 });
+
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        customFields={setup}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
+
+    expect(wrapper.find('.small-promo-one').length).toBe(1);
+    expect(wrapper.find('article.wrap-bottom').length).toBe(0);
+  });
+});

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -128,6 +128,7 @@ const TopTableList = (props) => {
       large = 0,
       medium = 0,
       small = 0,
+      storiesPerRowSM,
     } = {},
     id = '',
     placeholderResizedImageOptions,
@@ -164,8 +165,10 @@ const TopTableList = (props) => {
     return acc;
   }, []);
 
+  const onePerLine = storiesPerRowSM === 1;
+
   return (
-    <div key={id} className="top-table-list-container layout-section wrap-bottom">
+    <div key={id} className={`top-table-list-container layout-section ${onePerLine ? '' : 'wrap-bottom'}`}>
       {siteContent.map(unserializeStory(arcSite)).map((itemObject, index) => {
         const {
           id: itemId,
@@ -325,6 +328,11 @@ TopTableListWrapper.propTypes = {
       group: 'Small story settings',
     }),
     ...imageRatioCustomField('imageRatioSM', 'Small story settings', '3:2'),
+    storiesPerRowSM: PropTypes.oneOf([1, 2]).tag({
+      name: 'Stories per row',
+      defaultValue: 2,
+      group: 'Small story settings',
+    }),
   }),
 };
 

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -44,4 +44,9 @@
   &.wrap-bottom {
     margin-bottom: inherit !important;
   }
+
+  .small-promo-one {
+    display: block;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
[PEN-1244](https://arcpublishing.atlassian.net/browse/PEN-1244)

# What does this implement or fix?
- the display of small promo items on top-table-list when is used on the sidebar

# How was this tested?

- tests written
- visually on PB

# Show Effect Of Changes

## Before

![2020_0805_191428](https://user-images.githubusercontent.com/9757/89469622-37199380-d750-11ea-9c28-e0c31bd92f5b.png)

## After

![2020_0805_191730](https://user-images.githubusercontent.com/9757/89469680-59131600-d750-11ea-8b38-f86efc02a09a.png)

small promo blocks (the last 2 ones) on full-width with small promos set to 1

![2020_0805_191825](https://user-images.githubusercontent.com/9757/89469740-7c3dc580-d750-11ea-9fe8-7baaeb49fede.png)

When I clicked the search button, the button turned green.

[include screenshot or gif or link to video, storybook would be awesome]

# Dependencies or Side Effects

- none
