### PR TITLE
Pen 1296 beta release process

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -1,0 +1,42 @@
+name: Beta blocks publish to beta tag
+on:
+  push:
+    branches:
+      - beta
+
+# Publishes beta builds with the dist tag of "beta" and
+# with a version of 0.0.0 with a short git SHA appended to
+# the end.
+jobs:
+  publish:
+    name: Beta block publish
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Cache NPM files
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+          registry-url: "https://npm.pkg.github.com"
+      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+      - name: Publish to beta tag with a short git SHA as the version
+        run: npx lerna publish 0.0.0-$(git rev-parse --short HEAD) --no-git-tag-version --no-push --dist-tag beta --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check beta failure status
+        uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+        if: failure()

--- a/News Theme Development.md
+++ b/News Theme Development.md
@@ -125,17 +125,11 @@ WARNING: If you need help rolling back publish, please see the wiki [How A Dev C
 git checkout beta
 git fetch -a
 ```
+2. Make a pr against the `beta` branch. After merging, this will push a hashed version to the `beta` tag. You can view the result of the github action work with `npm view [package name]@beta` (eg, `npm view @wpmedia/date-block@beta`).
 
-2. When you're ready to start the production release process, you'll want to make prerelease (`beta`) builds of the blocks. Start by running the below command to publish packages with the `beta` dist-tag:
-
-```sh
-npx lerna publish --force-publish --preid beta --pre-dist-tag beta
-```
-
-3. Select either `prepatch`, `preminor`, or `premajor` if this is the first prerelease build for this production release (e.g. `-beta.0`). If this is a prerelease that makes changes on top of a prior prerelease then select the `Custom Prerelease` option and accept the default, this should result in the version having only an incremented prerelease number instead of an incremented major, minor, or patch number (e.g `-beta.1`). Note that this will publish all packages to aid our block installer process.
-4. Deploy a bundle with the `BLOCK_DIST_TAG` environment variable set as `beta` in your environment file(s).
-5. After either design QA or product QA approval of that deployed bundle, checkout `stable` and pull down the latest from that branch. Then run `git merge vX.X.X-beta.X` (where `X.X.X-beta.X` is the beta release we're releasing to production) to get the changes from `beta` into `stable`.
-6. Then, in `stable`, you can publish a production release with the following command:
+3. Deploy a bundle with the `BLOCK_DIST_TAG` environment variable set as `beta` in your environment file(s).
+4. After either design QA or product QA approval of that deployed bundle, checkout `stable` and pull down the latest from that branch. Then run `git merge vX.X.X-beta.X` (where `X.X.X-beta.X` is the beta release we're releasing to production) to get the changes from `beta` into `stable`.
+5. Then, in `stable`, you can publish a production release with the following command:
 
 ```sh
 npx lerna publish --conventional-commits --conventional-graduate


### PR DESCRIPTION
## Description
Push hashed commit version to beta tag, similar to canary

## Jira Ticket
- [PEN-1296](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=545&projectKey=PEN&modal=detail&selectedIssue=PEN-1296&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
- Can push current branch to beta tag 

## Test Steps
- Read over github action and compare to canary 

## Effect Of Changes
### Before
- we had to run manual push to beta

### After
- just merge into branch to see push 
- see mock push below 

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored). -> a github action change 
- [x] Confirmed relevant documentation has been updated/added.


adding the following, using the lead of canary push: 

```
Changes:
17
 - @wpmedia/a11y-testing-block: 5.8.0-beta.0 => 0.0.0-073fa80
18
 - @wpmedia/ad-taboola-block: 5.8.0-beta.0 => 0.0.0-073fa80
19
 - @wpmedia/alert-bar-block: 5.8.0-beta.0 => 0.0.0-073fa80
20
 - @wpmedia/alert-bar-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
21
 - @wpmedia/article-body-block: 5.8.0-beta.0 => 0.0.0-073fa80
22
 - @wpmedia/article-tag-block: 5.8.0-beta.0 => 0.0.0-073fa80
23
 - @wpmedia/author-bio-block: 5.8.0-beta.0 => 0.0.0-073fa80
24
 - @wpmedia/author-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
25
 - @wpmedia/byline-block: 5.8.0-beta.0 => 0.0.0-073fa80
26
 - @wpmedia/card-list-block: 5.8.0-beta.0 => 0.0.0-073fa80
27
 - @wpmedia/collections-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
28
 - @wpmedia/content-api-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
29
 - @wpmedia/date-block: 5.8.0-beta.0 => 0.0.0-073fa80
30
 - @wpmedia/default-output-block: 5.8.0-beta.0 => 0.0.0-073fa80
31
 - @wpmedia/double-chain-block: 5.8.0-beta.0 => 0.0.0-073fa80
32
 - @wpmedia/event-tester-block: 5.8.0-beta.0 => 0.0.0-073fa80
33
 - @wpmedia/extra-large-manual-promo-block: 5.8.0-beta.0 => 0.0.0-073fa80
34
 - @wpmedia/extra-large-promo-block: 5.8.0-beta.0 => 0.0.0-073fa80
35
 - @wpmedia/footer-block: 5.8.0-beta.0 => 0.0.0-073fa80
36
 - @wpmedia/full-author-bio-block: 5.8.0-beta.0 => 0.0.0-073fa80
37
 - @wpmedia/gallery-block: 5.8.0-beta.0 => 0.0.0-073fa80
38
 - @wpmedia/global-phrases-block: 5.8.0-beta.0 => 0.0.0-073fa80
39
 - @wpmedia/header-block: 5.8.0-beta.0 => 0.0.0-073fa80
40
 - @wpmedia/header-nav-block: 5.8.0-beta.0 => 0.0.0-073fa80
41
 - @wpmedia/header-nav-chain-block: 5.8.0-beta.0 => 0.0.0-073fa80
42
 - @wpmedia/headline-block: 5.8.0-beta.0 => 0.0.0-073fa80
43
 - @wpmedia/htmlbox-block: 5.8.0-beta.0 => 0.0.0-073fa80
44
 - @wpmedia/large-manual-promo-block: 5.8.0-beta.0 => 0.0.0-073fa80
45
 - @wpmedia/large-promo-block: 5.8.0-beta.0 => 0.0.0-073fa80
46
 - @wpmedia/lead-art-block: 5.8.0-beta.0 => 0.0.0-073fa80
47
 - @wpmedia/links-bar-block: 5.8.0-beta.0 => 0.0.0-073fa80
48
 - @wpmedia/masthead-block: 5.8.0-beta.0 => 0.0.0-073fa80
49
 - @wpmedia/medium-manual-promo-block: 5.8.0-beta.0 => 0.0.0-073fa80
50
 - @wpmedia/medium-promo-block: 5.8.0-beta.0 => 0.0.0-073fa80
51
 - @wpmedia/numbered-list-block: 5.8.0-beta.0 => 0.0.0-073fa80
52
 - @wpmedia/overline-block: 5.8.0-beta.0 => 0.0.0-073fa80
53
 - @wpmedia/placeholder-image-block: 5.8.0-beta.0 => 0.0.0-073fa80
54
 - @wpmedia/quad-chain-block: 5.8.0-beta.0 => 0.0.0-073fa80
55
 - @wpmedia/resizer-image-block: 5.8.0-beta.0 => 0.0.0-073fa80
56
 - @wpmedia/resizer-image-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
57
 - @wpmedia/results-list-block: 5.8.0-beta.0 => 0.0.0-073fa80
58
 - @wpmedia/right-rail-advanced-block: 5.8.0-beta.0 => 0.0.0-073fa80
59
 - @wpmedia/right-rail-block: 5.8.0-beta.0 => 0.0.0-073fa80
60
 - @wpmedia/search-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
61
 - @wpmedia/search-results-list-block: 5.8.0-beta.0 => 0.0.0-073fa80
62
 - @wpmedia/section-title-block: 5.8.0-beta.0 => 0.0.0-073fa80
63
 - @wpmedia/share-bar-block: 5.8.0-beta.0 => 0.0.0-073fa80
64
 - @wpmedia/shared-styles: 5.8.0-beta.0 => 0.0.0-073fa80
65
 - @wpmedia/simple-list-block: 5.8.0-beta.0 => 0.0.0-073fa80
66
 - @wpmedia/single-chain-block: 5.8.0-beta.0 => 0.0.0-073fa80
67
 - @wpmedia/site-hierarchy-content-block: 5.8.0-beta.0 => 0.0.0-073fa80
68
 - @wpmedia/small-manual-promo-block: 5.8.0-beta.0 => 0.0.0-073fa80
69
 - @wpmedia/small-promo-block: 5.8.0-beta.0 => 0.0.0-073fa80
70
 - @wpmedia/story-feed-author-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
71
 - @wpmedia/story-feed-query-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
72
 - @wpmedia/story-feed-sections-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
73
 - @wpmedia/story-feed-tag-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
74
 - @wpmedia/subheadline-block: 5.8.0-beta.0 => 0.0.0-073fa80
75
 - @wpmedia/tag-title-block: 5.8.0-beta.0 => 0.0.0-073fa80
76
 - @wpmedia/tags-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
77
 - @wpmedia/text-output-block: 5.8.0-beta.0 => 0.0.0-073fa80
78
 - @wpmedia/textfile-block: 5.8.0-beta.0 => 0.0.0-073fa80
79
 - @wpmedia/top-table-list-block: 5.8.0-beta.0 => 0.0.0-073fa80
80
 - @wpmedia/triple-chain-block: 5.8.0-beta.0 => 0.0.0-073fa80
81
 - @wpmedia/unpublished-content-source-block: 5.8.0-beta.0 => 0.0.0-073fa80
82
 - @wpmedia/video-player-block: 5.8.0-beta.0 => 0.0.0-073fa80
