### PR TITLE
PEN-1399 fix regression large promo blocks

### DIFF
--- a/blocks/shared-styles/scss/_medium-promo.scss
+++ b/blocks/shared-styles/scss/_medium-promo.scss
@@ -105,10 +105,10 @@
       left: unset;
       right: 8px;
       top: 8px;
-    }
-    
-    span {
-      display: none;
+
+      span {
+        display: none;
+      }
     }
   }
 
@@ -116,20 +116,20 @@
     .md-promo-headline {
       width: 68%;
       @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-        padding-left: 38%;
-        width: 100%;
+        margin-left: 39%;
+        width: 60%;
       }
     }
 
     .description-text {
       @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-        padding-left: 38%;
+        margin-left: 39%;
       }
     }
 
     .article-meta {
       @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-        padding-left: 38%;
+        margin-left: 39%;
       }
     }
   }

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -138,14 +138,15 @@ const HorizontalOverlineImageStoryItem = (props) => {
             />
           )} */}
           {customFields.showImageLG && /*! videoUUID && */ (
-            <div className="col-sm-12 col-md-xl-6">
+            <div className="col-sm-12 col-md-xl-6 flex-col">
               {imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>
                   <Image
                     resizedImageOptions={resizedImageOptions}
-                    url={targetFallbackImage}
+                    url={imageURL}
                     alt={
-                      getProperties(arcSite).primaryLogoAlt
+                      itemTitle
+                      || getProperties(arcSite).primaryLogoAlt
                       || 'Placeholder logo'
                     }
                     smallWidth={ratios.smallWidth}
@@ -169,7 +170,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
                     largeWidth={ratios.largeWidth}
                     largeHeight={ratios.largeHeight}
                     alt={
-                      getProperties(arcSite).primaryLogoAlt
+                      itemTitle
+                      || getProperties(arcSite).primaryLogoAlt
                       || 'Placeholder logo'
                     }
                     url={targetFallbackImage}
@@ -182,8 +184,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
               )}
             </div>
           )}
-          {/* customFields.headlinePositionLG === 'below'
-            && */ (customFields.showHeadlineLG
+          {/* customFields.headlinePositionLG === 'below' && */
+            (customFields.showHeadlineLG
               || customFields.showDescriptionLG
               || customFields.showBylineLG
               || customFields.showDateLG) && (
@@ -196,8 +198,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
                   {dateTmpl()}
                 </div>
               </div>
-    )
-}
+            )
+          }
         </div>
       </article>
       <hr />

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -31,15 +31,12 @@ const MediumListItem = (props) => {
     imageRatio,
   } = props;
   const showSeparator = by && by.length !== 0 && customFields.showDateMD;
-  const textClass = customFields.showImageMD
-    ? 'col-sm-12 col-md-xl-8 flex-col'
-    : 'col-sm-xl-12 flex-col';
 
   const headlineTmpl = () => {
     if (customFields.showHeadlineMD && itemTitle !== '') {
       return (
         <a href={websiteURL} title={itemTitle} className="md-promo-headline">
-          <Title className="md-promo-headline" primaryFont={primaryFont}>
+          <Title className="md-promo-headline-text" primaryFont={primaryFont}>
             {itemTitle}
           </Title>
         </a>
@@ -109,15 +106,15 @@ const MediumListItem = (props) => {
                 </div>
               </div>
           )} */}
-          {customFields.showImageMD && (
-          <div className="col-sm-12 col-md-xl-4">
-            <a href={websiteURL} title={itemTitle}>
+          {customFields.showImageMD
+            && (
+            <a className="image-link" href={websiteURL} title={itemTitle}>
               {imageURL !== '' ? (
                 <Image
                   resizedImageOptions={resizedImageOptions}
                   url={imageURL}
-                    // todo: get the proper alt tag for this image
-                    // 16:9 aspect for medium
+                  // todo: get the proper alt tag for this image
+                  // 16:9 aspect for medium
                   alt={itemTitle}
                   smallWidth={ratios.smallWidth}
                   smallHeight={ratios.smallHeight}
@@ -136,10 +133,7 @@ const MediumListItem = (props) => {
                   mediumHeight={ratios.mediumHeight}
                   largeWidth={ratios.largeWidth}
                   largeHeight={ratios.largeHeight}
-                  alt={
-                      getProperties(arcSite).primaryLogoAlt
-                      || 'Placeholder logo'
-                    }
+                  alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
                   url={targetFallbackImage}
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizedImageOptions={placeholderResizedImageOptions}
@@ -148,23 +142,22 @@ const MediumListItem = (props) => {
               )}
               <PromoLabel type={promoType} />
             </a>
-          </div>
-          )}
-          {/* customFields.headlinePositionMD === 'below'
-            && */ (customFields.showHeadlineMD
+            )}
+          {/* customFields.headlinePositionMD === 'below' && */
+            (customFields.showHeadlineMD
               || customFields.showDescriptionMD
               || customFields.showBylineMD
               || customFields.showDateMD) && (
-              <div className={textClass}>
+              <>
                 {headlineTmpl()}
                 {descriptionTmpl()}
                 <div className="article-meta">
                   {byLineTmpl()}
                   {dateTmpl()}
                 </div>
-              </div>
-    )
-}
+              </>
+            )
+          }
         </div>
       </article>
       <hr />


### PR DESCRIPTION
## Description
fix regression on large-promo-blocks

## Jira Ticket
- [PEN-1399](https://arcpublishing.atlassian.net/browse/PEN-1399)

## Acceptance Criteria
* The basic promo images should render for Large items in the Top Table List, like they do for Small/Medium/XL items. 


## Effect Of Changes
### Before
![index](https://user-images.githubusercontent.com/9757/95390895-7b4e1f00-08cc-11eb-946f-95fa47f35139.png)

### After
<img width="952" alt="Screen Shot 2020-10-07 at 18 30 49" src="https://user-images.githubusercontent.com/9757/95390940-8bfe9500-08cc-11eb-9d80-8368043afb81.png">


## Dependencies or Side Effects
- this PR sits on top https://github.com/WPMedia/fusion-news-theme-blocks/pull/484 because on some cases the fix is accumulative

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
