### PR TITLE
PEN-814 label on promo images

### DIFF
--- a/blocks/extra-large-promo-block/features/extra-large-promo/_children/discover.js
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/_children/discover.js
@@ -1,0 +1,28 @@
+
+function discoverPromoType(content) {
+  if (!content) {
+    return undefined;
+  }
+
+  let rc = '';
+
+  switch (content.type) {
+    case 'video':
+      rc = 'Video';
+      break;
+    case 'gallery':
+      rc = 'Gallery';
+      break;
+    default:
+      // eslint-disable-next-line camelcase
+      if (content.promo_items?.lead_art?.type) {
+        rc = discoverPromoType(content.promo_items.lead_art);
+      } else {
+        rc = 'other';
+      }
+  }
+
+  return rc;
+}
+
+export default discoverPromoType;

--- a/blocks/extra-large-promo-block/features/extra-large-promo/_children/discover.js
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/_children/discover.js
@@ -4,25 +4,25 @@ function discoverPromoType(content) {
     return undefined;
   }
 
-  let rc = '';
+  let promoType = '';
 
   switch (content.type) {
     case 'video':
-      rc = 'Video';
+      promoType = 'Video';
       break;
     case 'gallery':
-      rc = 'Gallery';
+      promoType = 'Gallery';
       break;
     default:
       // eslint-disable-next-line camelcase
       if (content.promo_items?.lead_art?.type) {
-        rc = discoverPromoType(content.promo_items.lead_art);
+        promoType = discoverPromoType(content.promo_items.lead_art);
       } else {
-        rc = 'other';
+        promoType = 'other';
       }
   }
 
-  return rc;
+  return promoType;
 }
 
 export default discoverPromoType;

--- a/blocks/extra-large-promo-block/features/extra-large-promo/_children/discover.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/_children/discover.test.jsx
@@ -1,0 +1,49 @@
+import discoverPromotype from './discover';
+
+const contentTypeVideo = { type: 'video' };
+const contentTypeVideoPromo = { type: 'story', promo_items: { lead_art: { type: 'video' } } };
+const contentTypeGallery = { type: 'gallery' };
+const contentTypeGalleryPromo = { type: 'story', promo_items: { lead_art: { type: 'gallery' } } };
+
+describe('should return type of content for labels', () => {
+  it('must return undefined if no parameters received', () => {
+    let rc = discoverPromotype();
+    expect(rc).toBeFalsy();
+    rc = discoverPromotype('');
+    expect(rc).toBeFalsy();
+  });
+
+  it('must return "other" if parameters no match', () => {
+    let rc = discoverPromotype('foo');
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype(1);
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype(true);
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype({});
+    expect(rc).toBe('other');
+  });
+
+  it('must return "Video" if story type is "video"', () => {
+    const rc = discoverPromotype(contentTypeVideo);
+    expect(rc).toBe('Video');
+  });
+
+  it('must return "Gallery" if story type is "gallery"', () => {
+    const rc = discoverPromotype(contentTypeGallery);
+    expect(rc).toBe('Gallery');
+  });
+
+  it('must return "Video" if story type is "story" and promo lead art is "video"', () => {
+    const rc = discoverPromotype(contentTypeVideoPromo);
+    expect(rc).toBe('Video');
+  });
+
+  it('must return "Gallery" if story type is "story" and promo lead art is "gallery"', () => {
+    const rc = discoverPromotype(contentTypeGalleryPromo);
+    expect(rc).toBe('Gallery');
+  });
+});

--- a/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getProperties from 'fusion:properties';
+import styled from 'styled-components';
+import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
+import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
+
+const LabelBoxLarge = styled.div`
+  align-items: center;
+  padding: 6px 8px 8px;
+  background-color: ${(props) => props.primaryColor};
+  border: none;
+  border-radius: 4px;
+  bottom: 8px;
+  display: flex;
+  flex-direction: row;
+  left: 8px;
+  position: absolute;
+`;
+
+const LabelBoxSmall = styled.div`
+  align-items: center;
+  padding: 8px;
+  background-color: ${(props) => props.primaryColor};
+  border: none;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  right: 8px;
+  top: 8px;
+`;
+
+const Label = styled.span`
+  color: white;
+  font-family: Arial;
+  font-size: 12px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  height: 12px;
+  letter-spacing: normal;
+  margin-left: 8px;
+`;
+
+const Icon = ({ type }) => {
+  switch (type) {
+    case 'Video':
+      return <PlayIcon fill="white" height={18} width={18} />;
+    case 'Gallery':
+      return <CameraIcon fill="white" height={18} width={18} />;
+    default:
+      return null;
+  }
+};
+
+const LabelLarge = ({ arcSite, type }) => (
+  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+    <Icon type={type} />
+    <Label>{type}</Label>
+  </LabelBoxLarge>
+);
+
+const LabelSmall = ({ arcSite, type }) => (
+  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+    <Icon type={type} />
+  </LabelBoxSmall>
+);
+
+const PromoLabel = ({ type, size }) => {
+  const { arcSite } = useFusionContext();
+  if (!type || type === 'other') {
+    return null;
+  }
+
+  const labelSize = size || 'large';
+
+  if (labelSize === 'small') {
+    return <LabelSmall type={type} arcSite={arcSite} />;
+  }
+
+  return <LabelLarge type={type} arcSite={arcSite} />;
+};
+
+export default PromoLabel;

--- a/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+describe('the promo label', () => {
+  beforeAll(() => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({ arcSite: 'the-sun' })),
+    }));
+    jest.mock('fusion:themes', () => (
+      jest.fn(() => ({ 'primary-color': '#ff0000' }))
+    ));
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  it('should not render when the promo type is missing', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+  });
+
+  it('should not render when the promo type is "other"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="other" />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+  });
+
+  it('should render when type is "video"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('Video');
+  });
+
+  it('should render when type is "gallery"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('Gallery');
+  });
+
+  it('should be rendered using the color of the site', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" />);
+    expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
+    expect(wrapper.find('PlayIcon').length).toBe(1);
+  });
+
+  it('should render only the Play icon when the label is Video and size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" size="small" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('PlayIcon').length).toBe(1);
+  });
+
+  it('should render only the Camera icon when the label is Gallery and size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('CameraIcon').length).toBe(1);
+  });
+
+  it('should render small and using the color of the site when size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
+    expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('CameraIcon').length).toBe(1);
+  });
+
+  it('should not render an icon if label type is not recognized', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="PromoType" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('PromoType');
+    expect(wrapper.find('Icon').html()).toBeFalsy();
+  });
+});

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -19,6 +19,8 @@ import {
   ratiosFor,
   extractImageFromStory,
 } from '@wpmedia/resizer-image-block';
