### PR TITLE
PEN-1251 hide logo navigation bar update

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -88,12 +88,6 @@ const Nav = (props) => {
     document.body.classList.remove('nav-open');
   };
 
-  const handleEscKey = (event) => {
-    if (event.keyCode === 27) {
-      closeNavigation();
-    }
-  };
-
   const closeDrawer = (event) => {
     const ele = event.target;
     if (ele.closest('.inner-drawer-nav')) {
@@ -108,6 +102,12 @@ const Nav = (props) => {
   };
 
   useEffect(() => {
+    const handleEscKey = (event) => {
+      if (event.keyCode === 27) {
+        closeNavigation();
+      }
+    };
+
     window.addEventListener('keydown', handleEscKey, true);
     return () => {
       window.removeEventListener('keydown', handleEscKey);
@@ -155,7 +155,7 @@ const Nav = (props) => {
       };
     }
     return undefined;
-  }, []);
+  }, [onScrollDebounced, breakpoints]);
 
   useEffect(() => {
     const vw = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
@@ -174,7 +174,7 @@ const Nav = (props) => {
     return () => {
       clearTimeout(timerID);
     };
-  }, []);
+  }, [breakpoints]);
 
   return (
     <>

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -142,7 +142,7 @@ const Nav = (props) => {
   const [onScrollDebounced] = useDebouncedCallback(onScrollEvent, 100);
 
   useEffect(() => {
-    const mastHead = document.querySelector('.masthead-block-container');
+    const mastHead = document.querySelector('.masthead-block-container .masthead-block-logo');
     if (!mastHead) {
       return undefined;
     }
@@ -165,7 +165,7 @@ const Nav = (props) => {
     }
 
     const timerID = setTimeout(() => {
-      const mastHead = document.querySelector('.masthead-block-container');
+      const mastHead = document.querySelector('.masthead-block-container .masthead-block-logo');
       if (!mastHead) {
         setLogoVisibility(true);
       }

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -161,7 +161,7 @@ describe('the header navigation feature for the default output type', () => {
         spy.mockRestore();
       });
 
-      it('should not show the logo after 1 second if there is masthead and logo', () => {
+      it('should not show the logo after 1 second if there is a masthead and logo', () => {
         jest.useFakeTimers();
         getProperties.mockImplementation(() => ({}));
         const spy = jest.spyOn(document, 'querySelector').mockImplementation((selector) => (

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -145,19 +145,90 @@ describe('the header navigation feature for the default output type', () => {
         expect(wrapper.find('.nav-logo.nav-logo-show').length).toBe(1);
       });
 
-      it('should setup scroll handlers, when enable logo', () => {
-        const spy = jest.spyOn(window, 'addEventListener');
+      it('should show the logo after 1 second if there is masthead but no logo', () => {
+        jest.useFakeTimers();
         getProperties.mockImplementation(() => ({}));
-        const wrapper = mount(
-          <div>
-            <Navigation />
-            <div className="masthead-block-container" />
-          </div>,
-        );
-        expect(wrapper.find('.masthead-block-container').length).toBe(1);
-        expect(spy).toHaveBeenCalled();
+        const spy = jest.spyOn(document, 'querySelector').mockImplementation((selector) => (
+          (selector === '.masthead-block-container .masthead-block-logo') ? undefined : {}
+        ));
+        const wrapper = mount(<Navigation />);
+        act(() => {
+          jest.runAllTimers();
+          wrapper.setProps({});
+        });
+
+        expect(wrapper.find('.nav-logo.nav-logo-show').length).toBe(1);
+        spy.mockRestore();
+      });
+
+      it('should not show the logo after 1 second if there is masthead and logo', () => {
+        jest.useFakeTimers();
+        getProperties.mockImplementation(() => ({}));
+        const spy = jest.spyOn(document, 'querySelector').mockImplementation((selector) => (
+          (selector === '.masthead-block-container .masthead-block-logo') ? {} : undefined
+        ));
+
+        const wrapper = mount(<Navigation />);
+        act(() => {
+          jest.runAllTimers();
+          wrapper.setProps({});
+        });
+
+        expect(wrapper.find('.nav-logo.nav-logo-hidden').length).toBe(1);
+        spy.mockRestore();
+      });
+
+      it('should not setup scroll handlers when enable logo and masthead logo missing', () => {
+        getProperties.mockImplementation(() => ({}));
+        let handlerSetup = false;
+        const spy = jest.spyOn(window, 'addEventListener').mockImplementation((...args) => {
+          if (args[0] === 'scroll') {
+            handlerSetup = true;
+          }
+          return undefined;
+        });
+        const spy2 = jest.spyOn(document, 'querySelector').mockImplementation((selector) => (
+          (selector === '.masthead-block-container .masthead-block-logo') ? undefined : { data: true }
+        ));
+
+        jest.useFakeTimers();
+        const wrapper = mount(<Navigation />);
+        act(() => {
+          jest.runAllTimers();
+          wrapper.setProps({});
+        });
+
+        expect(wrapper.find('.nav-logo.nav-logo-show').length).toBe(1);
+        expect(handlerSetup).toBeFalsy();
 
         spy.mockRestore();
+        spy2.mockRestore();
+      });
+
+      it('should setup scroll handlers, when enable logo', () => {
+        let handlerSetup = false;
+        const spy = jest.spyOn(window, 'addEventListener').mockImplementation((...args) => {
+          if (args[0] === 'scroll') {
+            handlerSetup = true;
+          }
+          return undefined;
+        });
+        const spy2 = jest.spyOn(document, 'querySelector').mockImplementation((selector) => (
+          (selector === '.masthead-block-container .masthead-block-logo') ? { data: true } : undefined
+        ));
+        getProperties.mockImplementation(() => ({}));
+        jest.useFakeTimers();
+        const wrapper = mount(<Navigation />);
+        act(() => {
+          jest.runAllTimers();
+          wrapper.setProps({});
+        });
+
+        expect(wrapper.find('.nav-logo.nav-logo-hidden').length).toBe(1);
+        expect(handlerSetup).toBeTruthy();
+
+        spy.mockRestore();
+        spy2.mockRestore();
       });
     });
   });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -178,7 +178,7 @@ describe('the header navigation feature for the default output type', () => {
         spy.mockRestore();
       });
 
-      it('should not setup scroll handlers when enable logo and masthead logo missing', () => {
+      it('should not setup scroll handlers when logo is enabled and masthead logo is missing', () => {
         getProperties.mockImplementation(() => ({}));
         let handlerSetup = false;
         const spy = jest.spyOn(window, 'addEventListener').mockImplementation((...args) => {

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -145,7 +145,7 @@ describe('the header navigation feature for the default output type', () => {
         expect(wrapper.find('.nav-logo.nav-logo-show').length).toBe(1);
       });
 
-      it('should show the logo after 1 second if there is masthead but no logo', () => {
+      it('should show the logo after 1 second if there is a masthead but no logo', () => {
         jest.useFakeTimers();
         getProperties.mockImplementation(() => ({}));
         const spy = jest.spyOn(document, 'querySelector').mockImplementation((selector) => (

--- a/blocks/masthead-block/features/masthead-block/default.jsx
+++ b/blocks/masthead-block/features/masthead-block/default.jsx
@@ -32,7 +32,7 @@ const Masthead = (props) => {
     <HeaderContainerHideMobile className="masthead-block-container">
       {
          logoURL && (
-         <HeightConstrainedImageContainer>
+         <HeightConstrainedImageContainer className="masthead-block-logo">
            <picture>
              <img src={logoURL} alt="Masthead logo" />
            </picture>


### PR DESCRIPTION
[PEN-1251](https://arcpublishing.atlassian.net/browse/PEN-1251)

# What does this implement or fix?
- when the masthead block is present but do not have a logo, must show the logo on the header

# How was this tested?

- test written

# Show Effect Of Changes

## Before
![pen-1251-3](https://user-images.githubusercontent.com/9757/91871980-c03bc180-ec4d-11ea-98a1-a317ce64d794.gif)


## After
![pen-1251-4](https://user-images.githubusercontent.com/9757/91871994-c5007580-ec4d-11ea-86f0-8379bf33c598.gif)


# Dependencies or Side Effects
- none
