### PR TITLE
update story-feed-query-cs-block dependencies

### DIFF
--- a/blocks/story-feed-query-content-source-block/package.json
+++ b/blocks/story-feed-query-content-source-block/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --ext js --ext jsx sources"
   },
   "dependencies": {
-    "@arc-core-components/content-source_story-feed_sections-v4": "^1.0.6-canary.0",
+    "@arc-core-components/content-source_story-feed_sections-v4": "latest",
     "@wpmedia/engine-theme-sdk": "canary",
     "@wpmedia/resizer-image-block": "canary"
   },


### PR DESCRIPTION
## Description

There is a dependency issue with `@wpmedia/story-feed-query-content-source-block` when try to generate a local bundle against canary

```
/opt/engine/scripts/block-installer.js:102
      throw new Error(`\`npm install\` process for blocks exited with status code ${status}: ${stderr.toString()}`)
      ^
Error: `npm install` process for blocks exited with status code 1: npm ERR! code ETARGET
npm ERR! notarget No matching version found for @arc-core-components/content-source_story-feed_sections-v4@^1.0.6-canary.0.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget
npm ERR! notarget It was specified as a dependency of '@wpmedia/story-feed-query-content-source-block'
npm ERR! notarget
```

```
npm view @arc-core-components/content-source_story-feed_sections-v4
dist-tags:
beta: 1.0.1-beta.1    latest: 1.0.6-beta.0
```

updated block dependency to use `latest` 

