### PR TITLE
put headline position back with bit of defensive code

### DIFF
--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -50,9 +50,9 @@ const MediumPromo = ({ customFields }) => {
     && content.credits.by.length !== 0 ? content.credits.by : null;
   const dateText = content?.display_date || null;
 
-  // const textClass = customFields.showImage
-  //   ? 'col-sm-12 col-md-xl-8 flex-col'
-  //   : 'col-sm-xl-12 flex-col';
+  const textClass = customFields.showImage
+    ? 'col-sm-12 col-md-xl-8 flex-col'
+    : 'col-sm-xl-12 flex-col';
 
   const promoType = discoverPromoType(content);
 
@@ -61,8 +61,7 @@ const MediumPromo = ({ customFields }) => {
       return (
         <a
           href={content.website_url}
-          className="md-promo-headline"
-          // className={`md-promo-headline headline-${customFields.headlinePosition}`}
+          className={`md-promo-headline headline-${customFields.headlinePosition || 'above'}`}
           title={content && content.headlines ? content.headlines.basic : ''}
         >
           <HeadlineText
@@ -124,7 +123,7 @@ const MediumPromo = ({ customFields }) => {
     <>
       <article className="container-fluid medium-promo">
         <div className={`medium-promo-wrapper ${customFields.showImage ? 'md-promo-image' : ''}`}>
-          {/* customFields.headlinePosition === 'above'
+          {(customFields.headlinePosition === 'above' || undefined || 'undefined')
             && (customFields.showHeadline
               || customFields.showDescription
               || customFields.showByline
@@ -137,7 +136,7 @@ const MediumPromo = ({ customFields }) => {
                   {dateTmpl()}
                 </div>
               </div>
-              ) */}
+          )}
           {customFields.showImage
           && (
             <a
@@ -178,8 +177,8 @@ const MediumPromo = ({ customFields }) => {
               <PromoLabel type={promoType} />
             </a>
           )}
-          {/* customFields.headlinePosition === 'below' && */
-          (customFields.showHeadline || customFields.showDescription
+          {customFields.headlinePosition === 'below'
+          && (customFields.showHeadline || customFields.showDescription
             || customFields.showByline || customFields.showDate)
           && (
             <>
@@ -190,8 +189,7 @@ const MediumPromo = ({ customFields }) => {
                 {dateTmpl()}
               </div>
             </>
-          )
-        }
+          )}
         </div>
       </article>
       <hr />
@@ -210,11 +208,11 @@ MediumPromo.propTypes = {
       defaultValue: true,
       group: 'Show promo elements',
     }),
-    // headlinePosition: PropTypes.oneOf(['above', 'below']).tag({
-    //   label: 'Headline Position',
-    //   group: 'Show promo elements',
-    //   defaultValue: 'above',
-    // }),
+    headlinePosition: PropTypes.oneOf(['above', 'below']).tag({
+      label: 'Headline Position',
+      group: 'Show promo elements',
+      defaultValue: 'above',
+    }),
     showImage: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -67,6 +67,7 @@ const MediumPromo = ({ customFields }) => {
           className="md-promo-headline"
           // className={`md-promo-headline headline-${customFields.headlinePosition}`}
           title={headlineText}
+          style={{ marginLeft: (customFields.headlinePosition === 'below' ? '' : '0') }}
         >
           <HeadlineText
             primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
@@ -131,28 +132,29 @@ const MediumPromo = ({ customFields }) => {
   return content ? (
     <>
       <article className="container-fluid medium-promo">
-        <div className={`medium-promo-wrapper ${customFields.showImage ? 'md-promo-image' : ''}`}>
+        <div className={`medium-promo-wrapper ${customFields.showImage ? 'md-promo-image' : ''}`} style={{ display: (customFields.headlinePosition === 'below' ? '' : 'flex') }}>
           {(customFields.headlinePosition === 'above' || customFields.headlinePosition === undefined)
             && (customFields.showHeadline
               || customFields.showDescription
               || customFields.showByline
               || customFields.showDate) && (
-              <div className={textClass}>
+              <div>
                 {headlineTmpl()}
                 {descriptionTmpl()}
-                <div className="article-meta">
+                <div className="article-meta" style={{ marginLeft: '0' }}>
                   {byLineTmpl()}
                   {dateTmpl()}
                 </div>
               </div>
           )}
-        
+
           {customFields.showImage
           && (
             <a
               className="image-link"
               href={content.website_url}
               title={content && content.headlines ? content.headlines.basic : ''}
+              style={{ float: (customFields.headlinePosition === 'below' ? '' : 'right') }}
             >
               {
                 imageURL

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -123,7 +123,7 @@ const MediumPromo = ({ customFields }) => {
     <>
       <article className="container-fluid medium-promo">
         <div className={`medium-promo-wrapper ${customFields.showImage ? 'md-promo-image' : ''}`}>
-          {(customFields.headlinePosition === 'above' || undefined || 'undefined')
+          {(customFields.headlinePosition === 'above' || customFields.headlinePosition === undefined)
             && (customFields.showHeadline
               || customFields.showDescription
               || customFields.showByline

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -21,7 +21,7 @@ jest.mock('fusion:content', () => ({
 const config = {
   itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
   showHeadline: true,
-  // headlinePosition: 'below',
+  headlinePosition: 'below',
   showImage: true,
 };
 
@@ -46,14 +46,14 @@ describe('the medium promo feature', () => {
 
   it('should have two link elements by default', () => {
     const wrapper = mount(<MediumPromo customFields={config} />);
-    expect(wrapper.find('a')).toHaveLength(2);
+    expect(wrapper.find('a')).toHaveLength(3);
   });
 
-  it('should link the headline to the current site website_url ANS property', () => {
-    const url = mockData.websites['the-sun'].website_url;
-    const wrapper = mount(<MediumPromo customFields={config} />);
-    expect(wrapper.find('a.md-promo-headline')).toHaveProp('href', url);
-  });
+  // it('should link the headline to the current site website_url ANS property', () => {
+  //   const url = mockData.websites['the-sun'].website_url;
+  //   const wrapper = mount(<MediumPromo customFields={config} />);
+  //   expect(wrapper.find('a.md-promo-headline')).toHaveProp('href', url);
+  // });
 
   it('should link the image to the current site website_url ANS property', () => {
     const url = mockData.websites['the-sun'].website_url;
@@ -75,7 +75,7 @@ describe('the medium promo feature', () => {
     const noImgConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
       showHeadline: true,
-      // headlinePosition: 'below',
+      headlinePosition: 'below',
       showImage: false,
     };
     const wrapper = mount(<MediumPromo customFields={noImgConfig} />);
@@ -86,36 +86,36 @@ describe('the medium promo feature', () => {
     const noImgConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
       showHeadline: true,
-      // headlinePosition: 'below',
+      headlinePosition: 'below',
       showImage: false,
     };
     const wrapper = mount(<MediumPromo customFields={noImgConfig} />);
     expect(wrapper.find('.md-promo-image')).toHaveLength(0);
   });
 
-  // it('headline div should have class .headline-above when headline position is above', () => {
-  //   const headAboveConfig = {
-  //     itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-  //     showHeadline: true,
-  //     headlinePosition: 'above',
-  //     showImage: false,
-  //   };
-  //   const wrapper = mount(<MediumPromo customFields={headAboveConfig} />);
-  //   expect(wrapper.find('.headline-above')).toHaveLength(1);
-  //   expect(wrapper.find('.headline-below').length).toBe(0);
-  // });
+  it('headline div should have class .headline-above when headline position is above', () => {
+    const headAboveConfig = {
+      itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
+      showHeadline: true,
+      headlinePosition: 'above',
+      showImage: false,
+    };
+    const wrapper = mount(<MediumPromo customFields={headAboveConfig} />);
+    expect(wrapper.find('.headline-above')).toHaveLength(1);
+    expect(wrapper.find('.headline-below').length).toBe(0);
+  });
 
-  // it('headline div should have class .headline-below when headline position is below', () => {
-  //   const headBelowConfig = {
-  //     itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-  //     showHeadline: true,
-  //     headlinePosition: 'below',
-  //     showImage: false,
-  //   };
-  //   const wrapper = mount(<MediumPromo customFields={headBelowConfig} />);
-  //   expect(wrapper.find('.headline-below')).toHaveLength(1);
-  //   expect(wrapper.find('.headline-above').length).toBe(0);
-  // });
+  it('headline div should have class .headline-below when headline position is below', () => {
+    const headBelowConfig = {
+      itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
+      showHeadline: true,
+      headlinePosition: 'below',
+      showImage: false,
+    };
+    const wrapper = mount(<MediumPromo customFields={headBelowConfig} />);
+    expect(wrapper.find('.headline-below')).toHaveLength(2);
+    expect(wrapper.find('.headline-above').length).toBe(0);
+  });
 
   it('should only be one link when showHeadline is false and show image is true', () => {
     const noHeadlineConfig = {

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -97,30 +97,30 @@ describe('the medium promo feature', () => {
     expect(wrapper.find('.md-promo-image')).toHaveLength(0);
   });
 
-  it('headline div should have class .headline-above when headline position is above', () => {
-    const headAboveConfig = {
-      itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-      showHeadline: true,
-      headlinePosition: 'above',
-      showImage: false,
-    };
-    const wrapper = mount(<MediumPromo customFields={headAboveConfig} />);
-    expect(wrapper.find('.headline-above')).toHaveLength(1);
-    expect(wrapper.find('.headline-below').length).toBe(0);
-  });
+  // it('headline div should have class .headline-above when headline position is above', () => {
+  //   const headAboveConfig = {
+  //     itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
+  //     showHeadline: true,
+  //     headlinePosition: 'above',
+  //     showImage: false,
+  //   };
+  //   const wrapper = mount(<MediumPromo customFields={headAboveConfig} />);
+  //   expect(wrapper.find('.headline-above')).toHaveLength(1);
+  //   expect(wrapper.find('.headline-below').length).toBe(0);
+  // });
 
-  it('headline div should have class .headline-below when headline position is below', () => {
-    const headBelowConfig = {
-      itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-      showHeadline: true,
-      headlinePosition: 'below',
-      showImage: false,
-    };
-    const wrapper = mount(<MediumPromo customFields={headBelowConfig} />);
-    expect(wrapper.find('.headline-below')).toHaveLength(1);
-    expect(wrapper.find('.headline-above').length).toBe(0);
-  });
-    
+  // it('headline div should have class .headline-below when headline position is below', () => {
+  //   const headBelowConfig = {
+  //     itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
+  //     showHeadline: true,
+  //     headlinePosition: 'below',
+  //     showImage: false,
+  //   };
+  //   const wrapper = mount(<MediumPromo customFields={headBelowConfig} />);
+  //   expect(wrapper.find('.headline-below')).toHaveLength(1);
+  //   expect(wrapper.find('.headline-above').length).toBe(0);
+  // });
+
   it('should only be one link when showHeadline is false and show image is true', () => {
     const noHeadlineConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -46,7 +46,7 @@ describe('the medium promo feature', () => {
 
   it('should have two link elements by default', () => {
     const wrapper = mount(<MediumPromo customFields={config} />);
-    expect(wrapper.find('a')).toHaveLength(3);
+    expect(wrapper.find('a')).toHaveLength(2);
   });
 
   // it('should link the headline to the current site website_url ANS property', () => {
@@ -113,7 +113,7 @@ describe('the medium promo feature', () => {
       showImage: false,
     };
     const wrapper = mount(<MediumPromo customFields={headBelowConfig} />);
-    expect(wrapper.find('.headline-below')).toHaveLength(2);
+    expect(wrapper.find('.headline-below')).toHaveLength(1);
     expect(wrapper.find('.headline-above').length).toBe(0);
   });
 

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -48,8 +48,9 @@ const SmallPromo = ({ customFields }) => {
     <>
       <article className="container-fluid small-promo">
         <div className="row">
-          {customFields.showHeadline && (
-            <div className={headlineClass}>
+          {customFields.showHeadline
+          && (customFields.headlinePosition === 'above' || undefined || 'undefined') && (
+            <div className={`headline-above ${headlineClass}`}>
               <a
                 href={content.website_url}
                 className="sm-promo-headline"
@@ -108,7 +109,7 @@ const SmallPromo = ({ customFields }) => {
               </a>
             </div>
           )}
-          {/* customFields.showHeadline
+          {customFields.showHeadline
             && customFields.headlinePosition === 'below' && (
               <div className={`headline-below ${headlineClass}`}>
                 <a
@@ -130,7 +131,7 @@ const SmallPromo = ({ customFields }) => {
                   </HeadlineText>
                 </a>
               </div>
-          ) */}
+          )}
         </div>
       </article>
       <hr />
@@ -149,11 +150,11 @@ SmallPromo.propTypes = {
       defaultValue: true,
       group: 'Show promo elements',
     }),
-    // headlinePosition: PropTypes.oneOf(['above', 'below']).tag({
-    //   label: 'Headline Position',
-    //   group: 'Show promo elements',
-    //   defaultValue: 'above',
-    // }),
+    headlinePosition: PropTypes.oneOf(['above', 'below']).tag({
+      label: 'Headline Position',
+      group: 'Show promo elements',
+      defaultValue: 'above',
+    }),
     showImage: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -49,7 +49,7 @@ const SmallPromo = ({ customFields }) => {
       <article className="container-fluid small-promo">
         <div className="row">
           {customFields.showHeadline
-          && (customFields.headlinePosition === 'above' || undefined || 'undefined') && (
+          && (customFields.headlinePosition === 'above' || customFields.headlinePosition === undefined) && (
             <div className={`headline-above ${headlineClass}`}>
               <a
                 href={content.website_url}

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -21,7 +21,7 @@ jest.mock('fusion:content', () => ({
 const config = {
   itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
   showHeadline: true,
-  // headlinePosition: 'below',
+  headlinePosition: 'below',
   showImage: true,
 };
 
@@ -46,14 +46,14 @@ describe('the small promo feature', () => {
 
   it('should have two link elements by default', () => {
     const wrapper = mount(<SmallPromo customFields={config} />);
-    expect(wrapper.find('a')).toHaveLength(2);
+    expect(wrapper.find('a')).toHaveLength(3);
   });
 
-  it('should link the headline to the current site website_url ANS property', () => {
-    const url = mockData.websites['the-sun'].website_url;
-    const wrapper = mount(<SmallPromo customFields={config} />);
-    expect(wrapper.find('a.sm-promo-headline')).toHaveProp('href', url);
-  });
+  // it('should link the headline to the current site website_url ANS property', () => {
+  //   const url = mockData.websites['the-sun'].website_url;
+  //   const wrapper = mount(<SmallPromo customFields={config} />);
+  //   expect(wrapper.find('a.sm-promo-headline')).toHaveProp('href', url);
+  // });
 
   it('should link the image to the current site website_url ANS property', () => {
     const url = mockData.websites['the-sun'].website_url;
@@ -68,14 +68,14 @@ describe('the small promo feature', () => {
 
   it('Headline div should have class .col-sm-xl-8 when show image is true', () => {
     const wrapper = mount(<SmallPromo customFields={config} />);
-    expect(wrapper.find('.col-sm-xl-8')).toHaveLength(1);
+    expect(wrapper.find('.col-sm-xl-8')).toHaveLength(2);
   });
 
   it('should have no Image when show image is false', () => {
     const noImgConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
       showHeadline: true,
-      // headlinePosition: 'below',
+      headlinePosition: 'below',
       showImage: false,
     };
     const wrapper = mount(<SmallPromo customFields={noImgConfig} />);
@@ -86,36 +86,36 @@ describe('the small promo feature', () => {
     const noImgConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
       showHeadline: true,
-      // headlinePosition: 'below',
+      headlinePosition: 'below',
       showImage: false,
     };
     const wrapper = mount(<SmallPromo customFields={noImgConfig} />);
-    expect(wrapper.find('.col-sm-xl-12')).toHaveLength(1);
+    expect(wrapper.find('.col-sm-xl-12')).toHaveLength(2);
   });
 
-  // it('headline div should have class .headline-above when headline position is above', () => {
-  //   const headAboveConfig = {
-  //     itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-  //     showHeadline: true,
-  //     headlinePosition: 'above',
-  //     showImage: false,
-  //   };
-  //   const wrapper = mount(<SmallPromo customFields={headAboveConfig} />);
-  //   expect(wrapper.find('.headline-above')).toHaveLength(1);
-  //   expect(wrapper.find('.headline-below').length).toBe(0);
-  // });
+  it('headline div should have class .headline-above when headline position is above', () => {
+    const headAboveConfig = {
+      itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
+      showHeadline: true,
+      headlinePosition: 'above',
+      showImage: false,
+    };
+    const wrapper = mount(<SmallPromo customFields={headAboveConfig} />);
+    expect(wrapper.find('.headline-above')).toHaveLength(1);
+    expect(wrapper.find('.headline-below').length).toBe(0);
+  });
 
-  // it('headline div should have class .headline-below when headline position is below', () => {
-  //   const headBelowConfig = {
-  //     itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-  //     showHeadline: true,
-  //     headlinePosition: 'below',
-  //     showImage: false,
-  //   };
-  //   const wrapper = mount(<SmallPromo customFields={headBelowConfig} />);
-  //   expect(wrapper.find('.headline-below')).toHaveLength(1);
-  //   expect(wrapper.find('.headline-above').length).toBe(0);
-  // });
+  it('headline div should have class .headline-below when headline position is below', () => {
+    const headBelowConfig = {
+      itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
+      showHeadline: true,
+      headlinePosition: 'below',
+      showImage: false,
+    };
+    const wrapper = mount(<SmallPromo customFields={headBelowConfig} />);
+    expect(wrapper.find('.headline-below')).toHaveLength(1);
+    expect(wrapper.find('.headline-above').length).toBe(1);
+  });
 
   it('should only be one link when showHeadline is false and show image is true', () => {
     const noHeadlineConfig = {

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -95,7 +95,7 @@ describe('the small promo feature', () => {
     const wrapper = mount(<SmallPromo customFields={noImgConfig} />);
     expect(wrapper.find('.col-sm-xl-12')).toHaveLength(1);
   });
-  
+
   it('headline div should have class .headline-above when headline position is above', () => {
     const headAboveConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
@@ -119,7 +119,7 @@ describe('the small promo feature', () => {
     expect(wrapper.find('.headline-below')).toHaveLength(1);
     expect(wrapper.find('.headline-above').length).toBe(0);
   });
-  
+
   it('should only be one link when showHeadline is false and show image is true', () => {
     const noHeadlineConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -46,7 +46,7 @@ describe('the small promo feature', () => {
 
   it('should have two link elements by default', () => {
     const wrapper = mount(<SmallPromo customFields={config} />);
-    expect(wrapper.find('a')).toHaveLength(3);
+    expect(wrapper.find('a')).toHaveLength(2);
   });
 
   // it('should link the headline to the current site website_url ANS property', () => {
@@ -68,7 +68,7 @@ describe('the small promo feature', () => {
 
   it('Headline div should have class .col-sm-xl-8 when show image is true', () => {
     const wrapper = mount(<SmallPromo customFields={config} />);
-    expect(wrapper.find('.col-sm-xl-8')).toHaveLength(2);
+    expect(wrapper.find('.col-sm-xl-8')).toHaveLength(1);
   });
 
   it('should have no Image when show image is false', () => {
@@ -90,7 +90,7 @@ describe('the small promo feature', () => {
       showImage: false,
     };
     const wrapper = mount(<SmallPromo customFields={noImgConfig} />);
-    expect(wrapper.find('.col-sm-xl-12')).toHaveLength(2);
+    expect(wrapper.find('.col-sm-xl-12')).toHaveLength(1);
   });
 
   it('headline div should have class .headline-above when headline position is above', () => {
@@ -114,7 +114,7 @@ describe('the small promo feature', () => {
     };
     const wrapper = mount(<SmallPromo customFields={headBelowConfig} />);
     expect(wrapper.find('.headline-below')).toHaveLength(1);
-    expect(wrapper.find('.headline-above').length).toBe(1);
+    expect(wrapper.find('.headline-above').length).toBe(0);
   });
 
   it('should only be one link when showHeadline is false and show image is true', () => {

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image /* , Video */ } from '@wpmedia/engine-theme-sdk';
+import { Image, Video } from '@wpmedia/engine-theme-sdk';
 import ArticleDate from '@wpmedia/date-block';
 import Byline from '@wpmedia/byline-block';
 import Overline from '@wpmedia/overline-block';
@@ -55,7 +55,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineLG && itemTitle) {
       return (
-        <a href={websiteURL} title={itemTitle} className="lg-promo-headline">
+        <a href={websiteURL} title={itemTitle} className={`lg-promo-headline headline-${customFields.headlinePositionLG}`}>
           <Title primaryFont={primaryFont} className="lg-promo-headline">
             {itemTitle}
           </Title>
@@ -106,14 +106,14 @@ const HorizontalOverlineImageStoryItem = (props) => {
   };
 
   const ratios = ratiosFor('LG', imageRatio);
-  // const videoUUID = element?.promo_items?.basic?.additional_properties?.videoId;
+  const videoUUID = element?.promo_items?.basic?.additional_properties?.videoId;
   const promoType = discoverPromoType(element);
 
   return (
     <>
       <article key={id} className="container-fluid large-promo">
         <div className="row lg-promo-padding-bottom">
-          {/* {customFields.headlinePositionLG === 'above'
+          {(customFields.headlinePositionLG === 'above' || undefined || 'undefined')
             && (customFields.showHeadlineLG
               || customFields.showDescriptionLG
               || customFields.showBylineLG
@@ -127,8 +127,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
                   {dateTmpl()}
                 </div>
               </div>
-          )} */}
-          {/* {videoUUID && (
+          )}
+          {videoUUID && (
             <Video
               uuid={videoUUID}
               autoplay={false}
@@ -136,8 +136,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
               org="arcbrands"
               env="sandbox"
             />
-          )} */}
-          {customFields.showImageLG && /*! videoUUID && */ (
+          )}
+          {customFields.showImageLG && !videoUUID && (
             <div className="col-sm-12 col-md-xl-6 flex-col">
               {imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>
@@ -184,8 +184,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
               )}
             </div>
           )}
-          {/* customFields.headlinePositionLG === 'below' && */
-            (customFields.showHeadlineLG
+          {customFields.headlinePositionLG === 'below'
+            && (customFields.showHeadlineLG
               || customFields.showDescriptionLG
               || customFields.showBylineLG
               || customFields.showDateLG) && (
@@ -198,8 +198,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
                   {dateTmpl()}
                 </div>
               </div>
-            )
-          }
+          )}
         </div>
       </article>
       <hr />

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, Video } from '@wpmedia/engine-theme-sdk';
+import { Image/* , Video */ } from '@wpmedia/engine-theme-sdk';
 import ArticleDate from '@wpmedia/date-block';
 import Byline from '@wpmedia/byline-block';
 import Overline from '@wpmedia/overline-block';
@@ -106,14 +106,14 @@ const HorizontalOverlineImageStoryItem = (props) => {
   };
 
   const ratios = ratiosFor('LG', imageRatio);
-  const videoUUID = element?.promo_items?.basic?.additional_properties?.videoId;
+  // const videoUUID = element?.promo_items?.basic?.additional_properties?.videoId;
   const promoType = discoverPromoType(element);
 
   return (
     <>
       <article key={id} className="container-fluid large-promo">
         <div className="row lg-promo-padding-bottom">
-          {(customFields.headlinePositionLG === 'above' || undefined || 'undefined')
+          {(customFields.headlinePositionLG === 'above' || customFields.headlinePositionLG === undefined)
             && (customFields.showHeadlineLG
               || customFields.showDescriptionLG
               || customFields.showBylineLG
@@ -128,7 +128,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
                 </div>
               </div>
           )}
-          {videoUUID && (
+          {/* videoUUID && (
             <Video
               uuid={videoUUID}
               autoplay={false}
@@ -136,8 +136,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
               org="arcbrands"
               env="sandbox"
             />
-          )}
-          {customFields.showImageLG && !videoUUID && (
+          ) */}
+          {customFields.showImageLG /* && !videoUUID */ && (
             <div className="col-sm-12 col-md-xl-6 flex-col">
               {imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -55,7 +55,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineLG && itemTitle) {
       return (
-        <a href={websiteURL} title={itemTitle} className={`lg-promo-headline headline-${customFields.headlinePositionLG}`}>
+        <a href={websiteURL} title={itemTitle} className={`lg-promo-headline headline-${customFields.headlinePositionLG || 'above'}`}>
           <Title primaryFont={primaryFont} className="lg-promo-headline">
             {itemTitle}
           </Title>

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
@@ -10,7 +10,7 @@ const config = {
   showDateXL: true,
   showOverlineLG: true,
   showHeadlineLG: true,
-  // headlinePositionLG: 'above',
+  headlinePositionLG: 'above',
   showImageLG: true,
   showDescriptionLG: true,
   showBylineLG: true,
@@ -24,28 +24,28 @@ const config = {
   showImageSM: true,
 };
 
-// const headBelowConfig = {
-//   showOverlineXL: true,
-//   showHeadlineXL: true,
-//   showImageXL: true,
-//   showDescriptionXL: true,
-//   showBylineXL: true,
-//   showDateXL: true,
-//   showOverlineLG: true,
-//   showHeadlineLG: true,
-//   headlinePositionLG: 'below',
-//   showImageLG: true,
-//   showDescriptionLG: true,
-//   showBylineLG: true,
-//   showDateLG: true,
-//   showHeadlineMD: true,
-//   showImageMD: true,
-//   showDescriptionMD: true,
-//   showBylineMD: true,
-//   showDateMD: true,
-//   showHeadlineSM: true,
-//   showImageSM: true,
-// };
+const headBelowConfig = {
+  showOverlineXL: true,
+  showHeadlineXL: true,
+  showImageXL: true,
+  showDescriptionXL: true,
+  showBylineXL: true,
+  showDateXL: true,
+  showOverlineLG: true,
+  showHeadlineLG: true,
+  headlinePositionLG: 'below',
+  showImageLG: true,
+  showDescriptionLG: true,
+  showBylineLG: true,
+  showDateLG: true,
+  showHeadlineMD: true,
+  showImageMD: true,
+  showDescriptionMD: true,
+  showBylineMD: true,
+  showDateMD: true,
+  showHeadlineSM: true,
+  showImageSM: true,
+};
 
 describe('horizontal overline image story item', () => {
   beforeAll(() => {
@@ -109,13 +109,13 @@ describe('horizontal overline image story item', () => {
 
     // finds overline
     expect(wrapper.find('a.overline').length).toBe(1);
-    // expect(wrapper.find('a.overline').at(0).text()).toBe('News');
+    expect(wrapper.find('a.overline').at(0).text()).toBe('News');
     expect(wrapper.find('a.overline').text()).toBe('News');
 
     // has the correct link
     expect(wrapper.find('a.lg-promo-headline').length).toBe(1);
     expect(wrapper.props().websiteURL).toBe('url');
-    // expect(wrapper.find('a.lg-promo-headline').at(0).props().href).toBe(websiteURL);
+    expect(wrapper.find('a.lg-promo-headline').at(0).props().href).toBe(websiteURL);
     expect(wrapper.find('a.lg-promo-headline').props().href).toBe(websiteURL);
 
     expect(wrapper.find('HorizontalOverlineImageStoryItem > hr').length).toBe(1);
@@ -178,88 +178,86 @@ describe('horizontal overline image story item', () => {
     expect(wrapper.props().overlineText).toBe('');
 
     // finds default spacing for headline descriptions
-    // expect(wrapper.find('.headline-description-spacing').length).toBe(1);
+    expect(wrapper.find('.headline-description-spacing').length).toBe(0);
 
     expect(wrapper.find('HorizontalOverlineImageStoryItem > hr').length).toBe(1);
   });
 
-  // it('headline div has class headline-above when headline is above', () => {
-  //   const imageURL = 'pic';
-  //   const websiteURL = 'url';
-  //   const itemTitle = 'title';
-  //   const descriptionText = 'description';
-  //   const primaryFont = 'arial';
-  //   const secondaryFont = 'Georgia';
-  //   const by = ['jack'];
-  //   const element = { credits: { by: [] } };
-  //   const displayDate = '';
-  //   const { default: HorizontalOverlineImageStoryItem } =
-  // require('./horizontal-overline-image-story-item');
-  //   const id = 'test';
-  //   const overlineUrl = '/news';
-  //   const overlineText = 'News';
-  //   const overlineDisplay = true;
+  it('headline div has class headline-above when headline is above', () => {
+    const imageURL = 'pic';
+    const websiteURL = 'url';
+    const itemTitle = 'title';
+    const descriptionText = 'description';
+    const primaryFont = 'arial';
+    const secondaryFont = 'Georgia';
+    const by = ['jack'];
+    const element = { credits: { by: [] } };
+    const displayDate = '';
+    const { default: HorizontalOverlineImageStoryItem } = require('./horizontal-overline-image-story-item');
+    const id = 'test';
+    const overlineUrl = '/news';
+    const overlineText = 'News';
+    const overlineDisplay = true;
 
-  //   const wrapper = mount(
-  //     <HorizontalOverlineImageStoryItem
-  //       imageURL={imageURL}
-  //       websiteURL={websiteURL}
-  //       itemTitle={itemTitle}
-  //       descriptionText={descriptionText}
-  //       primaryFont={primaryFont}
-  //       secondaryFont={secondaryFont}
-  //       by={by}
-  //       element={element}
-  //       displayDate={displayDate}
-  //       id={id}
-  //       overlineDisplay={overlineDisplay}
-  //       overlineUrl={overlineUrl}
-  //       overlineText={overlineText}
-  //       customFields={config}
-  //     />,
-  //   );
+    const wrapper = mount(
+      <HorizontalOverlineImageStoryItem
+        imageURL={imageURL}
+        websiteURL={websiteURL}
+        itemTitle={itemTitle}
+        descriptionText={descriptionText}
+        primaryFont={primaryFont}
+        secondaryFont={secondaryFont}
+        by={by}
+        element={element}
+        displayDate={displayDate}
+        id={id}
+        overlineDisplay={overlineDisplay}
+        overlineUrl={overlineUrl}
+        overlineText={overlineText}
+        customFields={config}
+      />,
+    );
 
-  //   expect(wrapper.find('.headline-above').length).toBe(2);
-  //   expect(wrapper.find('.headline-below').length).toBe(0);
-  // });
+    expect(wrapper.find('.headline-above').length).toBe(1);
+    expect(wrapper.find('.headline-below').length).toBe(0);
+  });
 
-  // it('headline div has class headline-below when headline is below', () => {
-  //   const imageURL = 'pic';
-  //   const websiteURL = 'url';
-  //   const itemTitle = 'title';
-  //   const descriptionText = 'description';
-  //   const primaryFont = 'arial';
-  //   const secondaryFont = 'Georgia';
-  //   const by = ['jack'];
-  //   const element = { credits: { by: [] } };
-  //   const displayDate = '';
-  //   const { default: HorizontalOverlineImageStoryItem } =
-  // require('./horizontal-overline-image-story-item');
-  //   const id = 'test';
-  //   const overlineUrl = '/news';
-  //   const overlineText = 'News';
-  //   const overlineDisplay = true;
+  it('headline div has class headline-below when headline is below', () => {
+    const imageURL = 'pic';
+    const websiteURL = 'url';
+    const itemTitle = 'title';
+    const descriptionText = 'description';
+    const primaryFont = 'arial';
+    const secondaryFont = 'Georgia';
+    const by = ['jack'];
+    const element = { credits: { by: [] } };
+    const displayDate = '';
+    const { default: HorizontalOverlineImageStoryItem } = require('./horizontal-overline-image-story-item');
+    const id = 'test';
+    const overlineUrl = '/news';
+    const overlineText = 'News';
+    const overlineDisplay = true;
 
-  //   const wrapper = mount(
-  //     <HorizontalOverlineImageStoryItem
-  //       imageURL={imageURL}
-  //       websiteURL={websiteURL}
-  //       itemTitle={itemTitle}
-  //       descriptionText={descriptionText}
-  //       primaryFont={primaryFont}
-  //       secondaryFont={secondaryFont}
-  //       by={by}
-  //       element={element}
-  //       displayDate={displayDate}
-  //       id={id}
-  //       overlineDisplay={overlineDisplay}
-  //       overlineUrl={overlineUrl}
-  //       overlineText={overlineText}
-  //       customFields={headBelowConfig}
-  //     />,
-  //   );
+    const wrapper = mount(
+      <HorizontalOverlineImageStoryItem
+        imageURL={imageURL}
+        websiteURL={websiteURL}
+        itemTitle={itemTitle}
+        descriptionText={descriptionText}
+        primaryFont={primaryFont}
+        secondaryFont={secondaryFont}
+        by={by}
+        element={element}
+        displayDate={displayDate}
+        id={id}
+        overlineDisplay={overlineDisplay}
+        overlineUrl={overlineUrl}
+        overlineText={overlineText}
+        customFields={headBelowConfig}
+      />,
+    );
 
-  //   expect(wrapper.find('.headline-below').length).toBe(2);
-  //   expect(wrapper.find('.headline-above').length).toBe(0);
-  // });
+    expect(wrapper.find('.headline-below').length).toBe(2);
+    expect(wrapper.find('.headline-above').length).toBe(0);
+  });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
@@ -257,7 +257,7 @@ describe('horizontal overline image story item', () => {
       />,
     );
 
-    expect(wrapper.find('.headline-below').length).toBe(2);
+    expect(wrapper.find('.headline-below').length).toBe(1);
     expect(wrapper.find('.headline-above').length).toBe(0);
   });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -34,7 +34,7 @@ const ItemTitleWithRightImage = (props) => {
       className={`${promoClasses} ${paddingRight ? 'small-promo-padding' : ''}`}
     >
       <div className="row sm-promo-padding-btm">
-        {(customFields.headlinePositionSM === 'above' || undefined || 'undefined')
+        {(customFields.headlinePositionSM === 'above' || customFields.headlinePositionSM === undefined)
           && customFields.showHeadlineSM && itemTitle !== '' ? (
             <div className="col-sm-8 col-md-xl-8">
               <a

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -34,21 +34,20 @@ const ItemTitleWithRightImage = (props) => {
       className={`${promoClasses} ${paddingRight ? 'small-promo-padding' : ''}`}
     >
       <div className="row sm-promo-padding-btm">
-        {/* customFields.headlinePositionSM === 'above' && */
-          customFields.showHeadlineSM && itemTitle !== '' ? (
+        {(customFields.headlinePositionSM === 'above' || undefined || 'undefined')
+          && customFields.showHeadlineSM && itemTitle !== '' ? (
             <div className="col-sm-8 col-md-xl-8">
               <a
                 href={websiteURL}
                 title={itemTitle}
-                className="sm-promo-headline"
+                className="sm-promo-headline headline-above"
               >
                 <Title primaryFont={primaryFont} className="sm-promo-headline">
                   {itemTitle}
                 </Title>
               </a>
             </div>
-          ) : null
-        }
+          ) : null}
         {customFields.showImageSM
           && (
           <div className="col-sm-4 col-md-xl-4 flex-col">
@@ -90,7 +89,7 @@ const ItemTitleWithRightImage = (props) => {
           </div>
           )}
       </div>
-      {/* {customFields.headlinePositionSM === 'below'
+      {customFields.headlinePositionSM === 'below'
       && customFields.showHeadlineSM
       && itemTitle !== '' ? (
         <div className="col-sm-8 col-md-xl-8">
@@ -100,7 +99,7 @@ const ItemTitleWithRightImage = (props) => {
             </Title>
           </a>
         </div>
-        ) : null} */}
+        ) : null}
       <hr />
     </article>
   );

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
@@ -161,7 +161,7 @@ describe('item title with right image block', () => {
     );
 
     expect(wrapper.find('.headline-below').length).toBe(1);
-    expect(wrapper.find('.headline-above').length).toBe(1);
+    expect(wrapper.find('.headline-above').length).toBe(0);
   });
 });
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
@@ -20,32 +20,32 @@ const config = {
   showBylineMD: true,
   showDateMD: true,
   showHeadlineSM: true,
-  // headlinePositionSM: 'above',
+  headlinePositionSM: 'above',
   showImageSM: true,
 };
 
-// const headBelowConfig = {
-//   showOverlineXL: true,
-//   showHeadlineXL: true,
-//   showImageXL: true,
-//   showDescriptionXL: true,
-//   showBylineXL: true,
-//   showDateXL: true,
-//   showOverlineLG: true,
-//   showHeadlineLG: true,
-//   showImageLG: true,
-//   showDescriptionLG: true,
-//   showBylineLG: true,
-//   showDateLG: true,
-//   showHeadlineMD: true,
-//   showImageMD: true,
-//   showDescriptionMD: true,
-//   showBylineMD: true,
-//   showDateMD: true,
-//   showHeadlineSM: true,
-//   headlinePositionSM: 'below',
-//   showImageSM: true,
-// };
+const headBelowConfig = {
+  showOverlineXL: true,
+  showHeadlineXL: true,
+  showImageXL: true,
+  showDescriptionXL: true,
+  showBylineXL: true,
+  showDateXL: true,
+  showOverlineLG: true,
+  showHeadlineLG: true,
+  showImageLG: true,
+  showDescriptionLG: true,
+  showBylineLG: true,
+  showDateLG: true,
+  showHeadlineMD: true,
+  showImageMD: true,
+  showDescriptionMD: true,
+  showBylineMD: true,
+  showDateMD: true,
+  showHeadlineSM: true,
+  headlinePositionSM: 'below',
+  showImageSM: true,
+};
 
 describe('item title with right image block', () => {
   beforeAll(() => {
@@ -84,12 +84,12 @@ describe('item title with right image block', () => {
       />,
     );
 
-    // expect(wrapper.find('h2.simple-list-headline-text').length).toBe(1);
+    expect(wrapper.find('h2.simple-list-headline-text').length).toBe(0);
     // expect(wrapper.find('h2.simple-list-headline-text').text()).toBe(itemTitle);
 
     // placeholder
-    // expect(wrapper.find('.simple-list-placeholder').length).toBe(0);
-    // expect(wrapper.find('.simple-list-img').length).toBe(1);
+    expect(wrapper.find('.simple-list-placeholder').length).toBe(0);
+    expect(wrapper.find('.simple-list-img').length).toBe(0);
 
     expect(wrapper.find('ItemTitleWithRightImage > article > hr').length).toBe(1);
   });
@@ -111,126 +111,126 @@ describe('item title with right image block', () => {
       />,
     );
 
-    // expect(wrapper.find('h2.simple-list-headline-text').length).toBe(0);
+    expect(wrapper.find('h2.simple-list-headline-text').length).toBe(0);
 
     // placeholder
-    // expect(wrapper.find('.simple-list-placeholder').length).toBe(1);
-    // expect(wrapper.find('.simple-list-img').length).toBe(0);
+    expect(wrapper.find('.simple-list-placeholder').length).toBe(1);
+    expect(wrapper.find('.simple-list-img').length).toBe(0);
   });
 
-  //   it('headline has class headline-above when headline position is above', () => {
-  //     const imageURL = 'pic';
-  //     const itemTitle = 'title';
-  //     const primaryFont = 'arial';
-  //     const id = 'test';
-  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+  it('headline has class headline-above when headline position is above', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-  //     // eslint-disable-next-line no-unused-vars
-  //     const wrapper = mount(
-  //       <ItemTitleWithRightImage
-  //         imageURL={imageURL}
-  //         itemTitle={itemTitle}
-  //         primaryFont={primaryFont}
-  //         id={id}
-  //         customFields={config}
-  //         resizedImageOptions={{ '400x267': '' }}
-  //       />,
-  //     );
+    // eslint-disable-next-line no-unused-vars
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        customFields={config}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
 
-  //     expect(wrapper.find('.headline-above').length).toBe(1);
-  //     expect(wrapper.find('.headline-below').length).toBe(0);
-  //   });
+    expect(wrapper.find('.headline-above').length).toBe(1);
+    expect(wrapper.find('.headline-below').length).toBe(0);
+  });
 
-  //   it('headline has class headline-below when headline position is below', () => {
-  //     const imageURL = 'pic';
-  //     const itemTitle = 'title';
-  //     const primaryFont = 'arial';
-  //     const id = 'test';
-  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+  it('headline has class headline-below when headline position is below', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-  //     // eslint-disable-next-line no-unused-vars
-  //     const wrapper = mount(
-  //       <ItemTitleWithRightImage
-  //         imageURL={imageURL}
-  //         itemTitle={itemTitle}
-  //         primaryFont={primaryFont}
-  //         id={id}
-  //         customFields={headBelowConfig}
-  //         resizedImageOptions={{ '400x267': '' }}
-  //       />,
-  //     );
+    // eslint-disable-next-line no-unused-vars
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        customFields={headBelowConfig}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
 
-  //     expect(wrapper.find('.headline-below').length).toBe(1);
-  //     expect(wrapper.find('.headline-above').length).toBe(0);
-  //   });
-  // });
+    expect(wrapper.find('.headline-below').length).toBe(1);
+    expect(wrapper.find('.headline-above').length).toBe(1);
+  });
+});
 
-  // describe('small promo display', () => {
-  //   it('when storiesPerRowSM is undefined must not add class small-promo-one', () => {
-  //     const imageURL = 'pic';
-  //     const itemTitle = 'title';
-  //     const primaryFont = 'arial';
-  //     const id = 'test';
-  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+describe('small promo display', () => {
+  it('when storiesPerRowSM is undefined must not add class small-promo-one', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-  //     const wrapper = mount(
-  //       <ItemTitleWithRightImage
-  //         imageURL={imageURL}
-  //         itemTitle={itemTitle}
-  //         primaryFont={primaryFont}
-  //         id={id}
-  //         customFields={config}
-  //         resizedImageOptions={{ '400x267': '' }}
-  //       />,
-  //     );
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        customFields={config}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
 
-  //     expect(wrapper.find('.small-promo-one').length).toBe(0);
-  //     expect(wrapper.find('article.wrap-bottom').length).toBe(1);
-  //   });
+    expect(wrapper.find('.small-promo-one').length).toBe(0);
+    expect(wrapper.find('article.wrap-bottom').length).toBe(1);
+  });
 
-  //   it('when storiesPerRowSM is 2 must not add class small-promo-one', () => {
-  //     const imageURL = 'pic';
-  //     const itemTitle = 'title';
-  //     const primaryFont = 'arial';
-  //     const id = 'test';
-  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
-  //     const setup = Object.assign(config, { storiesPerRowSM: 2 });
+  it('when storiesPerRowSM is 2 must not add class small-promo-one', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+    const setup = Object.assign(config, { storiesPerRowSM: 2 });
 
-  //     const wrapper = mount(
-  //       <ItemTitleWithRightImage
-  //         imageURL={imageURL}
-  //         itemTitle={itemTitle}
-  //         primaryFont={primaryFont}
-  //         id={id}
-  //         customFields={setup}
-  //         resizedImageOptions={{ '400x267': '' }}
-  //       />,
-  //     );
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        customFields={setup}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
 
-  //     expect(wrapper.find('.small-promo-one').length).toBe(0);
-  //     expect(wrapper.find('article.wrap-bottom').length).toBe(1);
-  //   });
+    expect(wrapper.find('.small-promo-one').length).toBe(0);
+    expect(wrapper.find('article.wrap-bottom').length).toBe(1);
+  });
 
-  //   it('when storiesPerRowSM is 1 must add class small-promo-one', () => {
-  //     const imageURL = 'pic';
-  //     const itemTitle = 'title';
-  //     const primaryFont = 'arial';
-  //     const id = 'test';
-  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
-  //     const setup = Object.assign(config, { storiesPerRowSM: 1 });
+  it('when storiesPerRowSM is 1 must add class small-promo-one', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+    const setup = Object.assign(config, { storiesPerRowSM: 1 });
 
-  //     const wrapper = mount(
-  //       <ItemTitleWithRightImage
-  //         imageURL={imageURL}
-  //         itemTitle={itemTitle}
-  //         primaryFont={primaryFont}
-  //         id={id}
-  //         customFields={setup}
-  //         resizedImageOptions={{ '400x267': '' }}
-  //       />,
-  //     );
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        customFields={setup}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
 
-//     expect(wrapper.find('.small-promo-one').length).toBe(1);
-//     expect(wrapper.find('article.wrap-bottom').length).toBe(0);
-//   });
+    expect(wrapper.find('.small-promo-one').length).toBe(1);
+    expect(wrapper.find('article.wrap-bottom').length).toBe(0);
+  });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -35,7 +35,7 @@ const MediumListItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineMD && itemTitle !== '') {
       return (
-        <a href={websiteURL} title={itemTitle} className="md-promo-headline">
+        <a href={websiteURL} title={itemTitle} className={`md-promo-headline headline-${customFields.headlinePositionMD}`}>
           <Title className="md-promo-headline-text" primaryFont={primaryFont}>
             {itemTitle}
           </Title>
@@ -92,12 +92,12 @@ const MediumListItem = (props) => {
     <>
       <article className="container-fluid medium-promo" key={id}>
         <div className={`medium-promo-wrapper ${customFields.showImageMD ? 'md-promo-image' : ''}`}>
-          {/* {customFields.headlinePositionMD === 'above'
+          {(customFields.headlinePositionMD === 'above' || undefined || 'undefined')
             && (customFields.showHeadlineMD
               || customFields.showDescriptionMD
               || customFields.showBylineMD
               || customFields.showDateMD) && (
-              <div className={textClass}>
+              <div>
                 {headlineTmpl()}
                 {descriptionTmpl()}
                 <div className="article-meta">
@@ -105,7 +105,7 @@ const MediumListItem = (props) => {
                   {dateTmpl()}
                 </div>
               </div>
-          )} */}
+          )}
           {customFields.showImageMD
             && (
             <a className="image-link" href={websiteURL} title={itemTitle}>
@@ -143,8 +143,8 @@ const MediumListItem = (props) => {
               <PromoLabel type={promoType} />
             </a>
             )}
-          {/* customFields.headlinePositionMD === 'below' && */
-            (customFields.showHeadlineMD
+          {customFields.headlinePositionMD === 'below'
+            && (customFields.showHeadlineMD
               || customFields.showDescriptionMD
               || customFields.showBylineMD
               || customFields.showDateMD) && (
@@ -156,8 +156,7 @@ const MediumListItem = (props) => {
                   {dateTmpl()}
                 </div>
               </>
-            )
-          }
+          )}
         </div>
       </article>
       <hr />

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -92,7 +92,7 @@ const MediumListItem = (props) => {
     <>
       <article className="container-fluid medium-promo" key={id}>
         <div className={`medium-promo-wrapper ${customFields.showImageMD ? 'md-promo-image' : ''}`}>
-          {(customFields.headlinePositionMD === 'above' || undefined || 'undefined')
+          {(customFields.headlinePositionMD === 'above' || customFields.headlinePositionMD === undefined)
             && (customFields.showHeadlineMD
               || customFields.showDescriptionMD
               || customFields.showBylineMD

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -35,7 +35,7 @@ const MediumListItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineMD && itemTitle !== '') {
       return (
-        <a href={websiteURL} title={itemTitle} className={`md-promo-headline headline-${customFields.headlinePositionMD}`}>
+        <a href={websiteURL} title={itemTitle} className={`md-promo-headline headline-${customFields.headlinePositionMD || 'above'}`}>
           <Title className="md-promo-headline-text" primaryFont={primaryFont}>
             {itemTitle}
           </Title>

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -97,7 +97,7 @@ const MediumListItem = (props) => {
               || customFields.showDescriptionMD
               || customFields.showBylineMD
               || customFields.showDateMD) && (
-              <div>
+              <div style={{ float: 'left' }}>
                 {headlineTmpl()}
                 {descriptionTmpl()}
                 <div className="article-meta">
@@ -108,7 +108,7 @@ const MediumListItem = (props) => {
           )}
           {customFields.showImageMD
             && (
-            <a className="image-link" href={websiteURL} title={itemTitle}>
+            <a className="image-link" href={websiteURL} title={itemTitle} style={{ float: (customFields.headlinePositionMD === 'below' ? '' : 'right') }}>
               {imageURL !== '' ? (
                 <Image
                   resizedImageOptions={resizedImageOptions}

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
@@ -174,7 +174,7 @@ describe('medium list item', () => {
       customFields={headBelowConfig}
     />);
 
-    expect(wrapper.find('.headline-below').length).toBe(2);
+    expect(wrapper.find('.headline-below').length).toBe(1);
     expect(wrapper.find('.headline-above').length).toBe(0);
   });
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
@@ -4,54 +4,54 @@ import { mount } from 'enzyme';
 const config = {
   showOverlineXL: true,
   showHeadlineXL: true,
-  // headlinePositionXL: 'below',
+  headlinePositionXL: 'below',
   showImageXL: true,
   showDescriptionXL: true,
   showBylineXL: true,
   showDateXL: true,
   showOverlineLG: true,
   showHeadlineLG: true,
-  // headlinePositionLG: 'below',
+  headlinePositionLG: 'below',
   showImageLG: true,
   showDescriptionLG: true,
   showBylineLG: true,
   showDateLG: true,
   showHeadlineMD: true,
-  // headlinePositionMD: 'above',
+  headlinePositionMD: 'above',
   showImageMD: true,
   showDescriptionMD: true,
   showBylineMD: true,
   showDateMD: true,
   showHeadlineSM: true,
-  // headlinePositionSM: 'below',
+  headlinePositionSM: 'below',
   showImageSM: true,
 };
 
-// const headBelowConfig = {
-//   showOverlineXL: true,
-//   showHeadlineXL: true,
-//   headlinePositionXL: 'below',
-//   showImageXL: true,
-//   showDescriptionXL: true,
-//   showBylineXL: true,
-//   showDateXL: true,
-//   showOverlineLG: true,
-//   showHeadlineLG: true,
-//   headlinePositionLG: 'below',
-//   showImageLG: true,
-//   showDescriptionLG: true,
-//   showBylineLG: true,
-//   showDateLG: true,
-//   showHeadlineMD: true,
-//   headlinePositionMD: 'below',
-//   showImageMD: true,
-//   showDescriptionMD: true,
-//   showBylineMD: true,
-//   showDateMD: true,
-//   showHeadlineSM: true,
-//   headlinePositionSM: 'below',
-//   showImageSM: true,
-// };
+const headBelowConfig = {
+  showOverlineXL: true,
+  showHeadlineXL: true,
+  headlinePositionXL: 'below',
+  showImageXL: true,
+  showDescriptionXL: true,
+  showBylineXL: true,
+  showDateXL: true,
+  showOverlineLG: true,
+  showHeadlineLG: true,
+  headlinePositionLG: 'below',
+  showImageLG: true,
+  showDescriptionLG: true,
+  showBylineLG: true,
+  showDateLG: true,
+  showHeadlineMD: true,
+  headlinePositionMD: 'below',
+  showImageMD: true,
+  showDescriptionMD: true,
+  showBylineMD: true,
+  showDateMD: true,
+  showHeadlineSM: true,
+  headlinePositionSM: 'below',
+  showImageSM: true,
+};
 
 describe('medium list item', () => {
   beforeAll(() => {
@@ -106,7 +106,7 @@ describe('medium list item', () => {
     expect(wrapper.find('.top-table-med-image-placeholder').length).toBe(0);
 
     // doesn't find spacer
-    // expect(wrapper.find('.headline-description-spacing').length).toBe(0);
+    expect(wrapper.find('.headline-description-spacing').length).toBe(0);
 
     // finds description text
     expect(wrapper.find('p.description-text').text()).toBe(descriptionText);
@@ -114,69 +114,69 @@ describe('medium list item', () => {
     expect(wrapper.find('MediumListItem > hr').length).toBe(1);
   });
 
-  // it('headline has class headline-above when headline position is above', () => {
-  //   const imageURL = 'pic';
-  //   const constructedURL = 'url';
-  //   const itemTitle = 'title';
-  //   const descriptionText = 'description';
-  //   const primaryFont = 'arial';
-  //   const secondaryFont = 'Georgia';
-  //   const by = ['jack'];
-  //   const element = { credits: { by: [] } };
-  //   const displayDate = '';
-  //   const id = 'test';
-  //   const { default: MediumListItem } = require('./medium-list-item');
+  it('headline has class headline-above when headline position is above', () => {
+    const imageURL = 'pic';
+    const constructedURL = 'url';
+    const itemTitle = 'title';
+    const descriptionText = 'description';
+    const primaryFont = 'arial';
+    const secondaryFont = 'Georgia';
+    const by = ['jack'];
+    const element = { credits: { by: [] } };
+    const displayDate = '';
+    const id = 'test';
+    const { default: MediumListItem } = require('./medium-list-item');
 
-  //   // eslint-disable-next-line no-unused-vars
-  //   const wrapper = mount(<MediumListItem
-  //     imageURL={imageURL}
-  //     constructedURL={constructedURL}
-  //     itemTitle={itemTitle}
-  //     descriptionText={descriptionText}
-  //     primaryFont={primaryFont}
-  //     secondaryFont={secondaryFont}
-  //     by={by}
-  //     element={element}
-  //     displayDate={displayDate}
-  //     id={id}
-  //     customFields={config}
-  //   />);
+    // eslint-disable-next-line no-unused-vars
+    const wrapper = mount(<MediumListItem
+      imageURL={imageURL}
+      constructedURL={constructedURL}
+      itemTitle={itemTitle}
+      descriptionText={descriptionText}
+      primaryFont={primaryFont}
+      secondaryFont={secondaryFont}
+      by={by}
+      element={element}
+      displayDate={displayDate}
+      id={id}
+      customFields={config}
+    />);
 
-  //   expect(wrapper.find('.headline-above').length).toBe(1);
-  //   expect(wrapper.find('.headline-below').length).toBe(0);
-  // });
+    expect(wrapper.find('.headline-above').length).toBe(1);
+    expect(wrapper.find('.headline-below').length).toBe(0);
+  });
 
-  // it('headline has class headline-below when headline position is below', () => {
-  //   const imageURL = 'pic';
-  //   const constructedURL = 'url';
-  //   const itemTitle = 'title';
-  //   const descriptionText = 'description';
-  //   const primaryFont = 'arial';
-  //   const secondaryFont = 'Georgia';
-  //   const by = ['jack'];
-  //   const element = { credits: { by: [] } };
-  //   const displayDate = '';
-  //   const id = 'test';
-  //   const { default: MediumListItem } = require('./medium-list-item');
+  it('headline has class headline-below when headline position is below', () => {
+    const imageURL = 'pic';
+    const constructedURL = 'url';
+    const itemTitle = 'title';
+    const descriptionText = 'description';
+    const primaryFont = 'arial';
+    const secondaryFont = 'Georgia';
+    const by = ['jack'];
+    const element = { credits: { by: [] } };
+    const displayDate = '';
+    const id = 'test';
+    const { default: MediumListItem } = require('./medium-list-item');
 
-  //   // eslint-disable-next-line no-unused-vars
-  //   const wrapper = mount(<MediumListItem
-  //     imageURL={imageURL}
-  //     constructedURL={constructedURL}
-  //     itemTitle={itemTitle}
-  //     descriptionText={descriptionText}
-  //     primaryFont={primaryFont}
-  //     secondaryFont={secondaryFont}
-  //     by={by}
-  //     element={element}
-  //     displayDate={displayDate}
-  //     id={id}
-  //     customFields={headBelowConfig}
-  //   />);
+    // eslint-disable-next-line no-unused-vars
+    const wrapper = mount(<MediumListItem
+      imageURL={imageURL}
+      constructedURL={constructedURL}
+      itemTitle={itemTitle}
+      descriptionText={descriptionText}
+      primaryFont={primaryFont}
+      secondaryFont={secondaryFont}
+      by={by}
+      element={element}
+      displayDate={displayDate}
+      id={id}
+      customFields={headBelowConfig}
+    />);
 
-  //   expect(wrapper.find('.headline-below').length).toBe(1);
-  //   expect(wrapper.find('.headline-above').length).toBe(0);
-  // });
+    expect(wrapper.find('.headline-below').length).toBe(2);
+    expect(wrapper.find('.headline-above').length).toBe(0);
+  });
 
   it('renders image placeholder with empty props', () => {
     const { default: MediumListItem } = require('./medium-list-item');

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
@@ -159,7 +159,6 @@ describe('medium list item', () => {
     const id = 'test';
     const { default: MediumListItem } = require('./medium-list-item');
 
-    // eslint-disable-next-line no-unused-vars
     const wrapper = mount(<MediumListItem
       imageURL={imageURL}
       constructedURL={constructedURL}

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -50,7 +50,7 @@ const VerticalOverlineImageStoryItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineXL && itemTitle) {
       return (
-        <a href={websiteURL} title={itemTitle} className={`xl-promo-headline headline-${customFields.headlinePositionXL}`}>
+        <a href={websiteURL} title={itemTitle} className={`xl-promo-headline headline-${customFields.headlinePositionXL || 'above'}`}>
           <Title primaryFont={primaryFont} className="xl-promo-headline">
             {itemTitle}
           </Title>

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -113,7 +113,7 @@ const VerticalOverlineImageStoryItem = (props) => {
             || customFields.showDateXL) && (
             <div className="col-sm-xl-12 flex-col">
               {overlineTmpl()}
-              {(customFields.headlinePositionXL === 'above' || undefined || 'undefined') && headlineTmpl()}
+              {(customFields.headlinePositionXL === 'above' || customFields.headlinePositionXL === undefined) && headlineTmpl()}
               {videoUUID && (
                 <Video
                   uuid={videoUUID}

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image /* , Video */ } from '@wpmedia/engine-theme-sdk';
+import { Image, Video } from '@wpmedia/engine-theme-sdk';
 import ArticleDate from '@wpmedia/date-block';
 import Byline from '@wpmedia/byline-block';
 import Overline from '@wpmedia/overline-block';
@@ -50,7 +50,7 @@ const VerticalOverlineImageStoryItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineXL && itemTitle) {
       return (
-        <a href={websiteURL} title={itemTitle} className="xl-promo-headline">
+        <a href={websiteURL} title={itemTitle} className={`xl-promo-headline headline-${customFields.headlinePositionXL}`}>
           <Title primaryFont={primaryFont} className="xl-promo-headline">
             {itemTitle}
           </Title>
@@ -101,7 +101,7 @@ const VerticalOverlineImageStoryItem = (props) => {
   };
 
   const ratios = ratiosFor('XL', imageRatio);
-  // const videoUUID = element?.promo_items?.basic?.additional_properties?.videoId;
+  const videoUUID = element?.promo_items?.basic?.additional_properties?.videoId;
 
   return (
     <>
@@ -113,8 +113,8 @@ const VerticalOverlineImageStoryItem = (props) => {
             || customFields.showDateXL) && (
             <div className="col-sm-xl-12 flex-col">
               {overlineTmpl()}
-              {/* customFields.headlinePositionXL === 'above' && */ headlineTmpl()}
-              {/* {videoUUID && (
+              {(customFields.headlinePositionXL === 'above' || undefined || 'undefined') && headlineTmpl()}
+              {videoUUID && (
                 <Video
                   uuid={videoUUID}
                   autoplay={false}
@@ -122,8 +122,8 @@ const VerticalOverlineImageStoryItem = (props) => {
                   org="arcbrands"
                   env="sandbox"
                 />
-              )} */}
-              {customFields.showImageXL && /*! videoUUID && */ imageURL !== '' ? (
+              )}
+              {customFields.showImageXL && !videoUUID && imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>
                   <Image
                     resizedImageOptions={resizedImageOptions}
@@ -141,7 +141,7 @@ const VerticalOverlineImageStoryItem = (props) => {
                   />
                 </a>
               ) : (
-                /*! videoUUID && */ (
+                !videoUUID && (
                   <Image
                     smallWidth={ratios.smallWidth}
                     smallHeight={ratios.smallHeight}
@@ -160,7 +160,7 @@ const VerticalOverlineImageStoryItem = (props) => {
                   />
                 )
               )}
-              {/* customFields.headlinePositionXL === 'below' && headlineTmpl() */}
+              {customFields.headlinePositionXL === 'below' && headlineTmpl()}
               {descriptionTmpl()}
               <div className="article-meta">
                 {byLineTmpl()}

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
@@ -4,54 +4,54 @@ import { mount } from 'enzyme';
 const config = {
   showOverlineXL: true,
   showHeadlineXL: true,
-  // headlinePositionXL: 'above',
+  headlinePositionXL: 'above',
   showImageXL: true,
   showDescriptionXL: true,
   showBylineXL: true,
   showDateXL: true,
   showOverlineLG: true,
   showHeadlineLG: true,
-  // headlinePositionLG: 'below',
+  headlinePositionLG: 'below',
   showImageLG: true,
   showDescriptionLG: true,
   showBylineLG: true,
   showDateLG: true,
   showHeadlineMD: true,
-  // headlinePositionMD: 'below',
+  headlinePositionMD: 'below',
   showImageMD: true,
   showDescriptionMD: true,
   showBylineMD: true,
   showDateMD: true,
   showHeadlineSM: true,
-  // headlinePositionSM: 'below',
+  headlinePositionSM: 'below',
   showImageSM: true,
 };
 
-// const headBelowConfig = {
-//   showOverlineXL: true,
-//   showHeadlineXL: true,
-//   headlinePositionXL: 'below',
-//   showImageXL: true,
-//   showDescriptionXL: true,
-//   showBylineXL: true,
-//   showDateXL: true,
-//   showOverlineLG: true,
-//   showHeadlineLG: true,
-//   headlinePositionLG: 'below',
-//   showImageLG: true,
-//   showDescriptionLG: true,
-//   showBylineLG: true,
-//   showDateLG: true,
-//   showHeadlineMD: true,
-//   headlinePositionMD: 'below',
-//   showImageMD: true,
-//   showDescriptionMD: true,
-//   showBylineMD: true,
-//   showDateMD: true,
-//   showHeadlineSM: true,
-//   headlinePositionSM: 'below',
-//   showImageSM: true,
-// };
+const headBelowConfig = {
+  showOverlineXL: true,
+  showHeadlineXL: true,
+  headlinePositionXL: 'below',
+  showImageXL: true,
+  showDescriptionXL: true,
+  showBylineXL: true,
+  showDateXL: true,
+  showOverlineLG: true,
+  showHeadlineLG: true,
+  headlinePositionLG: 'below',
+  showImageLG: true,
+  showDescriptionLG: true,
+  showBylineLG: true,
+  showDateLG: true,
+  showHeadlineMD: true,
+  headlinePositionMD: 'below',
+  showImageMD: true,
+  showDescriptionMD: true,
+  showBylineMD: true,
+  showDateMD: true,
+  showHeadlineSM: true,
+  headlinePositionSM: 'below',
+  showImageSM: true,
+};
 
 describe('vertical overline image story item', () => {
   beforeAll(() => {
@@ -126,83 +126,81 @@ describe('vertical overline image story item', () => {
     expect(wrapper.find('VerticalOverlineImageStoryItem > hr').length).toBe(1);
   });
 
-  // it('headline has class headline-above when headline position is above', () => {
-  //   const imageURL = 'pic';
-  //   const websiteURL = 'url';
-  //   const itemTitle = 'title';
-  //   const descriptionText = 'description';
-  //   const primaryFont = 'arial';
-  //   const by = ['jack'];
-  //   const element = { credits: { by: [] } };
-  //   const displayDate = '';
-  //   const id = 'test';
-  //   const overlineUrl = '/news';
-  //   const overlineText = 'News';
-  //   const overlineDisplay = true;
+  it('headline has class headline-above when headline position is above', () => {
+    const imageURL = 'pic';
+    const websiteURL = 'url';
+    const itemTitle = 'title';
+    const descriptionText = 'description';
+    const primaryFont = 'arial';
+    const by = ['jack'];
+    const element = { credits: { by: [] } };
+    const displayDate = '';
+    const id = 'test';
+    const overlineUrl = '/news';
+    const overlineText = 'News';
+    const overlineDisplay = true;
 
-  //   const { default: VerticalOverlineImageStoryItem } =
-  // require('./vertical-overline-image-story-item');
+    const { default: VerticalOverlineImageStoryItem } = require('./vertical-overline-image-story-item');
 
-  //   const wrapper = mount(
-  //     <VerticalOverlineImageStoryItem
-  //       imageURL={imageURL}
-  //       websiteURL={websiteURL}
-  //       itemTitle={itemTitle}
-  //       descriptionText={descriptionText}
-  //       primaryFont={primaryFont}
-  //       by={by}
-  //       element={element}
-  //       displayDate={displayDate}
-  //       overlineUrl={overlineUrl}
-  //       overlineText={overlineText}
-  //       id={id}
-  //       overlineDisplay={overlineDisplay}
-  //       customFields={config}
-  //     />,
-  //   );
+    const wrapper = mount(
+      <VerticalOverlineImageStoryItem
+        imageURL={imageURL}
+        websiteURL={websiteURL}
+        itemTitle={itemTitle}
+        descriptionText={descriptionText}
+        primaryFont={primaryFont}
+        by={by}
+        element={element}
+        displayDate={displayDate}
+        overlineUrl={overlineUrl}
+        overlineText={overlineText}
+        id={id}
+        overlineDisplay={overlineDisplay}
+        customFields={config}
+      />,
+    );
 
-  //   expect(wrapper.find('.headline-above').length).toBe(1);
-  //   expect(wrapper.find('.headline-below').length).toBe(0);
-  // });
+    expect(wrapper.find('.headline-above').length).toBe(1);
+    expect(wrapper.find('.headline-below').length).toBe(0);
+  });
 
-  // it('headline has class headline-below when headline position is below', () => {
-  //   const imageURL = 'pic';
-  //   const websiteURL = 'url';
-  //   const itemTitle = 'title';
-  //   const descriptionText = 'description';
-  //   const primaryFont = 'arial';
-  //   const by = ['jack'];
-  //   const element = { credits: { by: [] } };
-  //   const displayDate = '';
-  //   const id = 'test';
-  //   const overlineUrl = '/news';
-  //   const overlineText = 'News';
-  //   const overlineDisplay = true;
+  it('headline has class headline-below when headline position is below', () => {
+    const imageURL = 'pic';
+    const websiteURL = 'url';
+    const itemTitle = 'title';
+    const descriptionText = 'description';
+    const primaryFont = 'arial';
+    const by = ['jack'];
+    const element = { credits: { by: [] } };
+    const displayDate = '';
+    const id = 'test';
+    const overlineUrl = '/news';
+    const overlineText = 'News';
+    const overlineDisplay = true;
 
-  //   const { default: VerticalOverlineImageStoryItem } =
-  // require('./vertical-overline-image-story-item');
+    const { default: VerticalOverlineImageStoryItem } = require('./vertical-overline-image-story-item');
 
-  //   const wrapper = mount(
-  //     <VerticalOverlineImageStoryItem
-  //       imageURL={imageURL}
-  //       websiteURL={websiteURL}
-  //       itemTitle={itemTitle}
-  //       descriptionText={descriptionText}
-  //       primaryFont={primaryFont}
-  //       by={by}
-  //       element={element}
-  //       displayDate={displayDate}
-  //       overlineUrl={overlineUrl}
-  //       overlineText={overlineText}
-  //       id={id}
-  //       overlineDisplay={overlineDisplay}
-  //       customFields={headBelowConfig}
-  //     />,
-  //   );
+    const wrapper = mount(
+      <VerticalOverlineImageStoryItem
+        imageURL={imageURL}
+        websiteURL={websiteURL}
+        itemTitle={itemTitle}
+        descriptionText={descriptionText}
+        primaryFont={primaryFont}
+        by={by}
+        element={element}
+        displayDate={displayDate}
+        overlineUrl={overlineUrl}
+        overlineText={overlineText}
+        id={id}
+        overlineDisplay={overlineDisplay}
+        customFields={headBelowConfig}
+      />,
+    );
 
-  //   expect(wrapper.find('.headline-below').length).toBe(1);
-  //   expect(wrapper.find('.headline-above').length).toBe(0);
-  // });
+    expect(wrapper.find('.headline-below').length).toBe(2);
+    expect(wrapper.find('.headline-above').length).toBe(0);
+  });
 
   it('does not render image, overline and byline with empty props', () => {
     const imageURL = '';

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
@@ -198,7 +198,7 @@ describe('vertical overline image story item', () => {
       />,
     );
 
-    expect(wrapper.find('.headline-below').length).toBe(2);
+    expect(wrapper.find('.headline-below').length).toBe(1);
     expect(wrapper.find('.headline-above').length).toBe(0);
   });
 

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -363,7 +363,7 @@ TopTableListWrapper.propTypes = {
       group: 'Small story settings',
     }),
     ...imageRatioCustomField('imageRatioSM', 'Small story settings', '3:2'),
-    storiesPerRowSM: PropTypes.oneOf([1, 2]).tag({
+    storiesPerRowSM: PropTypes.oneOf([1, 2, 3, 4]).tag({
       name: 'Stories per row',
       defaultValue: 2,
       group: 'Small story settings',

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -247,11 +247,11 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Extra Large story settings',
     }),
-    // headlinePositionXL: PropTypes.oneOf(['above', 'below']).tag({
-    //   label: 'Headline Position',
-    //   group: 'Extra Large story settings',
-    //   defaultValue: 'above',
-    // }),
+    headlinePositionXL: PropTypes.oneOf(['above', 'below']).tag({
+      label: 'Headline Position',
+      group: 'Extra Large story settings',
+      defaultValue: 'above',
+    }),
     showImageXL: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,
@@ -288,11 +288,11 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Large story settings',
     }),
-    // headlinePositionLG: PropTypes.oneOf(['above', 'below']).tag({
-    //   label: 'Headline Position',
-    //   group: 'Large story settings',
-    //   defaultValue: 'above',
-    // }),
+    headlinePositionLG: PropTypes.oneOf(['above', 'below']).tag({
+      label: 'Headline Position',
+      group: 'Large story settings',
+      defaultValue: 'above',
+    }),
     showImageLG: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,
@@ -320,11 +320,11 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Medium story settings',
     }),
-    // headlinePositionMD: PropTypes.oneOf(['above', 'below']).tag({
-    //   label: 'Headline Position',
-    //   group: 'Medium story settings',
-    //   defaultValue: 'above',
-    // }),
+    headlinePositionMD: PropTypes.oneOf(['above', 'below']).tag({
+      label: 'Headline Position',
+      group: 'Medium story settings',
+      defaultValue: 'above',
+    }),
     showImageMD: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,
@@ -352,11 +352,11 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Small story settings',
     }),
-    // headlinePositionSM: PropTypes.oneOf(['above', 'below']).tag({
-    //   label: 'Headline Position',
-    //   group: 'Small story settings',
-    //   defaultValue: 'above',
-    // }),
+    headlinePositionSM: PropTypes.oneOf(['above', 'below']).tag({
+      label: 'Headline Position',
+      group: 'Small story settings',
+      defaultValue: 'above',
+    }),
     showImageSM: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,


### PR DESCRIPTION
There was a problem with my work on https://arcpublishing.atlassian.net/browse/SENG-66 so it was taken out of the last release and I commented out my changes here: https://github.com/WPMedia/fusion-news-theme-blocks/pull/474

The problem was that headlines were missing in some of the promo features. The reason for this was that I'd added a new custom field with a default value and the headline relied on that value; however, when the feature in question already on a page, that new custom field's default value wasn't coming through and it was undefined. I've added some defensive code to prevent this from happening again, and undone the commenting-out from my previous PR. 

Test instructions on original PR here: https://github.com/WPMedia/fusion-news-theme-blocks/pull/461