### PR TITLE
PEN-1270 alert bar displayed after dismissed

### DIFF
--- a/blocks/alert-bar-block/features/alert-bar/cookies.js
+++ b/blocks/alert-bar-block/features/alert-bar/cookies.js
@@ -1,0 +1,26 @@
+import cookie from 'cookie';
+
+const COOKIE_NAME = 'arcblock_alert-bar';
+
+function twoDaysInFuture() {
+  const future = new Date();
+  future.setDate(future.getDate() + 2);
+  return future;
+}
+
+export function readCookie() {
+  const cookies = cookie.parse(document.cookie);
+  return cookies[COOKIE_NAME];
+}
+
+export function saveCookie(value) {
+  const options = {
+    expires: twoDaysInFuture(),
+    httpOnly: false,
+    maxAge: 60 * 60 * 24 * 2, // 2 days
+    path: '/',
+    sameSite: 'Lax',
+    secure: window.location.protocol === 'https:',
+  };
+  document.cookie = cookie.serialize(COOKIE_NAME, value, options);
+}

--- a/blocks/alert-bar-block/features/alert-bar/default.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.jsx
@@ -5,6 +5,8 @@ import Consumer from 'fusion:consumer';
 import getThemeStyle from 'fusion:themes';
 import { CloseIcon } from '@wpmedia/engine-theme-sdk';
 
