### PR TITLE
PEN-1258 Related Content content source block initial version

### DIFF
--- a/blocks/related-content-content-source-block/CHANGELOG.md
+++ b/blocks/related-content-content-source-block/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [5.7.0](https://github.com/WPMedia/fusion-news-theme-blocks/compare/v5.6.0-beta.0...v5.6.0) (2020-09-30)
+
+**Note:** Initial version
+

--- a/blocks/related-content-content-source-block/README.md
+++ b/blocks/related-content-content-source-block/README.md
@@ -1,0 +1,46 @@
+# `@wpmedia/related-content-content-source-block`
+_Content source block to get stories related content, using the story Id as key._ 
+
+## Configurable Params
+| **Param** | **Type** | **Required** | **Description** |
+|---|---|---|---|
+| **_id** | String | true | Story ID go get related content from (ex: CMVOSB2VCRDIBPC356BF2AXBFI) |
+
+
+## API Reference
+
+Reference documentation for the API used by this content source can be on [ALC](https://redirector.arcpublishing.com/alc/docs/swagger/?url=./arc-products/content-api.json#/Related_Content/get_related_content)
+
+## ANS Schema reference
+
+Documents retrieved by this content source comply with Ans Schema [v0.10.6](https://github.com/washingtonpost/ans-schema/tree/master/src/main/resources/schema/ans/0.10.6)
+
+## Usage
+
+```
+import { useContent } from 'fusion:content';
+
+...
+
+const relatedContent = useContent({
+  sounce: 'related-content',
+  query: {
+    _id: 'CMVOSB2VCRDIBPC356BF2AXBFI',
+  },
+});
+```
+
+### Example output
+
+```
+{
+  basic: [
+    ANS Object
+    ANS Object
+    ANS Object
+    ANS Object
+  ],
+  "_id": "CMVOSB2VCRDIBPC356BF2AXBFI"
+}
+```
+

--- a/blocks/related-content-content-source-block/README.md
+++ b/blocks/related-content-content-source-block/README.md
@@ -35,10 +35,196 @@ const relatedContent = useContent({
 ```
 {
   basic: [
-    ANS Object
-    ANS Object
-    ANS Object
-    ANS Object
+    {
+      _id: 'BPGB4PD6UJFJBMBFCZD7IHHRU4',
+      additional_properties: {
+        clipboard: {},
+        has_published_copy: true,
+        is_published: true,
+        publish_date: '2020-09-15T18:33:29.404Z',
+      },
+      address: {},
+      canonical_url: '/health/2020/09/15/testing-image-focal-point/',
+      canonical_website: 'the-sun',
+      content_elements: [
+        {
+          _id: 'ZUBFLUHI2NF23NILNSLT2UPX6M',
+          additional_properties: {
+            _id: 1600187300741,
+            comments: [],
+            inline_comments: [],
+          },
+          content: '<br/>',
+          type: 'text',
+        },
+      ],
+      content_restrictions: {},
+      created_date: '2020-09-15T16:30:31.419Z',
+      credits: {
+        by: [],
+      },
+      description: {
+        basic: '',
+      },
+      display_date: '2020-09-15T16:33:12.862Z',
+      distributor: {
+        category: 'staff',
+        name: 'corecomponents',
+        subcategory: '',
+      },
+      first_publish_date: '2020-09-15T16:33:12.862Z',
+      geo: {},
+      headlines: {
+        basic: 'testing image focal point',
+        meta_title: '',
+        mobile: '',
+        native: '',
+        print: '',
+        tablet: '',
+        web: '',
+      },
+      label: {},
+      language: '',
+      last_updated_date: '2020-09-15T18:33:29.883Z',
+      owner: {
+        id: 'corecomponents',
+        sponsored: false,
+      },
+      planning: {
+        internal_note: '',
+        story_length: {
+          character_count_actual: 0,
+          character_encoding: 'UTF-16',
+          inch_count_actual: 0,
+          line_count_actual: 0,
+          word_count_actual: 0,
+        },
+      },
+      promo_items: {
+        basic: {
+          _id: 'ROWVW4VI5ZEJ7ISJNYEMVQ5YTE',
+          additional_properties: {
+            fullSizeResizeUrl: '/photo/resize/vw1sQ3cLpQq21AzJRls-usF5NMU=/arc-anglerfish-arc2-prod-corecomponents/public/ROWVW4VI5ZEJ7ISJNYEMVQ5YTE.png',
+            galleries: [],
+            ingestionMethod: 'manual',
+            keywords: [],
+            mime_type: 'application/octet-stream',
+            originalName: 'L6NPTPXSLBGGXIPJGCHZI7KM4E.png',
+            originalUrl: 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/ROWVW4VI5ZEJ7ISJNYEMVQ5YTE.png',
+            owner: 'sara.carothers@washpost.com',
+            proxyUrl: '/photo/resize/vw1sQ3cLpQq21AzJRls-usF5NMU=/arc-anglerfish-arc2-prod-corecomponents/public/ROWVW4VI5ZEJ7ISJNYEMVQ5YTE.png',
+            published: true,
+            resizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/vw1sQ3cLpQq21AzJRls-usF5NMU=/arc-anglerfish-arc2-prod-corecomponents/public/ROWVW4VI5ZEJ7ISJNYEMVQ5YTE.png',
+            restricted: false,
+            template_id: 297,
+            thumbnailResizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/otY4xsB1W_mAYGxYZX3ZD9yz0tQ=/300x0/arc-anglerfish-arc2-prod-corecomponents/public/ROWVW4VI5ZEJ7ISJNYEMVQ5YTE.png',
+            version: 4,
+          },
+          address: {},
+          caption: 'Mexican guitarist Cham\u00edn Correa performs \'La Barca\' in a musical tribute to the Los Tres Caballeros, the musical trio he played in. Correa died at age 90.',
+          created_date: '2020-01-17T20:29:20Z',
+          credits: {
+            affiliation: [
+              {
+                name: 'Enrique Valles',
+                type: 'author',
+              },
+            ],
+            by: [],
+          },
+          focal_point: {
+            x: 1679,
+            y: 457,
+          },
+          geo: {},
+          height: 1080,
+          image_type: 'photograph',
+          last_updated_date: '2020-09-15T18:32:01Z',
+          licensable: false,
+          owner: {
+            id: 'corecomponents',
+            sponsored: false,
+          },
+          source: {
+            additional_properties: {
+              editor: 'photo center',
+            },
+            edit_url: 'https://corecomponents.arcpublishing.com/photo/ROWVW4VI5ZEJ7ISJNYEMVQ5YTE',
+            system: 'photo center',
+          },
+          status: '',
+          subtitle: 'Cham\u00edn Correa',
+          syndication: {
+            external_distribution: '',
+            search: '',
+          },
+          taxonomy: {
+            associated_tasks: [],
+          },
+          type: 'image',
+          url: 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/ROWVW4VI5ZEJ7ISJNYEMVQ5YTE.png',
+          version: '0.10.3',
+          width: 1920,
+        },
+      },
+      publish_date: '2020-09-15T18:33:29.404Z',
+      publishing: {
+        scheduled_operations: {
+          publish_edition: [],
+          unpublish_edition: [],
+        },
+      },
+      related_content: {
+        basic: [],
+        redirect: [],
+      },
+      revision: {
+        branch: 'default',
+        editions: [
+          'default',
+        ],
+        parent_id: 'QFBVZZ3KABCGNBNIQG5XLPTJIM',
+        published: true,
+        revision_id: 'IC7SX523PZBADLLZ76M64NXAAE',
+        user_id: 'fernandezn@washpost.com',
+      },
+      source: {
+        name: 'corecomponents',
+        source_type: 'staff',
+        system: 'composer',
+      },
+      subheadlines: {
+        basic: '',
+      },
+      taxonomy: {},
+      type: 'story',
+      version: '0.10.5',
+      website: 'the-sun',
+      website_url: '/health/2020/09/15/testing-image-focal-point/',
+      websites: {
+        'the-sun': {
+          website_section: {
+            _id: '/health',
+            _website: 'the-sun',
+            _website_section_id: 'the-sun./health',
+            additional_properties: {},
+            description: null,
+            name: 'Health',
+            parent: {
+              default: '/',
+            },
+            parent_id: '/',
+            path: '/health',
+            type: 'section',
+            version: '0.6.0',
+          },
+          website_url: '/health/2020/09/15/testing-image-focal-point/',
+        },
+      },
+      workflow: {
+        status_code: 1,
+      },
+    }
   ],
   "_id": "CMVOSB2VCRDIBPC356BF2AXBFI"
 }

--- a/blocks/related-content-content-source-block/index.js
+++ b/blocks/related-content-content-source-block/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/blocks/related-content-content-source-block/jest.config.js
+++ b/blocks/related-content-content-source-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require('../../jest/jest.config.base');
+
+module.exports = {
+  ...base,
+};

--- a/blocks/related-content-content-source-block/package.json
+++ b/blocks/related-content-content-source-block/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@wpmedia/related-content-content-source-block",
+  "version": "0.0.0",
+  "description": "Content source block to get stories related content.",
+  "author": "nelson fernandez <nelson.fernandez@washpost.com>",
+  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "license": "CC-BY-NC-ND-4.0",
+  "main": "index.js",
+  "files": [
+    "sources"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "lint": "eslint --ext js --ext jsx features"
+  },
+  "dependencies": {
+    "@wpmedia/engine-theme-sdk": "canary"
+  }
+}

--- a/blocks/related-content-content-source-block/sources/related-content.js
+++ b/blocks/related-content-content-source-block/sources/related-content.js
@@ -1,0 +1,38 @@
+import getResizedImageData from '@wpmedia/resizer-image-block';
+
+export default {
+  resolve: ({ _id, 'arc-site': arcSite } = {}) => {
+    const baseUrl = '/content/v4/related-content';
+
+    let params = [];
+    params = params.concat(_id ? `_id=${_id}` : undefined);
+    params = params.concat(arcSite ? `website=${arcSite}` : undefined);
+    params = params.reduce((acc, ele) => (ele ? acc.concat(ele) : acc), []);
+
+    if (params.length < 2) {
+      return '';
+    }
+
+    return `${baseUrl}?${params.join('&')}`;
+  },
+  schemaName: 'ans-feed',
+  params: {
+    _id: 'text',
+  },
+  transform: (data, query) => {
+    if (data && data.basic && typeof Array.isArray(data.basic)) {
+      return {
+        basic: data.basic.map((ele) => (
+          getResizedImageData(
+            ele,
+            null,
+            null,
+            null,
+            query['arc-site'],
+          )
+        )),
+      };
+    }
+    return data;
+  },
+};

--- a/blocks/related-content-content-source-block/sources/related-content.test.js
+++ b/blocks/related-content-content-source-block/sources/related-content.test.js
@@ -1,0 +1,81 @@
+describe('the related-content content source block', () => {
+  it('should use the proper param types', () => {
+    const { default: contentSource } = require('./related-content');
+    expect(contentSource.params).toEqual({
+      _id: 'text',
+    });
+  });
+
+  it('should use the proper schema', () => {
+    const { default: contentSource } = require('./related-content');
+    expect(contentSource.schemaName).toEqual('ans-feed');
+  });
+
+  it('should build the correct url', () => {
+    const { default: contentSource } = require('./related-content');
+    const url = contentSource.resolve({ _id: 'test', 'arc-site': 'bbbbb-ccccc' });
+
+    expect(url).toEqual('/content/v4/related-content?_id=test&website=bbbbb-ccccc');
+  });
+
+  it('should not build an url with missing id and website', () => {
+    const { default: contentSource } = require('./related-content');
+    const url = contentSource.resolve({ });
+
+    expect(url).toBeFalsy();
+  });
+
+  it('should not build an url with missing data', () => {
+    const { default: contentSource } = require('./related-content');
+    const url = contentSource.resolve();
+
+    expect(url).toBeFalsy();
+  });
+
+  it('should not build an url with missing id param', () => {
+    const { default: contentSource } = require('./related-content');
+    const url = contentSource.resolve({ _id: 'test' });
+
+    expect(url).toBeFalsy();
+  });
+
+  it('should not build an url with missing website param', () => {
+    const { default: contentSource } = require('./related-content');
+    const url = contentSource.resolve({ 'arc-site': 'test' });
+
+    expect(url).toBeFalsy();
+  });
+
+  describe('when use transform function', () => {
+    const mockFn = jest.fn(() => ({}));
+    beforeAll(() => {
+      jest.mock('@wpmedia/resizer-image-block', () => mockFn);
+    });
+    afterAll(() => {
+      jest.resetModules();
+    });
+    afterEach(() => {
+      mockFn.mockClear();
+    });
+
+    it('should call getResizedImageData if has information', () => {
+      const { default: contentSource } = require('./related-content');
+      contentSource.transform({
+        basic: [{}],
+      }, {});
+      expect(mockFn.mock.calls.length).toBe(1);
+    });
+
+    it('should not call getResizedImageData if data missing', () => {
+      const { default: contentSource } = require('./related-content');
+      contentSource.transform(null, {});
+      expect(mockFn.mock.calls.length).toBe(0);
+    });
+
+    it('should not call getResizedImageData if data is not array', () => {
+      const { default: contentSource } = require('./related-content');
+      contentSource.transform({ basic: '' }, {});
+      expect(mockFn.mock.calls.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Description
_Implementation of a content source to retrieve related content form an story_

## Jira Ticket
- [PEN-1258](https://arcpublishing.atlassian.net/browse/PEN-1258)

## Acceptance Criteria
* A new Content Source Arc block is created called related-content
* It should retrieve stories from the Content API /related-content endpoint, per documentation: https://corecomponents.arcpublishing.com/alc/docs/swagger/?url=./arc-products/content-api.json#/Related_Content/get_related_content
* Users should be able to configure the _id 
* website should be set automatically 
* This content source should have a schema of ans-feed so that is available for use in all blocks that use this schema (e.g. Top Table, Simple List, etc.) 
* Tests and documentation are written to cover this functionality 


## Test Steps
- go to the Content Debugger (/pagebuilder/tools/debugger)
- select `related-content` content sournce
- on the parameters use a story id that has related content assigned
- verify the output

## Effect Of Changes

<img width="1803" alt="Screen Shot 2020-10-01 at 16 37 07" src="https://user-images.githubusercontent.com/9757/94856915-1182d080-0407-11eb-95fa-550fe5051398.png">


## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