+import PromoLabel from './_children/promo_label';
+import discoverPromoType from './_children/discover';
 
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
@@ -58,6 +60,7 @@ const ExtraLargePromo = ({ customFields }) => {
   const overlineText = (content?.label?.basic?.text ?? null)
     || (content?.websites?.[arcSite] && websiteSection && websiteSection.name)
     || '';
+  const promoType = discoverPromoType(content);
 
   const overlineTmpl = () => {
     if (customFields.showOverline && overlineDisplay) {
@@ -182,6 +185,7 @@ const ExtraLargePromo = ({ customFields }) => {
                         largeHeight={ratios.largeHeight}
                       />
                     )}
+                  <PromoLabel type={promoType} />
                 </a>
               )}
               {descriptionTmpl()}

--- a/blocks/large-promo-block/features/large-promo/_children/discover.js
+++ b/blocks/large-promo-block/features/large-promo/_children/discover.js
@@ -1,0 +1,28 @@
+
+function discoverPromoType(content) {
+  if (!content) {
+    return undefined;
+  }
+
+  let rc = '';
+
+  switch (content.type) {
+    case 'video':
+      rc = 'Video';
+      break;
+    case 'gallery':
+      rc = 'Gallery';
+      break;
+    default:
+      // eslint-disable-next-line camelcase
+      if (content.promo_items?.lead_art?.type) {
+        rc = discoverPromoType(content.promo_items.lead_art);
+      } else {
+        rc = 'other';
+      }
+  }
+
+  return rc;
+}
+
+export default discoverPromoType;

--- a/blocks/large-promo-block/features/large-promo/_children/discover.js
+++ b/blocks/large-promo-block/features/large-promo/_children/discover.js
@@ -4,25 +4,25 @@ function discoverPromoType(content) {
     return undefined;
   }
 
-  let rc = '';
+  let promoType = '';
 
   switch (content.type) {
     case 'video':
-      rc = 'Video';
+      promoType = 'Video';
       break;
     case 'gallery':
-      rc = 'Gallery';
+      promoType = 'Gallery';
       break;
     default:
       // eslint-disable-next-line camelcase
       if (content.promo_items?.lead_art?.type) {
-        rc = discoverPromoType(content.promo_items.lead_art);
+        promoType = discoverPromoType(content.promo_items.lead_art);
       } else {
-        rc = 'other';
+        promoType = 'other';
       }
   }
 
-  return rc;
+  return promoType;
 }
 
 export default discoverPromoType;

--- a/blocks/large-promo-block/features/large-promo/_children/discover.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/_children/discover.test.jsx
@@ -1,0 +1,49 @@
+import discoverPromotype from './discover';
+
+const contentTypeVideo = { type: 'video' };
+const contentTypeVideoPromo = { type: 'story', promo_items: { lead_art: { type: 'video' } } };
+const contentTypeGallery = { type: 'gallery' };
+const contentTypeGalleryPromo = { type: 'story', promo_items: { lead_art: { type: 'gallery' } } };
+
+describe('should return type of content for labels', () => {
+  it('must return undefined if no parameters received', () => {
+    let rc = discoverPromotype();
+    expect(rc).toBeFalsy();
+    rc = discoverPromotype('');
+    expect(rc).toBeFalsy();
+  });
+
+  it('must return "other" if parameters no match', () => {
+    let rc = discoverPromotype('foo');
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype(1);
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype(true);
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype({});
+    expect(rc).toBe('other');
+  });
+
+  it('must return "Video" if story type is "video"', () => {
+    const rc = discoverPromotype(contentTypeVideo);
+    expect(rc).toBe('Video');
+  });
+
+  it('must return "Gallery" if story type is "gallery"', () => {
+    const rc = discoverPromotype(contentTypeGallery);
+    expect(rc).toBe('Gallery');
+  });
+
+  it('must return "Video" if story type is "story" and promo lead art is "video"', () => {
+    const rc = discoverPromotype(contentTypeVideoPromo);
+    expect(rc).toBe('Video');
+  });
+
+  it('must return "Gallery" if story type is "story" and promo lead art is "gallery"', () => {
+    const rc = discoverPromotype(contentTypeGalleryPromo);
+    expect(rc).toBe('Gallery');
+  });
+});

--- a/blocks/large-promo-block/features/large-promo/_children/promo_label.jsx
+++ b/blocks/large-promo-block/features/large-promo/_children/promo_label.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getProperties from 'fusion:properties';
+import styled from 'styled-components';
+import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
+import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
+
+const LabelBoxLarge = styled.div`
+  align-items: center;
+  padding: 6px 8px 8px;
+  background-color: ${(props) => props.primaryColor};
+  border: none;
+  border-radius: 4px;
+  bottom: 8px;
+  display: flex;
+  flex-direction: row;
+  left: 8px;
+  position: absolute;
+`;
+
+const LabelBoxSmall = styled.div`
+  align-items: center;
+  padding: 8px;
+  background-color: ${(props) => props.primaryColor};
+  border: none;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  right: 8px;
+  top: 8px;
+`;
+
+const Label = styled.span`
+  color: white;
+  font-family: Arial;
+  font-size: 12px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  height: 12px;
+  letter-spacing: normal;
+  margin-left: 8px;
+`;
+
+const Icon = ({ type }) => {
+  switch (type) {
+    case 'Video':
+      return <PlayIcon fill="white" height={18} width={18} />;
+    case 'Gallery':
+      return <CameraIcon fill="white" height={18} width={18} />;
+    default:
+      return null;
+  }
+};
+
+const LabelLarge = ({ arcSite, type }) => (
+  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+    <Icon type={type} />
+    <Label>{type}</Label>
+  </LabelBoxLarge>
+);
+
+const LabelSmall = ({ arcSite, type }) => (
+  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+    <Icon type={type} />
+  </LabelBoxSmall>
+);
+
+const PromoLabel = ({ type, size }) => {
+  const { arcSite } = useFusionContext();
+  if (!type || type === 'other') {
+    return null;
+  }
+
+  const labelSize = size || 'large';
+
+  if (labelSize === 'small') {
+    return <LabelSmall type={type} arcSite={arcSite} />;
+  }
+
+  return <LabelLarge type={type} arcSite={arcSite} />;
+};
+
+export default PromoLabel;

--- a/blocks/large-promo-block/features/large-promo/_children/promo_label.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/_children/promo_label.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+describe('the promo label', () => {
+  beforeAll(() => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({ arcSite: 'the-sun' })),
+    }));
+    jest.mock('fusion:themes', () => (
+      jest.fn(() => ({ 'primary-color': '#ff0000' }))
+    ));
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  it('should not render when the promo type is missing', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+  });
+
+  it('should not render when the promo type is "other"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="other" />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+  });
+
+  it('should render when type is "video"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('Video');
+  });
+
+  it('should render when type is "gallery"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('Gallery');
+  });
+
+  it('should be rendered using the color of the site', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" />);
+    expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
+    expect(wrapper.find('PlayIcon').length).toBe(1);
+  });
+
+  it('should render only the Play icon when the label is Video and size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" size="small" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('PlayIcon').length).toBe(1);
+  });
+
+  it('should render only the Camera icon when the label is Gallery and size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('CameraIcon').length).toBe(1);
+  });
+
+  it('should render small and using the color of the site when size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
+    expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('CameraIcon').length).toBe(1);
+  });
+
+  it('should not render an icon if label type is not recognized', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="PromoType" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('PromoType');
+    expect(wrapper.find('Icon').html()).toBeFalsy();
+  });
+});

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -19,6 +19,8 @@ import {
   ratiosFor,
   extractImageFromStory,
 } from '@wpmedia/resizer-image-block';
