### PR TITLE
PEN-1347 change h1 tags from blocks

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -9,7 +9,7 @@ import '@wpmedia/shared-styles/scss/_extra-large-promo.scss';
 import { Image } from '@wpmedia/engine-theme-sdk';
 import { useContent } from 'fusion:content';
 
-const HeadlineText = styled.h1`
+const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 
@@ -23,7 +23,7 @@ const OverlineLink = styled.a`
   text-decoration: none;
 `;
 
-const OverlineHeader = styled.h1`
+const OverlineHeader = styled.h2`
   font-family: ${(props) => props.primaryFont};
   font-weight: bold;
   text-decoration: none;

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -22,7 +22,7 @@ import {
 import PromoLabel from './_children/promo_label';
 import discoverPromoType from './_children/discover';
 
-const HeadlineText = styled.h1`
+const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -9,7 +9,7 @@ import { useContent } from 'fusion:content';
 
 import '@wpmedia/shared-styles/scss/_large-promo.scss';
 
-const HeadlineText = styled.h1`
+const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 
@@ -23,7 +23,7 @@ const OverlineLink = styled.a`
   text-decoration: none;
 `;
 
-const OverlineHeader = styled.h1`
+const OverlineHeader = styled.h2`
   font-family: ${(props) => props.primaryFont};
   font-weight: bold;
   text-decoration: none;

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -22,7 +22,7 @@ import {
 import PromoLabel from './_children/promo_label';
 import discoverPromoType from './_children/discover';
 
-const HeadlineText = styled.h1`
+const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -9,7 +9,7 @@ import { useContent } from 'fusion:content';
 
 import '@wpmedia/shared-styles/scss/_medium-promo.scss';
 
-const HeadlineText = styled.h1`
+const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -21,7 +21,7 @@ import {
 import PromoLabel from './_children/promo_label';
 import discoverPromoType from './_children/discover';
 
-const HeadlineText = styled.h1`
+const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 

--- a/blocks/shared-styles/scss/_small-promo.scss
+++ b/blocks/shared-styles/scss/_small-promo.scss
@@ -5,7 +5,7 @@
   a {
     color: $ui-primary-font-color;
     position: relative;
-    h1 {
+    h2 {
       display: inline;
     }
   }

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -9,7 +9,7 @@ import { useContent } from 'fusion:content';
 
 import '@wpmedia/shared-styles/scss/_small-promo.scss';
 
-const HeadlineText = styled.h1`
+const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -19,7 +19,7 @@ import {
 import PromoLabel from './_children/promo_label';
 import discoverPromoType from './_children/discover';
 
-const HeadlineText = styled.h1`
+const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/title.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/title.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const Title = styled.h1`
+const Title = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 export default Title;

--- a/blocks/video-promo-block/features/video-promo/default.jsx
+++ b/blocks/video-promo-block/features/video-promo/default.jsx
@@ -9,7 +9,7 @@ import { videoOrg, videoEnv } from 'fusion:environment';
 import { useFusionContext } from 'fusion:context';
 import { Video } from '@wpmedia/engine-theme-sdk';
 
-const TitleText = styled.h1`
+const TitleText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 

--- a/blocks/video-promo-block/features/video-promo/default.test.jsx
+++ b/blocks/video-promo-block/features/video-promo/default.test.jsx
@@ -43,7 +43,7 @@ describe('the video promo feature', () => {
 
   it('should have show title, description, and video with default configs', () => {
     const wrapper = mount(<VideoPromo customFields={config} />);
-    expect(wrapper.find('h1').text()).toBe('Title');
+    expect(wrapper.find('h2').text()).toBe('Title');
     expect(wrapper.find('p').text()).toBe('Description');
     const video = wrapper.find('#video').at(0);
     expect(video.prop('data-props')).toEqual({
@@ -58,7 +58,7 @@ describe('the video promo feature', () => {
   it('should have show title, description, live label, and video with default configs', () => {
     config.live = true;
     const wrapper = mount(<VideoPromo customFields={config} />);
-    expect(wrapper.find('h1').text()).toBe('Title');
+    expect(wrapper.find('h2').text()).toBe('Title');
     expect(wrapper.find('p').text()).toBe('Description');
     expect(wrapper.find('span').text()).toBe('LIVE VIDEO');
     const video = wrapper.find('#video').at(0);
@@ -74,7 +74,7 @@ describe('the video promo feature', () => {
   it('should have show title, description, and video with autoplay', () => {
     config.autoplay = true;
     const wrapper = mount(<VideoPromo customFields={config} />);
-    expect(wrapper.find('h1').text()).toBe('Title');
+    expect(wrapper.find('h2').text()).toBe('Title');
     expect(wrapper.find('p').text()).toBe('Description');
     const video = wrapper.find('#video').at(0);
     expect(video.prop('data-props')).toEqual({
@@ -89,7 +89,7 @@ describe('the video promo feature', () => {
   it('should have show title, description, and video with different ratio', () => {
     config.ratio = 0.75;
     const wrapper = mount(<VideoPromo customFields={config} />);
-    expect(wrapper.find('h1').text()).toBe('Title');
+    expect(wrapper.find('h2').text()).toBe('Title');
     expect(wrapper.find('p').text()).toBe('Description');
     const video = wrapper.find('#video').at(0);
     expect(video.prop('data-props')).toEqual({
@@ -104,7 +104,7 @@ describe('the video promo feature', () => {
   it('should have show title, description, and video with uuid specified directly', () => {
     config.uuid = 'new-uuid';
     const wrapper = mount(<VideoPromo customFields={config} />);
-    expect(wrapper.find('h1').text()).toBe('Title');
+    expect(wrapper.find('h2').text()).toBe('Title');
     expect(wrapper.find('p').text()).toBe('Description');
     const video = wrapper.find('#video').at(0);
     expect(video.prop('data-props')).toEqual({


### PR DESCRIPTION
## Description
Updated all the blocks to switch from using H1 tags for the titles to use H2

## Jira Ticket
- [PEN-1347](https://arcpublishing.atlassian.net/browse/PEN-1347)

## Acceptance Criteria
* Any promo blocks that currently use H1 for headlines should switch to using H2. This includes: 
  * Top Table List
  * XL Promo Block
  * L Promo Block
  * M Promo Block
  * S Promo Block
  * XL Manual Promo Block
  * L Manual Promo Block
  * M Manual Promo Block
  * S Manual Promo Block
  * Card List
  * Simple List
  * Numbered List
  * Results List
  * Search Results List

## Test Steps
- check on Home page, Search Results, Tags page, All Blocks page that all the title blocks are rendered with h2 tags

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
