### PR TITLE
Fix readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This command does all the installing and linking we need to have access to our d
 
 ##### Adding a new dependency
 
-Much like installing existing dependencies, we'll want to rely on lerna commands for adding new dependecies and linking subpackages together as well.
+Much like installing existing dependencies, we'll want to rely on lerna commands for adding new dependencies and linking subpackages together as well.
 
 [We'll want to use lerna's 'add' command to install new dependencies.](https://github.com/lerna/lerna/tree/master/commands/add#readme) It's unlikely any of our usage will end up deviating from that doc.
 
@@ -173,7 +173,7 @@ For either the Engine SDK or the CSS Framework, the process is as follows:
 
 2. Replace all instances with the new version. In the example above, you would replace `"@wpmedia/engine-theme-sdk": "^2.1.0"` with `"@wpmedia/engine-theme-sdk": "^3.0.0"`
 
-3. Run `npx lerna boostrap` to make sure the dependencies are being pulled properly
+3. Run `npx lerna bootstrap` to make sure the dependencies are being pulled properly
 
 #### 5. Writing Unit Tests
 Unit tests should be written alongside the feature before it is pushed to Code Review. We're using Jest as our test runner and Enzyme as our testing tool for testing React components. Not only will you have the standard Jest assertion available to you. You'll also have all of assertion matchers provided by [jest-enzyme](https://github.com/FormidableLabs/enzyme-matchers/tree/master/packages/jest-enzyme). The test files should be placed in the same directory as the main feature React file as well as be named the same. If you're testing `default.jsx`, your tests would be in the same directory in a file called `default.test.jsx`.

--- a/blocks/a11y-testing-block/README.md
+++ b/blocks/a11y-testing-block/README.md
@@ -12,7 +12,7 @@ on your page that when clicked will open/close the issue panel where you can see
 2) UI Panel Trigger Control:  If have `Show A11y UI` set to `true`, then you can decide where to place the control button that
 opens and closes the issue panel.  The button can be placed in one of the four corners of the page, however the issue panel will always 
 be displayed on the right side when it is open.
-3) WCAG A11y Levels: Choose the WACG (Web Content Accessibility Guidelines) level you want to target.  The default setting of
+3) WCAG A11y Levels: Choose the WCAG (Web Content Accessibility Guidelines) level you want to target.  The default setting of
 `Level AA` is recommended.  More information on the different types of WCAG levels and what they target can be found here: 
 https://www.w3.org/WAI/WCAG21/quickref/
 4) Include additional best practices: Enabled by default.  This adds additional best practice checks during the audit that are not in the 

