### PR TITLE
Update blocks dependencies

### DIFF
--- a/blocks/story-feed-author-content-source-block/package-lock.json
+++ b/blocks/story-feed-author-content-source-block/package-lock.json
@@ -146,23 +146,34 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
-    "@wpmedia/engine-theme-sdk": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.2.0/4dd9d94540ae477f1f0d051881db344e22cb9d5fa335925697aafb3b4435312e",
-      "integrity": "sha512-bYi8OsC99T1eYkRxfjto3DJ6k1MzKNIKb4Z9fKNftViYY1IzPE2nXGqL6efoN/ntqczbR7tlgpqHNGt3/XThFw==",
+    "@wpmedia/resizer-image-block": {
+      "version": "0.0.0-b2343d5",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/resizer-image-block/0.0.0-b2343d5/0bb697b4ecb293d76466093e24db1b89828bbf722b681a159ffdc110db9cd505",
+      "integrity": "sha512-gffXL62bj8jMt6RAT0NRGHkBUCiU7jfO+4rxaHAC+OnpWxRRCXbrnULtlWZgD4iiJBDhCah+q3F75JMc8vlKBw==",
       "requires": {
-        "dom-parser": "^0.1.6",
-        "is-react": "^1.3.3",
-        "lazy-child": "^0.2.0",
-        "polished": "^3.4.4",
-        "prop-types": "^15.7.2",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0",
-        "react-modal": "^3.11.1",
-        "react-swipeable": "^5.5.0",
-        "styled-components": "^4.4.1",
-        "thumbor-lite": "^0.1.6",
-        "timezone": "^1.0.23"
+        "@wpmedia/engine-theme-sdk": "^2.4.0-canary.5",
+        "thumbor-lite": "^0.1.8"
+      },
+      "dependencies": {
+        "@wpmedia/engine-theme-sdk": {
+          "version": "2.4.0-canary.5",
+          "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.4.0-canary.5/6db46988869d2ab30142edefb349657f69de5cd68eb45bfbca3ab1b9c71838c2",
+          "integrity": "sha512-4fM43EmlV7ZjfxCw0iNHg3lloeTCu7HMDxsk8Wed+HdH0mc50rt6Sx70YEUHY/OTK4lrExQjtwLI2X6GtrnmRw==",
+          "requires": {
+            "dom-parser": "^0.1.6",
+            "is-react": "^1.3.3",
+            "lazy-child": "^0.2.0",
+            "polished": "^3.4.4",
+            "prop-types": "^15.7.2",
+            "react": "^16.12.0",
+            "react-dom": "^16.12.0",
+            "react-modal": "^3.11.1",
+            "react-swipeable": "^5.5.0",
+            "styled-components": "^4.4.1",
+            "thumbor-lite": "^0.1.6",
+            "timezone": "^1.0.23"
+          }
+        }
       }
     },
     "ansi-styles": {

--- a/blocks/story-feed-author-content-source-block/package.json
+++ b/blocks/story-feed-author-content-source-block/package.json
@@ -24,6 +24,6 @@
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "canary"
+    "@wpmedia/resizer-image-block": "canary"
   }
 }

