### PR TITLE
PEN-814 fix getThemeStyle usage

### DIFF
--- a/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
-import getProperties from 'fusion:properties';
 import styled from 'styled-components';
 import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
 import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
@@ -56,14 +55,14 @@ const Icon = ({ type }) => {
 };
 
 const LabelLarge = ({ arcSite, type }) => (
-  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
     <Label>{type}</Label>
   </LabelBoxLarge>
 );
 
 const LabelSmall = ({ arcSite, type }) => (
-  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
   </LabelBoxSmall>
 );

--- a/blocks/large-promo-block/features/large-promo/_children/promo_label.jsx
+++ b/blocks/large-promo-block/features/large-promo/_children/promo_label.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
-import getProperties from 'fusion:properties';
 import styled from 'styled-components';
 import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
 import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
@@ -56,14 +55,14 @@ const Icon = ({ type }) => {
 };
 
 const LabelLarge = ({ arcSite, type }) => (
-  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
     <Label>{type}</Label>
   </LabelBoxLarge>
 );
 
 const LabelSmall = ({ arcSite, type }) => (
-  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
   </LabelBoxSmall>
 );

--- a/blocks/medium-promo-block/features/medium-promo/_children/promo_label.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/_children/promo_label.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
-import getProperties from 'fusion:properties';
 import styled from 'styled-components';
 import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
 import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
@@ -56,14 +55,14 @@ const Icon = ({ type }) => {
 };
 
 const LabelLarge = ({ arcSite, type }) => (
-  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
     <Label>{type}</Label>
   </LabelBoxLarge>
 );
 
 const LabelSmall = ({ arcSite, type }) => (
-  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
   </LabelBoxSmall>
 );

--- a/blocks/small-promo-block/features/small-promo/_children/promo_label.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_label.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
-import getProperties from 'fusion:properties';
 import styled from 'styled-components';
 import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
 import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
@@ -56,14 +55,14 @@ const Icon = ({ type }) => {
 };
 
 const LabelLarge = ({ arcSite, type }) => (
-  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
     <Label>{type}</Label>
   </LabelBoxLarge>
 );
 
 const LabelSmall = ({ arcSite, type }) => (
-  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
   </LabelBoxSmall>
 );

--- a/blocks/top-table-list-block/features/top-table-list/_children/promo_label.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/promo_label.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
-import getProperties from 'fusion:properties';
 import styled from 'styled-components';
 import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
 import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
@@ -56,14 +55,14 @@ const Icon = ({ type }) => {
 };
 
 const LabelLarge = ({ arcSite, type }) => (
-  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+  <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
     <Label>{type}</Label>
   </LabelBoxLarge>
 );
 
 const LabelSmall = ({ arcSite, type }) => (
-  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(getProperties(arcSite))['primary-color']}>
+  <LabelBoxSmall className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
   </LabelBoxSmall>
 );


### PR DESCRIPTION
## Description
There was an issue on how `getThemeStyle` function was used.
The test originally written are not invalid or need to be updated by this fix. 

## Jira Ticket
- [PEN-814](https://arcpublishing.atlassian.net/browse/PEN-814)

## Acceptance Criteria
check original PR https://github.com/WPMedia/fusion-news-theme-blocks/pull/445

## Dependencies or Side Effects
- none

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
