### PR TITLE
Standardize peer deps sdk css (wip)

### DIFF
--- a/blocks/article-body-block/package.json
+++ b/blocks/article-body-block/package.json
@@ -25,9 +25,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "@wpmedia/video-player-block": "latest",
     "react-oembed-container": "^0.3.0",
     "styled-components": "^4.4.0"

--- a/blocks/article-body-block/package.json
+++ b/blocks/article-body-block/package.json
@@ -27,10 +27,10 @@
   },
   "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "stable",
-    "@wpmedia/news-theme-css": "stable"
+    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/video-player-block": "stable"
   },
   "dependencies": {
-    "@wpmedia/video-player-block": "latest",
     "react-oembed-container": "^0.3.0",
     "styled-components": "^4.4.0"
   },

--- a/blocks/article-tag-block/package.json
+++ b/blocks/article-tag-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/author-bio-block/package.json
+++ b/blocks/author-bio-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/byline-block/package.json
+++ b/blocks/byline-block/package.json
@@ -26,9 +26,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/date-block/package.json
+++ b/blocks/date-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/full-author-bio-block/package.json
+++ b/blocks/full-author-bio-block/package.json
@@ -23,9 +23,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "bugs": {

--- a/blocks/header-nav-block/package.json
+++ b/blocks/header-nav-block/package.json
@@ -28,9 +28,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/header-nav-chain-block/package.json
+++ b/blocks/header-nav-chain-block/package.json
@@ -25,9 +25,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0",
     "use-debounce": "^3.4.3"

--- a/blocks/headline-block/package.json
+++ b/blocks/headline-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "19de22f905fd1a2b3efee242235ab15af41bd96c"

--- a/blocks/htmlbox-block/package.json
+++ b/blocks/htmlbox-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "b80023124aed777cfa92f1215bf4ccc2b7b65868"

--- a/blocks/large-manual-promo-block/package.json
+++ b/blocks/large-manual-promo-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/lead-art-block/package.json
+++ b/blocks/lead-art-block/package.json
@@ -20,9 +20,11 @@
     "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
     "directory": "blocks/lead-art-block"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "@wpmedia/video-player-block": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/links-bar-block/package.json
+++ b/blocks/links-bar-block/package.json
@@ -25,9 +25,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "b80023124aed777cfa92f1215bf4ccc2b7b65868"

--- a/blocks/masthead-block/package.json
+++ b/blocks/masthead-block/package.json
@@ -13,9 +13,11 @@
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^5.0.1"
   },
   "scripts": {

--- a/blocks/medium-manual-promo-block/package.json
+++ b/blocks/medium-manual-promo-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/numbered-list-block/package.json
+++ b/blocks/numbered-list-block/package.json
@@ -26,9 +26,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "b80023124aed777cfa92f1215bf4ccc2b7b65868"

--- a/blocks/right-rail-advanced-block/package.json
+++ b/blocks/right-rail-advanced-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/right-rail-block/package.json
+++ b/blocks/right-rail-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/share-bar-block/package.json
+++ b/blocks/share-bar-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/simple-list-block/package.json
+++ b/blocks/simple-list-block/package.json
@@ -21,9 +21,11 @@
     "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
     "directory": "blocks/simple-list-block"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "scripts": {

--- a/blocks/site-hierarchy-content-block/package.json
+++ b/blocks/site-hierarchy-content-block/package.json
@@ -29,9 +29,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx sources"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/small-manual-promo-block/package.json
+++ b/blocks/small-manual-promo-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/small-promo-block/package.json
+++ b/blocks/small-promo-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "@wpmedia/shared-styles": "latest",
     "styled-components": "^4.4.0"
   },

--- a/blocks/subheadline-block/package.json
+++ b/blocks/subheadline-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "styled-components": "^4.4.0"
   },
   "gitHead": "7e5881cd8abeec2c2540cd76d5f4720a74d80a77"

--- a/blocks/video-player-block/package.json
+++ b/blocks/video-player-block/package.json
@@ -24,9 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "stable",
+    "@wpmedia/news-theme-css": "stable"
+  },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "@wpmedia/news-theme-css": "stable",
     "react-oembed-container": "^0.3.0",
     "styled-components": "^4.4.0"
   },


### PR DESCRIPTION
After seeing Beltran's demo/ticket, Fusion is basically installing whatever engine sdk and news theme version it pleases and ripping out the blocks deps. so ... we can possibly simplify the local dev experience AND more closely match fusion actually rendering by using peerDeps. 

This is still WIP. But yarn workspaces and utilizing workspaces could make the local dev experience faster and more reliable. This is exploratory but @kascote has run into issues of top-level dependencies vs nested ones. 

I still need to do some more regex find and replace to add any blocks and news-theme-css and engine-theme-sdk into peerDependencies. 

But stable would become the default for local dev and clarity purposes. Because we're abstracting npm packages and deps away to some extent with fusion. This will also allow us to cache versions of the blocks from branch to branch and tag to tag.

goal: 

```json
  "devDependencies": {
    "@wpmedia/engine-theme-sdk": "stable",
    "@wpmedia/news-theme-css": "stable",
    "@wpmedia/video-player-block": "stable"
  },
  "peerDependencies": {
    "react-oembed-container": "^0.3.0",
    "styled-components": "^4.4.0"
  },
```
See devDependencies vs external dependencies with shared libraries and apps ...
![image](https://user-images.githubusercontent.com/5950956/92037599-a1b1f500-ed37-11ea-921b-9982df2cbcb8.png)

Inspired by https://www.youtube.com/watch?v=ZUVPBsURP8Q&list=PL3HD-tFDWrQeulDMcQhjA_0qIdY6gDSFt&index=12&t=0s