### PR TITLE
PEN-429 taboola widget

### DIFF
--- a/blocks/ad-taboola-block/CHANGELOG.md
+++ b/blocks/ad-taboola-block/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [5.3.0](https://github.com/WPMedia/fusion-news-theme-blocks/compare/v5.3.0-beta.0...v5.3.0) (2020-08-12)
+
+**Note:** Initial version
+

--- a/blocks/ad-taboola-block/README.md
+++ b/blocks/ad-taboola-block/README.md
@@ -1,0 +1,43 @@
+# `@wpmedia/ad-taboola-widget`
+_Block that implement a [Taboola Widget](https://www.taboola.com/)._
+
+## Props
+
+### Global
+| **Prop** | **Required** | **Descripton** |
+|---|---|---|
+| **taboolaPublisherId** | yes | Publishier ID provided by Taboola |
+
+This configuration need to added to `blocks.json` like this:
+```
+{
+    ...
+    "values": {
+        "default": {
+            "siteProperties": {
+                ...
+                "taboolaPublisherId": "client-publisher-id",
+                ...
+            }
+        }
+    }
+}
+```
+
+### Per widget
+| **Prop** | **Required** | **Descripton** |
+|---|---|---|
+| **taboolaPlacement** | yes | Widget placement description, provided by Taboola |
+| **taboolaMode** | yes | Widget mode, provided by Taboola |
+| **taboolaContainer** | yes | Widget container name, provided by Taboola |
+
+This properties will be defined on each block added to the page.
+
+
+## Reference Material
+
+[Implementing Taboola Javascript Placement Code](https://pubhelp.taboola.com/hc/en-us/articles/360003181054-Implementing-Javascript-Placement-Code)
+
+## Additional Considerations
+The block will not render inside PageBuilder editor. Inside the editor, when the widget has his properties correctly configured, will show a dummy block with the placement name.
+To see the widget working, need to publish the page and on the preview url add the parameter `&taboola_sim_domain=XXX`, replacing XXX with the domain provided by Taboola for testing.

--- a/blocks/ad-taboola-block/features/ad-taboola/default.jsx
+++ b/blocks/ad-taboola-block/features/ad-taboola/default.jsx
@@ -1,0 +1,162 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import getProperties from 'fusion:properties';
+import Consumer from 'fusion:consumer';
+
+const taboolaLoader = (publisherID) => (
+  `window._taboola = window._taboola || [];
+    _taboola.push({article:'auto'});
+    !function (e, f, u, i) {
+      if (!document.getElementById(i)){
+        e.async = 1;
+        e.src = u;
+        e.id = i;
+        f.parentNode.insertBefore(e, f);
+      }
+    }(document.createElement('script'),
+    document.getElementsByTagName('script')[0],
+    '//cdn.taboola.com/libtrc/${publisherID}/loader.js',
+    'tb_loader_script');
+    if(window.performance && typeof window.performance.mark == 'function')
+      {window.performance.mark('tbl_ic');}
+  `
+);
+
+const taboolaFlusher = () => (
+  `
+  window._taboola = window._taboola || [];
+  _taboola.push({flush: true});
+  `
+);
+
+@Consumer
+class AdTaboola extends Component {
+  constructor(props) {
+    super(props);
+
+    const { arcSite } = this.props;
+    this.publisherID = getProperties(arcSite).taboolaPublisherId;
+    const { customFields: { placement, mode, container } = {} } = props;
+
+    this.state = {
+      placement,
+      mode,
+      container,
+    };
+  }
+
+  componentDidMount() {
+    if (!this.canRender()) {
+      return;
+    }
+
+    this.insertLoader();
+    this.insertFlusher();
+  }
+
+  appendScript = (name, container, sourceResolver) => {
+    const script = document.createElement('script');
+    script.id = name;
+    script.async = true;
+    script.type = 'text/javascript';
+    script.innerHTML = sourceResolver();
+
+    container.appendChild(script);
+  }
+
+  canRender() {
+    const { placement, mode, container } = this.state;
+    return (this.publisherID && placement && mode && container);
+  }
+
+  insertLoader() {
+    const loader = document.getElementById('tbl-loader');
+    if (loader) {
+      return;
+    }
+    const head = document.getElementsByTagName('head')[0];
+    if (!head) {
+      return;
+    }
+
+    this.appendScript('tbl-loader', head, () => taboolaLoader(this.publisherID));
+  }
+
+  insertFlusher() {
+    const flusher = document.getElementById('tbl-flusher');
+    if (flusher) {
+      return;
+    }
+    const body = document.getElementsByTagName('body')[0];
+    if (!body) {
+      return;
+    }
+
+    this.appendScript('tbl-flusher', body, taboolaFlusher);
+  }
+
+  render() {
+    if (!this.canRender()) {
+      return null;
+    }
+    const { isAdmin } = this.props;
+    const { placement, mode, container } = this.state;
+
+    if (isAdmin) {
+      return (
+        <>
+          <div
+            className="tbl-wrapper"
+            style={{
+              backgroundColor: 'papayawhip',
+              padding: '20px',
+            }}
+          >
+            <small>Taboola widget&nbsp;</small>
+            <strong>{placement}</strong>
+          </div>
+          <hr />
+        </>
+      );
+    }
+
+    const scriptString = `
+      window._taboola = window._taboola || [];
+      _taboola.push({
+        mode: '${mode}',
+        container: '${container}',
+        placement: '${placement}',
+        target_type: 'mix'
+      });
+    `;
+
+    return (
+      <>
+        <div id={`${container}`} />
+        <hr />
+        <script type="text/javascript" dangerouslySetInnerHTML={{ __html: scriptString }} />
+      </>
+    );
+  }
+}
+
+AdTaboola.label = 'Taboola – Arc Block';
+
+AdTaboola.propTypes = {
+  customFields: PropTypes.shape({
+    placement: PropTypes.string.tag({
+      label: 'Taboola Placement',
+      group: 'Configure Taboola Widget',
+    }),
+    mode: PropTypes.string.tag({
+      label: 'Taboola Mode',
+      group: 'Configure Taboola Widget',
+    }),
+    container: PropTypes.string.tag({
+      label: 'Taboola Container',
+      group: 'Configure Taboola Widget',
+    }),
+  }),
+};
+
+export default AdTaboola;

--- a/blocks/ad-taboola-block/features/ad-taboola/default.jsx
+++ b/blocks/ad-taboola-block/features/ad-taboola/default.jsx
@@ -140,7 +140,7 @@ class AdTaboola extends Component {
   }
 }
 
-AdTaboola.label = 'Taboola – Arc Block';
+AdTaboola.label = 'Taboola Ad – Arc Block';
 
 AdTaboola.propTypes = {
   customFields: PropTypes.shape({

--- a/blocks/ad-taboola-block/features/ad-taboola/default.test.jsx
+++ b/blocks/ad-taboola-block/features/ad-taboola/default.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import getProperties from 'fusion:properties';
+
+const TBL_WRAPPER = '.tbl-wrapper';
+
+jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+
+describe('render Taboola widget', () => {
+  describe('when missing configuration parameters', () => {
+    const { default: AdTaboola } = require('./default');
+
+    it("must not render when there isn't parameters", () => {
+      const wrapper = shallow(<AdTaboola />);
+
+      expect(wrapper.find('#tbl-widget').length).toBe(0);
+      expect(wrapper.find(TBL_WRAPPER).length).toBe(0);
+    });
+
+    it('must not render when only the publisher id is present', () => {
+      getProperties.mockImplementation(() => ({ taboolaPublisherId: 'taboolaPublisherId' }));
+      const wrapper = shallow(<AdTaboola />);
+
+      expect(wrapper.find('#tbl-widget').length).toBe(0);
+      expect(wrapper.find(TBL_WRAPPER).length).toBe(0);
+    });
+
+    it('must not render when some of the widget parameters are missing', () => {
+      getProperties.mockImplementation(() => ({ taboolaPublisherId: 'taboolaPublisherId' }));
+      const customFields = {
+        container: 'tbl-widget',
+      };
+
+      const wrapper = shallow(<AdTaboola customFields={customFields} />);
+      expect(wrapper.find('#tbl-widget').length).toBe(0);
+      expect(wrapper.find(TBL_WRAPPER).length).toBe(0);
+    });
+  });
+
+  describe('when have all config the paramters', () => {
+    const { default: AdTaboola } = require('./default');
+
+    it('must render the widget', () => {
+      getProperties.mockImplementation(() => ({ taboolaPublisherId: 'taboolaPublisherId' }));
+      const customFields = {
+        placement: 'a',
+        mode: 'b',
+        container: 'tbl-widget',
+      };
+
+      const wrapper = shallow(<AdTaboola customFields={customFields} />);
+
+      expect(wrapper.find('#tbl-widget').length).toBe(1);
+      expect(wrapper.find('hr').length).toBe(1);
+      expect(wrapper.find('script').length).toBe(1);
+    });
+
+    it('must render the visual wrapper on admin', () => {
+      getProperties.mockImplementation(() => ({ taboolaPublisherId: 'taboolaPublisherId' }));
+      const customFields = {
+        placement: 'a',
+        mode: 'b',
+        container: 'tbl-widget',
+      };
+
+      const wrapper = shallow(<AdTaboola customFields={customFields} isAdmin />);
+
+      expect(wrapper.find(TBL_WRAPPER).length).toBe(1);
+      expect(wrapper.find('AdTaboola #tbl-widget').length).toBe(0);
+      expect(wrapper.find('AdTaboola script').length).toBe(0);
+    });
+  })
+});

--- a/blocks/ad-taboola-block/features/ad-taboola/default.test.jsx
+++ b/blocks/ad-taboola-block/features/ad-taboola/default.test.jsx
@@ -70,5 +70,5 @@ describe('render Taboola widget', () => {
       expect(wrapper.find('AdTaboola #tbl-widget').length).toBe(0);
       expect(wrapper.find('AdTaboola script').length).toBe(0);
     });
-  })
+  });
 });