+import { readCookie, saveCookie } from './cookies';
+
 import './alert-bar.scss';
 
 const AlertBarLink = styled.a`
@@ -26,14 +28,19 @@ class AlertBar extends Component {
       },
     });
 
-    this.state = {
-      content: cached,
-      visible: true,
-    };
-    fetched.then((content) => {
-      const visible = content?.content_elements?.length > 0;
-      this.setState({ content, visible });
-    });
+    if (typeof window !== 'undefined') {
+      this.cookie = readCookie();
+      this.state = {
+        content: cached,
+        visible: this.checkAlertVisible(cached),
+      };
+      fetched.then(this.updateContent);
+    } else {
+      this.state = {
+        content: cached,
+        visible: false,
+      };
+    }
   }
 
   componentDidMount() {
@@ -50,15 +57,32 @@ class AlertBar extends Component {
           size: 1,
         },
       });
-      fetched.then((content) => {
-        const visible = content?.content_elements?.length > 0;
-        this.setState({ content, visible });
-      });
+      fetched.then(this.updateContent);
     }, 120000);
   }
 
   componentWillUnmount() {
     clearInterval(this.timeID);
+  }
+
+  updateContent = (content) => {
+    const isAlertVisible = this.checkAlertVisible(content);
+    this.setState({ content, visible: isAlertVisible });
+  }
+
+  checkAlertVisible = (content) => {
+    const elements = content?.content_elements;
+    const hasAlert = elements?.length > 0;
+    return hasAlert
+      ? elements?.[0].headlines?.basic !== this.cookie
+      : false;
+  }
+
+  hideAlert = () => {
+    const { content = {} } = this.state;
+    const story = content?.content_elements?.[0]?.headlines?.basic;
+    saveCookie(story);
+    this.setState({ visible: false });
   }
 
   render() {
@@ -79,7 +103,7 @@ class AlertBar extends Component {
           >
             {headlines.basic}
           </AlertBarLink>
-          <button type="button" onClick={() => this.setState({ visible: false })}>
+          <button type="button" onClick={this.hideAlert}>
             <CloseIcon className="close" fill="white" />
           </button>
         </nav>

--- a/blocks/alert-bar-block/features/alert-bar/default.test.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 jest.mock('fusion:themes', () => jest.fn(() => ({})));
 describe('the alert bar feature for the default output type', () => {
@@ -64,5 +64,101 @@ describe('the alert bar feature for the default output type', () => {
     });
     const wrapper = mount(<AlertBar customFields={customFields} arcSite="the-sun" />);
     expect(wrapper.find('.alert-bar')).toHaveLength(0);
+  });
+});
+
+describe('the alert can handle user interaction', () => {
+  it('must hide when click the close button', () => {
+    const { default: AlertBar } = require('./default');
+    const content = {
+      _id: 'VTKOTRJXEVATHG7MELTPZ2RIBU',
+      type: 'collection',
+      content_elements:
+        [{
+          _id: '55FCWHR6SRCQ3OIJJKWPWUGTBM',
+          headlines: {
+            basic: 'This is a test headline',
+          },
+          websites: {
+            'the-sun': {
+              website_url: '/2019/12/02/baby-panda-born-at-the-zoo/',
+            },
+          },
+        }],
+    };
+
+    AlertBar.prototype.getContent = jest.fn().mockReturnValue({
+      cached: content,
+      fetched: new Promise((r) => r(content)),
+    });
+    const wrapper = shallow(<AlertBar arcSite="the-sun" />);
+    expect(wrapper.find('.alert-bar')).toHaveLength(1);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.find('.alert-bar')).toHaveLength(0);
+  });
+
+  it('must set a cookie with the headline text when is dismissed', () => {
+    const { default: AlertBar } = require('./default');
+    const cookieText = 'This is a test headline for cookie';
+    const encodedCookie = 'arcblock_alert-bar=This%20is%20a%20test%20headline%20for%20cookie';
+    const content = {
+      _id: 'VTKOTRJXEVATHG7MELTPZ2RIBU',
+      type: 'collection',
+      content_elements:
+        [{
+          _id: '55FCWHR6SRCQ3OIJJKWPWUGTBM',
+          headlines: {
+            basic: cookieText,
+          },
+          websites: {
+            'the-sun': {
+              website_url: '/2019/12/02/baby-panda-born-at-the-zoo/',
+            },
+          },
+        }],
+    };
+
+    AlertBar.prototype.getContent = jest.fn().mockReturnValue({
+      cached: content,
+      fetched: new Promise((r) => r(content)),
+    });
+    const wrapper = shallow(<AlertBar arcSite="the-sun" />);
+    expect(wrapper.find('.alert-bar')).toHaveLength(1);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.find('.alert-bar')).toHaveLength(0);
+    expect(document.cookie).toEqual(encodedCookie);
+  });
+
+
+  it('must not render alert when cookie match the headline text', () => {
+    const { default: AlertBar } = require('./default');
+    const cookieText = 'cookie with text';
+    const encodedCookie = 'arcblock_alert-bar=cookie%20with%20text';
+
+    const content = {
+      _id: 'VTKOTRJXEVATHG7MELTPZ2RIBU',
+      type: 'collection',
+      content_elements:
+        [{
+          _id: '55FCWHR6SRCQ3OIJJKWPWUGTBM',
+          headlines: {
+            basic: cookieText,
+          },
+          websites: {
+            'the-sun': {
+              website_url: '/2019/12/02/baby-panda-born-at-the-zoo/',
+            },
+          },
+        }],
+    };
+    document.cookie = encodedCookie;
+
+    AlertBar.prototype.getContent = jest.fn().mockReturnValue({
+      cached: content,
+      fetched: new Promise((r) => r(content)),
+    });
+    const wrapper = shallow(<AlertBar arcSite="the-sun" />);
+    expect(wrapper.find('.alert-bar')).toHaveLength(0);
+    expect(document.cookie).toEqual(encodedCookie);
   });
 });

--- a/blocks/alert-bar-block/features/alert-bar/default.test.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.test.jsx
@@ -130,7 +130,7 @@ describe('the alert can handle user interaction', () => {
   });
 
 
-  it('must not render alert when cookie match the headline text', () => {
+  it('must not render alert when cookie matches the headline text', () => {
     const { default: AlertBar } = require('./default');
     const cookieText = 'cookie with text';
     const encodedCookie = 'arcblock_alert-bar=cookie%20with%20text';

--- a/blocks/alert-bar-block/features/alert-bar/default.test.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.test.jsx
@@ -97,7 +97,7 @@ describe('the alert can handle user interaction', () => {
     expect(wrapper.find('.alert-bar')).toHaveLength(0);
   });
 
-  it('must set a cookie with the headline text when is dismissed', () => {
+  it("must set a cookie with the headline text when it's dismissed", () => {
     const { default: AlertBar } = require('./default');
     const cookieText = 'This is a test headline for cookie';
     const encodedCookie = 'arcblock_alert-bar=This%20is%20a%20test%20headline%20for%20cookie';

--- a/blocks/alert-bar-block/package-lock.json
+++ b/blocks/alert-bar-block/package-lock.json
@@ -222,6 +222,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",

--- a/blocks/alert-bar-block/package.json
+++ b/blocks/alert-bar-block/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "styled-components": "^4.4.0"
+    "styled-components": "^4.4.0",
+    "cookie": "^0.4.1"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"
 }


### PR DESCRIPTION
[PEN-1270](https://arcpublishing.atlassian.net/browse/PEN-1270)

# What does this implement or fix?
- prevent alert bar from display again after being dismissed.

# How was this tested?

- tests written

# IE11 test

![pen-1270-1](https://user-images.githubusercontent.com/9757/92029363-ce680b80-ed3b-11ea-9be7-ca7ea5e914a0.gif)



# Dependencies or Side Effects

- a new package was added to the block to handle cookies serializing
