### PR TITLE
PEN-1400 fix regression small promo blocks

### DIFF
--- a/blocks/shared-styles/scss/_medium-promo.scss
+++ b/blocks/shared-styles/scss/_medium-promo.scss
@@ -105,10 +105,10 @@
       left: unset;
       right: 8px;
       top: 8px;
-    }
-    
-    span {
-      display: none;
+
+      span {
+        display: none;
+      }
     }
   }
 
@@ -116,20 +116,20 @@
     .md-promo-headline {
       width: 68%;
       @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-        padding-left: 38%;
-        width: 100%;
+        margin-left: 39%;
+        width: 60%;
       }
     }
 
     .description-text {
       @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-        padding-left: 38%;
+        margin-left: 39%;
       }
     }
 
     .article-meta {
       @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-        padding-left: 38%;
+        margin-left: 39%;
       }
     }
   }

--- a/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/conditional-story-item.jsx
@@ -107,7 +107,10 @@ const ConditionalStoryItem = (props) => {
       );
     case SMALL: {
       let hasPaddingRight = false;
-      if ((typeof customFields.storiesPerRowSM === 'undefined') || (customFields.storiesPerRowSM === 2)) {
+      if (
+        (typeof customFields.storiesPerRowSM === 'undefined')
+        || (customFields.storiesPerRowSM === null)
+        || (customFields.storiesPerRowSM === 2)) {
         hasPaddingRight = (
           index - (storySizeMap.extraLarge + storySizeMap.large + storySizeMap.medium)
         ) % 2 === 0;

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -138,14 +138,15 @@ const HorizontalOverlineImageStoryItem = (props) => {
             />
           )} */}
           {customFields.showImageLG && /*! videoUUID && */ (
-            <div className="col-sm-12 col-md-xl-6">
+            <div className="col-sm-12 col-md-xl-6 flex-col">
               {imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>
                   <Image
                     resizedImageOptions={resizedImageOptions}
-                    url={targetFallbackImage}
+                    url={imageURL}
                     alt={
-                      getProperties(arcSite).primaryLogoAlt
+                      itemTitle
+                      || getProperties(arcSite).primaryLogoAlt
                       || 'Placeholder logo'
                     }
                     smallWidth={ratios.smallWidth}
@@ -169,7 +170,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
                     largeWidth={ratios.largeWidth}
                     largeHeight={ratios.largeHeight}
                     alt={
-                      getProperties(arcSite).primaryLogoAlt
+                      itemTitle
+                      || getProperties(arcSite).primaryLogoAlt
                       || 'Placeholder logo'
                     }
                     url={targetFallbackImage}
@@ -182,8 +184,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
               )}
             </div>
           )}