+import PromoLabel from './_children/promo_label';
+import discoverPromoType from './_children/discover';
 
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
@@ -60,6 +62,7 @@ const LargePromo = ({ customFields }) => {
       || '';
 
   const textClass = customFields.showImage ? 'col-sm-12 col-md-xl-6 flex-col' : 'col-sm-xl-12 flex-col';
+  const promoType = discoverPromoType(content);
 
   const overlineTmpl = () => {
     if (customFields.showOverline && overlineDisplay) {
@@ -146,7 +149,7 @@ const LargePromo = ({ customFields }) => {
         <div className="row">
           {customFields.showImage
           && (
-            <div className="col-sm-12 col-md-xl-6">
+            <div className="col-sm-12 col-md-xl-6 flex-col">
               <a
                 href={content.website_url}
                 title={content && content.headlines ? content.headlines.basic : ''}
@@ -181,7 +184,8 @@ const LargePromo = ({ customFields }) => {
                         largeHeight={ratios.largeHeight}
                       />
                     )
-  }
+                }
+                <PromoLabel type={promoType} />
               </a>
             </div>
           )}

--- a/blocks/medium-promo-block/features/medium-promo/_children/discover.js
+++ b/blocks/medium-promo-block/features/medium-promo/_children/discover.js
@@ -1,0 +1,28 @@
+
+function discoverPromoType(content) {
+  if (!content) {
+    return undefined;
+  }
+
+  let rc = '';
+
+  switch (content.type) {
+    case 'video':
+      rc = 'Video';
+      break;
+    case 'gallery':
+      rc = 'Gallery';
+      break;
+    default:
+      // eslint-disable-next-line camelcase
+      if (content.promo_items?.lead_art?.type) {
+        rc = discoverPromoType(content.promo_items.lead_art);
+      } else {
+        rc = 'other';
+      }
+  }
+
+  return rc;
+}
+
+export default discoverPromoType;

--- a/blocks/medium-promo-block/features/medium-promo/_children/discover.js
+++ b/blocks/medium-promo-block/features/medium-promo/_children/discover.js
@@ -4,25 +4,25 @@ function discoverPromoType(content) {
     return undefined;
   }
 
-  let rc = '';
+  let promoType = '';
 
   switch (content.type) {
     case 'video':
-      rc = 'Video';
+      promoType = 'Video';
       break;
     case 'gallery':
-      rc = 'Gallery';
+      promoType = 'Gallery';
       break;
     default:
       // eslint-disable-next-line camelcase
       if (content.promo_items?.lead_art?.type) {
-        rc = discoverPromoType(content.promo_items.lead_art);
+        promoType = discoverPromoType(content.promo_items.lead_art);
       } else {
-        rc = 'other';
+        promoType = 'other';
       }
   }
 
-  return rc;
+  return promoType;
 }
 
 export default discoverPromoType;

--- a/blocks/medium-promo-block/features/medium-promo/_children/discover.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/_children/discover.test.jsx
@@ -1,0 +1,49 @@
+import discoverPromotype from './discover';
+
+const contentTypeVideo = { type: 'video' };
+const contentTypeVideoPromo = { type: 'story', promo_items: { lead_art: { type: 'video' } } };
+const contentTypeGallery = { type: 'gallery' };
+const contentTypeGalleryPromo = { type: 'story', promo_items: { lead_art: { type: 'gallery' } } };
+
+describe('should return type of content for labels', () => {
+  it('must return undefined if no parameters received', () => {
+    let rc = discoverPromotype();
+    expect(rc).toBeFalsy();
+    rc = discoverPromotype('');
+    expect(rc).toBeFalsy();
+  });
+
+  it('must return "other" if parameters no match', () => {
+    let rc = discoverPromotype('foo');
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype(1);
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype(true);
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype({});
+    expect(rc).toBe('other');
+  });
+
+  it('must return "Video" if story type is "video"', () => {
+    const rc = discoverPromotype(contentTypeVideo);
+    expect(rc).toBe('Video');
+  });
+
+  it('must return "Gallery" if story type is "gallery"', () => {
+    const rc = discoverPromotype(contentTypeGallery);
+    expect(rc).toBe('Gallery');
+  });
+
+  it('must return "Video" if story type is "story" and promo lead art is "video"', () => {
+    const rc = discoverPromotype(contentTypeVideoPromo);
+    expect(rc).toBe('Video');
+  });
+
+  it('must return "Gallery" if story type is "story" and promo lead art is "gallery"', () => {
+    const rc = discoverPromotype(contentTypeGalleryPromo);
+    expect(rc).toBe('Gallery');
+  });
+});

--- a/blocks/medium-promo-block/features/medium-promo/_children/promo_label.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/_children/promo_label.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getProperties from 'fusion:properties';
+import styled from 'styled-components';
+import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
+import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
+
+const LabelBoxLarge = styled.div`
+  align-items: center;
+  padding: 6px 8px 8px;
+  background-color: ${(props) => props.primaryColor};
+  border: none;
+  border-radius: 4px;
+  bottom: 8px;
+  display: flex;
+  flex-direction: row;
+  left: 8px;
+  position: absolute;
+`;
+
+const LabelBoxSmall = styled.div`
+  align-items: center;
+  padding: 8px;
+  background-color: ${(props) => props.primaryColor};
+  border: none;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  right: 8px;
+  top: 8px;
+`;
+
+const Label = styled.span`
+  color: white;
+  font-family: Arial;
+  font-size: 12px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  height: 12px;
+  letter-spacing: normal;
+  margin-left: 8px;
+`;
+
+const Icon = ({ type }) => {
+  switch (type) {
+    case 'Video':
+      return <PlayIcon fill="white" height={18} width={18} />;
+    case 'Gallery':
+      return <CameraIcon fill="white" height={18} width={18} />;
+    default:
+      return null;
+  }
+};
+
+const LabelLarge = ({ arcSite, type }) => (
+  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+    <Icon type={type} />
+    <Label>{type}</Label>
+  </LabelBoxLarge>
+);
+
+const LabelSmall = ({ arcSite, type }) => (
+  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+    <Icon type={type} />
+  </LabelBoxSmall>
+);
+
+const PromoLabel = ({ type, size }) => {
+  const { arcSite } = useFusionContext();
+  if (!type || type === 'other') {
+    return null;
+  }
+
+  const labelSize = size || 'large';
+
+  if (labelSize === 'small') {
+    return <LabelSmall type={type} arcSite={arcSite} />;
+  }
+
+  return <LabelLarge type={type} arcSite={arcSite} />;
+};
+
+export default PromoLabel;

--- a/blocks/medium-promo-block/features/medium-promo/_children/promo_label.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/_children/promo_label.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+describe('the promo label', () => {
+  beforeAll(() => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({ arcSite: 'the-sun' })),
+    }));
+    jest.mock('fusion:themes', () => (
+      jest.fn(() => ({ 'primary-color': '#ff0000' }))
+    ));
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  it('should not render when the promo type is missing', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+  });
+
+  it('should not render when the promo type is "other"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="other" />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+  });
+
+  it('should render when type is "video"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('Video');
+  });
+
+  it('should render when type is "gallery"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('Gallery');
+  });
+
+  it('should be rendered using the color of the site', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" />);
+    expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
+    expect(wrapper.find('PlayIcon').length).toBe(1);
+  });
+
+  it('should render only the Play icon when the label is Video and size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" size="small" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('PlayIcon').length).toBe(1);
+  });
+
+  it('should render only the Camera icon when the label is Gallery and size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('CameraIcon').length).toBe(1);
+  });
+
+  it('should render small and using the color of the site when size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
+    expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('CameraIcon').length).toBe(1);
+  });
+
+  it('should not render an icon if label type is not recognized', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="PromoType" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('PromoType');
+    expect(wrapper.find('Icon').html()).toBeFalsy();
+  });
+});

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -18,6 +18,8 @@ import {
   ratiosFor,
   extractImageFromStory,
 } from '@wpmedia/resizer-image-block';
