### PR TITLE
PEN-1241 - remove padding generated by images inside anchors

### DIFF
--- a/blocks/card-list-block/features/card-list/card-list.scss
+++ b/blocks/card-list-block/features/card-list/card-list.scss
@@ -6,6 +6,10 @@
     margin-right: 16px;
   }
 
+  a > picture > img {
+    vertical-align: middle;
+  }
+
   .simple-results-list-container {
     @include container-vertial-spacing;
     @include container-hr-separator;

--- a/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
+++ b/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
@@ -5,6 +5,10 @@
     font-weight: bold;
     line-height: calculateRem(24px);
   }
+
+  a > picture > img {
+    vertical-align: middle;
+  }
 }
 
 .numbered-list-item {

--- a/blocks/shared-styles/scss/_extra-large-promo.scss
+++ b/blocks/shared-styles/scss/_extra-large-promo.scss
@@ -4,6 +4,9 @@
   a {
     color: $ui-primary-font-color;
   }
+  a > picture > img {
+    vertical-align: middle;
+  }
 
   .overline {
     display: block;

--- a/blocks/shared-styles/scss/_large-promo.scss
+++ b/blocks/shared-styles/scss/_large-promo.scss
@@ -5,6 +5,10 @@
     color: $ui-primary-font-color;
   }
 
+  a > picture > img {
+    vertical-align: middle;
+  }
+
   .overline {
     display: inline-block;
     font-size: calculateRem(16px);

--- a/blocks/shared-styles/scss/_medium-promo.scss
+++ b/blocks/shared-styles/scss/_medium-promo.scss
@@ -5,6 +5,10 @@
     color: $ui-primary-font-color;
   }
 
+  a > picture > img {
+    vertical-align: middle;
+  }
+
   .md-promo-headline {
     @include link-color-active-hover($ui-primary-font-color);
     font-size: calculateRem(16px);

--- a/blocks/shared-styles/scss/_results-list.scss
+++ b/blocks/shared-styles/scss/_results-list.scss
@@ -40,6 +40,10 @@
     max-width: max-content;
     width: 100%;
   }
+
+  a > picture > img {
+    vertical-align: middle;
+  }
 }
 
 .see-more {

--- a/blocks/shared-styles/scss/_small-promo.scss
+++ b/blocks/shared-styles/scss/_small-promo.scss
@@ -6,6 +6,10 @@
     color: $ui-primary-font-color;
   }
 
+  a > picture > img {
+    vertical-align: middle;
+  }
+
   .sm-promo-headline {
     @include link-color-active-hover($ui-primary-font-color);
     font-size: calculateRem(16px);

--- a/blocks/simple-list-block/features/simple-list/simple-list.scss
+++ b/blocks/simple-list-block/features/simple-list/simple-list.scss
@@ -10,6 +10,10 @@
     line-height: calculateRem(24px);
   }
 
+  a > picture > img {
+    vertical-align: middle;
+  }
+
   .list-item-simple {
     display: flex;
     justify-content: flex-start;


### PR DESCRIPTION
[PEN-1241](https://arcpublishing.atlassian.net/browse/PEN-1241)

# What does this implement or fix?
- remove padding generated by images inside anchors

# How was this tested?

- visually on PB

# Show Effect Of Changes

## Before
added this style to the images to show the padding
```
a > picture {
    background-color: red
}
```
![2020_0817_170331](https://user-images.githubusercontent.com/9757/90817719-90fb8b00-e304-11ea-8f63-238adc0dd22b.png)
![2020_0817_171737](https://user-images.githubusercontent.com/9757/90817695-8b05aa00-e304-11ea-8e3b-8c9ff3bd4e7e.png)


## After
![2020_0817_173241](https://user-images.githubusercontent.com/9757/90817607-76291680-e304-11ea-95d0-5d07eedf204d.png)
![2020_0817_171749](https://user-images.githubusercontent.com/9757/90817679-850fc900-e304-11ea-8a89-138728c18408.png)


# Dependencies or Side Effects

- none
