### PR TITLE
PEN-1291 use getResizedImageData on content source

### DIFF
--- a/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
+++ b/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
@@ -1,3 +1,5 @@
+import getResizedImageData from '@wpmedia/resizer-image-block';
+
 export default {
   resolve(contentOptions) {
     const { _id, 'arc-site': arcSite } = contentOptions;
@@ -6,4 +8,11 @@ export default {
   params: {
     _id: 'text',
   },
+  transform: (data, query) => getResizedImageData(
+    data,
+    null,
+    null,
+    null,
+    query['arc-site'],
+  ),
 };

--- a/blocks/unpublished-content-source-block/sources/content-api-unpublished.test.js
+++ b/blocks/unpublished-content-source-block/sources/content-api-unpublished.test.js
@@ -1,7 +1,6 @@
-import contentSource from './content-api-unpublished';
-
 describe('the unpublished content source block', () => {
   it('should use the proper param types', () => {
+    const { default: contentSource } = require('./content-api-unpublished');
     expect(contentSource.params).toEqual({
       _id: 'text',
     });
@@ -9,6 +8,7 @@ describe('the unpublished content source block', () => {
 
   describe('when an id is provided', () => {
     it('should build the correct url', () => {
+      const { default: contentSource } = require('./content-api-unpublished');
       const url = contentSource.resolve({ _id: 'test', 'arc-site': 'bbbbb-ccccc' });
 
       expect(url).toEqual('content/v4?_id=test&website=bbbbb-ccccc&published=false');
@@ -17,9 +17,26 @@ describe('the unpublished content source block', () => {
 
   describe('when an id and website are NOT provided', () => {
     it('should not build a url with an id and website', () => {
+      const { default: contentSource } = require('./content-api-unpublished');
       const url = contentSource.resolve({ });
 
       expect(url).toEqual('content/v4?_id=undefined&website=undefined&published=false');
+    });
+  });
+
+  describe('when use transform function', () => {
+    const mockFn = jest.fn(() => ({}));
+    beforeAll(() => {
+      jest.mock('@wpmedia/resizer-image-block', () => mockFn);
+    });
+    afterAll(() => {
+      jest.resetModules();
+    });
+
+    it('should call getResizedImageData', () => {
+      const { default: contentSource } = require('./content-api-unpublished');
+      contentSource.transform([], {});
+      expect(mockFn.mock.calls.length).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Description
add resized urls to data from content source

## Jira Ticket
- [PEN-1291](https://arcpublishing.atlassian.net/browse/PEN-1291)

## Acceptance Criteria
Images rendered in composer preview as they are rendered on the published article page

## Test Steps
- use the content debugger and verify that `resized_params` key is added to `promo_items`

## Effect Of Changes
### Before

<img width="1664" alt="Screen Shot 2020-09-25 at 18 58 33" src="https://user-images.githubusercontent.com/9757/94320678-f2e28c80-ff63-11ea-8af4-5f5de2fcf47a.png">

### After
<img width="798" alt="Screen Shot 2020-09-25 at 18 51 47" src="https://user-images.githubusercontent.com/9757/94320691-f8d86d80-ff63-11ea-9299-77e2bbefbb56.png">

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