+import PromoLabel from './_children/promo_label';
+import discoverPromoType from './_children/discover';
 
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
@@ -47,6 +49,7 @@ const MediumPromo = ({ customFields }) => {
   const dateText = content && content.display_date ? content.display_date : null;
 
   const textClass = customFields.showImage ? 'col-sm-12 col-md-xl-8 flex-col' : 'col-sm-xl-12 flex-col';
+  const promoType = discoverPromoType(content);
 
   const headlineTmpl = () => {
     if (customFields.showHeadline && headlineText) {
@@ -117,7 +120,7 @@ const MediumPromo = ({ customFields }) => {
         <div className="row med-promo-padding-bottom">
           {customFields.showImage
           && (
-            <div className="col-sm-12 col-md-xl-4">
+            <div className="col-sm-12 col-md-xl-4 flex-col">
               <a
                 href={content.website_url}
                 title={content && content.headlines ? content.headlines.basic : ''}
@@ -152,6 +155,7 @@ const MediumPromo = ({ customFields }) => {
                       />
                     )
                   }
+                <PromoLabel type={promoType} />
               </a>
             </div>
           )}

--- a/blocks/shared-styles/scss/_extra-large-promo.scss
+++ b/blocks/shared-styles/scss/_extra-large-promo.scss
@@ -3,6 +3,7 @@
 
   a {
     color: $ui-primary-font-color;
+    position: relative;
   }
   a > picture > img {
     vertical-align: middle;

--- a/blocks/shared-styles/scss/_large-promo.scss
+++ b/blocks/shared-styles/scss/_large-promo.scss
@@ -3,6 +3,7 @@
 
   a {
     color: $ui-primary-font-color;
+    position: relative;
   }
 
   a > picture > img {

--- a/blocks/shared-styles/scss/_medium-promo.scss
+++ b/blocks/shared-styles/scss/_medium-promo.scss
@@ -3,6 +3,7 @@
 
   a {
     color: $ui-primary-font-color;
+    position: relative;
   }
 
   a > picture > img {

--- a/blocks/shared-styles/scss/_small-promo.scss
+++ b/blocks/shared-styles/scss/_small-promo.scss
@@ -4,6 +4,7 @@
 
   a {
     color: $ui-primary-font-color;
+    position: relative;
   }
 
   a > picture > img {
@@ -26,6 +27,11 @@
   img {
     height: auto;
     max-width: 100%;
+  }
+
+  .flex-col {
+    display: flex;
+    flex-direction: column;
   }
 }
 

--- a/blocks/small-promo-block/features/small-promo/_children/discover.js
+++ b/blocks/small-promo-block/features/small-promo/_children/discover.js
@@ -1,0 +1,28 @@
+
+function discoverPromoType(content) {
+  if (!content) {
+    return undefined;
+  }
+
+  let rc = '';
+
+  switch (content.type) {
+    case 'video':
+      rc = 'Video';
+      break;
+    case 'gallery':
+      rc = 'Gallery';
+      break;
+    default:
+      // eslint-disable-next-line camelcase
+      if (content.promo_items?.lead_art?.type) {
+        rc = discoverPromoType(content.promo_items.lead_art);
+      } else {
+        rc = 'other';
+      }
+  }
+
+  return rc;
+}
+
+export default discoverPromoType;

--- a/blocks/small-promo-block/features/small-promo/_children/discover.js
+++ b/blocks/small-promo-block/features/small-promo/_children/discover.js
@@ -4,25 +4,25 @@ function discoverPromoType(content) {
     return undefined;
   }
 
-  let rc = '';
+  let promoType = '';
 
   switch (content.type) {
     case 'video':
-      rc = 'Video';
+      promoType = 'Video';
       break;
     case 'gallery':
-      rc = 'Gallery';
+      promoType = 'Gallery';
       break;
     default:
       // eslint-disable-next-line camelcase
       if (content.promo_items?.lead_art?.type) {
-        rc = discoverPromoType(content.promo_items.lead_art);
+        promoType = discoverPromoType(content.promo_items.lead_art);
       } else {
-        rc = 'other';
+        promoType = 'other';
       }
   }
 
-  return rc;
+  return promoType;
 }
 
 export default discoverPromoType;

--- a/blocks/small-promo-block/features/small-promo/_children/discover.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/discover.test.jsx
@@ -1,0 +1,49 @@
+import discoverPromotype from './discover';
+
+const contentTypeVideo = { type: 'video' };
+const contentTypeVideoPromo = { type: 'story', promo_items: { lead_art: { type: 'video' } } };
+const contentTypeGallery = { type: 'gallery' };
+const contentTypeGalleryPromo = { type: 'story', promo_items: { lead_art: { type: 'gallery' } } };
+
+describe('should return type of content for labels', () => {
+  it('must return undefined if no parameters received', () => {
+    let rc = discoverPromotype();
+    expect(rc).toBeFalsy();
+    rc = discoverPromotype('');
+    expect(rc).toBeFalsy();
+  });
+
+  it('must return "other" if parameters no match', () => {
+    let rc = discoverPromotype('foo');
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype(1);
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype(true);
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype({});
+    expect(rc).toBe('other');
+  });
+
+  it('must return "Video" if story type is "video"', () => {
+    const rc = discoverPromotype(contentTypeVideo);
+    expect(rc).toBe('Video');
+  });
+
+  it('must return "Gallery" if story type is "gallery"', () => {
+    const rc = discoverPromotype(contentTypeGallery);
+    expect(rc).toBe('Gallery');
+  });
+
+  it('must return "Video" if story type is "story" and promo lead art is "video"', () => {
+    const rc = discoverPromotype(contentTypeVideoPromo);
+    expect(rc).toBe('Video');
+  });
+
+  it('must return "Gallery" if story type is "story" and promo lead art is "gallery"', () => {
+    const rc = discoverPromotype(contentTypeGalleryPromo);
+    expect(rc).toBe('Gallery');
+  });
+});

--- a/blocks/small-promo-block/features/small-promo/_children/promo_label.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_label.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getProperties from 'fusion:properties';
+import styled from 'styled-components';
+import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
+import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
+
+const LabelBoxLarge = styled.div`
+  align-items: center;
+  padding: 6px 8px 8px;
+  background-color: ${(props) => props.primaryColor};
+  border: none;
+  border-radius: 4px;
+  bottom: 8px;
+  display: flex;
+  flex-direction: row;
+  left: 8px;
+  position: absolute;
+`;
+
+const LabelBoxSmall = styled.div`
+  align-items: center;
+  padding: 8px;
+  background-color: ${(props) => props.primaryColor};
+  border: none;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  right: 8px;
+  top: 8px;
+`;
+
+const Label = styled.span`
+  color: white;
+  font-family: Arial;
+  font-size: 12px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  height: 12px;
+  letter-spacing: normal;
+  margin-left: 8px;
+`;
+
+const Icon = ({ type }) => {
+  switch (type) {
+    case 'Video':
+      return <PlayIcon fill="white" height={18} width={18} />;
+    case 'Gallery':
+      return <CameraIcon fill="white" height={18} width={18} />;
+    default:
+      return null;
+  }
+};
+
+const LabelLarge = ({ arcSite, type }) => (
+  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+    <Icon type={type} />
+    <Label>{type}</Label>
+  </LabelBoxLarge>
+);
+
+const LabelSmall = ({ arcSite, type }) => (
+  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+    <Icon type={type} />
+  </LabelBoxSmall>
+);
+
+const PromoLabel = ({ type, size }) => {
+  const { arcSite } = useFusionContext();
+  if (!type || type === 'other') {
+    return null;
+  }
+
+  const labelSize = size || 'large';
+
+  if (labelSize === 'small') {
+    return <LabelSmall type={type} arcSite={arcSite} />;
+  }
+
+  return <LabelLarge type={type} arcSite={arcSite} />;
+};
+
+export default PromoLabel;

--- a/blocks/small-promo-block/features/small-promo/_children/promo_label.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_label.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+describe('the promo label', () => {
+  beforeAll(() => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({ arcSite: 'the-sun' })),
+    }));
+    jest.mock('fusion:themes', () => (
+      jest.fn(() => ({ 'primary-color': '#ff0000' }))
+    ));
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  it('should not render when the promo type is missing', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+  });
+
+  it('should not render when the promo type is "other"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="other" />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+  });
+
+  it('should render when type is "video"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('Video');
+  });
+
+  it('should render when type is "gallery"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('Gallery');
+  });
+
+  it('should be rendered using the color of the site', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" />);
+    expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
+    expect(wrapper.find('PlayIcon').length).toBe(1);
+  });
+
+  it('should render only the Play icon when the label is Video and size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" size="small" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('PlayIcon').length).toBe(1);
+  });
+
+  it('should render only the Camera icon when the label is Gallery and size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('CameraIcon').length).toBe(1);
+  });
+
+  it('should render small and using the color of the site when size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
+    expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('CameraIcon').length).toBe(1);
+  });
+
+  it('should not render an icon if label type is not recognized', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="PromoType" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('PromoType');
+    expect(wrapper.find('Icon').html()).toBeFalsy();
+  });
+});

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -16,6 +16,8 @@ import {
   ratiosFor,
   extractImageFromStory,
 } from '@wpmedia/resizer-image-block';
