### PR TITLE
PEN-1259 - increase css specificity

### DIFF
--- a/blocks/shared-styles/scss/_medium-promo.scss
+++ b/blocks/shared-styles/scss/_medium-promo.scss
@@ -52,7 +52,7 @@
     }
   }
 
-  img {
+  picture img {
     height: auto;
     max-width: 100px;
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {


### PR DESCRIPTION
## Description
increase the css specificity on the medium promo block images to win a rule over news-theme-css
this is a fix for the PR https://github.com/WPMedia/fusion-news-theme-blocks/pull/454

Seems the issue is a difference on how `news-theme-css` is inserted on local versus the server, and this inpact the rules with the same specificity.

## Jira Ticket
- [PEN-1259](https://arcpublishing.atlassian.net/browse/PEN-1259)


## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
