### PR TITLE
PEN-1258 rename the container element from the result set

### DIFF
--- a/blocks/related-content-content-source-block/sources/related-content.js
+++ b/blocks/related-content-content-source-block/sources/related-content.js
@@ -22,7 +22,7 @@ export default {
   transform: (data, query) => {
     if (data && data.basic && typeof Array.isArray(data.basic)) {
       return {
-        basic: data.basic.map((ele) => (
+        content_elements: data.basic.map((ele) => (
           getResizedImageData(
             ele,
             null,

--- a/blocks/related-content-content-source-block/sources/related-content.test.js
+++ b/blocks/related-content-content-source-block/sources/related-content.test.js
@@ -66,6 +66,14 @@ describe('the related-content content source block', () => {
       expect(mockFn.mock.calls.length).toBe(1);
     });
 
+    it('should rename the top property as content_elements', () => {
+      const { default: contentSource } = require('./related-content');
+      const result = contentSource.transform({
+        basic: [{}],
+      }, {});
+      expect(result.content_elements).toBeTruthy();
+    });
+
     it('should not call getResizedImageData if data missing', () => {
       const { default: contentSource } = require('./related-content');
       contentSource.transform(null, {});


### PR DESCRIPTION
## Description
rename the container element from the result set to `content_elements`

## Jira Ticket
- [PEN-1258](https://arcpublishing.atlassian.net/browse/PEN-1258)

## Acceptance Criteria
It should only be this very first level of basic that is renamed to content_elements – we should not rename anything within the stories (e.g. headlines.basic for each story should stay as-is). Let me know if this is possible to do or if you have any questions. 


## Test Steps
- use the content debugger to check that `related-content`content source return `content_elements` as top level element


## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [ x Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
