### PR TITLE
PEN-1260 alert bar covers content on navigation zone

### DIFF
--- a/blocks/alert-bar-block/features/alert-bar/alert-bar.scss
+++ b/blocks/alert-bar-block/features/alert-bar/alert-bar.scss
@@ -1,10 +1,14 @@
+$nav-bar-height: 56px;
+$alert-bar-height: 56px;
+
 .alert-bar {
   align-items: center;
   background-color: $danger-color;
-  display: inline-flex;
-  flex-wrap: wrap;
-  height: 56px;
+  display: flex;
+  flex-wrap: nowrap;
+  height: $alert-bar-height;
   justify-content: space-between;
+  overflow: hidden;
   padding-left: calculateRem(20px);
   padding-right: 0;
   width: 100%;
@@ -12,7 +16,7 @@
   .article-link {
     align-items: center;
     color: white;
-    display: inline-flex;
+    display: flex;
     font-family: $theme-primary-font-family;
     font-size: calculateRem(16px);
     font-weight: bold;
@@ -30,5 +34,12 @@
     margin-right: 0;
     padding-left: calculateRem(8px);
     padding-right: calculateRem(8px);
+  }
+}
+
+#fusion-app .has-alert + .main {
+  padding-top: calc(#{$nav-bar-height} + #{$alert-bar-height} + #{map-get($spacers, 'lg')});
+  @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
+    padding-top: calc(#{$nav-bar-height} + #{$alert-bar-height} + #{map-get($spacers, 'md')});
   }
 }

--- a/blocks/alert-bar-block/features/alert-bar/default.test.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { mount, shallow } from 'enzyme';
 
 jest.mock('fusion:themes', () => jest.fn(() => ({})));

--- a/blocks/alert-bar-block/features/alert-bar/default.test.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.test.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { mount, shallow } from 'enzyme';
 
 jest.mock('fusion:themes', () => jest.fn(() => ({})));
 describe('the alert bar feature for the default output type', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
   afterEach(() => {
     jest.resetModules();
   });
@@ -40,6 +44,8 @@ describe('the alert bar feature for the default output type', () => {
       fetched,
     });
     const wrapper = mount(<AlertBar customFields={customFields} arcSite="the-sun" />);
+    jest.advanceTimersByTime(1000);
+    wrapper.update();
     expect(wrapper.find('.alert-bar')).toHaveLength(1);
     expect(wrapper.find('.alert-bar').children().find('a').props().href).toBe('/2019/12/02/baby-panda-born-at-the-zoo/');
     expect(wrapper.find('.alert-bar').children().find('a').props().children).toBe('This is a test headline');
@@ -63,11 +69,16 @@ describe('the alert bar feature for the default output type', () => {
       fetched,
     });
     const wrapper = mount(<AlertBar customFields={customFields} arcSite="the-sun" />);
+    jest.advanceTimersByTime(1000);
+    wrapper.update();
     expect(wrapper.find('.alert-bar')).toHaveLength(0);
   });
 });
 
 describe('the alert can handle user interaction', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
   it('must hide when click the close button', () => {
     const { default: AlertBar } = require('./default');
     const content = {
@@ -92,6 +103,8 @@ describe('the alert can handle user interaction', () => {
       fetched: new Promise((r) => r(content)),
     });
     const wrapper = shallow(<AlertBar arcSite="the-sun" />);
+    jest.advanceTimersByTime(1000);
+    wrapper.update();
     expect(wrapper.find('.alert-bar')).toHaveLength(1);
     wrapper.find('button').simulate('click');
     expect(wrapper.find('.alert-bar')).toHaveLength(0);
@@ -123,6 +136,8 @@ describe('the alert can handle user interaction', () => {
       fetched: new Promise((r) => r(content)),
     });
     const wrapper = shallow(<AlertBar arcSite="the-sun" />);
+    jest.advanceTimersByTime(1000);
+    wrapper.update();
     expect(wrapper.find('.alert-bar')).toHaveLength(1);
     wrapper.find('button').simulate('click');
     expect(wrapper.find('.alert-bar')).toHaveLength(0);
@@ -157,7 +172,131 @@ describe('the alert can handle user interaction', () => {
       fetched: new Promise((r) => r(content)),
     });
     const wrapper = shallow(<AlertBar arcSite="the-sun" />);
+    jest.advanceTimersByTime(1000);
+    wrapper.update();
     expect(wrapper.find('.alert-bar')).toHaveLength(0);
     expect(document.cookie).toEqual(encodedCookie);
+  });
+});
+
+describe('when add the alert to the header-nav-chain', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('must add has-alert class to page-header', () => {
+    const wrapperComponent = ({ children }) => (
+      <div className="fusion-app">
+        <div className="page-header">{children}</div>
+        <div className="main" />
+      </div>
+    );
+    const { default: AlertBar } = require('./default');
+    const customFields = {
+      refreshIntervals: 120,
+    };
+    const content = {
+      _id: 'VTKOTRJXEVATHG7MELTPZ2RIBU',
+      type: 'collection',
+      content_elements:
+        [{
+          _id: '55FCWHR6SRCQ3OIJJKWPWUGTBM',
+          headlines: {
+            basic: 'This is a test headline',
+          },
+          websites: {
+            'the-sun': {
+              website_url: '/2019/12/02/baby-panda-born-at-the-zoo/',
+            },
+          },
+        }],
+    };
+
+    function getContent() {
+      return new Promise((resolve) => {
+        resolve(content);
+      });
+    }
+    const fetched = getContent();
+    AlertBar.prototype.getContent = jest.fn().mockReturnValue({
+      cached: content,
+      fetched,
+    });
+    const wrapper = mount(
+      <AlertBar customFields={customFields} arcSite="the-sun" />,
+      {
+        wrappingComponent: wrapperComponent,
+      },
+    );
+    jest.advanceTimersByTime(1000);
+    wrapper.update();
+    const wrapping = wrapper.getWrappingComponent();
+    wrapping.update();
+
+    expect(wrapping.find('.page-header').html()).toMatch(/page-header has-alert/);
+  });
+});
+
+describe('when add the alert to main section', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('must add nothing to page-header', () => {
+    const wrapperComponent = ({ children }) => (
+      <div className="fusion-app">
+        <div className="page-header" />
+        <div className="main">{children}</div>
+      </div>
+    );
+    const { default: AlertBar } = require('./default');
+    const customFields = {
+      refreshIntervals: 120,
+    };
+    const content = {
+      _id: 'VTKOTRJXEVATHG7MELTPZ2RIBU',
+      type: 'collection',
+      content_elements:
+        [{
+          _id: '55FCWHR6SRCQ3OIJJKWPWUGTBM',
+          headlines: {
+            basic: 'This is a test headline',
+          },
+          websites: {
+            'the-sun': {
+              website_url: '/2019/12/02/baby-panda-born-at-the-zoo/',
+            },
+          },
+        }],
+    };
+
+    function getContent() {
+      return new Promise((resolve) => {
+        resolve(content);
+      });
+    }
+    const fetched = getContent();
+    AlertBar.prototype.getContent = jest.fn().mockReturnValue({
+      cached: content,
+      fetched,
+    });
+    const wrapper = mount(
+      <AlertBar customFields={customFields} arcSite="the-sun" />,
+      {
+        wrappingComponent: wrapperComponent,
+      },
+    );
+    jest.advanceTimersByTime(1000);
+    wrapper.update();
+    const wrapping = wrapper.getWrappingComponent();
+    wrapping.update();
+
+    expect(wrapping.find('.page-header').html()).toMatch(/class="page-header"/);
   });
 });

