### PR TITLE
PEN-985 fix the overlay size when the side menu is closed

### DIFF
--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -228,6 +228,7 @@ body.nav-open {
 
   &.closed {
     transform: translate(-$section-width, 0);
+    width: 0;
   }
 
   @media screen and (min-width: map-get($grid-breakpoints, 'md')) {


### PR DESCRIPTION
[PEN-985](https://arcpublishing.atlassian.net/browse/PEN-985)

# What does this implement or fix?
- fix the menu overlay width when is closed

# How was this tested?

- visually on PB
when the menu is closed, the hidden overlay make impossible to interact with the page.

# Dependencies or Side Effects

- none