--- a/blocks/ad-taboola-block/README.md
+++ b/blocks/ad-taboola-block/README.md
@@ -4,7 +4,7 @@ _Block that implement a [Taboola Widget](https://www.taboola.com/)._
 ## Props
 
 ### Global
-| **Prop** | **Required** | **Descripton** |
+| **Prop** | **Required** | **Description** |
 |---|---|---|
 | **taboolaPublisherId** | yes | Publishier ID provided by Taboola |
 
@@ -25,7 +25,7 @@ This configuration need to added to `blocks.json` like this:
 ```
 
 ### Per widget
-| **Prop** | **Required** | **Descripton** |
+| **Prop** | **Required** | **Description** |
 |---|---|---|
 | **taboolaPlacement** | yes | Widget placement description, provided by Taboola |
 | **taboolaMode** | yes | Widget mode, provided by Taboola |

--- a/blocks/ad-taboola-block/README.md
+++ b/blocks/ad-taboola-block/README.md
@@ -6,7 +6,7 @@ _Block that implement a [Taboola Widget](https://www.taboola.com/)._
 ### Global
 | **Prop** | **Required** | **Description** |
 |---|---|---|
-| **taboolaPublisherId** | yes | Publishier ID provided by Taboola |
+| **taboolaPublisherId** | yes | Publisher ID provided by Taboola |
 
 This configuration need to added to `blocks.json` like this:
 ```

--- a/blocks/alert-bar-block/README.md
+++ b/blocks/alert-bar-block/README.md
@@ -5,7 +5,7 @@ _This is the alert bar block that feeds from the `alert-bar-content-source-block
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/alert-bar-block/README.md
+++ b/blocks/alert-bar-block/README.md
@@ -80,7 +80,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/article-body-block/README.md
+++ b/blocks/article-body-block/README.md
@@ -35,7 +35,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/article-body-block/README.md
+++ b/blocks/article-body-block/README.md
@@ -7,7 +7,7 @@ _Fusion News Theme article-body block_
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/article-tag-block/README.md
+++ b/blocks/article-tag-block/README.md
@@ -63,7 +63,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/article-tag-block/README.md
+++ b/blocks/article-tag-block/README.md
@@ -8,7 +8,7 @@ _Fusion News Article Tags block_
 - If taxonomy section is missing, it will not render anything.
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/author-bio-block/README.md
+++ b/blocks/author-bio-block/README.md
@@ -5,7 +5,7 @@ _Author Short Biography block for Fusion News Theme_
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/author-bio-block/README.md
+++ b/blocks/author-bio-block/README.md
@@ -67,7 +67,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/byline-block/README.md
+++ b/blocks/byline-block/README.md
@@ -45,7 +45,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/byline-block/README.md
+++ b/blocks/byline-block/README.md
@@ -9,7 +9,7 @@ Byline block for Fusion News Theme
 - If there's no authors, it will return null.
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/card-list-block/README.md
+++ b/blocks/card-list-block/README.md
@@ -37,7 +37,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/card-list-block/README.md
+++ b/blocks/card-list-block/README.md
@@ -11,7 +11,7 @@ _Please provide a 1-2 sentence description of what the block is and what it does
   - If there are three or more authors, it will return with the pattern `By <author_0>, <author_1>, ... <author_(n-1)> and <author_(n)>`
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/date-block/README.md
+++ b/blocks/date-block/README.md
@@ -34,7 +34,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/date-block/README.md
+++ b/blocks/date-block/README.md
@@ -5,7 +5,7 @@ Fusion News Theme date block. _Please provide a 1-2 sentence description of what
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/default-output-block/README.md
+++ b/blocks/default-output-block/README.md
@@ -55,7 +55,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/default-output-block/README.md
+++ b/blocks/default-output-block/README.md
@@ -5,7 +5,7 @@ Fusion News Theme default output type. _Please provide a 1-2 sentence descriptio
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/double-chain-block/README.md
+++ b/blocks/double-chain-block/README.md
@@ -7,7 +7,7 @@ Fusion News Theme double-chain block. Takes in a number of how many items to be 
 - PageBuilder editor can configure how many features are placed in each column within the chain. 
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/double-chain-block/README.md
+++ b/blocks/double-chain-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/event-tester-block/README.md
+++ b/blocks/event-tester-block/README.md
@@ -28,7 +28,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/event-tester-block/README.md
+++ b/blocks/event-tester-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme event tester block. Used for testing the event emitter.  When
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/extra-large-manual-promo-block/README.md
+++ b/blocks/extra-large-manual-promo-block/README.md
@@ -5,7 +5,7 @@ _Block containing an extra large manual promo component. Please provide a 1-2 se
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/extra-large-manual-promo-block/README.md
+++ b/blocks/extra-large-manual-promo-block/README.md
@@ -28,7 +28,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/extra-large-promo-block/README.md
+++ b/blocks/extra-large-promo-block/README.md
@@ -5,7 +5,7 @@ _Block containing an extra large promo component. Please provide a 1-2 sentence 
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/extra-large-promo-block/README.md
+++ b/blocks/extra-large-promo-block/README.md
@@ -28,7 +28,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/footer-block/README.md
+++ b/blocks/footer-block/README.md
@@ -34,7 +34,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/footer-block/README.md
+++ b/blocks/footer-block/README.md
@@ -5,7 +5,7 @@ _Footer block for the Fusion News Theme. This will pull the data from the footer
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/full-author-bio-block/README.md
+++ b/blocks/full-author-bio-block/README.md
@@ -69,7 +69,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/full-author-bio-block/README.md
+++ b/blocks/full-author-bio-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme full author bio block. Please provide a 1-2 sentence descript
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/gallery-block/README.md
+++ b/blocks/gallery-block/README.md
@@ -8,7 +8,7 @@ _Block containing a gallery that reads in a gallery from a content source. Pleas
 | **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **customFields.inheritGlobalContent** | no | Boolean | Determines whether or not the feature will use global content instead of the provided content config at the feature level. This is used by default. |
-| **ocustomFields.galleryContentConfig** | no | Fusion Content Config | Content config that will be used if `inheritGlobalContent` is false. |
+| **customFields.galleryContentConfig** | no | Fusion Content Config | Content config that will be used if `inheritGlobalContent` is false. |
 
 ## ANS Schema
 Outline any schema information requirements necessary to know for ths block

--- a/blocks/gallery-block/README.md
+++ b/blocks/gallery-block/README.md
@@ -5,7 +5,7 @@ _Block containing a gallery that reads in a gallery from a content source. Pleas
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **customFields.inheritGlobalContent** | no | Boolean | Determines whether or not the feature will use global content instead of the provided content config at the feature level. This is used by default. |
 | **ocustomFields.galleryContentConfig** | no | Fusion Content Config | Content config that will be used if `inheritGlobalContent` is false. |

--- a/blocks/global-phrases-block/README.md
+++ b/blocks/global-phrases-block/README.md
@@ -32,7 +32,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/global-phrases-block/README.md
+++ b/blocks/global-phrases-block/README.md
@@ -7,7 +7,7 @@ _The translations can be found the `intl.json` file._
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/header-block/README.md
+++ b/blocks/header-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme header block. Please provide a 1-2 sentence description of wh
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **customFields.text** | no | string | add description |
 | **customfields.size** | no | oneOf | 'Extra Large', 'Large', 'Medium', 'Small' |

--- a/blocks/header-block/README.md
+++ b/blocks/header-block/README.md
@@ -28,7 +28,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/header-nav-block/README.md
+++ b/blocks/header-nav-block/README.md
@@ -5,7 +5,7 @@ _Block containing our News Theme nav for the header. Please provide a 1-2 senten
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/header-nav-block/README.md
+++ b/blocks/header-nav-block/README.md
@@ -47,7 +47,7 @@ This block does not emit any events.
 ### Custom Search Action
 If you are creating custom blocks that are leveraging all or parts of the header-nav-block and 
 need to over-ride the action taken when the search box field has been submitted 
-(for both click and keyboard submisstions) an over-ride function can be passed as a prop to either the 
+(for both click and keyboard submissions) an over-ride function can be passed as a prop to either the 
 main default.jsx (nav component) or to the search-box.jsx component.  The prop name is called `customSearchAction`.
 If passed into default.jsx it will pass it down to search-box.  Your implementation of `customSearchAction`
 should expect one param that will be the value of the search entry.  If `customSearchAction` is not implemented, default 

--- a/blocks/header-nav-block/README.md
+++ b/blocks/header-nav-block/README.md
@@ -37,7 +37,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/header-nav-chain-block/README.md
+++ b/blocks/header-nav-chain-block/README.md
@@ -35,7 +35,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/header-nav-chain-block/README.md
+++ b/blocks/header-nav-chain-block/README.md
@@ -5,7 +5,7 @@ _Please provide a 1-2 sentence description of what the block is and what it does
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/headline-block/README.md
+++ b/blocks/headline-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme headline block. Please provide a 1-2 sentence description of 
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/headline-block/README.md
+++ b/blocks/headline-block/README.md
@@ -28,7 +28,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/htmlbox-block/README.md
+++ b/blocks/htmlbox-block/README.md
@@ -32,7 +32,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/htmlbox-block/README.md
+++ b/blocks/htmlbox-block/README.md
@@ -7,7 +7,7 @@ _HTML Box for block for Fusion News Theme. Please provide a 1-2 sentence descrip
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/large-manual-promo-block/README.md
+++ b/blocks/large-manual-promo-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/large-manual-promo-block/README.md
+++ b/blocks/large-manual-promo-block/README.md
@@ -5,7 +5,7 @@ _Block containing a large manual promo component. Please provide a 1-2 sentence 
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/large-promo-block/README.md
+++ b/blocks/large-promo-block/README.md
@@ -144,7 +144,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/large-promo-block/README.md
+++ b/blocks/large-promo-block/README.md
@@ -5,7 +5,7 @@ _Block containing a large promo component. Please provide a 1-2 sentence descrip
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/lead-art-block/README.md
+++ b/blocks/lead-art-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme lead art block. Please provide a 1-2 sentence description of 
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/links-bar-block/README.md
+++ b/blocks/links-bar-block/README.md
@@ -5,7 +5,7 @@ _This is the links bar block for the news theme, written as a functional compone
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/links-bar-block/README.md
+++ b/blocks/links-bar-block/README.md
@@ -34,7 +34,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/masthead-block/README.md
+++ b/blocks/masthead-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/masthead-block/README.md
+++ b/blocks/masthead-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme masthead block is a relatively simple feature that is typical
 - As a Themes customer, I can put a Masthead Arc Block onto my homepage, because I want this traditional newspaper design element 
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/medium-manual-promo-block/README.md
+++ b/blocks/medium-manual-promo-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/medium-manual-promo-block/README.md
+++ b/blocks/medium-manual-promo-block/README.md
@@ -5,7 +5,7 @@ _Block containing a medium manual promo component. Please provide a 1-2 sentence
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/medium-promo-block/README.md
+++ b/blocks/medium-promo-block/README.md
@@ -33,7 +33,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/medium-promo-block/README.md
+++ b/blocks/medium-promo-block/README.md
@@ -5,7 +5,7 @@ _Block containing a medium promo component. Please provide a 1-2 sentence descri
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/numbered-list-block/README.md
+++ b/blocks/numbered-list-block/README.md
@@ -32,7 +32,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/numbered-list-block/README.md
+++ b/blocks/numbered-list-block/README.md
@@ -5,7 +5,7 @@ _Numbered List block for Fusion News Theme. Displays a numbered list where each 
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/overline-block/README.md
+++ b/blocks/overline-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme overline block. Please provide a 1-2 sentence description of 
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/overline-block/README.md
+++ b/blocks/overline-block/README.md
@@ -34,7 +34,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/placeholder-image-block/README.md
+++ b/blocks/placeholder-image-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/placeholder-image-block/README.md
+++ b/blocks/placeholder-image-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme placeholder image. The intended use is to take the feature pa
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/quad-chain-block/README.md
+++ b/blocks/quad-chain-block/README.md
@@ -32,7 +32,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/quad-chain-block/README.md
+++ b/blocks/quad-chain-block/README.md
@@ -7,7 +7,7 @@ _Fusion News Theme quad-chain block. Utilizes bootstrap's three column approach 
 - PageBuilder editor can configure how many features are placed in each column within the chain.
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/resizer-image-block/README.md
+++ b/blocks/resizer-image-block/README.md
@@ -5,7 +5,7 @@ _This is a helper to transform the return value of the content sources. This is 
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/resizer-image-block/README.md
+++ b/blocks/resizer-image-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 ## Additional Considerations
 

--- a/blocks/results-list-block/README.md
+++ b/blocks/results-list-block/README.md
@@ -38,7 +38,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/results-list-block/README.md
+++ b/blocks/results-list-block/README.md
@@ -8,7 +8,7 @@ _Results List block for Fusion News Theme. Displays a results list where each re
 - It expects the user to configure its content source.
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/right-rail-advanced-block/README.md
+++ b/blocks/right-rail-advanced-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/right-rail-advanced-block/README.md
+++ b/blocks/right-rail-advanced-block/README.md
@@ -5,7 +5,7 @@ _Please provide a 1-2 sentence description of what the block is and what it does
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/right-rail-block/README.md
+++ b/blocks/right-rail-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/right-rail-block/README.md
+++ b/blocks/right-rail-block/README.md
@@ -5,7 +5,7 @@ _Please provide a 1-2 sentence description of what the block is and what it does
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/search-content-source-block/README.md
+++ b/blocks/search-content-source-block/README.md
@@ -64,7 +64,7 @@ Search Key is required to be set as an environment variable.
 
 For local set this in your `.env.` file
 
-For all other environments make sure you have updated the neccessary files in the environment folder of your feature pack repo.
+For all other environments make sure you have updated the necessary files in the environment folder of your feature pack repo.
 
 ```
 searchKey=ABCDEF

--- a/blocks/search-results-list-block/README.md
+++ b/blocks/search-results-list-block/README.md
@@ -32,7 +32,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/search-results-list-block/README.md
+++ b/blocks/search-results-list-block/README.md
@@ -5,7 +5,7 @@ _Search Results List block for Fusion News Theme. This block displays a search b
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/search-results-list-block/README.md
+++ b/blocks/search-results-list-block/README.md
@@ -48,6 +48,6 @@ _It also makes use of ByLine to display authors of each story and it is included
 
 ### Custom Search Action
 If you are creating custom blocks that are leveraging the global content part of the Search Results List block and need to over-ride the action taken when the search box field has been submitted 
-(for both click and keyboard submisstions) an over-ride function can be passed as a prop to either the main default.jsx or to the global-content.jsx component.  The prop name is called `customSearchAction`.
+(for both click and keyboard submissions) an over-ride function can be passed as a prop to either the main default.jsx or to the global-content.jsx component.  The prop name is called `customSearchAction`.
 
 If passed into default.jsx it will pass it down to global-content.  Your implementation of `customSearchAction` should expect one param that will be the value of the search entry.  If `customSearchAction` is not implemented, default behavior will occur during a search submission.

--- a/blocks/section-title-block/README.md
+++ b/blocks/section-title-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme section title block# Name of Block. Please provide a 1-2 sent
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/section-title-block/README.md
+++ b/blocks/section-title-block/README.md
@@ -71,7 +71,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/share-bar-block/README.md
+++ b/blocks/share-bar-block/README.md
@@ -5,7 +5,7 @@ _This is the share bar block for the news theme, written as a functional compone
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/share-bar-block/README.md
+++ b/blocks/share-bar-block/README.md
@@ -31,7 +31,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/shared-styles/README.md
+++ b/blocks/shared-styles/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/shared-styles/README.md
+++ b/blocks/shared-styles/README.md
@@ -5,7 +5,7 @@ _Block containing shared styles (sass file partials)._
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/simple-list-block/README.md
+++ b/blocks/simple-list-block/README.md
@@ -35,7 +35,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/simple-list-block/README.md
+++ b/blocks/simple-list-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme Simple List block is a dynamically-sized list with items of a
 - As a Themes customer, I can place a Simple List Block on my PageBuilder pages and templates, so that I can showcase most read or editor's picks content to my readers.
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/single-chain-block/README.md
+++ b/blocks/single-chain-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/single-chain-block/README.md
+++ b/blocks/single-chain-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme single-chain block. Please provide a 1-2 sentence description
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/small-manual-promo-block/README.md
+++ b/blocks/small-manual-promo-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/small-manual-promo-block/README.md
+++ b/blocks/small-manual-promo-block/README.md
@@ -5,7 +5,7 @@ _Block containing a small manual promo component. Please provide a 1-2 sentence 
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/small-promo-block/README.md
+++ b/blocks/small-promo-block/README.md
@@ -5,7 +5,7 @@ _Block containing a small promo component. Please provide a 1-2 sentence descrip
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/small-promo-block/README.md
+++ b/blocks/small-promo-block/README.md
@@ -33,7 +33,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/subheadline-block/README.md
+++ b/blocks/subheadline-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme sub-headline block. Please provide a 1-2 sentence description
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/subheadline-block/README.md
+++ b/blocks/subheadline-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/tag-title-block/README.md
+++ b/blocks/tag-title-block/README.md
@@ -31,7 +31,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/tag-title-block/README.md
+++ b/blocks/tag-title-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme tag title block. Please provide a 1-2 sentence description of
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/text-output-block/README.md
+++ b/blocks/text-output-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme text output type. Please provide a 1-2 sentence description o
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/text-output-block/README.md
+++ b/blocks/text-output-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/textfile-block/README.md
+++ b/blocks/textfile-block/README.md
@@ -31,7 +31,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/textfile-block/README.md
+++ b/blocks/textfile-block/README.md
@@ -6,7 +6,7 @@ _Text File block for Fusion News Theme. This block offers a convenient way to re
 - Be sure to use the page output type `text` or nothing will render. 
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/triple-chain-block/README.md
+++ b/blocks/triple-chain-block/README.md
@@ -31,7 +31,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/triple-chain-block/README.md
+++ b/blocks/triple-chain-block/README.md
@@ -6,7 +6,7 @@ _Fusion News Theme triple-chain block. Utilizes bootstrap's three column approac
 - PageBuilder editor can configure how many features are placed in each column within the chain. 
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |

--- a/blocks/video-player-block/README.md
+++ b/blocks/video-player-block/README.md
@@ -30,7 +30,7 @@ Blocks can emit events. The following is a list of events that are emitted by th
 | **eventName** | Describe the event |
 
 ### Event Listening
-Include block specific intructions for event listening.
+Include block specific instructions for event listening.
 
 OR
 

--- a/blocks/video-player-block/README.md
+++ b/blocks/video-player-block/README.md
@@ -5,7 +5,7 @@ _Fusion News Theme video player block. Please provide a 1-2 sentence description
 - Add AC relevant to the block
 
 ## Props
-| **Prop** | **Required** | **Type** | **Descripton** |
+| **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
 | **required prop** | yes | | |
 | **optional prop** | no | | |


### PR DESCRIPTION
Eric found a typo so I wanted to check more generally for typos. I found a vscode extension called cspell https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker

Would highly recommend it as we're now writing customer-facing documentation. @RobinGiannattasio @beltrancaliz @jgrosspietsch @visionbegin @kascote @shk172 @seans887 

I also added words to ignore misspellings so it's a tad less noisy

.vscode/settings.json

```
{
  "cSpell.enabled": true,
  "cSpell.words": [
    "WCAG",
    "autoplay",
    "corecomponents",
    "proptypes",
    "requestidlecallback",
    "resizer",
    "taboola",
    "wpmedia"
  ],
}
```