### PR TITLE
PEN-862 chartbeat integration

### DIFF
--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -164,6 +164,8 @@ describe('head content', () => {
       gtmID: 'GTM-12345ID',
       gaID: 'UA-6789ID',
       fontUrl: 'https://fonts.googleapis.com/css?family=Open Sans',
+      chartBeatAccountId: 994949,
+      chartBeatDomain: 'example.com',
     }))));
   });
   afterAll(() => {
@@ -202,5 +204,37 @@ describe('head content', () => {
     for (let i = 0; i < scripts.length; i += 1) {
       expect(scripts.at(i).html().match(/<script[^>]*>.*?<script/gs)).toBeNull();
     }
+  });
+
+  it('must render chartbeat code', () => {
+    const { default: DefaultOutputType } = require('../default');
+    const wrapper = shallow(<DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} />);
+    expect(wrapper.find('script[data-integration="chartbeat"]').length).toBe(1);
+  });
+});
+
+describe('head content without properties', () => {
+  beforeAll(() => {
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({
+        globalContent: {},
+        arcSite: 'the-sun',
+      })),
+    }));
+
+    jest.mock('react-dom/server', () => ({
+      renderToString: jest.fn().mockReturnValue('<meta />'),
+    }));
+
+    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+  });
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  it('must not render chartbeat code', () => {
+    const { default: DefaultOutputType } = require('../default');
+    const wrapper = shallow(<DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} />);
+    expect(wrapper.find('script[data-integration="chartbeat"]').length).toBe(0);
   });
 });

--- a/blocks/default-output-block/output-types/_children/chart_beat_code.js
+++ b/blocks/default-output-block/output-types/_children/chart_beat_code.js
@@ -1,0 +1,27 @@
+const chartBeatCode = (accountId, domain) => {
+  if (!accountId || !domain) {
+    return null;
+  }
+  return `
+    (function() {
+        var _sf_async_config = window._sf_async_config = (window._sf_async_config || {});
+        _sf_async_config.uid = ${accountId};
+        _sf_async_config.domain = "${domain}";
+        _sf_async_config.useCanonical = true;
+        _sf_async_config.useCanonicalDomain = true;
+        _sf_async_config.sections = '';
+        _sf_async_config.authors = '';
+        function loadChartbeat() {
+            var e = document.createElement('script');
+            var n = document.getElementsByTagName('script')[0];
+            e.type = 'text/javascript';
+            e.async = true;
+            e.src = '//static.chartbeat.com/js/chartbeat.js';
+            n.parentNode.insertBefore(e, n);
+        }
+        loadChartbeat();
+     })();
+  `;
+};
+
+module.exports = chartBeatCode;

--- a/blocks/default-output-block/output-types/_children/chart_beat_code.test.js
+++ b/blocks/default-output-block/output-types/_children/chart_beat_code.test.js
@@ -1,0 +1,18 @@
+import chartBeatCode from './chart_beat_code';
+
+describe('ChartBeat code', () => {
+  it('must not render if accountId missing', () => {
+    expect(chartBeatCode(null, 'a')).toBeFalsy();
+    expect(chartBeatCode(undefined, 'a')).toBeFalsy();
+  });
+
+  it('must not render if Domain missing', () => {
+    expect(chartBeatCode(1)).toBeFalsy();
+    expect(chartBeatCode(1, null)).toBeFalsy();
+    expect(chartBeatCode(1, undefined)).toBeFalsy();
+  });
+
+  it('must render if both values present', () => {
+    expect(chartBeatCode(1, 'a')).toBeTruthy();
+  });
+});

--- a/blocks/default-output-block/output-types/_children/chart_beat_code.test.js
+++ b/blocks/default-output-block/output-types/_children/chart_beat_code.test.js
@@ -9,7 +9,7 @@ describe('ChartBeat code', () => {
     expect(chartBeatCode(undefined, null)).toBeFalsy();
   });
 
