### PR TITLE
PEN-1344 fix mismatched translations

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -181,9 +181,9 @@ const Nav = (props) => {
       <StyledNav id="main-nav" className={`${navColor === 'light' ? 'light' : 'dark'}`} font={primaryFont} navBarColor={navColor}>
         <div className="news-theme-navigation-container news-theme-navigation-bar">
           <div className="nav-left">
-            <SearchBox iconSize={20} navBarColor={navColor} placeholderText={phrases.t('header-nav-block.search-text')} customSearchAction={customSearchAction} />
+            <SearchBox iconSize={20} navBarColor={navColor} placeholderText={phrases.t('header-nav-chain-block.search-text')} customSearchAction={customSearchAction} />
             <button onClick={hamburgerClick} className={`nav-btn nav-sections-btn border transparent ${navColor === 'light' ? 'nav-btn-light' : 'nav-btn-dark'}`} type="button">
-              <span>{phrases.t('header-nav-block.sections-button')}</span>
+              <span>{phrases.t('header-nav-chain-block.sections-button')}</span>
               <HamburgerMenuIcon fill={null} height={iconSize} width={iconSize} />
             </button>
           </div>
@@ -202,7 +202,7 @@ const Nav = (props) => {
         <StyledSectionDrawer id="nav-sections" className={`nav-sections ${isSectionDrawerOpen ? 'open' : 'closed'}`} onClick={closeDrawer} font={primaryFont}>
           <div className="inner-drawer-nav" style={{ zIndex: 10 }}>
             <SectionNav sections={sections}>
-              <SearchBox iconSize={21} alwaysOpen placeholderText={phrases.t('header-nav-block.search-text')} />
+              <SearchBox iconSize={21} alwaysOpen placeholderText={phrases.t('header-nav-chain-block.search-text')} />
             </SectionNav>
           </div>
         </StyledSectionDrawer>

--- a/blocks/header-nav-chain-block/intl.json
+++ b/blocks/header-nav-chain-block/intl.json
@@ -4,6 +4,11 @@
       "sv":"Meny",
       "no":"Deler"
    },
+   "header-nav-chain-block.sign-in-button": {
+      "en": "Sign In",
+      "sv": "Logga in",
+      "no":"Logg på"
+  },
    "header-nav-chain-block.search-text":{
       "en":"Search",
       "sv":"Sök",

--- a/blocks/header-nav-chain-block/intl.json
+++ b/blocks/header-nav-chain-block/intl.json
@@ -4,11 +4,6 @@
       "sv":"Meny",
       "no":"Deler"
    },
-   "header-nav-chain-block.sign-in-button": {
-      "en": "Sign In",
-      "sv": "Logga in",
-      "no":"Logg på"
-  },
    "header-nav-chain-block.search-text":{
       "en":"Search",
       "sv":"Sök",


### PR DESCRIPTION
## Description
This updates the keys used for the chain translations to fix the mismatch caused when moved over from a feature to a chain

## Jira Ticket
- [PEN-1344](https://arcpublishing.atlassian.net/browse/PEN-1344)

## Acceptance Criteria
    Given I’m a Reader on Themes site

    When I see the Header Nav Chain

    Then I do not see the  header-nav-block.sections-button.

## Test Steps
Add the header-nav-chain-block to a page. Validate that the button contains the correct "sections" text for your language.

## Effect Of Changes
### Before
Button displayed the translation key

### After
Buttons display the translated values

## Dependencies or Side Effects
None
## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
