### PR TITLE
PEN-1381: Footer Icons and Results Read More button should use primary color

### DIFF
--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -16,6 +16,15 @@ const FooterSection = styled.ul`
   font-family: ${(props) => props.primaryFont};
 `;
 
+const StyledSocialContainer = styled.div`
+  border: 1px solid ${(props) => props.primaryColor}; 
+  fill: ${(props) => props.primaryColor};
+
+  a {
+    border-right: 1px solid ${(props) => props.primaryColor};;
+  }
+`;
+
 const Footer = ({ customFields: { navigationConfig } }) => {
   const { arcSite, deployment, contextPath } = useFusionContext();
   const {
@@ -28,6 +37,7 @@ const Footer = ({ customFields: { navigationConfig } }) => {
     primaryLogo,
     primaryLogoAlt,
   } = getProperties(arcSite);
+
 
   // Check if URL is absolute/base64
   let logoUrl = lightBackgroundLogo || primaryLogo;
@@ -54,7 +64,7 @@ const Footer = ({ customFields: { navigationConfig } }) => {
               rel="noopener noreferrer"
               href={facebookPage}
             >
-              <FacebookAltIcon fill="#2980B9" />
+              <FacebookAltIcon fill={getThemeStyle(arcSite)['primary-color']} />
             </a>
           )
           : ''
@@ -68,7 +78,7 @@ const Footer = ({ customFields: { navigationConfig } }) => {
               rel="noopener noreferrer"
               href={`https://twitter.com/${twitterUsername}`}
             >
-              <TwitterIcon fill="#2980B9" />
+              <TwitterIcon fill={getThemeStyle(arcSite)['primary-color']} />
             </a>
           )
           : ''
@@ -82,7 +92,7 @@ const Footer = ({ customFields: { navigationConfig } }) => {
               rel="noopener noreferrer"
               href={rssUrl}
             >
-              <RssIcon fill="#2980B9" />
+              <RssIcon fill={getThemeStyle(arcSite)['primary-color']} />
             </a>
           )
           : ''
@@ -96,9 +106,9 @@ const Footer = ({ customFields: { navigationConfig } }) => {
         <section className="footer-header">
           <div className="footer-row">
             <div className="social-column">
-              <div className="socialBtn-container">
+              <StyledSocialContainer className="socialBtn-container" primaryColor={getThemeStyle(arcSite)['primary-color']} >
                 {socialButtons}
-              </div>
+              </StyledSocialContainer>
             </div>
             <div className="copyright-column">
               {/* If large screen, show copyright over border */}

--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -38,7 +38,6 @@ const Footer = ({ customFields: { navigationConfig } }) => {
     primaryLogoAlt,
   } = getProperties(arcSite);
 
-
   // Check if URL is absolute/base64
   let logoUrl = lightBackgroundLogo || primaryLogo;
   if (logoUrl && !(logoUrl.indexOf('http') === 0 || logoUrl.indexOf('base64') === 0)) logoUrl = deployment(`${contextPath}/${logoUrl}`);
@@ -106,7 +105,7 @@ const Footer = ({ customFields: { navigationConfig } }) => {
         <section className="footer-header">
           <div className="footer-row">
             <div className="social-column">
-              <StyledSocialContainer className="socialBtn-container" primaryColor={getThemeStyle(arcSite)['primary-color']} >
+              <StyledSocialContainer className="socialBtn-container" primaryColor={getThemeStyle(arcSite)['primary-color']}>
                 {socialButtons}
               </StyledSocialContainer>
             </div>

--- a/blocks/footer-block/features/footer/footer.scss
+++ b/blocks/footer-block/features/footer/footer.scss
@@ -75,7 +75,6 @@ footer {
 
   .socialBtn-container {
     align-items: center;
-    border: 1px solid $primary-color;
     border-radius: calculateRem(5px);
     display: inline-flex;
     justify-content: space-between;
@@ -83,7 +82,6 @@ footer {
 
     a {
       align-self: center;
-      border-right: 1px solid $primary-color;
       display: inline-block;
       flex: auto;
       padding: map-get($spacers, 'xs') map-get($spacers, 'xs') map-get($spacers, 'xs') map-get($spacers, 'xs');
@@ -99,15 +97,15 @@ footer {
         width: 24px;
       }
 
-      svg path {
-        fill: $primary-color;
-      }
+      // svg path {
+      //   fill: $primary-color;
+      // }
 
-      &:hover {
-        svg path {
-          fill: $primary-color;
-        }
-      }
+      // &:hover {
+      //   svg path {
+      //     fill: $primary-color;
+      //   }
+      // }
     }
   }
 

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -31,6 +31,14 @@ const DescriptionText = styled.p`
   font-family: ${(props) => props.secondaryFont};
 `;
 
+const ReadMoreButton = styled.button`
+  background-color:${(props) => props.primaryColor}; 
+
+  &:not(:disabled):not(.disabled):active:hover, &:not(:disabled):not(.disabled):hover:hover{
+    background-color:${(props) => props.primaryColor}; 
+  }
+`;
+
 @Consumer
 class ResultsList extends Component {
   constructor(props) {
@@ -259,17 +267,18 @@ class ResultsList extends Component {
         {
           !!(contentElements && contentElements.length > 0 && seeMore) && (
             <div className="see-more">
-              <button
+              <ReadMoreButton
                 type="button"
                 onClick={() => this.fetchStories(true)}
                 className="btn btn-sm"
+                primaryColor={getThemeStyle(arcSite)['primary-color']}
               >
                 {this.phrases.t('results-list-block.see-more-button')}
                 {' '}
                 <span className="visuallyHidden">
                   stories about this topic
                 </span>
-              </button>
+              </ReadMoreButton>
             </div>
           )
         }

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -40,6 +40,16 @@ const ReadMoreButton = styled.button`
 
 @Consumer
 class ResultsList extends Component {
+  static fetchStoriesTransform(data, storedList) {
+    const result = storedList;
+    if (data) {
+      // Add new data to previous list
+      result.content_elements = storedList.content_elements.concat(data.content_elements);
+      result.next = data.next;
+    }
+    return result;
+  }
+
   constructor(props) {
     super(props);
     this.arcSite = props.arcSite;
@@ -57,11 +67,11 @@ class ResultsList extends Component {
   getFallbackImageURL() {
     const { arcSite, deployment, contextPath } = this.props;
     let targetFallbackImage = getProperties(arcSite).fallbackImage;
-    
+
     if (!targetFallbackImage.includes('http')) {
       targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
     }
-   
+
     return targetFallbackImage;
   }
 
@@ -76,16 +86,6 @@ class ResultsList extends Component {
         },
       });
     }
-  }
-
-  fetchStoriesTransform(data, storedList){
-    if (data) {
-      // Add new data to previous list
-      const combinedList = storedList.content_elements.concat(data.content_elements);
-      storedList.content_elements = combinedList;
-      storedList.next = data.next;
-    }
-    return storedList;
   }
 
   fetchStories(additionalStoryAmount) {

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -57,11 +57,11 @@ class ResultsList extends Component {
   getFallbackImageURL() {
     const { arcSite, deployment, contextPath } = this.props;
     let targetFallbackImage = getProperties(arcSite).fallbackImage;
-
+    console.log('targetFallbackImage = ', targetFallbackImage)
     if (!targetFallbackImage.includes('http')) {
       targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
     }
-
+    console.log('FINAL targetFallbackImage = ', targetFallbackImage)
     return targetFallbackImage;
   }
 

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -33,7 +33,6 @@ const DescriptionText = styled.p`
 
 const ReadMoreButton = styled.button`
   background-color:${(props) => props.primaryColor}; 
-
   &:not(:disabled):not(.disabled):active:hover, &:not(:disabled):not(.disabled):hover:hover{
     background-color:${(props) => props.primaryColor}; 
   }

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -57,11 +57,11 @@ class ResultsList extends Component {
   getFallbackImageURL() {
     const { arcSite, deployment, contextPath } = this.props;
     let targetFallbackImage = getProperties(arcSite).fallbackImage;
-    console.log('targetFallbackImage = ', targetFallbackImage)
+    
     if (!targetFallbackImage.includes('http')) {
       targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
     }
-    console.log('FINAL targetFallbackImage = ', targetFallbackImage)
+   
     return targetFallbackImage;
   }
 
@@ -76,6 +76,16 @@ class ResultsList extends Component {
         },
       });
     }
+  }
+
+  fetchStoriesTransform(data, storedList){
+    if (data) {
+      // Add new data to previous list
+      const combinedList = storedList.content_elements.concat(data.content_elements);
+      storedList.content_elements = combinedList;
+      storedList.next = data.next;
+    }
+    return storedList;
   }
 
   fetchStories(additionalStoryAmount) {
@@ -108,15 +118,7 @@ class ResultsList extends Component {
           resultList: {
             source: contentService,
             query: contentConfigValues,
-            transform(data) {
-              if (data) {
-                // Add new data to previous list
-                const combinedList = storedList.content_elements.concat(data.content_elements);
-                storedList.content_elements = combinedList;
-                storedList.next = data.next;
-              }
-              return storedList;
-            },
+            transform: (data) => this.fetchStoriesTransform(data, storedList),
           },
         });
         // Hide button if no more stories to load

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -403,7 +403,7 @@ describe('The results list', () => {
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
 
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ resultList: mockData, seeMore:true }, () => {
+    wrapper.setState({ resultList: mockData, seeMore: true }, () => {
       wrapper.update();
       it('should render a button to display more stories', () => {
         expect(wrapper.find('.btn').length).toEqual(1);

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -406,7 +406,6 @@ describe('The results list', () => {
     wrapper.setState({ resultList: mockData, seeMore:true }, () => {
       wrapper.update();
       it('should render a button to display more stories', () => {
-        console.log('wrapper 409', wrapper.state());
         expect(wrapper.find('.btn').length).toEqual(1);
       });
 

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -403,19 +403,20 @@ describe('The results list', () => {
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
 
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ resultList: mockData }, () => {
+    wrapper.setState({ resultList: mockData, seeMore:true }, () => {
       wrapper.update();
       it('should render a button to display more stories', () => {
-        expect(wrapper.find('button').length).toEqual(1);
+        console.log('wrapper 409', wrapper.state());
+        expect(wrapper.find('.btn').length).toEqual(1);
       });
 
       it('should have invisible text for accessibility purposes', () => {
-        expect(wrapper.find('button').text()).toEqual('See More stories about this topic');
+        expect(wrapper.find('.btn').text()).toEqual('See More stories about this topic');
       });
 
       it('should call fetchContent when clicked', () => {
         expect(ResultsList.prototype.fetchStories.mock.calls.length).toEqual(1);
-        wrapper.find('button').simulate('click');
+        wrapper.find('.btn').simulate('click');
         expect(ResultsList.prototype.fetchStories.mock.calls.length).toEqual(2);
       });
     });

--- a/blocks/results-list-block/features/results-list/helpers.test.jsx
+++ b/blocks/results-list-block/features/results-list/helpers.test.jsx
@@ -1,10 +1,11 @@
-import { resolveDefaultPromoElements } from './helpers.jsx';
+import { resolveDefaultPromoElements } from './helpers';
 
 describe('resolveDefaultPromoElements', () => {
-
-    it('should use default custom fields as empty object', () => {
-        const result = resolveDefaultPromoElements();
-        const expectedResult = {"showByline": true, "showDate": true, "showDescription": true, "showHeadline": true, "showImage": true}
-        expect(result).toEqual(expectedResult);
-      });
+  it('should use default custom fields as empty object', () => {
+    const result = resolveDefaultPromoElements();
+    const expectedResult = {
+      showByline: true, showDate: true, showDescription: true, showHeadline: true, showImage: true,
+    };
+    expect(result).toEqual(expectedResult);
+  });
 });

--- a/blocks/results-list-block/features/results-list/helpers.test.jsx
+++ b/blocks/results-list-block/features/results-list/helpers.test.jsx
@@ -1,0 +1,10 @@
+import { resolveDefaultPromoElements } from './helpers.jsx';
+
+describe('resolveDefaultPromoElements', () => {
+
+    it('should use default custom fields as empty object', () => {
+        const result = resolveDefaultPromoElements();
+        const expectedResult = {"showByline": true, "showDate": true, "showDescription": true, "showHeadline": true, "showImage": true}
+        expect(result).toEqual(expectedResult);
+      });
+});

--- a/blocks/results-list-block/features/results-list/internalTests.test.jsx
+++ b/blocks/results-list-block/features/results-list/internalTests.test.jsx
@@ -1,7 +1,12 @@
 
 import ResultsList from './default.jsx';
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount} from 'enzyme';
+import mockData, { oneListItem, LineItemWithOutDescription, withoutByline } from './mock-data';
+
+const mockReturnData = mockData;
+
+jest.mock('fusion:themes', () => jest.fn(() => ({})));
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({
     fallbackImage: 'http://test/resources/fallback.jpg',
@@ -232,13 +237,41 @@ describe('getFallbackImageURL', () => {
         expect(result).toEqual('storedList');
     });
 
-    it('if has  data, return concentated data with storedList', () => {
+    it('if has  data, return concatenated data with storedList', () => {
         ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
 
         const mockDeployment = jest.fn();
-        const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath='/pf' customFields={customFields} />);
+        const wrapper = mount(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath='/pf' customFields={customFields} />);
 
         const result = wrapper.instance().fetchStoriesTransform({content_elements:['A', 'B'], next:10}, {content_elements:['C', 'D']});
         expect(result).toEqual( {"content_elements": ["C", "D", "A", "B"], "next": 10});
+    });
+  });
+
+  describe('styled components', () => {
+
+    const listContentConfig = {
+        contentConfigValues: {
+          offset: '0',
+          query: 'type: story',
+          size: '1',
+        },
+        contentService: 'story-feed-query',
+      };
+      const customFields = { listContentConfig };
+
+    it('renders styled headline, read more button and description', () => {
+        ResultsList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
+        ResultsList.prototype.getThemeStyle = jest.fn().mockReturnValue({'primary-font-family':'font1'});
+        
+        const mockDeployment = jest.fn();
+        const wrapper = mount(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath='/pf' customFields={customFields} />);
+        wrapper.setState({ resultList: oneListItem });
+        wrapper.update();
+
+
+        expect(wrapper.find('.list-item').find('.headline-text').length).toEqual(3);
+        expect(wrapper.find('.list-item').find('.description-text').length).toEqual(3);
+
     });
   });

--- a/blocks/results-list-block/features/results-list/internalTests.test.jsx
+++ b/blocks/results-list-block/features/results-list/internalTests.test.jsx
@@ -1,277 +1,250 @@
-
-import ResultsList from './default.jsx';
 import React from 'react';
-import { shallow, mount} from 'enzyme';
-import mockData, { oneListItem, LineItemWithOutDescription, withoutByline } from './mock-data';
+import { shallow, mount } from 'enzyme';
+import ResultsList from './default';
+import mockData, { oneListItem } from './mock-data';
 
 const mockReturnData = mockData;
 
 jest.mock('fusion:themes', () => jest.fn(() => ({})));
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({
-    fallbackImage: 'http://test/resources/fallback.jpg',
-  }))));
+  fallbackImage: 'http://test/resources/fallback.jpg',
+}))));
 
 describe('getFallbackImageURL', () => {
+  const listContentConfig = {
+    contentConfigValues: {
+      offset: '0',
+      query: 'type: story',
+      size: '1',
+    },
+    contentService: 'story-feed-query',
+  };
+  const customFields = { listContentConfig };
 
-    const listContentConfig = {
-        contentConfigValues: {
+  it('should NOT call deployment with context path if http is contained in fallback image url', () => {
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+
+    const mockDeployment = jest.fn();
+    const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath="/pf" customFields={customFields} />);
+
+    mockDeployment.mockClear();
+    const result = wrapper.instance().getFallbackImageURL();
+    expect(result).toEqual('http://test/resources/fallback.jpg');
+    expect(mockDeployment).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('fetchPlaceholder', () => {
+  const listContentConfig = {
+    contentConfigValues: {
+      offset: '0',
+      query: 'type: story',
+      size: '1',
+    },
+    contentService: 'story-feed-query',
+  };
+  const customFields = { listContentConfig };
+
+  it('should call fetchContent if fallback image contains resources', () => {
+    const fetchContentMock = jest.fn().mockReturnValue({});
+    ResultsList.prototype.fetchContent = fetchContentMock;
+    const mockDeployment = jest.fn();
+    const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath="/pf" customFields={customFields} />);
+    mockDeployment.mockClear();
+    expect(mockDeployment).toHaveBeenCalledTimes(0);
+    wrapper.instance().fetchPlaceholder();
+
+    expect(fetchContentMock).toHaveBeenCalledTimes(1);
+    expect(fetchContentMock).toHaveBeenCalledWith({ resultList: { query: { offset: '0', query: 'type: story', size: '1' }, source: 'story-feed-query' } });
+  });
+});
+
+describe('fetchStories', () => {
+  const listContentConfig = {
+    contentConfigValues: {
+      offset: '0',
+      query: 'type: story',
+      size: '1',
+    },
+    contentService: 'story-feed-query',
+  };
+  const customFields = { listContentConfig };
+
+  it('should make appropriate calculations if has additionalStoryAmount and story-feed-query', () => {
+    const fetchContentMock = jest.fn().mockReturnValue({});
+    ResultsList.prototype.fetchContent = fetchContentMock;
+
+    const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFields} />);
+    fetchContentMock.mockClear();
+    wrapper.setState({ storedList: { next: 2 } });
+    wrapper.update();
+    wrapper.instance().fetchStories(true);
+
+    expect(wrapper.state('resultList')).toEqual({});
+    expect(fetchContentMock).toHaveBeenCalledTimes(1);
+    const partialObj = {
+      resultList: {
+        query: {
+          offset: '2',
+          query: 'type: story',
+          size: '1',
+        },
+        source: 'story-feed-query',
+        transform: expect.any(Function),
+      },
+    };
+    expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
+  });
+
+  it('should make appropriate calculations if has additionalStoryAmount and story-feed-query and no storedList.next', () => {
+    const fetchContentMock = jest.fn().mockReturnValue({});
+    ResultsList.prototype.fetchContent = fetchContentMock;
+
+    const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFields} />);
+    fetchContentMock.mockClear();
+    wrapper.setState({ storedList: {} });
+    wrapper.update();
+    wrapper.instance().fetchStories(true);
+
+    expect(wrapper.state('resultList')).toEqual({});
+    expect(fetchContentMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should make appropriate calculations if has additionalStoryAmount and story-feed-query and no storedList.next', () => {
+    const fetchContentMock = jest.fn().mockReturnValue({});
+    ResultsList.prototype.fetchContent = fetchContentMock;
+
+    const listContentConfigStory = {
+      contentConfigValues: {
+        offset: '0',
+        query: 'type: story',
+        size: '1',
+      },
+      contentService: 'story-feed-author',
+    };
+    const customFieldsNoSize = { listContentConfig: listContentConfigStory };
+
+    const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFieldsNoSize} />);
+    fetchContentMock.mockClear();
+    wrapper.setState({ storedList: { next: 2 } });
+    wrapper.update();
+    wrapper.instance().fetchStories(true);
+
+    expect(wrapper.state('resultList')).toEqual({});
+    expect(fetchContentMock).toHaveBeenCalledTimes(1);
+    const partialObj = {
+      resultList: {
+        query: {
+          feedOffset: '2',
           offset: '0',
           query: 'type: story',
           size: '1',
         },
-        contentService: 'story-feed-query',
-      };
-      const customFields = { listContentConfig };
-
-    it('should NOT call deployment with context path if http is contained in fallback image url', () => {
-        ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
-
-        const mockDeployment = jest.fn();
-        const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath='/pf' customFields={customFields} />);
-
-        mockDeployment.mockClear();
-        const result = wrapper.instance().getFallbackImageURL();
-        expect(result).toEqual("http://test/resources/fallback.jpg");
-        expect(mockDeployment).toHaveBeenCalledTimes(0);
-    });
+        source: 'story-feed-author',
+        transform: expect.any(Function),
+      },
+    };
+    expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
   });
 
-  describe('fetchPlaceholder', () => {
+  it('should make appropriate calculations if has additionalStoryAmount and non-specified and no storedList.next', () => {
+    const fetchContentMock = jest.fn().mockReturnValue({});
+    ResultsList.prototype.fetchContent = fetchContentMock;
 
-    const listContentConfig = {
-        contentConfigValues: {
+    const listContentConfigOther = {
+      contentConfigValues: {
+        offset: '0',
+        query: 'type: story',
+        size: '1',
+      },
+      contentService: 'other',
+    };
+    const customFieldsOther = { listContentConfig: listContentConfigOther };
+
+    const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFieldsOther} />);
+    fetchContentMock.mockClear();
+    wrapper.setState({ storedList: { next: 2 } });
+    wrapper.update();
+    wrapper.instance().fetchStories(true);
+
+    expect(wrapper.state('resultList')).toEqual({});
+    expect(fetchContentMock).toHaveBeenCalledTimes(1);
+    const partialObj = {
+      resultList: {
+        query: {
           offset: '0',
           query: 'type: story',
           size: '1',
         },
-        contentService: 'story-feed-query',
-      };
-      const customFields = { listContentConfig };
-
-    it('should call fetchContent if fallback image contains resources', () => {
-        const fetchContentMock = jest.fn().mockReturnValue({});
-        ResultsList.prototype.fetchContent = fetchContentMock;
-        const mockDeployment = jest.fn();
-        const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath='/pf' customFields={customFields} />);
-        mockDeployment.mockClear();
-        expect(mockDeployment).toHaveBeenCalledTimes(0);
-        wrapper.instance().fetchPlaceholder();
-
-
-        expect(fetchContentMock).toHaveBeenCalledTimes(1);
-        expect(fetchContentMock).toHaveBeenCalledWith({"resultList": {"query": {"offset": "0", "query": "type: story", "size": "1"}, "source": "story-feed-query"}});
-    });
+        source: 'other',
+        transform: expect.any(Function),
+      },
+    };
+    expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
   });
 
+  it('should update seeMore if value is greater than storied list count', () => {
+    const fetchContentMock = jest.fn().mockReturnValue({ content_elements: ['elem1', 'elem2'] });
+    ResultsList.prototype.getContent = fetchContentMock;
 
-  describe('fetchStories', () => {
+    const listContentConfigStoryFeed = {
+      contentConfigValues: {
+        offset: '0',
+        query: 'type: story',
+        size: '1',
+      },
+      contentService: 'story-feed-query',
+    };
+    const customFieldsStoryFeed = { listContentConfig: listContentConfigStoryFeed };
 
-    const listContentConfig = {
-        contentConfigValues: {
-          offset: '0',
-          query: 'type: story',
-          size: '1',
-        },
-        contentService: 'story-feed-query',
-      };
-      const customFields = { listContentConfig };
+    const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFieldsStoryFeed} />);
+    fetchContentMock.mockClear();
+    wrapper.setState({ storedList: { next: 2, count: 0 } });
+    wrapper.update();
+    wrapper.instance().fetchStories(true);
 
-    it('should make appropriate calculations if has additionalStoryAmount and story-feed-query', () => {
-        const fetchContentMock = jest.fn().mockReturnValue({});
-        ResultsList.prototype.fetchContent = fetchContentMock;
+    expect(wrapper.state('seeMore')).toBeFalsy();
+  });
+});
 
-        const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath='/pf' customFields={customFields} />);
-        fetchContentMock.mockClear();
-        wrapper.setState({ storedList: {next: 2} });
-        wrapper.update();
-        wrapper.instance().fetchStories(true);
+describe('fetchStoriesTransform', () => {
+  it('if has no data, return storedList', () => {
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
 
-        expect(wrapper.state('resultList')).toEqual({});
-        expect(fetchContentMock).toHaveBeenCalledTimes(1);
-        const partialObj = {
-               "resultList":  {
-                 "query":  {
-                   "offset": "2",
-                   "query": "type: story",
-                   "size": "1",
-                 },
-                 "source": "story-feed-query",
-                 "transform": expect.any(Function),
-               }
-            };
-        expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
-    });
-
-    it('should make appropriate calculations if has additionalStoryAmount and story-feed-query and no storedList.next', () => {
-        const fetchContentMock = jest.fn().mockReturnValue({});
-        ResultsList.prototype.fetchContent = fetchContentMock;
-
-        const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath='/pf' customFields={customFields} />);
-        fetchContentMock.mockClear();
-        wrapper.setState({ storedList: {} });
-        wrapper.update();
-        wrapper.instance().fetchStories(true);
-
-        expect(wrapper.state('resultList')).toEqual({});
-        expect(fetchContentMock).toHaveBeenCalledTimes(0);
-    });
-
-    it('should make appropriate calculations if has additionalStoryAmount and story-feed-query and no storedList.next', () => {
-        const fetchContentMock = jest.fn().mockReturnValue({});
-        ResultsList.prototype.fetchContent = fetchContentMock;
-
-        const listContentConfig = {
-            contentConfigValues: {
-              offset: '0',
-              query: 'type: story',
-              size: '1',
-            },
-            contentService: 'story-feed-author',
-        };
-        const customFields = { listContentConfig };
-
-        const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath='/pf' customFields={customFields} />);
-        fetchContentMock.mockClear();
-        wrapper.setState({ storedList: {next: 2} });
-        wrapper.update();
-        wrapper.instance().fetchStories(true);
-
-        expect(wrapper.state('resultList')).toEqual({});
-        expect(fetchContentMock).toHaveBeenCalledTimes(1);
-        const partialObj = {
-            "resultList":  {
-                "query":  {
-                    "feedOffset": "2",
-                    "offset": "0",
-                    "query": "type: story",
-                    "size": "1",
-                },
-                 "source": 'story-feed-author',
-                 "transform": expect.any(Function),
-               }
-            };
-        expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
-    });
-
-    it('should make appropriate calculations if has additionalStoryAmount and non-specified and no storedList.next', () => {
-        const fetchContentMock = jest.fn().mockReturnValue({});
-        ResultsList.prototype.fetchContent = fetchContentMock;
-
-        const listContentConfig = {
-            contentConfigValues: {
-              offset: '0',
-              query: 'type: story',
-              size: '1',
-            },
-            contentService: 'other',
-        };
-        const customFields = { listContentConfig };
-
-        const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath='/pf' customFields={customFields} />);
-        fetchContentMock.mockClear();
-        wrapper.setState({ storedList: {next: 2} });
-        wrapper.update();
-        wrapper.instance().fetchStories(true);
-
-        expect(wrapper.state('resultList')).toEqual({});
-        expect(fetchContentMock).toHaveBeenCalledTimes(1);
-        const partialObj = {
-            "resultList":  {
-                "query":  {
-                    "offset": "0",
-                    "query": "type: story",
-                    "size": "1",
-                },
-                 "source": 'other',
-                 "transform": expect.any(Function),
-               }
-            };
-        expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
-    });
-
-    it('should update seeMore if value is greater than storied list count', () => {
-        const fetchContentMock = jest.fn().mockReturnValue({content_elements:['elem1', 'elem2']});
-        ResultsList.prototype.getContent = fetchContentMock;
-
-        const listContentConfig = {
-            contentConfigValues: {
-              offset: '0',
-              query: 'type: story',
-              size: '1',
-            },
-            contentService: 'story-feed-query',
-        };
-        const customFields = { listContentConfig };
-
-        const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath='/pf' customFields={customFields} />);
-        fetchContentMock.mockClear();
-        wrapper.setState({ storedList: {next: 2, count: 0} });
-        wrapper.update();
-        wrapper.instance().fetchStories(true);
-
-        expect(wrapper.state('seeMore')).toBeFalsy()
-        
-    });
+    const result = ResultsList.fetchStoriesTransform(null, 'storedList');
+    expect(result).toEqual('storedList');
   });
 
-  describe('fetchStoriesTransform', () => {
+  it('if has  data, return concatenated data with storedList', () => {
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
 
-    const listContentConfig = {
-        contentConfigValues: {
-          offset: '0',
-          query: 'type: story',
-          size: '1',
-        },
-        contentService: 'story-feed-query',
-      };
-      const customFields = { listContentConfig };
-
-    it('if has no data, return storedList', () => {
-        ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
-
-        const mockDeployment = jest.fn();
-        const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath='/pf' customFields={customFields} />);
-
-        const result = wrapper.instance().fetchStoriesTransform(null, 'storedList');
-        expect(result).toEqual('storedList');
-    });
-
-    it('if has  data, return concatenated data with storedList', () => {
-        ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
-
-        const mockDeployment = jest.fn();
-        const wrapper = mount(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath='/pf' customFields={customFields} />);
-
-        const result = wrapper.instance().fetchStoriesTransform({content_elements:['A', 'B'], next:10}, {content_elements:['C', 'D']});
-        expect(result).toEqual( {"content_elements": ["C", "D", "A", "B"], "next": 10});
-    });
+    const result = ResultsList.fetchStoriesTransform({ content_elements: ['A', 'B'], next: 10 }, { content_elements: ['C', 'D'] });
+    expect(result).toEqual({ content_elements: ['C', 'D', 'A', 'B'], next: 10 });
   });
+});
 
-  describe('styled components', () => {
+describe('styled components', () => {
+  const listContentConfig = {
+    contentConfigValues: {
+      offset: '0',
+      query: 'type: story',
+      size: '1',
+    },
+    contentService: 'story-feed-query',
+  };
+  const customFields = { listContentConfig };
 
-    const listContentConfig = {
-        contentConfigValues: {
-          offset: '0',
-          query: 'type: story',
-          size: '1',
-        },
-        contentService: 'story-feed-query',
-      };
-      const customFields = { listContentConfig };
+  it('renders styled headline, read more button and description', () => {
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
+    ResultsList.prototype.getThemeStyle = jest.fn().mockReturnValue({ 'primary-font-family': 'font1' });
 
-    it('renders styled headline, read more button and description', () => {
-        ResultsList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
-        ResultsList.prototype.getThemeStyle = jest.fn().mockReturnValue({'primary-font-family':'font1'});
-        
-        const mockDeployment = jest.fn();
-        const wrapper = mount(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath='/pf' customFields={customFields} />);
-        wrapper.setState({ resultList: oneListItem });
-        wrapper.update();
+    const mockDeployment = jest.fn();
+    const wrapper = mount(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath="/pf" customFields={customFields} />);
+    wrapper.setState({ resultList: oneListItem });
+    wrapper.update();
 
-
-        expect(wrapper.find('.list-item').find('.headline-text').length).toEqual(3);
-        expect(wrapper.find('.list-item').find('.description-text').length).toEqual(3);
-
-    });
+    expect(wrapper.find('.list-item').find('.headline-text').length).toEqual(3);
+    expect(wrapper.find('.list-item').find('.description-text').length).toEqual(3);
   });
+});

--- a/blocks/results-list-block/features/results-list/internalTests.test.jsx
+++ b/blocks/results-list-block/features/results-list/internalTests.test.jsx
@@ -1,0 +1,60 @@
+
+import ResultsList from './default.jsx';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+jest.mock('fusion:properties', () => (jest.fn(() => ({
+    fallbackImage: 'http://test/resources/fallback.jpg',
+  }))));
+
+describe('getFallbackImageURL', () => {
+
+    const listContentConfig = {
+        contentConfigValues: {
+          offset: '0',
+          query: 'type: story',
+          size: '1',
+        },
+        contentService: 'story-feed-query',
+      };
+      const customFields = { listContentConfig };
+
+    it('should NOT call deployment with context path if http is contained in fallback image url', () => {
+        ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+
+        const mockDeployment = jest.fn();
+        const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath='/pf' customFields={customFields} />);
+
+        mockDeployment.mockClear();
+        const result = wrapper.instance().getFallbackImageURL();
+        expect(result).toEqual("http://test/resources/fallback.jpg");
+        expect(mockDeployment).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('fetchPlaceholder', () => {
+
+    const listContentConfig = {
+        contentConfigValues: {
+          offset: '0',
+          query: 'type: story',
+          size: '1',
+        },
+        contentService: 'story-feed-query',
+      };
+      const customFields = { listContentConfig };
+
+    it('should call fetchContent if fallback image contains resources', () => {
+        const fetchContentMock = jest.fn().mockReturnValue({});
+        ResultsList.prototype.fetchContent = fetchContentMock;
+        const mockDeployment = jest.fn();
+        const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath='/pf' customFields={customFields} />);
+        mockDeployment.mockClear();
+        expect(mockDeployment).toHaveBeenCalledTimes(0);
+        wrapper.instance().fetchPlaceholder();
+
+
+        expect(fetchContentMock).toHaveBeenCalledTimes(1);
+        expect(fetchContentMock).toHaveBeenCalledWith({"resultList": {"query": {"offset": "0", "query": "type: story", "size": "1"}, "source": "story-feed-query"}});
+    });
+  });


### PR DESCRIPTION
## Description
Updated footer so the social icons are rendered using the configured primary color.
Updated results lists so that its read more button is rendered using the configured primary color.

## Jira Ticket
- [PEN-1381](https://arcpublishing.atlassian.net/browse/PEN-1381)

## Acceptance Criteria

The See More button (on both the Results List) and the Footer Icons do not use the customer's primary color Theme Setting. Instead, it seems to be hard-coded to use a blue color: https://corecomponents.arcpublishing.com/pf/all-blocks/?_website=dagen
This button should inherit the website's primary color, which in this case (for the Dagen website) is a red – like some other blocks already do correctly https://github.com/WPMedia/Fusion-News-Theme/blob/master/blocks.json#L207


## Test Steps

1. Checkout branch
2. data restore from core components production pb data tile
3. npm fusion start
4. visit the local page:      http://localhost/pf/all-blocks/?_website=dagen
5. confirm that the Results List block is rendered useing the configured primary color (for Dagen it is a dark red)
6. Confirm that the Footer social icons and border are rendered using the configured primary color ( for Dagen it is a dark red color)

## Effect Of Changes
### Before
Results list Read More button is hard coded to be blue.

Footer social icons and border are hard coded to be blue.

### After
Results list Read More button uses the configured primary color.

Footer social icons and border use configured primary color.


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json- NONE
- Changes to the custom fields which will require users to reconfigure features - NONE
- Update to css framework or SDK - NONE
- Dependency on another PR that needs to be merged first - NONE

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ x] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [x ] Confirmed this PR has reasonable code coverage
  - [x ] Confirmed this PR has unit test files
  - [ x] Ran `npm test`, made sure all tests are passing
  - [x ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x ] Confirmed relevant documentation has been updated/added.