+import PromoLabel from './_children/promo_label';
+import discoverPromoType from './_children/discover';
 
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
@@ -35,6 +37,7 @@ const SmallPromo = ({ customFields }) => {
   const headlineClass = customFields.showImage ? 'col-sm-xl-8' : 'col-sm-xl-12 no-image-padding';
 
   const ratios = ratiosFor('SM', customFields.imageRatio);
+  const promoType = discoverPromoType(content);
 
   return content ? (
     <>
@@ -61,7 +64,7 @@ const SmallPromo = ({ customFields }) => {
           )}
           {customFields.showImage
           && (
-            <div className="col-sm-xl-4">
+            <div className="col-sm-xl-4 flex-col">
               <a
                 href={content.website_url}
                 title={content && content.headlines ? content.headlines.basic : ''}
@@ -94,6 +97,7 @@ const SmallPromo = ({ customFields }) => {
                       largeHeight={ratios.largeHeight}
                     />
                   )}
+                <PromoLabel type={promoType} size="small" />
               </a>
             </div>
           )}

--- a/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.jsx
@@ -127,6 +127,7 @@ const ConditionalStoryItem = (props) => {
           arcSite={arcSite}
           paddingRight={hasPaddingRight}
           imageRatio={customFields.imageRatioSM}
+          element={element}
         />
       );
     }

--- a/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.test.jsx
@@ -30,13 +30,17 @@ const config = {
   showImageSM: true,
 };
 
