### PR TITLE
PEN-1379 update to use '+=' to append spacing for 2 authors

### DIFF
--- a/blocks/byline-block/features/byline/default.jsx
+++ b/blocks/byline-block/features/byline/default.jsx
@@ -84,7 +84,7 @@ class ArticleByline extends Component {
           break;
         }
         case 2: {
-          bylineString = `${authors[0]} ${this.phrases.t('byline-block.and-text')} ${authors[1]}`;
+          bylineString += `${authors[0]} ${this.phrases.t('byline-block.and-text')} ${authors[1]}`;
           break;
         }
         default: {

--- a/blocks/byline-block/features/byline/default.test.jsx
+++ b/blocks/byline-block/features/byline/default.test.jsx
@@ -162,7 +162,7 @@ describe('Given an author list', () => {
     const wrapper = mount(<ArticleByline globalContent={globalContent} />);
     expect(
       wrapper.find('span').at(1).prop('dangerouslySetInnerHTML'),
-    ).toStrictEqual({ __html: '<a href="/author/sanghee-kim">SangHee Kim</a> and <a href="/author/sara-carothers">Sara Carothers</a>' });
+    ).toStrictEqual({ __html: ' <a href="/author/sanghee-kim">SangHee Kim</a> and <a href="/author/sara-carothers">Sara Carothers</a>' });
   });
 
   it('should return three authors, oxford comma', () => {


### PR DESCRIPTION
## Description
- byline spacing update for 2 authors 

## Jira Ticket
- [PEN-1379](https://arcpublishing.atlassian.net/browse/PEN-1379)

## Acceptance Criteria
There should be a space between the word "By" and the author names. 

## Test Steps
- test article 7OGBDCTEEBHFPBWIYKBDSWOHAA and confirm the byline with 2 authors has spacing after "By"
- test articles with one author or 2+ that spacing remain the same

## Effect Of Changes
### Before
No spacing after "By" for 2 authors

![Screen Shot 2020-10-08 at 2 38 57 PM](https://user-images.githubusercontent.com/4411687/95615233-c0816680-0a1c-11eb-84f6-221741fbaa42.png)


### After
Spacing between 2 authors in byline
![Screen Shot 2020-10-09 at 11 06 16 AM](https://user-images.githubusercontent.com/4411687/95616924-76e64b00-0a1f-11eb-9e75-238c72e2c5a5.png)


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
