### PR TITLE
PEN-1402: README update

### DIFF
--- a/News Theme Development.md
+++ b/News Theme Development.md
@@ -107,7 +107,7 @@ npm i
 npx lerna bootstrap
 ```
 
-As of 10/13/2020, In fusion-news-theme-blocks, Blocks/header-nav-chain-block us-debounce which needs to be installed manually. Navigate to this block, copy .npmrc file to this dir, do npm install, the (re)start fusion 
+As of 10/13/2020, In fusion-news-theme-blocks, Blocks/header-nav-chain-block use-debounce which needs to be installed manually. Navigate to this block, copy .npmrc file to this dir, do npm install, the (re)start fusion. You can also look into setting up a [global npmrc configuration](https://docs.npmjs.com/cli-commands/config.html).
 ```sh
 cd blocks/header-nav-chain-block
 check .npmrc file here exists

--- a/News Theme Development.md
+++ b/News Theme Development.md
@@ -78,6 +78,54 @@ The development process is similar engine-theme-sdk, except when it comes time t
 
 Note: When publishing, you will need a .npmrc file that gives you access to the private NPM repo. Reach out to a team member to get this.
 
+Local development work on  fusion-news-theme-blocks can be set up so that the changes you make on your local fusion-news-theme-blocks  can be manifested within another local client code base, or Fusion-News-Theme.  
+
+Update the client code base .env file to include:
+```sh
+CONTENT_BASE=https://api.corecomponents.arcpublishing.com OR Client content base
+ARC_ACCESS_TOKEN=XXX access token generated from client Developer Center
+FUSION_RELEASE=2.6.3-blockrelease.1 //OR latest fusion block release
+DEBUG=fusion:* //May comment this out if extra fusion logging is not desired
+THEMES_BLOCKS_REPO=/path/to/local/fusion-news-theme-blocks/directory
+CONTEXT_PATH=pf
+resizerURL=//client resizer url
+resizerKey=//unencrypted client resizer key
+WATCH=true
+DB_NAME=Fusion_News_Theme
+COMPOSE_HTTP_TIMEOUT=240
+DOCKER_CLIENT_TIMEOUT=240
+BLOCK_DIST_TAG=canary
+CSS_DIST_TAG=canary
+ENGINE_SDK_DIST_TAG=canary
+```
+
+Within fusion-news-theme-blocks directory root, run the following:
+```sh
+rm -rf ./node_modules
+npx lerna clean
+npm i
+npx lerna bootstrap
+```
+
+As of 10/13/2020, In fusion-news-theme-blocks, Blocks/header-nav-chain-block us-debounce which needs to be installed manually. Navigate to this block, copy .npmrc file to this dir, do npm install, the (re)start fusion 
+```sh
+cd blocks/header-nav-chain-block
+check .npmrc file here exists
+npm install
+```
+then restart fusion from within client dir (fusion-news-theme):
+```sh
+npm fusion start -l
+```
+
+To check if blocks are being properly linked, run:
+```sh
+ cat .fusion/docker-compose.yml
+ ```
+  If blocks linking was successful, you'll see the listing for volumes with all the block names linked. 
+
+  NOTE:  'npm fusion' will use the  globally available fusion, but using 'npx fusion' will use the local fusion available from within the folder
+
 ### Development Process
 
 1. Pull the latest `canary` branch:

--- a/News Theme Development.md
+++ b/News Theme Development.md
@@ -115,7 +115,7 @@ npm install
 ```
 then restart fusion from within client dir (fusion-news-theme):
 ```sh
-npm fusion start -l
+npx fusion start -l
 ```
 
 To check if blocks are being properly linked, run:


### PR DESCRIPTION
## Description
Updated News Theme Development.md  based on working session with Nelson

## Jira Ticket
- [PEN-1402](https://arcpublishing.atlassian.net/browse/PEN-1402)

## Acceptance Criteria
Current News Theme Development.md for fusion-news-theme-blocks repo could be improved for engineers setting up their local environment for themes blocks development. 

## Test Steps
NONE - only inspection of documentation News Theme Development.md  is required to test. No code has been touched as part of this change.

## Effect Of Changes
### Before
News Theme Development.md has smaller section on "fusion-news-theme-blocks"

<img width="985" alt="Screen Shot 2020-10-13 at 10 50 46 AM" src="https://user-images.githubusercontent.com/2664083/95877454-1f5b1e80-0d42-11eb-9503-a0ed38a221de.png">


### After
News Theme Development.md   section on "fusion-news-theme-blocks" is fleshed out.

<img width="1478" alt="Screen Shot 2020-10-13 at 10 50 02 AM" src="https://user-images.githubusercontent.com/2664083/95877473-241fd280-0d42-11eb-8bb2-32f1a6bbb500.png">

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json - NONE
- Changes to the custom fields which will require users to reconfigure features - NONE
- Update to css framework or SDK - NONE
- Dependency on another PR that needs to be merged first - NONE

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ x] Confirmed all the test steps above are working
- [ x] Confirmed there are no linter errors
- [ x] Confirmed this PR has reasonable code coverage
  - [x ] Confirmed this PR has unit test files
  - [x ] Ran `npm test`, made sure all tests are passing
  - [ x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x ] Confirmed relevant documentation has been updated/added.