-  it('must not render if accountId missing', () => {
+  it('must not render if accountId is missing', () => {
     expect(chartBeatCode(null, 'a')).toBeFalsy();
     expect(chartBeatCode(undefined, 'a')).toBeFalsy();
   });

--- a/blocks/default-output-block/output-types/_children/chart_beat_code.test.js
+++ b/blocks/default-output-block/output-types/_children/chart_beat_code.test.js
@@ -14,7 +14,7 @@ describe('ChartBeat code', () => {
     expect(chartBeatCode(undefined, 'a')).toBeFalsy();
   });
 
-  it('must not render if Domain missing', () => {
+  it('must not render if Domain is missing', () => {
     expect(chartBeatCode(1)).toBeFalsy();
     expect(chartBeatCode(1, null)).toBeFalsy();
     expect(chartBeatCode(1, undefined)).toBeFalsy();

--- a/blocks/default-output-block/output-types/_children/chart_beat_code.test.js
+++ b/blocks/default-output-block/output-types/_children/chart_beat_code.test.js
@@ -1,6 +1,14 @@
 import chartBeatCode from './chart_beat_code';
 
 describe('ChartBeat code', () => {
+  it('must not render if both parameters are missing', () => {
+    expect(chartBeatCode()).toBeFalsy();
+    expect(chartBeatCode(null, null)).toBeFalsy();
+    expect(chartBeatCode(undefined, undefined)).toBeFalsy();
+    expect(chartBeatCode(null, undefined)).toBeFalsy();
+    expect(chartBeatCode(undefined, null)).toBeFalsy();
+  });
+
   it('must not render if accountId missing', () => {
     expect(chartBeatCode(null, 'a')).toBeFalsy();
     expect(chartBeatCode(undefined, 'a')).toBeFalsy();

--- a/blocks/default-output-block/output-types/_children/chart_beat_code.test.js
+++ b/blocks/default-output-block/output-types/_children/chart_beat_code.test.js
@@ -20,7 +20,7 @@ describe('ChartBeat code', () => {
     expect(chartBeatCode(1, undefined)).toBeFalsy();
   });
 
-  it('must render if both values present', () => {
+  it('must render if both values are present', () => {
     expect(chartBeatCode(1, 'a')).toBeTruthy();
   });
 });

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -5,6 +5,8 @@ import { useFusionContext } from 'fusion:context';
 import { MetaData } from '@wpmedia/engine-theme-sdk';
 import './default.scss';
 
+const chartBeatCode = require('./_children/chart_beat_code');
+
 const powaBoot = `${playerRoot}/prod/powaBoot.js?=org=${videoOrg}`;
 const powaDrive = `${playerRoot}/prod/powaDrive.js?org=${videoOrg}`;
 
@@ -34,6 +36,8 @@ const SampleOutputType = ({
     fontUrl,
     resizerURL,
     facebookAdmins,
+    chartBeatAccountId,
+    chartBeatDomain,
   } = getProperties(arcSite);
 
   const googleFonts = () => {
@@ -88,6 +92,7 @@ const SampleOutputType = ({
       <script dangerouslySetInnerHTML={{ __html: gaScript }} />
     </>
   );
+  const chartBeat = chartBeatCode(chartBeatAccountId, chartBeatDomain);
 
   return (
     <html lang="en">
@@ -129,6 +134,7 @@ const SampleOutputType = ({
         />
         <link rel="preload" as="script" href={powaDrive} />
         {googleFonts()}
+        {chartBeat && <script data-integration="chartbeat" dangerouslySetInnerHTML={{ __html: chartBeat }} /> }
       </head>
       <body>
         {gtmID


### PR DESCRIPTION
## Description
_Integration of Chartbeat code_

## Jira Ticket
- [PEN-862](https://arcpublishing.atlassian.net/browse/PEN-862)

## Acceptance Criteria
- Two new Theme Settings should be created, called chartbeatAccountId and chartbeatDomain
- If both of these Theme Settings are present for a given website, then the generic Chartbeat code should be added to the <head> of all pages on the website, per Chartbeat’s docs 
  - _sf_async_config.uid should be set to chartbeatAccountId
  - _sf_async_config.domain should be set to  chartbeatDomain
- Documentation and tests are updated as necessary to cover this functionality

## Test Steps
- add this likes the one site properties:
```
          "chartBeatAccountId": "3939393",
          "chartBeatDomain": "example.com"
```
- verify that when the page render the ChartBeat code is inserted at the end of the Head element
- if some or both of the properties are missing, no code must be inserted.

## Effect Of Changes
### After

<img width="751" alt="Screen Shot 2020-10-05 at 21 32 41" src="https://user-images.githubusercontent.com/9757/95145705-5afa5500-0752-11eb-8aa6-c0f6fd956074.png">

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