-jest.mock('./item-title-with-right-image', () => class ItemWithRightImage {});
-jest.mock('./medium-list-item', () => class MediumListItem {});
-jest.mock('./horizontal-overline-image-story-item', () => class HorizontalOverlineImageStoryItem {});
-jest.mock('./vertical-overline-image-story-item', () => class VerticalOverlineImageStoryItem {});
-
 describe('conditional story item', () => {
-  jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+  beforeAll(() => {
+    jest.mock('./item-title-with-right-image', () => class ItemWithRightImage {});
+    jest.mock('./medium-list-item', () => class MediumListItem {});
+    jest.mock('./horizontal-overline-image-story-item', () => class HorizontalOverlineImageStoryItem {});
+    jest.mock('./vertical-overline-image-story-item', () => class VerticalOverlineImageStoryItem {});
+    jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+  });
+  afterAll(() => {
+    jest.resetModules();
+  });
 
   it('renders a small component if small passed in', () => {
     const { default: ConditionalStoryItem } = require('./conditional-story-item');

--- a/blocks/top-table-list-block/features/top-table-list/_children/discover.js
+++ b/blocks/top-table-list-block/features/top-table-list/_children/discover.js
@@ -1,0 +1,28 @@
+
+function discoverPromoType(content) {
+  if (!content) {
+    return undefined;
+  }
+
+  let rc = '';
+
+  switch (content.type) {
+    case 'video':
+      rc = 'Video';
+      break;
+    case 'gallery':
+      rc = 'Gallery';
+      break;
+    default:
+      // eslint-disable-next-line camelcase
+      if (content.promo_items?.lead_art?.type) {
+        rc = discoverPromoType(content.promo_items.lead_art);
+      } else {
+        rc = 'other';
+      }
+  }
+
+  return rc;
+}
+
+export default discoverPromoType;

--- a/blocks/top-table-list-block/features/top-table-list/_children/discover.js
+++ b/blocks/top-table-list-block/features/top-table-list/_children/discover.js
@@ -4,25 +4,25 @@ function discoverPromoType(content) {
     return undefined;
   }
 
-  let rc = '';
+  let promoType = '';
 
   switch (content.type) {
     case 'video':
-      rc = 'Video';
+      promoType = 'Video';
       break;
     case 'gallery':
-      rc = 'Gallery';
+      promoType = 'Gallery';
       break;
     default:
       // eslint-disable-next-line camelcase
       if (content.promo_items?.lead_art?.type) {
-        rc = discoverPromoType(content.promo_items.lead_art);
+        promoType = discoverPromoType(content.promo_items.lead_art);
       } else {
-        rc = 'other';
+        promoType = 'other';
       }
   }
 
-  return rc;
+  return promoType;
 }
 
 export default discoverPromoType;

--- a/blocks/top-table-list-block/features/top-table-list/_children/discover.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/discover.test.jsx
@@ -1,0 +1,49 @@
+import discoverPromotype from './discover';
+
+const contentTypeVideo = { type: 'video' };
+const contentTypeVideoPromo = { type: 'story', promo_items: { lead_art: { type: 'video' } } };
+const contentTypeGallery = { type: 'gallery' };
+const contentTypeGalleryPromo = { type: 'story', promo_items: { lead_art: { type: 'gallery' } } };
+
+describe('should return type of content for labels', () => {
+  it('must return undefined if no parameters received', () => {
+    let rc = discoverPromotype();
+    expect(rc).toBeFalsy();
+    rc = discoverPromotype('');
+    expect(rc).toBeFalsy();
+  });
+
+  it('must return "other" if parameters no match', () => {
+    let rc = discoverPromotype('foo');
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype(1);
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype(true);
+    expect(rc).toBe('other');
+
+    rc = discoverPromotype({});
+    expect(rc).toBe('other');
+  });
+
+  it('must return "Video" if story type is "video"', () => {
+    const rc = discoverPromotype(contentTypeVideo);
+    expect(rc).toBe('Video');
+  });
+
+  it('must return "Gallery" if story type is "gallery"', () => {
+    const rc = discoverPromotype(contentTypeGallery);
+    expect(rc).toBe('Gallery');
+  });
+
+  it('must return "Video" if story type is "story" and promo lead art is "video"', () => {
+    const rc = discoverPromotype(contentTypeVideoPromo);
+    expect(rc).toBe('Video');
+  });
+
+  it('must return "Gallery" if story type is "story" and promo lead art is "gallery"', () => {
+    const rc = discoverPromotype(contentTypeGalleryPromo);
+    expect(rc).toBe('Gallery');
+  });
+});

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -9,6 +9,8 @@ import getProperties from 'fusion:properties';
 import Title from './title';
 import DescriptionText from './description-text';
 import checkObjectEmpty from '../shared/checkObjectEmpty';
+import PromoLabel from './promo_label';
+import discoverPromoType from './discover';
 
 const HorizontalOverlineImageStoryItem = (props) => {
   const {
@@ -98,6 +100,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
   };
 
   const ratios = ratiosFor('LG', imageRatio);
+  const promoType = discoverPromoType(element);
 
   return (
     <>
@@ -105,7 +108,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
         <div className="row lg-promo-padding-bottom">
           {customFields.showImageLG
           && (
-          <div className="col-sm-12 col-md-xl-6">
+          <div className="col-sm-12 col-md-xl-6 flex-col">
             {imageURL !== '' ? (
               <a href={websiteURL} title={itemTitle}>
                 <Image
@@ -122,21 +125,25 @@ const HorizontalOverlineImageStoryItem = (props) => {
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                 />
+                <PromoLabel type={promoType} />
               </a>
             ) : (
-              <Image
-                smallWidth={ratios.smallWidth}
-                smallHeight={ratios.smallHeight}
-                mediumWidth={ratios.mediumWidth}
-                mediumHeight={ratios.mediumHeight}
-                largeWidth={ratios.largeWidth}
-                largeHeight={ratios.largeHeight}
-                alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-                url={targetFallbackImage}
-                breakpoints={getProperties(arcSite)?.breakpoints}
-                resizedImageOptions={placeholderResizedImageOptions}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-              />
+              <div className="image-wrapper">
+                <Image
+                  smallWidth={ratios.smallWidth}
+                  smallHeight={ratios.smallHeight}
+                  mediumWidth={ratios.mediumWidth}
+                  mediumHeight={ratios.mediumHeight}
+                  largeWidth={ratios.largeWidth}
+                  largeHeight={ratios.largeHeight}
+                  alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
+                  url={targetFallbackImage}
+                  breakpoints={getProperties(arcSite)?.breakpoints}
+                  resizedImageOptions={placeholderResizedImageOptions}
+                  resizerURL={getProperties(arcSite)?.resizerURL}
+                />
+                <PromoLabel type={promoType} />
+              </div>
             )}
           </div>
           )}

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-jest.mock('fusion:properties', () => (jest.fn(() => ({
-  fallbackImage: 'placeholder.jpg',
-  resizerURL: 'resizer',
-}))));
-jest.mock('@wpmedia/engine-theme-sdk', () => ({
-  Image: () => <img alt="test" />,
-}));
-
 const config = {
   showOverlineXL: true,
   showHeadlineXL: true,
@@ -31,19 +23,31 @@ const config = {
   showImageSM: true,
 };
 
-jest.mock('fusion:context', () => ({
-  useFusionContext: jest.fn(() => ({
-    arcSite: 'the-sun',
-    globalContent: {},
-  })),
-}));
-
-jest.mock('fusion:content', () => ({
-  useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),
-}));
-
 describe('horizontal overline image story item', () => {
-  jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+  beforeAll(() => {
+    jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({
+        arcSite: 'the-sun',
+        globalContent: {},
+      })),
+    }));
+    jest.mock('fusion:content', () => ({
+      useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),
+    }));
+    jest.mock('fusion:properties', () => (jest.fn(() => ({
+      fallbackImage: 'placeholder.jpg',
+      resizerURL: 'resizer',
+    }))));
+    jest.mock('@wpmedia/engine-theme-sdk', () => ({
+      Image: () => <img alt="test" />,
+    }));
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
   it('renders with the full required props', () => {
     const imageURL = 'pic';
     const websiteURL = 'url';
@@ -91,12 +95,6 @@ describe('horizontal overline image story item', () => {
     expect(wrapper.find('HorizontalOverlineImageStoryItem > hr').length).toBe(1);
   });
   it('renders with empty props with defaults', () => {
-    jest.mock('fusion:context', () => ({
-      useFusionContext: jest.fn(() => ({
-        arcSite: 'the-sun',
-        globalContent: {},
-      })),
-    }));
     const imageURL = '';
     const websiteURL = '';
     const itemTitle = '';

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -4,6 +4,8 @@ import { ratiosFor } from '@wpmedia/resizer-image-block';
 import getProperties from 'fusion:properties';
 
 import Title from './title';
+import PromoLabel from './promo_label';
+import discoverPromoType from './discover';
 
 const ItemTitleWithRightImage = (props) => {
   const {
@@ -17,6 +19,7 @@ const ItemTitleWithRightImage = (props) => {
     resizedImageOptions,
     targetFallbackImage,
     placeholderResizedImageOptions,
+    element,
     paddingRight = false,
     imageRatio,
   } = props;
@@ -24,6 +27,7 @@ const ItemTitleWithRightImage = (props) => {
   const ratios = ratiosFor('SM', imageRatio);
   const onePerLine = customFields.storiesPerRowSM === 1;
   const promoClasses = `container-fluid small-promo layout-section ${onePerLine ? 'small-promo-one' : 'wrap-bottom'}`;
+  const promoType = discoverPromoType(element);
 
   return (
     <article key={id} className={`${promoClasses} ${paddingRight ? 'small-promo-padding' : ''}`}>
@@ -39,7 +43,7 @@ const ItemTitleWithRightImage = (props) => {
         ) : null}
         {customFields.showImageSM
           && (
-          <div className="col-sm-4 col-md-xl-4">
+          <div className="col-sm-4 col-md-xl-4 flex-col">
             {imageURL !== '' ? (
               <a href={websiteURL} title={itemTitle}>
                 <Image
@@ -55,21 +59,25 @@ const ItemTitleWithRightImage = (props) => {
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                 />
+                <PromoLabel type={promoType} size="small" />
               </a>
             ) : (
-              <Image
-                smallWidth={ratios.smallWidth}
-                smallHeight={ratios.smallHeight}
-                mediumWidth={ratios.mediumWidth}
-                mediumHeight={ratios.mediumHeight}
-                largeWidth={ratios.largeWidth}
-                largeHeight={ratios.largeHeight}
-                alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-                url={targetFallbackImage}
-                breakpoints={getProperties(arcSite)?.breakpoints}
-                resizedImageOptions={placeholderResizedImageOptions}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-              />
+              <div className="image-wrapper">
+                <Image
+                  smallWidth={ratios.smallWidth}
+                  smallHeight={ratios.smallHeight}
+                  mediumWidth={ratios.mediumWidth}
+                  mediumHeight={ratios.mediumHeight}
+                  largeWidth={ratios.largeWidth}
+                  largeHeight={ratios.largeHeight}
+                  alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
+                  url={targetFallbackImage}
+                  breakpoints={getProperties(arcSite)?.breakpoints}
+                  resizedImageOptions={placeholderResizedImageOptions}
+                  resizerURL={getProperties(arcSite)?.resizerURL}
+                />
+                <PromoLabel type={promoType} size="small" />
+              </div>
             )}
           </div>
           )}

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-jest.mock('fusion:properties', () => (jest.fn(() => ({
-  fallbackImage: 'placeholder.jpg',
-  resizerURL: 'http://example.com',
-}))));
-
 const config = {
   showOverlineXL: true,
   showHeadlineXL: true,
@@ -29,6 +24,23 @@ const config = {
 };
 
 describe('item title with right image block', () => {
+  beforeAll(() => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({
+      fallbackImage: 'placeholder.jpg',
+      resizerURL: 'http://example.com',
+    }))));
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({
+        arcSite: 'the-sun',
+        globalContent: {},
+      })),
+    }));
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
   it('renders title and image with full props', () => {
     const imageURL = 'pic';
     const itemTitle = 'title';

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -8,6 +8,8 @@ import getProperties from 'fusion:properties';
 import Title from './title';
 import DescriptionText from './description-text';
 import checkObjectEmpty from '../shared/checkObjectEmpty';
+import PromoLabel from './promo_label';
+import discoverPromoType from './discover';
 
 // via results list
 const MediumListItem = (props) => {
@@ -79,6 +81,7 @@ const MediumListItem = (props) => {
   };
 
   const ratios = ratiosFor('MD', imageRatio);
+  const promoType = discoverPromoType(element);
 
   return (
     <>
@@ -86,7 +89,7 @@ const MediumListItem = (props) => {
         <div className="row med-promo-padding-bottom">
           {customFields.showImageMD
             && (
-            <div className="col-sm-12 col-md-xl-4">
+            <div className="col-sm-12 col-md-xl-4 flex-col">
               <a href={websiteURL} title={itemTitle}>
                 {imageURL !== '' ? (
                   <Image
@@ -120,6 +123,7 @@ const MediumListItem = (props) => {
 
                   />
                 )}
+                <PromoLabel type={promoType} />
               </a>
             </div>
             )}

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-jest.mock('@wpmedia/engine-theme-sdk', () => ({
-  Image: () => <img alt="placeholder" />,
-}));
-jest.mock('fusion:properties', () => (jest.fn(() => ({
-  fallbackImage: 'placeholder.jpg',
-}))));
 const config = {
   showOverlineXL: true,
   showHeadlineXL: true,
@@ -30,7 +24,26 @@ const config = {
 };
 
 describe('medium list item', () => {
-  jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+  beforeAll(() => {
+    jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+    jest.mock('@wpmedia/engine-theme-sdk', () => ({
+      Image: () => <img alt="placeholder" />,
+    }));
+    jest.mock('fusion:properties', () => (jest.fn(() => ({
+      fallbackImage: 'placeholder.jpg',
+    }))));
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({
+        arcSite: 'the-sun',
+        globalContent: {},
+      })),
+    }));
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
   it('renders title and image with full props', () => {
     const imageURL = 'pic';
     const constructedURL = 'url';

--- a/blocks/top-table-list-block/features/top-table-list/_children/promo_label.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/promo_label.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getProperties from 'fusion:properties';
+import styled from 'styled-components';
+import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
+import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
+
+const LabelBoxLarge = styled.div`
+  align-items: center;
+  padding: 6px 8px 8px;
+  background-color: ${(props) => props.primaryColor};
+  border: none;
+  border-radius: 4px;
+  bottom: 8px;
+  display: flex;
+  flex-direction: row;
+  left: 8px;
+  position: absolute;
+`;
+
+const LabelBoxSmall = styled.div`
+  align-items: center;
+  padding: 8px;
+  background-color: ${(props) => props.primaryColor};
+  border: none;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  right: 8px;
+  top: 8px;
+`;
+
+const Label = styled.span`
+  color: white;
+  font-family: Arial;
+  font-size: 12px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  height: 12px;
+  letter-spacing: normal;
+  margin-left: 8px;
+`;
+
+const Icon = ({ type }) => {
+  switch (type) {
+    case 'Video':
+      return <PlayIcon fill="white" height={18} width={18} />;
+    case 'Gallery':
+      return <CameraIcon fill="white" height={18} width={18} />;
+    default:
+      return null;
+  }
+};
+
+const LabelLarge = ({ arcSite, type }) => (
+  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+    <Icon type={type} />
+    <Label>{type}</Label>
+  </LabelBoxLarge>
+);
+
+const LabelSmall = ({ arcSite, type }) => (
+  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+    <Icon type={type} />
+  </LabelBoxSmall>
+);
+
+const PromoLabel = ({ type, size }) => {
+  const { arcSite } = useFusionContext();
+  if (!type || type === 'other') {
+    return null;
+  }
+
+  const labelSize = size || 'large';
+
+  if (labelSize === 'small') {
+    return <LabelSmall type={type} arcSite={arcSite} />;
+  }
+
+  return <LabelLarge type={type} arcSite={arcSite} />;
+};
+
+export default PromoLabel;

--- a/blocks/top-table-list-block/features/top-table-list/_children/promo_label.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/promo_label.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+describe('the promo label', () => {
+  beforeAll(() => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({ arcSite: 'the-sun' })),
+    }));
+    jest.mock('fusion:themes', () => (
+      jest.fn(() => ({ 'primary-color': '#ff0000' }))
+    ));
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  it('should not render when the promo type is missing', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+  });
+
+  it('should not render when the promo type is "other"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="other" />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+  });
+
+  it('should render when type is "video"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('Video');
+  });
+
+  it('should render when type is "gallery"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('Gallery');
+  });
+
+  it('should be rendered using the color of the site', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" />);
+    expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
+    expect(wrapper.find('PlayIcon').length).toBe(1);
+  });
+
+  it('should render only the Play icon when the label is Video and size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Video" size="small" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('PlayIcon').length).toBe(1);
+  });
+
+  it('should render only the Camera icon when the label is Gallery and size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('CameraIcon').length).toBe(1);
+  });
+
+  it('should render small and using the color of the site when size is "small"', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
+    expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
+    expect(wrapper.find('div.promo-label span').length).toBe(0);
+    expect(wrapper.find('CameraIcon').length).toBe(1);
+  });
+
+  it('should not render an icon if label type is not recognized', () => {
+    const { default: PromoLabel } = require('./promo_label');
+    const wrapper = mount(<PromoLabel type="PromoType" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('div.promo-label span').text()).toBe('PromoType');
+    expect(wrapper.find('Icon').html()).toBeFalsy();
+  });
+});

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -9,6 +9,8 @@ import getProperties from 'fusion:properties';
 import Title from './title';
 import DescriptionText from './description-text';
 import checkObjectEmpty from '../shared/checkObjectEmpty';
+import PromoLabel from './promo_label';
+import discoverPromoType from './discover';
 
 const VerticalOverlineImageStoryItem = (props) => {
   const {
@@ -99,6 +101,7 @@ const VerticalOverlineImageStoryItem = (props) => {
   };
 
   const ratios = ratiosFor('XL', imageRatio);
+  const promoType = discoverPromoType(element);
 
   return (
     <>
@@ -126,21 +129,25 @@ const VerticalOverlineImageStoryItem = (props) => {
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                 />
+                <PromoLabel type={promoType} />
               </a>
             ) : (
-              <Image
-                smallWidth={ratios.smallWidth}
-                smallHeight={ratios.smallHeight}
-                mediumWidth={ratios.mediumWidth}
-                mediumHeight={ratios.mediumHeight}
-                largeWidth={ratios.largeWidth}
-                largeHeight={ratios.largeHeight}
-                alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
-                url={targetFallbackImage}
-                breakpoints={getProperties(arcSite)?.breakpoints}
-                resizedImageOptions={placeholderResizedImageOptions}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-              />
+              <div className="image-wrapper">
+                <Image
+                  smallWidth={ratios.smallWidth}
+                  smallHeight={ratios.smallHeight}
+                  mediumWidth={ratios.mediumWidth}
+                  mediumHeight={ratios.mediumHeight}
+                  largeWidth={ratios.largeWidth}
+                  largeHeight={ratios.largeHeight}
+                  alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
+                  url={targetFallbackImage}
+                  breakpoints={getProperties(arcSite)?.breakpoints}
+                  resizedImageOptions={placeholderResizedImageOptions}
+                  resizerURL={getProperties(arcSite)?.resizerURL}
+                />
+                <PromoLabel type={promoType} />
+              </div>
             )}
             {descriptionTmpl()}
             <div className="article-meta">

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
@@ -22,24 +22,28 @@ const config = {
   showHeadlineSM: true,
   showImageSM: true,
 };
-jest.mock('@wpmedia/engine-theme-sdk', () => ({
-  Image: () => <img alt="placeholder" />,
-}));
-jest.mock('fusion:context', () => ({
-  useFusionContext: jest.fn(() => ({
-    arcSite: 'the-sun',
-    globalContent: {},
-  })),
-}));
 
-jest.mock('fusion:content', () => ({
-  useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),
-}));
-
-jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
 
 describe('vertical overline image story item', () => {
-  jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+  beforeAll(() => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+    jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+    jest.mock('@wpmedia/engine-theme-sdk', () => ({
+      Image: () => <img alt="placeholder" />,
+    }));
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({
+        arcSite: 'the-sun',
+        globalContent: {},
+      })),
+    }));
+    jest.mock('fusion:content', () => ({
+      useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),
+    }));
+  });
+  afterAll(() => {
+    jest.resetModules();
+  });
 
   it('renders image and overline with full props', () => {
     const imageURL = 'pic';
@@ -93,12 +97,6 @@ describe('vertical overline image story item', () => {
     expect(wrapper.find('VerticalOverlineImageStoryItem > hr').length).toBe(1);
   });
   it('does not render image, overline and byline with empty props', () => {
-    jest.mock('fusion:context', () => ({
-      useFusionContext: jest.fn(() => ({
-        arcSite: 'the-sun',
-        globalContent: {},
-      })),
-    }));
     const imageURL = '';
     const websiteURL = 'url';
     const itemTitle = 'title';

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -49,4 +49,12 @@
     display: block;
     width: 100%;
   }
+
+  .image-wrapper {
+    position: relative;
+
+    > picture > img {
+      vertical-align: middle;
+    }
+  }
 }

--- a/blocks/top-table-list-block/features/top-table-list/default.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.test.jsx
@@ -23,10 +23,6 @@ const config = {
   showImageSM: true,
 };
 
-jest.mock('fusion:properties', () => jest.fn(() => ({
-  fallbackImage: 'placeholder.jpg',
-})));
-
 describe('top table list', () => {
   beforeAll(() => {
     jest.mock('fusion:properties', () => (jest.fn(() => ({
@@ -34,6 +30,9 @@ describe('top table list', () => {
     }))));
     jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
     jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+    jest.mock('fusion:properties', () => jest.fn(() => ({
+      fallbackImage: 'placeholder.jpg',
+    })));
   });
   afterAll(() => {
     jest.resetModules();


### PR DESCRIPTION
[PEN-814](https://arcpublishing.atlassian.net/browse/PEN-814)

# What does this implement or fix?
- create a function to detect the promo blocks type and implement a label to display it

# How was this tested?
- tests written

# Show Effect Of Changes

## After
![2020_0909_111720](https://user-images.githubusercontent.com/9757/92611567-4e87f700-f28f-11ea-9177-ba8f0808cb27.png)

# Dependencies or Side Effects

- depends on this PR from engine sdk, to fix the CameraIcon
https://github.com/WPMedia/engine-theme-sdk/pull/87