-          {/* customFields.headlinePositionLG === 'below'
-            && */ (customFields.showHeadlineLG
+          {/* customFields.headlinePositionLG === 'below' && */
+            (customFields.showHeadlineLG
               || customFields.showDescriptionLG
               || customFields.showBylineLG
               || customFields.showDateLG) && (
@@ -196,8 +198,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
                   {dateTmpl()}
                 </div>
               </div>
-    )
-}
+            )
+          }
         </div>
       </article>
       <hr />

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -32,27 +32,23 @@ const ItemTitleWithRightImage = (props) => {
     <article
       key={id}
       className={`${promoClasses} ${paddingRight ? 'small-promo-padding' : ''}`}
-      style={{
-        width: `calc((100% - 1.5rem) / ${customFields.storiesPerRowSM || 1})`,
-      }}
     >
       <div className="row sm-promo-padding-btm">
-        {/* customFields.headlinePositionSM === 'above'
-        && */ customFields.showHeadlineSM
-        && itemTitle !== '' ? (
-          <div className="col-sm-8 col-md-xl-8">
-            <a
-              href={websiteURL}
-              title={itemTitle}
-              className="sm-promo-headline"
-            >
-              <Title primaryFont={primaryFont} className="sm-promo-headline">
-                {itemTitle}
-              </Title>
-            </a>
-          </div>
-      ) : null
-}
+        {/* customFields.headlinePositionSM === 'above' && */
+          customFields.showHeadlineSM && itemTitle !== '' ? (
+            <div className="col-sm-8 col-md-xl-8">
+              <a
+                href={websiteURL}
+                title={itemTitle}
+                className="sm-promo-headline"
+              >
+                <Title primaryFont={primaryFont} className="sm-promo-headline">
+                  {itemTitle}
+                </Title>
+              </a>
+            </div>
+          ) : null
+        }
         {customFields.showImageSM
           && (
           <div className="col-sm-4 col-md-xl-4 flex-col">

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -31,15 +31,12 @@ const MediumListItem = (props) => {
     imageRatio,
   } = props;
   const showSeparator = by && by.length !== 0 && customFields.showDateMD;
-  const textClass = customFields.showImageMD
-    ? 'col-sm-12 col-md-xl-8 flex-col'
-    : 'col-sm-xl-12 flex-col';
 
   const headlineTmpl = () => {
     if (customFields.showHeadlineMD && itemTitle !== '') {
       return (
         <a href={websiteURL} title={itemTitle} className="md-promo-headline">
-          <Title className="md-promo-headline" primaryFont={primaryFont}>
+          <Title className="md-promo-headline-text" primaryFont={primaryFont}>
             {itemTitle}
           </Title>
         </a>
@@ -109,15 +106,15 @@ const MediumListItem = (props) => {
                 </div>
               </div>
           )} */}
-          {customFields.showImageMD && (
-          <div className="col-sm-12 col-md-xl-4">
-            <a href={websiteURL} title={itemTitle}>
+          {customFields.showImageMD
+            && (
+            <a className="image-link" href={websiteURL} title={itemTitle}>
               {imageURL !== '' ? (
                 <Image
                   resizedImageOptions={resizedImageOptions}
                   url={imageURL}
-                    // todo: get the proper alt tag for this image
-                    // 16:9 aspect for medium
+                  // todo: get the proper alt tag for this image
+                  // 16:9 aspect for medium
                   alt={itemTitle}
                   smallWidth={ratios.smallWidth}
                   smallHeight={ratios.smallHeight}
@@ -136,10 +133,7 @@ const MediumListItem = (props) => {
                   mediumHeight={ratios.mediumHeight}
                   largeWidth={ratios.largeWidth}
                   largeHeight={ratios.largeHeight}
-                  alt={
-                      getProperties(arcSite).primaryLogoAlt
-                      || 'Placeholder logo'
-                    }
+                  alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
                   url={targetFallbackImage}
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizedImageOptions={placeholderResizedImageOptions}
@@ -148,23 +142,22 @@ const MediumListItem = (props) => {
               )}
               <PromoLabel type={promoType} />
             </a>
-          </div>
-          )}
-          {/* customFields.headlinePositionMD === 'below'
-            && */ (customFields.showHeadlineMD
+            )}
+          {/* customFields.headlinePositionMD === 'below' && */
+            (customFields.showHeadlineMD
               || customFields.showDescriptionMD
               || customFields.showBylineMD
               || customFields.showDateMD) && (
-              <div className={textClass}>
+              <>
                 {headlineTmpl()}
                 {descriptionTmpl()}
                 <div className="article-meta">
                   {byLineTmpl()}
                   {dateTmpl()}
                 </div>
-              </div>
-    )
-}
+              </>
+            )
+          }
         </div>
       </article>
       <hr />


### PR DESCRIPTION
## Description
fix regression on small promo blocks

## Jira Ticket
- [PEN-1400](https://arcpublishing.atlassian.net/browse/PEN-1400)

## Acceptance Criteria
* If no value is set for Stories per row, it needs to render 2 stories per row, so that existing Top Table Lists aren’t broken when we release 1.4.0. 

## Effect Of Changes
### Before
<img width="1631" alt="Screen Shot 2020-10-06 at 3 17 01 PM" src="https://user-images.githubusercontent.com/9757/95395695-98d3b680-08d5-11eb-8863-e27763421318.png">

### After
<img width="1314" alt="Screen Shot 2020-10-07 at 19 27 33" src="https://user-images.githubusercontent.com/9757/95395723-a5f0a580-08d5-11eb-8f33-08178772ecc6.png">


## Dependencies or Side Effects
- this PR sits on top https://github.com/WPMedia/fusion-news-theme-blocks/pull/488 because on some cases the fix is accumulative

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
