### PR TITLE
PEN-1229 increase css specificity to override default config

### DIFF
--- a/blocks/alert-bar-block/features/alert-bar/default.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.jsx
@@ -8,7 +8,9 @@ import { CloseIcon } from '@wpmedia/engine-theme-sdk';
 import './alert-bar.scss';
 
 const AlertBarLink = styled.a`
-  font-family: ${(props) => props.primaryFont};
+  &&& {
+    font-family: ${(props) => props.primaryFont};
+  }
 `;
 @Consumer
 class AlertBar extends Component {


### PR DESCRIPTION
[PEN-1229](https://arcpublishing.atlassian.net/browse/PEN-1229)

# What does this implement or fix?
- increase css specificity to override default config ( the styled component rule had lower specificity than the rule from css block )

# How was this tested?

visually on PB

# Show Effect Of Changes

## Before

![2020_0811_190817](https://user-images.githubusercontent.com/9757/89953743-0f21a880-dc06-11ea-9ec1-390b59af4a96.png)

## After

![2020_0811_190855](https://user-images.githubusercontent.com/9757/89953782-25c7ff80-dc06-11ea-9dbe-bf5c5bf23761.png)


Examples of dependencies or side effects are:
- none
