### PR TITLE
PEN-1398 fix medium-promo-block layout

### DIFF
--- a/blocks/shared-styles/scss/_medium-promo.scss
+++ b/blocks/shared-styles/scss/_medium-promo.scss
@@ -105,10 +105,10 @@
       left: unset;
       right: 8px;
       top: 8px;
-    }
-    
-    span {
-      display: none;
+
+      span {
+        display: none;
+      }
     }
   }
 
@@ -116,20 +116,20 @@
     .md-promo-headline {
       width: 68%;
       @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-        padding-left: 38%;
-        width: 100%;
+        margin-left: 39%;
+        width: 60%;
       }
     }
 
     .description-text {
       @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-        padding-left: 38%;
+        margin-left: 39%;
       }
     }
 
     .article-meta {
       @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-        padding-left: 38%;
+        margin-left: 39%;
       }
     }
   }

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -31,15 +31,12 @@ const MediumListItem = (props) => {
     imageRatio,
   } = props;
   const showSeparator = by && by.length !== 0 && customFields.showDateMD;
-  const textClass = customFields.showImageMD
-    ? 'col-sm-12 col-md-xl-8 flex-col'
-    : 'col-sm-xl-12 flex-col';
 
   const headlineTmpl = () => {
     if (customFields.showHeadlineMD && itemTitle !== '') {
       return (
         <a href={websiteURL} title={itemTitle} className="md-promo-headline">
-          <Title className="md-promo-headline" primaryFont={primaryFont}>
+          <Title className="md-promo-headline-text" primaryFont={primaryFont}>
             {itemTitle}
           </Title>
         </a>
@@ -109,15 +106,15 @@ const MediumListItem = (props) => {
                 </div>
               </div>
           )} */}
-          {customFields.showImageMD && (
-          <div className="col-sm-12 col-md-xl-4">
-            <a href={websiteURL} title={itemTitle}>
+          {customFields.showImageMD
+            && (
+            <a className="image-link" href={websiteURL} title={itemTitle}>
               {imageURL !== '' ? (
                 <Image
                   resizedImageOptions={resizedImageOptions}
                   url={imageURL}
-                    // todo: get the proper alt tag for this image
-                    // 16:9 aspect for medium
+                  // todo: get the proper alt tag for this image
+                  // 16:9 aspect for medium
                   alt={itemTitle}
                   smallWidth={ratios.smallWidth}
                   smallHeight={ratios.smallHeight}
@@ -136,10 +133,7 @@ const MediumListItem = (props) => {
                   mediumHeight={ratios.mediumHeight}
                   largeWidth={ratios.largeWidth}
                   largeHeight={ratios.largeHeight}
-                  alt={
-                      getProperties(arcSite).primaryLogoAlt
-                      || 'Placeholder logo'
-                    }
+                  alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
                   url={targetFallbackImage}
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizedImageOptions={placeholderResizedImageOptions}
@@ -148,23 +142,22 @@ const MediumListItem = (props) => {
               )}
               <PromoLabel type={promoType} />
             </a>
-          </div>
-          )}
-          {/* customFields.headlinePositionMD === 'below'
-            && */ (customFields.showHeadlineMD
+            )}
+          {/* customFields.headlinePositionMD === 'below' && */
+            (customFields.showHeadlineMD
               || customFields.showDescriptionMD
               || customFields.showBylineMD
               || customFields.showDateMD) && (
-              <div className={textClass}>
+              <>
                 {headlineTmpl()}
                 {descriptionTmpl()}
                 <div className="article-meta">
                   {byLineTmpl()}
                   {dateTmpl()}
                 </div>
-              </div>
-    )
-}
+              </>
+            )
+          }
         </div>
       </article>
       <hr />


### PR DESCRIPTION
## Description
_fix a regression on medium-promo-blocks _

## Jira Ticket
- [PEN-1938](https://arcpublishing.atlassian.net/browse/PEN-1938)

## Acceptance Criteria
* Medium stories in the Top Table List should match the design of Medium Promo Block, like they previously had been doing

## Effect Of Changes
### Before
<img width="1352" alt="Screen Shot 2020-10-06 at 3 28 21 PM" src="https://user-images.githubusercontent.com/9757/95348739-b46a9d00-0894-11eb-8167-9247085c5e33.png">

### After
<img width="669" alt="Screen Shot 2020-10-06 at 21 30 23" src="https://user-images.githubusercontent.com/9757/95348805-c77d6d00-0894-11eb-908e-1bb67e7fe96c.png">
<img width="398" alt="Screen Shot 2020-10-06 at 21 31 01" src="https://user-images.githubusercontent.com/9757/95348816-c9dfc700-0894-11eb-8840-ecb7ee2ef424.png">
<img width="654" alt="Screen Shot 2020-10-06 at 21 32 57" src="https://user-images.githubusercontent.com/9757/95348827-cc422100-0894-11eb-84e6-7ab4ad519608.png">

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