--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
@@ -18,6 +18,7 @@ body {
   .main {
     flex-grow: 1;
     padding-top: calc(56px + #{map-get($spacers, 'lg')});
+    transition: padding-top 0.3s linear;
     width: 100%;
 
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {

--- a/blocks/right-rail-block/layouts/right-rail/default.scss
+++ b/blocks/right-rail-block/layouts/right-rail/default.scss
@@ -18,6 +18,7 @@ body {
   .main {
     flex-grow: 1;
     padding-top: calc(56px + #{map-get($spacers, 'lg')});
+    transition: padding-top 0.3s linear;
     width: 100%;
 
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {


### PR DESCRIPTION
## Description
increase/decrease padding when alert bar show/hide and add animation 

## Jira Ticket
- [PEN-1260](https://arcpublishing.atlassian.net/browse/PEN-1260)

## Acceptance Criteria
* If there is an Alert present, the page content should be pushed down, so that the alert bar is not covering the page content
* Once a user dismisses an alert, the page content should move back up 
* It should follow the transition animation that the Washington Post alert bar uses. Example gif: https://share.getcloudapp.com/qGuNOZpL

## Test Steps
- add an story to the alert bar collection
- add an alert bar to the header-nav-chain-block
- when the alert bar is displayed must not hide content below it
- when the alert bar is dismissed, the content must move up

## Effect Of Changes
### Before

### After
mobile view
![PEN-1260-1](https://user-images.githubusercontent.com/9757/94068989-47e89c00-fdc6-11ea-905b-ca08ee47052a.gif)

desktop view
![PEN-1260-2](https://user-images.githubusercontent.com/9757/94068996-4ae38c80-fdc6-11ea-8613-7897885ef40d.gif)

dismiss action
![PEN-1260-3](https://user-images.githubusercontent.com/9757/94069007-4e771380-fdc6-11ea-804d-055966e18246.gif)

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