--- a/blocks/ad-taboola-block/index.js
+++ b/blocks/ad-taboola-block/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/blocks/ad-taboola-block/jest.config.js
+++ b/blocks/ad-taboola-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require('../../jest/jest.config.base');
+
+module.exports = {
+  ...base,
+};

--- a/blocks/ad-taboola-block/package.json
+++ b/blocks/ad-taboola-block/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wpmedia/ad-taboola-block",
+  "version": "5.3.0",
+  "description": "Fusion News Theme Taboola Widget",
+  "author": "nelson fernandez <nelson.fernandez@washpost.com>",
+  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "license": "CC-BY-NC-ND",
+  "main": "index.js",
+  "files": [
+    "features"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "directory": "blocks/ad-taboola-block"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "lint": "eslint --ext js --ext jsx features"
+  }
+}


### PR DESCRIPTION
[PEN-429](https://arcpublishing.atlassian.net/browse/PEN-429)

# What does this implement or fix?
- implements a new ad block for the Taboola widget

# How was this tested?
- tests written
- visually on PB

# Show Effect Of Changes

## After
blocks rendered inside PB editor

![2020_0814_183117](https://user-images.githubusercontent.com/9757/90294287-7173e680-de5c-11ea-9a30-0bd8631c9de7.png)

working widgets on page preview

![2020_0814_183128](https://user-images.githubusercontent.com/9757/90294299-76389a80-de5c-11ea-829f-dfd58bfc2c0f.png)

# Dependencies or Side Effects

- Need to setup the `taboolaPublisherId` on blocks json and valid widget values on each widget on the page