--- a/blocks/story-feed-query-content-source-block/package-lock.json
+++ b/blocks/story-feed-query-content-source-block/package-lock.json
@@ -4,14 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@arc-core-components/content-source_story-feed_sections-v4": {
-      "version": "1.0.6-beta.0",
-      "resolved": "https://registry.npmjs.org/@arc-core-components/content-source_story-feed_sections-v4/-/content-source_story-feed_sections-v4-1.0.6-beta.0.tgz",
-      "integrity": "sha512-Ndj9YJd3NHF/Fhs0CDskGqNJIlu6TAqiAaBW01xXUZR1vU8CnrAWq5cq8/crfQnJE26hivP6q5crG8tGXDQDdQ==",
-      "requires": {
-        "@babel/runtime": "^7.4.3"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -154,23 +146,34 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
-    "@wpmedia/engine-theme-sdk": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.2.0/4dd9d94540ae477f1f0d051881db344e22cb9d5fa335925697aafb3b4435312e",
-      "integrity": "sha512-bYi8OsC99T1eYkRxfjto3DJ6k1MzKNIKb4Z9fKNftViYY1IzPE2nXGqL6efoN/ntqczbR7tlgpqHNGt3/XThFw==",
+    "@wpmedia/resizer-image-block": {
+      "version": "0.0.0-b2343d5",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/resizer-image-block/0.0.0-b2343d5/0bb697b4ecb293d76466093e24db1b89828bbf722b681a159ffdc110db9cd505",
+      "integrity": "sha512-gffXL62bj8jMt6RAT0NRGHkBUCiU7jfO+4rxaHAC+OnpWxRRCXbrnULtlWZgD4iiJBDhCah+q3F75JMc8vlKBw==",
       "requires": {
-        "dom-parser": "^0.1.6",
-        "is-react": "^1.3.3",
-        "lazy-child": "^0.2.0",
-        "polished": "^3.4.4",
-        "prop-types": "^15.7.2",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0",
-        "react-modal": "^3.11.1",
-        "react-swipeable": "^5.5.0",
-        "styled-components": "^4.4.1",
-        "thumbor-lite": "^0.1.6",
-        "timezone": "^1.0.23"
+        "@wpmedia/engine-theme-sdk": "^2.4.0-canary.5",
+        "thumbor-lite": "^0.1.8"
+      },
+      "dependencies": {
+        "@wpmedia/engine-theme-sdk": {
+          "version": "2.4.0-canary.5",
+          "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.4.0-canary.5/6db46988869d2ab30142edefb349657f69de5cd68eb45bfbca3ab1b9c71838c2",
+          "integrity": "sha512-4fM43EmlV7ZjfxCw0iNHg3lloeTCu7HMDxsk8Wed+HdH0mc50rt6Sx70YEUHY/OTK4lrExQjtwLI2X6GtrnmRw==",
+          "requires": {
+            "dom-parser": "^0.1.6",
+            "is-react": "^1.3.3",
+            "lazy-child": "^0.2.0",
+            "polished": "^3.4.4",
+            "prop-types": "^15.7.2",
+            "react": "^16.12.0",
+            "react-dom": "^16.12.0",
+            "react-modal": "^3.11.1",
+            "react-swipeable": "^5.5.0",
+            "styled-components": "^4.4.1",
+            "thumbor-lite": "^0.1.6",
+            "timezone": "^1.0.23"
+          }
+        }
       }
     },
     "ansi-styles": {

--- a/blocks/story-feed-query-content-source-block/package.json
+++ b/blocks/story-feed-query-content-source-block/package.json
@@ -23,8 +23,6 @@
     "lint": "eslint --ext js --ext jsx sources"
   },
   "dependencies": {
-    "@arc-core-components/content-source_story-feed_sections-v4": "latest",
-    "@wpmedia/engine-theme-sdk": "canary",
     "@wpmedia/resizer-image-block": "canary"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/story-feed-sections-content-source-block/package-lock.json
+++ b/blocks/story-feed-sections-content-source-block/package-lock.json
@@ -93,11 +93,11 @@
       "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
     },
     "@babel/runtime": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
+      "integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
       "requires": {
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
@@ -154,23 +154,34 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
-    "@wpmedia/engine-theme-sdk": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.2.0/4dd9d94540ae477f1f0d051881db344e22cb9d5fa335925697aafb3b4435312e",
-      "integrity": "sha512-bYi8OsC99T1eYkRxfjto3DJ6k1MzKNIKb4Z9fKNftViYY1IzPE2nXGqL6efoN/ntqczbR7tlgpqHNGt3/XThFw==",
+    "@wpmedia/resizer-image-block": {
+      "version": "0.0.0-b2343d5",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/resizer-image-block/0.0.0-b2343d5/0bb697b4ecb293d76466093e24db1b89828bbf722b681a159ffdc110db9cd505",
+      "integrity": "sha512-gffXL62bj8jMt6RAT0NRGHkBUCiU7jfO+4rxaHAC+OnpWxRRCXbrnULtlWZgD4iiJBDhCah+q3F75JMc8vlKBw==",
       "requires": {
-        "dom-parser": "^0.1.6",
-        "is-react": "^1.3.3",
-        "lazy-child": "^0.2.0",
-        "polished": "^3.4.4",
-        "prop-types": "^15.7.2",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0",
-        "react-modal": "^3.11.1",
-        "react-swipeable": "^5.5.0",
-        "styled-components": "^4.4.1",
-        "thumbor-lite": "^0.1.6",
-        "timezone": "^1.0.23"
+        "@wpmedia/engine-theme-sdk": "^2.4.0-canary.5",
+        "thumbor-lite": "^0.1.8"
+      },
+      "dependencies": {
+        "@wpmedia/engine-theme-sdk": {
+          "version": "2.4.0-canary.5",
+          "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.4.0-canary.5/6db46988869d2ab30142edefb349657f69de5cd68eb45bfbca3ab1b9c71838c2",
+          "integrity": "sha512-4fM43EmlV7ZjfxCw0iNHg3lloeTCu7HMDxsk8Wed+HdH0mc50rt6Sx70YEUHY/OTK4lrExQjtwLI2X6GtrnmRw==",
+          "requires": {
+            "dom-parser": "^0.1.6",
+            "is-react": "^1.3.3",
+            "lazy-child": "^0.2.0",
+            "polished": "^3.4.4",
+            "prop-types": "^15.7.2",
+            "react": "^16.12.0",
+            "react-dom": "^16.12.0",
+            "react-modal": "^3.11.1",
+            "react-swipeable": "^5.5.0",
+            "styled-components": "^4.4.1",
+            "thumbor-lite": "^0.1.6",
+            "timezone": "^1.0.23"
+          }
+        }
       }
     },
     "ansi-styles": {
@@ -458,9 +469,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "safe-buffer": {
       "version": "5.2.1",

--- a/blocks/story-feed-sections-content-source-block/package.json
+++ b/blocks/story-feed-sections-content-source-block/package.json
@@ -23,9 +23,8 @@
     "lint": "eslint --ext js --ext jsx sources"
   },
   "dependencies": {
-    "@arc-core-components/content-source_story-feed_sections-v4": "^1.0.6-canary.0",
-    "@wpmedia/engine-theme-sdk": "canary",
-    "@wpmedia/story-feed-tag-content-source-block": "canary"
+    "@arc-core-components/content-source_story-feed_sections-v4": "latest",
+    "@wpmedia/resizer-image-block": "canary"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }

--- a/blocks/story-feed-tag-content-source-block/package-lock.json
+++ b/blocks/story-feed-tag-content-source-block/package-lock.json
@@ -21,11 +21,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-      "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
+      "integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
       "requires": {
-        "@babel/types": "^7.10.5",
+        "@babel/types": "^7.12.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -65,11 +65,11 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-      "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.11.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -88,16 +88,16 @@
       }
     },
     "@babel/parser": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-      "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
+      "integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg=="
     },
     "@babel/runtime": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
+      "integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
       "requires": {
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
@@ -111,25 +111,25 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-      "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
+      "integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.10.5",
+        "@babel/generator": "^7.12.0",
         "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.10.4",
-        "@babel/parser": "^7.10.5",
-        "@babel/types": "^7.10.5",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.12.0",
+        "@babel/types": "^7.12.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       }
     },
     "@babel/types": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-      "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
+      "integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "lodash": "^4.17.19",
@@ -155,9 +155,9 @@
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.2.0/4dd9d94540ae477f1f0d051881db344e22cb9d5fa335925697aafb3b4435312e",
-      "integrity": "sha512-bYi8OsC99T1eYkRxfjto3DJ6k1MzKNIKb4Z9fKNftViYY1IzPE2nXGqL6efoN/ntqczbR7tlgpqHNGt3/XThFw==",
+      "version": "2.4.0-canary.5",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.4.0-canary.5/6db46988869d2ab30142edefb349657f69de5cd68eb45bfbca3ab1b9c71838c2",
+      "integrity": "sha512-4fM43EmlV7ZjfxCw0iNHg3lloeTCu7HMDxsk8Wed+HdH0mc50rt6Sx70YEUHY/OTK4lrExQjtwLI2X6GtrnmRw==",
       "requires": {
         "dom-parser": "^0.1.6",
         "is-react": "^1.3.3",
@@ -182,9 +182,9 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz",
-      "integrity": "sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.11.1.tgz",
+      "integrity": "sha512-YwrInHyKUk1PU3avIRdiLyCpM++18Rs1NgyMXEAQC33rIXs/vro0A+stf4sT0Gf22Got+xRWB8Cm0tw+qkRzBA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -250,11 +250,11 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "dom-parser": {
@@ -288,17 +288,17 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-react": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/is-react/-/is-react-1.4.0.tgz",
-      "integrity": "sha512-6MfKyatgJfuvvKPPKvdaEnFlvdbwhAma4jiTOjxp9uL8oTKo9uKw9U/vTvMB2jiYkPoXBvK2QSUGI5m4egJsgw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/is-react/-/is-react-1.4.1.tgz",
+      "integrity": "sha512-XnY1qZnMLasBCogVp+HoaMmJ4v2Sy6artHsec2OVl3qeEIGJgFZvdR8bA6vGsr9JtSh3rIYNo5nNBrbXc/glmA==",
       "requires": {
         "react": "^16.13.1"
       }
     },
     "is-what": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.10.0.tgz",
-      "integrity": "sha512-U4RYCXNOmATQHlOPlOCHCfXyKEFIPqvyaKDqYRuLbD6EYKcTTfc3YXkAYjzOVxO3zt34L+Wh2feIyWrYiZ7kng=="
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.11.2.tgz",
+      "integrity": "sha512-m7LzBsC9TqUhkBrozSmmWfVO7VYnjk9UHu0U+Y8BiJRnc1TYIK/3Qv4DteuiBpn2S4K7n3N4WNC4pe6wEx2xYg=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -320,9 +320,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.throttle": {
       "version": "4.1.1",
@@ -361,26 +361,11 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "polished": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.5.tgz",
-      "integrity": "sha512-VwhC9MlhW7O5dg/z7k32dabcAFW1VI2+7fSe8cE/kXcfL7mVdoa5UxciYGW2sJU78ldDLT6+ROEKIZKFNTnUXQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.7.tgz",
+      "integrity": "sha512-b4OViUOihwV0icb9PHmWbR+vPqaSzSAEbgLskvb7ANPATVXGiYv/TQFHQo65S53WU9i5EQ1I03YDOJW7K0bmYg==",
       "requires": {
         "@babel/runtime": "^7.9.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
-          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-        }
       }
     },
     "postcss-value-parser": {
@@ -399,9 +384,9 @@
       }
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -409,9 +394,9 @@
       }
     },
     "react-dom": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -458,9 +443,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "safe-buffer": {
       "version": "5.2.1",

--- a/blocks/story-feed-tag-content-source-block/package-lock.json
+++ b/blocks/story-feed-tag-content-source-block/package-lock.json
@@ -154,23 +154,34 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
-    "@wpmedia/engine-theme-sdk": {
-      "version": "2.4.0-canary.5",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.4.0-canary.5/6db46988869d2ab30142edefb349657f69de5cd68eb45bfbca3ab1b9c71838c2",
-      "integrity": "sha512-4fM43EmlV7ZjfxCw0iNHg3lloeTCu7HMDxsk8Wed+HdH0mc50rt6Sx70YEUHY/OTK4lrExQjtwLI2X6GtrnmRw==",
+    "@wpmedia/resizer-image-block": {
+      "version": "0.0.0-b2343d5",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/resizer-image-block/0.0.0-b2343d5/0bb697b4ecb293d76466093e24db1b89828bbf722b681a159ffdc110db9cd505",
+      "integrity": "sha512-gffXL62bj8jMt6RAT0NRGHkBUCiU7jfO+4rxaHAC+OnpWxRRCXbrnULtlWZgD4iiJBDhCah+q3F75JMc8vlKBw==",
       "requires": {
-        "dom-parser": "^0.1.6",
-        "is-react": "^1.3.3",
-        "lazy-child": "^0.2.0",
-        "polished": "^3.4.4",
-        "prop-types": "^15.7.2",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0",
-        "react-modal": "^3.11.1",
-        "react-swipeable": "^5.5.0",
-        "styled-components": "^4.4.1",
-        "thumbor-lite": "^0.1.6",
-        "timezone": "^1.0.23"
+        "@wpmedia/engine-theme-sdk": "^2.4.0-canary.5",
+        "thumbor-lite": "^0.1.8"
+      },
+      "dependencies": {
+        "@wpmedia/engine-theme-sdk": {
+          "version": "2.4.0-canary.5",
+          "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.4.0-canary.5/6db46988869d2ab30142edefb349657f69de5cd68eb45bfbca3ab1b9c71838c2",
+          "integrity": "sha512-4fM43EmlV7ZjfxCw0iNHg3lloeTCu7HMDxsk8Wed+HdH0mc50rt6Sx70YEUHY/OTK4lrExQjtwLI2X6GtrnmRw==",
+          "requires": {
+            "dom-parser": "^0.1.6",
+            "is-react": "^1.3.3",
+            "lazy-child": "^0.2.0",
+            "polished": "^3.4.4",
+            "prop-types": "^15.7.2",
+            "react": "^16.12.0",
+            "react-dom": "^16.12.0",
+            "react-modal": "^3.11.1",
+            "react-swipeable": "^5.5.0",
+            "styled-components": "^4.4.1",
+            "thumbor-lite": "^0.1.6",
+            "timezone": "^1.0.23"
+          }
+        }
       }
     },
     "ansi-styles": {

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --ext js --ext jsx sources"
   },
   "dependencies": {
-    "@arc-core-components/content-source_story-feed_tag-v4": "^1.0.6-canary.0",
+    "@arc-core-components/content-source_story-feed_tag-v4": "latest",
     "@wpmedia/engine-theme-sdk": "canary"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@arc-core-components/content-source_story-feed_tag-v4": "latest",
-    "@wpmedia/engine-theme-sdk": "canary"
+    "@wpmedia/resizer-image-block": "canary"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }


### PR DESCRIPTION
updated the dependencies on all story-feed blocks.
* most of the cases was having depency against `engine-sdk` when is not needed.
* added dependency on `resizer-image-block`
* remove dependency on `content-source_story-feed_sections-v4` from `story-feed-query`

tested each cs locally in PB content debugger 