### PR TITLE
LIB-46 Add french translation to Byline

### DIFF
--- a/blocks/byline-block/intl.json
+++ b/blocks/byline-block/intl.json
@@ -2,11 +2,13 @@
    "byline-block.by-text":{
       "en":"By",
       "sv":"Av",
-      "no":"Av"
+      "no":"Av",
+      "fr":"Par"
    },
    "byline-block.and-text":{
       "en":"and",
       "sv":"och",
-      "no":"og"
+      "no":"og",
+      "fr":"et"
    }
 }


### PR DESCRIPTION
## Description
Adding french to the Byline Block 

## Jira Ticket
- [LIB-46](https://arcpublishing.atlassian.net/browse/LIB-46)

## Acceptance Criteria
Given I am a reader on the desktop or mobile site
- When I view the byline
- Then I see the words are in French “Par” (by) and “et” (and) so the byline reads as: Par Author 1, Author 2, Author 3 et Author 4
- Then I can click the author’s name to view their listing of articles

## Test Steps
- set translation in block.json to "fr"
- look at an example with Byline Arc Block and see that it uses the french translation