### PR TITLE
PEN-1388: Promo blocks image override not populating images properly

### DIFF
--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -41,6 +41,13 @@ const ExtraLargePromo = ({ customFields }) => {
       : null,
   }) || null;
 
+  const imageConfig = customFields.imageOverrideURL ? 'resize-image-api' : null;
+
+  const customFieldImageResizedImageOptions = useContent({
+    source: imageConfig,
+    query: { raw_image_url: customFields.imageOverrideURL },
+  }) || undefined;
+
   const { website_section: websiteSection } = content?.websites?.[arcSite] ?? {
     website_section: null,
   };
@@ -84,7 +91,7 @@ const ExtraLargePromo = ({ customFields }) => {
         <a
           href={content.website_url}
           className="xl-promo-headline"
-          title={content && content.headlines ? content.headlines.basic : ''}
+          title={headlineText}
         >
           <HeadlineText
             primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
@@ -140,6 +147,11 @@ const ExtraLargePromo = ({ customFields }) => {
   };
 
   const ratios = ratiosFor('XL', customFields.imageRatio);
+  const imageURL = customFields.imageOverrideURL
+    ? customFields.imageOverrideURL : extractImageFromStory(content);
+  const resizedImageOptions = customFields.imageOverrideURL
+    ? customFieldImageResizedImageOptions
+    : extractResizedParams(content);
 
   return content && (
     <>
@@ -157,11 +169,10 @@ const ExtraLargePromo = ({ customFields }) => {
                   href={content.website_url}
                   title={content && content.headlines ? content.headlines.basic : ''}
                 >
-                  {customFields.imageOverrideURL || extractImageFromStory(content)
+                  {imageURL
                     ? (
                       <Image
-                        url={customFields.imageOverrideURL
-                          ? customFields.imageOverrideURL : extractImageFromStory(content)}
+                        url={imageURL}
                         alt={content && content.headlines ? content.headlines.basic : ''}
                         smallWidth={ratios.smallWidth}
                         smallHeight={ratios.smallHeight}
@@ -171,10 +182,10 @@ const ExtraLargePromo = ({ customFields }) => {
                         largeHeight={ratios.largeHeight}
                         breakpoints={getProperties(arcSite)?.breakpoints}
                         resizerURL={getProperties(arcSite)?.resizerURL}
-                        resizedImageOptions={extractResizedParams(content)}
-                        // todo: this should have resized params
+                        resizedImageOptions={resizedImageOptions}
                       />
                     )
+
                     : (
                       <PlaceholderImage
                         smallWidth={ratios.smallWidth}
@@ -185,6 +196,7 @@ const ExtraLargePromo = ({ customFields }) => {
                         largeHeight={ratios.largeHeight}
                       />
                     )}
+
                   <PromoLabel type={promoType} />
                 </a>
               )}

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { useContent } from 'fusion:content';
 import ExtraLargePromo from './default';
 
 const { default: mockData } = require('./mock-data');
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
+  localizeDateTime: jest.fn(() => new Date().toDateString()),
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
-jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
-jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+jest.mock('fusion:properties', () => (jest.fn(() => ({
+  fallbackImage: 'placeholder.jpg',
+}))));
 jest.mock('fusion:context', () => ({
   useFusionContext: jest.fn(() => ({})),
 }));
@@ -35,6 +38,7 @@ jest.mock('fusion:context', () => ({
 describe('the extra large promo feature', () => {
   afterEach(() => {
     jest.resetModules();
+    jest.clearAllMocks();
   });
 
   beforeEach(() => {
@@ -105,5 +109,187 @@ describe('the extra large promo feature', () => {
     const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
     const img = wrapper.find('Image');
     expect(img.prop('largeHeight')).toBe(600);
+  });
+
+  it('should fetch content using null source and query if none in custom fields', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      itemContentConfig: {
+        contentConfigValues: { id: 1234 },
+        contentService: 'content-api',
+      },
+    };
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+    const expectedArgs = {
+      query: {
+        'arc-site': 'the-sun',
+        id: 1234,
+      },
+      source: 'content-api',
+    };
+    expect(useContent).toHaveBeenNthCalledWith(1, expectedArgs);
+    wrapper.unmount();
+  });
+
+  it('if undefined content return null result', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      itemContentConfig: {
+        contentConfigValues: { id: 1234 },
+        contentService: 'content-api',
+      },
+    };
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+    const expectedArgs = {
+      query: {
+        'arc-site': 'the-sun',
+        id: 1234,
+      },
+      source: 'content-api',
+    };
+    expect(useContent).toHaveBeenNthCalledWith(1, expectedArgs);
+    wrapper.unmount();
+  });
+
+  it('returns null if null content', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      imageOverrideURL: 'overrideImage.jpg',
+    };
+
+    useContent.mockReturnValueOnce(undefined);
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} arcSite="dagen" />);
+    expect(wrapper).toEqual({});
+    wrapper.unmount();
+  });
+
+  it('show image useContent for resizer parameter returns undefined if falsy', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      imageOverrideURL: 'overrideImage.jpg',
+    };
+
+    useContent.mockReturnValueOnce({}).mockReturnValueOnce(null);
+
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} arcSite="dagen" />);
+
+    const image = wrapper.find('Image');
+    expect(image.length).toBe(1);
+    expect(image.props().resizedImageOptions).toEqual(undefined);
+    wrapper.unmount();
+  });
+
+  it('uses websiteSection for overline if there is no content.label.basic', () => {
+    const myConfig = {
+      showHeadline: true,
+      showOverline: true,
+    };
+    useContent.mockReturnValueOnce({ websites: { 'the-sun': { website_section: { _id: 'the-sun-ID', name: 'the-sun-name' } } } });
+
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+
+    const wrapperOverline = wrapper.find('Overline');
+    expect(wrapperOverline.length).toBe(1);
+
+    expect(wrapperOverline.props().customUrl).toEqual('the-sun-ID');
+    expect(wrapperOverline.props().customText).toEqual('the-sun-name');
+    wrapper.unmount();
+  });
+
+  it('show ALL options if enabled', () => {
+    useContent.mockReturnValueOnce(mockData);
+
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      showOverline: true,
+      showDescription: true,
+      showByline: true,
+      showDate: true,
+    };
+
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+
+    expect(wrapper.find('Overline').length).toBe(1);
+    expect(wrapper.find('.xl-promo-headline').length).toBe(4);
+    expect(wrapper.find('.description-text').length).toBe(3);
+    expect(wrapper.find('ArticleByline').length).toBe(1);
+    expect(wrapper.find('ArticleDate').length).toBe(1);
+    expect(wrapper.find('Image').length).toBe(1);
+    wrapper.unmount();
+  });
+
+  it('show image if has showDescription enabled', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      showOverline: false,
+      showDescription: true,
+      showByline: false,
+      showDate: false,
+    };
+
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+    expect(wrapper.find('.description-text').length).toBe(3);
+    expect(wrapper.find('Image').length).toBe(1);
+    wrapper.unmount();
+  });
+
+  it('show image if has showByline enabled', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      showOverline: false,
+      showDescription: false,
+      showByline: true,
+      showDate: false,
+    };
+
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+    expect(wrapper.find('ArticleByline').length).toBe(1);
+    expect(wrapper.find('Image').length).toBe(1);
+    wrapper.unmount();
+  });
+
+  it('show image if has showDate enabled', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      showOverline: false,
+      showDescription: false,
+      showByline: false,
+      showDate: true,
+    };
+
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+    expect(wrapper.find('ArticleDate').length).toBe(1);
+    expect(wrapper.find('Image').length).toBe(1);
+    wrapper.unmount();
+  });
+
+  it('shows placeholder image if no image URL', () => {
+    useContent.mockReturnValueOnce({});
+
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+    };
+
+    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
+
+    expect(wrapper.find('PlaceholderImage').length).toBe(1);
+    expect(wrapper.find('Image').length).toBe(0);
+    wrapper.unmount();
   });
 });

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -19,6 +19,7 @@ import {
   ratiosFor,
   extractImageFromStory,
 } from '@wpmedia/resizer-image-block';
+
 import PromoLabel from './_children/promo_label';
 import discoverPromoType from './_children/discover';
 
@@ -41,6 +42,13 @@ const LargePromo = ({ customFields }) => {
       : null,
   }) || null;
 
+  const imageConfig = customFields.imageOverrideURL ? 'resize-image-api' : null;
+
+  const customFieldImageResizedImageOptions = useContent({
+    source: imageConfig,
+    query: { raw_image_url: customFields.imageOverrideURL },
+  }) || undefined;
+
   const { website_section: websiteSection } = content?.websites?.[arcSite] ?? {
     website_section: null,
   };
@@ -60,7 +68,6 @@ const LargePromo = ({ customFields }) => {
   const overlineText = (content?.label?.basic?.text ?? null)
       || (content?.websites?.[arcSite] && websiteSection && websiteSection.name)
       || '';
-
   const textClass = customFields.showImage ? 'col-sm-12 col-md-xl-6 flex-col' : 'col-sm-xl-12 flex-col';
   const promoType = discoverPromoType(content);
 
@@ -86,7 +93,7 @@ const LargePromo = ({ customFields }) => {
         <a
           href={content.website_url}
           className="lg-promo-headline"
-          title={content && content.headlines ? content.headlines.basic : ''}
+          title={headlineText}
         >
           <HeadlineText
             primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
@@ -142,6 +149,11 @@ const LargePromo = ({ customFields }) => {
   };
 
   const ratios = ratiosFor('LG', customFields.imageRatio);
+  const imageURL = customFields.imageOverrideURL
+    ? customFields.imageOverrideURL : extractImageFromStory(content || {});
+  const resizedImageOptions = customFields.imageOverrideURL
+    ? customFieldImageResizedImageOptions
+    : extractResizedParams(content);
 
   return content ? (
     <>
@@ -155,11 +167,10 @@ const LargePromo = ({ customFields }) => {
                 title={content && content.headlines ? content.headlines.basic : ''}
               >
                 {
-                  customFields.imageOverrideURL || extractImageFromStory(content)
+                  imageURL
                     ? (
                       <Image
-                        url={customFields.imageOverrideURL
-                          ? customFields.imageOverrideURL : extractImageFromStory(content)}
+                        url={imageURL}
                         alt={content && content.headlines ? content.headlines.basic : ''}
                         // large is 4:3 aspect ratio
                         smallWidth={ratios.smallWidth}
@@ -170,7 +181,7 @@ const LargePromo = ({ customFields }) => {
                         largeHeight={ratios.largeHeight}
                         breakpoints={getProperties(arcSite)?.breakpoints}
                         resizerURL={getProperties(arcSite)?.resizerURL}
-                        resizedImageOptions={extractResizedParams(content)}
+                        resizedImageOptions={resizedImageOptions}
                         // todo: should have resized params
                       />
                     )

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -1,27 +1,26 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { useContent } from 'fusion:content';
 import LargePromo from './default';
 
 const { default: mockData } = require('./mock-data');
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
+  localizeDateTime: jest.fn(() => new Date().toDateString()),
 }));
+
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
-jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
-jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
-jest.mock('fusion:context', () => ({
-  useFusionContext: jest.fn(() => ({})),
-}));
-jest.mock('fusion:content', () => ({
-  useContent: jest.fn(() => (mockData)),
-  useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),
-}));
+
+jest.mock('fusion:properties', () => (jest.fn(() => ({
+  fallbackImage: 'placeholder.jpg',
+}))));
 
 const config = {
   itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
   showHeadline: true,
   showImage: true,
+  showOverline: false,
 };
 
 const mockFusionContext = {
@@ -32,50 +31,59 @@ jest.mock('fusion:context', () => ({
   useFusionContext: jest.fn(() => mockFusionContext),
 }));
 
+jest.mock('fusion:content', () => ({
+  useContent: jest.fn(() => (mockData)),
+  useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),
+}));
+
 describe('the large promo feature', () => {
   afterEach(() => {
     jest.resetModules();
-  });
-
-  beforeEach(() => {
-    jest.mock('fusion:context', () => ({
-      useFusionContext: jest.fn(() => mockFusionContext),
-    }));
+    jest.clearAllMocks();
   });
 
   it('should have 1 container fluid class', () => {
     const wrapper = mount(<LargePromo customFields={config} />);
     expect(wrapper.find('.container-fluid')).toHaveLength(1);
+    wrapper.unmount();
   });
 
   it('should have two link elements by default', () => {
     const wrapper = mount(<LargePromo customFields={config} />);
     expect(wrapper.find('a')).toHaveLength(2);
+    wrapper.unmount();
   });
 
   it('should link the headline to the current site website_url ANS property', () => {
     const url = mockData.websites['the-sun'].website_url;
     const wrapper = mount(<LargePromo customFields={config} />);
     expect(wrapper.find('a.lg-promo-headline')).toHaveProp('href', url);
+    wrapper.unmount();
   });
 
   it('should link the image to the current site website_url ANS property', () => {
     const url = mockData.websites['the-sun'].website_url;
     const wrapper = mount(<LargePromo customFields={config} />);
     expect(wrapper.find('a').at(1)).toHaveProp('href', url);
+    wrapper.unmount();
   });
 
   it('should have one img when show image is true', () => {
+    useContent.mockReturnValueOnce(mockData);
     const wrapper = mount(<LargePromo customFields={config} />);
     expect(wrapper.find('Image')).toHaveLength(1);
+    wrapper.unmount();
   });
 
   it('Headline div should have class .col-md-xl-6 when show image is true', () => {
+    useContent.mockReturnValueOnce(mockData);
     const wrapper = mount(<LargePromo customFields={config} />);
     expect(wrapper.find('.col-md-xl-6')).toHaveLength(2);
+    wrapper.unmount();
   });
 
   it('should have no Image when show image is false', () => {
+    useContent.mockReturnValueOnce(mockData);
     const noImgConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
       showHeadline: true,
@@ -83,9 +91,11 @@ describe('the large promo feature', () => {
     };
     const wrapper = mount(<LargePromo customFields={noImgConfig} />);
     expect(wrapper.find('Image')).toHaveLength(0);
+    wrapper.unmount();
   });
 
   it('headline div should have class .col-sm-xl-12 when show image is false', () => {
+    useContent.mockReturnValueOnce(mockData);
     const noImgConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
       showHeadline: true,
@@ -93,9 +103,11 @@ describe('the large promo feature', () => {
     };
     const wrapper = mount(<LargePromo customFields={noImgConfig} />);
     expect(wrapper.find('.col-sm-xl-12')).toHaveLength(1);
+    wrapper.unmount();
   });
 
   it('should only be one link when showHeadline is false and show image is true', () => {
+    useContent.mockReturnValueOnce(mockData);
     const noHeadlineConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
       showHeadline: false,
@@ -103,32 +115,205 @@ describe('the large promo feature', () => {
     };
     const wrapper = mount(<LargePromo customFields={noHeadlineConfig} />);
     expect(wrapper.find('a')).toHaveLength(1);
+    wrapper.unmount();
   });
 
   it('should have by default an 4:3 image ratio', () => {
+    useContent.mockReturnValueOnce(mockData);
     const wrapper = mount(<LargePromo customFields={config} />);
     const img = wrapper.find('Image');
     expect(img.prop('largeHeight')).toBe(283);
+    wrapper.unmount();
   });
 
   it('should accept a 16:9 ratio', () => {
+    useContent.mockReturnValueOnce(mockData);
     const myConfig = { ...config, imageRatio: '16:9' };
     const wrapper = mount(<LargePromo customFields={myConfig} />);
     const img = wrapper.find('Image');
     expect(img.prop('largeHeight')).toBe(212);
+    wrapper.unmount();
   });
 
   it('should accept a 3:2 ratio', () => {
+    useContent.mockReturnValueOnce(mockData);
     const myConfig = { ...config, imageRatio: '3:2' };
     const wrapper = mount(<LargePromo customFields={myConfig} />);
     const img = wrapper.find('Image');
     expect(img.prop('largeHeight')).toBe(251);
+    wrapper.unmount();
   });
 
   it('should accept a 4:3 ratio', () => {
+    useContent.mockReturnValueOnce(mockData);
     const myConfig = { ...config, imageRatio: '4:3' };
     const wrapper = mount(<LargePromo customFields={myConfig} />);
     const img = wrapper.find('Image');
     expect(img.prop('largeHeight')).toBe(283);
+    wrapper.unmount();
+  });
+
+  it('not call content source if not custom fields for url', () => {
+    useContent.mockReturnValueOnce(mockData);
+    const myConfig = { showHeadline: true, showImage: true, imageRatio: '4:3' };
+    const wrapper = mount(<LargePromo customFields={myConfig} />);
+
+    expect(useContent).toHaveBeenNthCalledWith(1, { query: null, source: null });
+    expect(useContent).toHaveBeenNthCalledWith(2,
+      { query: { raw_image_url: undefined }, source: null });
+    wrapper.unmount();
+  });
+
+  it('show ALL options if enabled', () => {
+    useContent.mockReturnValueOnce(mockData);
+
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      showOverline: true,
+      showDescription: true,
+      showByline: true,
+      showDate: true,
+    };
+
+    const wrapper = mount(<LargePromo customFields={myConfig} arcSite="dagen" />);
+
+    expect(wrapper.find('Overline').length).toBe(1);
+    expect(wrapper.find('.lg-promo-headline').length).toBe(4);
+    expect(wrapper.find('.description-text').length).toBe(3);
+    expect(wrapper.find('ArticleByline').length).toBe(1);
+    expect(wrapper.find('ArticleDate').length).toBe(1);
+    expect(wrapper.find('Image').length).toBe(1);
+
+    wrapper.unmount();
+  });
+
+  it('show ALL options if enabled', () => {
+    useContent.mockReturnValueOnce(mockData);
+
+    const myConfig = {
+      showHeadline: true,
+      showImage: false,
+      imageRatio: '4:3',
+      showOverline: false,
+      showDescription: false,
+      showByline: false,
+      showDate: false,
+    };
+
+    const wrapper = mount(<LargePromo customFields={myConfig} arcSite="dagen" />);
+
+    expect(wrapper.find('Overline').length).toBe(0);
+    expect(wrapper.find('HeadlineText').length).toBe(0);
+    expect(wrapper.find('DescriptionText').length).toBe(0);
+    expect(wrapper.find('Byline').length).toBe(0);
+    expect(wrapper.find('ArticleDate').length).toBe(0);
+    expect(wrapper.find('Image').length).toBe(0);
+    wrapper.unmount();
+  });
+
+  it('show placeholder image if no image URL', () => {
+    useContent.mockReturnValueOnce({});
+
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+    };
+
+    const wrapper = mount(<LargePromo customFields={myConfig} arcSite="dagen" />);
+
+    expect(wrapper.find('PlaceholderImage').length).toBe(1);
+    expect(wrapper.find('Image').length).toBe(0);
+    wrapper.unmount();
+  });
+
+  it('show image override if provided in custom fields', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      imageOverrideURL: 'overrideImage.jpg',
+    };
+
+    const wrapper = mount(<LargePromo customFields={myConfig} arcSite="dagen" />);
+
+    const image = wrapper.find('Image');
+    expect(image.length).toBe(1);
+    expect(image.props().url).toEqual('overrideImage.jpg');
+    wrapper.unmount();
+  });
+
+  it('show image useContent for resizer parameter returns undefined if falsy', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      imageOverrideURL: 'overrideImage.jpg',
+    };
+
+    useContent.mockReturnValueOnce({}).mockReturnValueOnce(null);
+
+    const wrapper = mount(<LargePromo customFields={myConfig} arcSite="dagen" />);
+
+    const image = wrapper.find('Image');
+    expect(image.length).toBe(1);
+    expect(image.props().resizedImageOptions).toEqual(undefined);
+    wrapper.unmount();
+  });
+
+  it('returns null if null content', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      imageOverrideURL: 'overrideImage.jpg',
+    };
+
+    useContent.mockReturnValueOnce(undefined);
+    const wrapper = mount(<LargePromo customFields={myConfig} arcSite="dagen" />);
+    expect(wrapper).toEqual({});
+    wrapper.unmount();
+  });
+
+  it('uses websiteSection for overline if there is no content.label.basic', () => {
+    const myConfig = {
+      showHeadline: true,
+      showOverline: true,
+    };
+    useContent.mockReturnValueOnce({ websites: { 'the-sun': { website_section: { _id: 'the-sun-ID', name: 'the-sun-name' } } } });
+
+    const wrapper = mount(<LargePromo customFields={myConfig} />);
+
+    const wrapperOverline = wrapper.find('Overline');
+    expect(wrapperOverline.length).toBe(1);
+
+    expect(wrapperOverline.props().customUrl).toEqual('the-sun-ID');
+    expect(wrapperOverline.props().customText).toEqual('the-sun-name');
+    wrapper.unmount();
+  });
+
+  it('uses for content query contentConfigValues if it is present in custom fields', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      imageOverrideURL: 'overrideImage.jpg',
+      itemContentConfig: {
+        contentConfigValues: { id: 1234 },
+        contentService: 'content-api',
+      },
+    };
+    const wrapper = mount(<LargePromo customFields={myConfig} arcSite="dagen" />);
+    const expectedArgs = {
+      query: {
+        'arc-site': 'the-sun',
+        id: 1234,
+      },
+      source: 'content-api',
+    };
+    expect(useContent).toHaveBeenNthCalledWith(1, expectedArgs);
+    wrapper.unmount();
   });
 });

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -43,16 +43,19 @@ const MediumPromo = ({ customFields }) => {
       : null,
   }) || null;
 
+  const imageConfig = customFields.imageOverrideURL ? 'resize-image-api' : null;
+
+  const customFieldImageResizedImageOptions = useContent({
+    source: imageConfig,
+    query: { raw_image_url: customFields.imageOverrideURL },
+  }) || undefined;
+
   const headlineText = content && content.headlines ? content.headlines.basic : null;
   const descriptionText = content && content.description ? content.description.basic : null;
   const showSeparator = content?.credits?.by && content.credits.by.length !== 0;
   const byLineArray = content?.credits?.by
     && content.credits.by.length !== 0 ? content.credits.by : null;
   const dateText = content?.display_date || null;
-
-  // const textClass = customFields.showImage
-  //   ? 'col-sm-12 col-md-xl-8 flex-col'
-  //   : 'col-sm-xl-12 flex-col';
 
   const promoType = discoverPromoType(content);
 
@@ -63,7 +66,7 @@ const MediumPromo = ({ customFields }) => {
           href={content.website_url}
           className="md-promo-headline"
           // className={`md-promo-headline headline-${customFields.headlinePosition}`}
-          title={content && content.headlines ? content.headlines.basic : ''}
+          title={headlineText}
         >
           <HeadlineText
             primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
@@ -119,25 +122,16 @@ const MediumPromo = ({ customFields }) => {
   };
 
   const ratios = ratiosFor('MD', customFields.imageRatio);
+  const imageURL = customFields.imageOverrideURL
+    ? customFields.imageOverrideURL : extractImageFromStory(content);
+  const resizedImageOptions = customFields.imageOverrideURL
+    ? customFieldImageResizedImageOptions
+    : extractResizedParams(content);
 
   return content ? (
     <>
       <article className="container-fluid medium-promo">
         <div className={`medium-promo-wrapper ${customFields.showImage ? 'md-promo-image' : ''}`}>
-          {/* customFields.headlinePosition === 'above'
-            && (customFields.showHeadline
-              || customFields.showDescription
-              || customFields.showByline
-              || customFields.showDate) && (
-              <div className={textClass}>
-                {headlineTmpl()}
-                {descriptionTmpl()}
-                <div className="article-meta">
-                  {byLineTmpl()}
-                  {dateTmpl()}
-                </div>
-              </div>
-              ) */}
           {customFields.showImage
           && (
             <a
@@ -146,11 +140,10 @@ const MediumPromo = ({ customFields }) => {
               title={content && content.headlines ? content.headlines.basic : ''}
             >
               {
-                customFields.imageOverrideURL || extractImageFromStory(content)
+                imageURL
                   ? (
                     <Image
-                      url={customFields.imageOverrideURL
-                        ? customFields.imageOverrideURL : extractImageFromStory(content)}
+                      url={imageURL}
                       alt={content && content.headlines ? content.headlines.basic : ''}
                       // medium is 16:9
                       smallWidth={ratios.smallWidth}
@@ -161,7 +154,7 @@ const MediumPromo = ({ customFields }) => {
                       largeHeight={ratios.largeHeight}
                       breakpoints={getProperties(arcSite)?.breakpoints}
                       resizerURL={getProperties(arcSite)?.resizerURL}
-                      resizedImageOptions={extractResizedParams(content)}
+                      resizedImageOptions={resizedImageOptions}
                     />
                   )
                   : (
@@ -210,11 +203,6 @@ MediumPromo.propTypes = {
       defaultValue: true,
       group: 'Show promo elements',
     }),
-    // headlinePosition: PropTypes.oneOf(['above', 'below']).tag({
-    //   label: 'Headline Position',
-    //   group: 'Show promo elements',
-    //   defaultValue: 'above',
-    // }),
     showImage: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { useContent } from 'fusion:content';
 import MediumPromo from './default';
 
 const { default: mockData } = require('./mock-data');
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
+  localizeDateTime: jest.fn(() => new Date().toDateString()),
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
-jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
-jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+jest.mock('fusion:properties', () => (jest.fn(() => ({
+  fallbackImage: 'placeholder.jpg',
+}))));
 jest.mock('fusion:context', () => ({
   useFusionContext: jest.fn(() => ({})),
 }));
@@ -28,6 +31,7 @@ const config = {
 describe('the medium promo feature', () => {
   afterEach(() => {
     jest.resetModules();
+    jest.clearAllMocks();
   });
 
   beforeEach(() => {
@@ -86,36 +90,11 @@ describe('the medium promo feature', () => {
     const noImgConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
       showHeadline: true,
-      // headlinePosition: 'below',
       showImage: false,
     };
     const wrapper = mount(<MediumPromo customFields={noImgConfig} />);
     expect(wrapper.find('.md-promo-image')).toHaveLength(0);
   });
-
-  // it('headline div should have class .headline-above when headline position is above', () => {
-  //   const headAboveConfig = {
-  //     itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-  //     showHeadline: true,
-  //     headlinePosition: 'above',
-  //     showImage: false,
-  //   };
-  //   const wrapper = mount(<MediumPromo customFields={headAboveConfig} />);
-  //   expect(wrapper.find('.headline-above')).toHaveLength(1);
-  //   expect(wrapper.find('.headline-below').length).toBe(0);
-  // });
-
-  // it('headline div should have class .headline-below when headline position is below', () => {
-  //   const headBelowConfig = {
-  //     itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-  //     showHeadline: true,
-  //     headlinePosition: 'below',
-  //     showImage: false,
-  //   };
-  //   const wrapper = mount(<MediumPromo customFields={headBelowConfig} />);
-  //   expect(wrapper.find('.headline-below')).toHaveLength(1);
-  //   expect(wrapper.find('.headline-above').length).toBe(0);
-  // });
 
   it('should only be one link when showHeadline is false and show image is true', () => {
     const noHeadlineConfig = {
@@ -152,5 +131,96 @@ describe('the medium promo feature', () => {
     const wrapper = mount(<MediumPromo customFields={myConfig} />);
     const img = wrapper.find('Image');
     expect(img.prop('largeHeight')).toBe(300);
+  });
+
+  it('should fetch content using null source and query if none in custom fields', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      itemContentConfig: {
+        contentConfigValues: { id: 1234 },
+        contentService: 'content-api',
+      },
+    };
+    const wrapper = mount(<MediumPromo customFields={myConfig} />);
+    const expectedArgs = {
+      query: {
+        'arc-site': undefined,
+        id: 1234,
+      },
+      source: 'content-api',
+    };
+    expect(useContent).toHaveBeenNthCalledWith(1, expectedArgs);
+    wrapper.unmount();
+  });
+
+  it('returns null if null content', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      imageOverrideURL: 'overrideImage.jpg',
+    };
+
+    useContent.mockReturnValueOnce(undefined);
+    const wrapper = mount(<MediumPromo customFields={myConfig} arcSite="dagen" />);
+    expect(wrapper).toEqual({});
+    wrapper.unmount();
+  });
+
+  it('show image useContent for resizer parameter returns undefined if falsy', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      imageOverrideURL: 'overrideImage.jpg',
+    };
+
+    useContent.mockReturnValueOnce({}).mockReturnValueOnce(null);
+
+    const wrapper = mount(<MediumPromo customFields={myConfig} arcSite="dagen" />);
+
+    const image = wrapper.find('Image');
+    expect(image.length).toBe(1);
+    expect(image.props().resizedImageOptions).toEqual(undefined);
+    wrapper.unmount();
+  });
+
+  it('show ALL options if enabled', () => {
+    useContent.mockReturnValueOnce(mockData);
+
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      showDescription: true,
+      showByline: true,
+      showDate: true,
+    };
+
+    const wrapper = mount(<MediumPromo customFields={myConfig} />);
+
+    expect(wrapper.find('.md-promo-headline').length).toBe(1);
+    expect(wrapper.find('.description-text').length).toBe(3);
+    expect(wrapper.find('ArticleByline').length).toBe(1);
+    expect(wrapper.find('ArticleDate').length).toBe(1);
+    expect(wrapper.find('Image').length).toBe(1);
+    wrapper.unmount();
+  });
+
+  it('shows placeholder image if no image URL', () => {
+    useContent.mockReturnValueOnce({});
+
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+    };
+
+    const wrapper = mount(<MediumPromo customFields={myConfig} />);
+
+    expect(wrapper.find('PlaceholderImage').length).toBe(1);
+    expect(wrapper.find('Image').length).toBe(0);
+    wrapper.unmount();
   });
 });

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -37,12 +37,24 @@ const SmallPromo = ({ customFields }) => {
       : null,
   }) || null;
 
+  const imageConfig = customFields.imageOverrideURL ? 'resize-image-api' : null;
+
+  const customFieldImageResizedImageOptions = useContent({
+    source: imageConfig,
+    query: { raw_image_url: customFields.imageOverrideURL },
+  }) || undefined;
+
   const headlineClass = customFields.showImage
     ? 'col-sm-xl-8'
     : 'col-sm-xl-12 no-image-padding';
 
   const ratios = ratiosFor('SM', customFields.imageRatio);
   const promoType = discoverPromoType(content);
+  const imageURL = customFields.imageOverrideURL
+    ? customFields.imageOverrideURL : extractImageFromStory(content);
+  const resizedImageOptions = customFields.imageOverrideURL
+    ? customFieldImageResizedImageOptions
+    : extractResizedParams(content);
 
   return content ? (
     <>
@@ -76,11 +88,10 @@ const SmallPromo = ({ customFields }) => {
                 href={content?.website_url || ''}
                 title={content?.headlines?.basic || ''}
               >
-                {customFields.imageOverrideURL || extractImageFromStory(content)
+                {imageURL
                   ? (
                     <Image
-                      url={customFields.imageOverrideURL
-                        ? customFields.imageOverrideURL : extractImageFromStory(content)}
+                      url={imageURL}
                       alt={content && content.headlines ? content.headlines.basic : ''}
                       // small should be 3:2 aspect ratio
                       smallWidth={ratios.smallWidth}
@@ -91,7 +102,7 @@ const SmallPromo = ({ customFields }) => {
                       largeHeight={ratios.largeHeight}
                       breakpoints={getProperties(arcSite)?.breakpoints}
                       resizerURL={getProperties(arcSite)?.resizerURL}
-                      resizedImageOptions={extractResizedParams(content)}
+                      resizedImageOptions={resizedImageOptions}
                     />
                   )
                   : (
@@ -149,11 +160,6 @@ SmallPromo.propTypes = {
       defaultValue: true,
       group: 'Show promo elements',
     }),
-    // headlinePosition: PropTypes.oneOf(['above', 'below']).tag({
-    //   label: 'Headline Position',
-    //   group: 'Show promo elements',
-    //   defaultValue: 'above',
-    // }),
     showImage: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { useContent } from 'fusion:content';
 import SmallPromo from './default';
 
 const { default: mockData } = require('./mock-data');
@@ -8,8 +9,9 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
-jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
-jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+jest.mock('fusion:properties', () => (jest.fn(() => ({
+  fallbackImage: 'placeholder.jpg',
+}))));
 jest.mock('fusion:context', () => ({
   useFusionContext: jest.fn(() => ({})),
 }));
@@ -28,6 +30,7 @@ const config = {
 describe('the small promo feature', () => {
   afterEach(() => {
     jest.resetModules();
+    jest.clearAllMocks();
   });
 
   beforeEach(() => {
@@ -93,30 +96,6 @@ describe('the small promo feature', () => {
     expect(wrapper.find('.col-sm-xl-12')).toHaveLength(1);
   });
 
-  // it('headline div should have class .headline-above when headline position is above', () => {
-  //   const headAboveConfig = {
-  //     itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-  //     showHeadline: true,
-  //     headlinePosition: 'above',
-  //     showImage: false,
-  //   };
-  //   const wrapper = mount(<SmallPromo customFields={headAboveConfig} />);
-  //   expect(wrapper.find('.headline-above')).toHaveLength(1);
-  //   expect(wrapper.find('.headline-below').length).toBe(0);
-  // });
-
-  // it('headline div should have class .headline-below when headline position is below', () => {
-  //   const headBelowConfig = {
-  //     itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-  //     showHeadline: true,
-  //     headlinePosition: 'below',
-  //     showImage: false,
-  //   };
-  //   const wrapper = mount(<SmallPromo customFields={headBelowConfig} />);
-  //   expect(wrapper.find('.headline-below')).toHaveLength(1);
-  //   expect(wrapper.find('.headline-above').length).toBe(0);
-  // });
-
   it('should only be one link when showHeadline is false and show image is true', () => {
     const noHeadlineConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
@@ -152,5 +131,74 @@ describe('the small promo feature', () => {
     const wrapper = mount(<SmallPromo customFields={myConfig} />);
     const img = wrapper.find('Image');
     expect(img.prop('largeHeight')).toBe(300);
+  });
+
+  it('should fetch content using null source and query if none in custom fields', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      itemContentConfig: {
+        contentConfigValues: { id: 1234 },
+        contentService: 'content-api',
+      },
+    };
+    const wrapper = mount(<SmallPromo customFields={myConfig} />);
+    const expectedArgs = {
+      query: {
+        'arc-site': undefined,
+        id: 1234,
+      },
+      source: 'content-api',
+    };
+    expect(useContent).toHaveBeenNthCalledWith(1, expectedArgs);
+    wrapper.unmount();
+  });
+
+  it('returns null if null content', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      imageOverrideURL: 'overrideImage.jpg',
+    };
+
+    useContent.mockReturnValueOnce(undefined);
+    const wrapper = mount(<SmallPromo customFields={myConfig} />);
+    expect(wrapper).toEqual({});
+    wrapper.unmount();
+  });
+
+  it('show image useContent for resizer parameter returns undefined if falsy', () => {
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+      imageOverrideURL: 'overrideImage.jpg',
+    };
+
+    useContent.mockReturnValueOnce({}).mockReturnValueOnce(null);
+
+    const wrapper = mount(<SmallPromo customFields={myConfig} arcSite="dagen" />);
+
+    const image = wrapper.find('Image');
+    expect(image.length).toBe(1);
+    expect(image.props().resizedImageOptions).toEqual(undefined);
+    wrapper.unmount();
+  });
+
+  it('shows placeholder image if no image URL', () => {
+    useContent.mockReturnValueOnce({});
+
+    const myConfig = {
+      showHeadline: true,
+      showImage: true,
+      imageRatio: '4:3',
+    };
+
+    const wrapper = mount(<SmallPromo customFields={myConfig} />);
+
+    expect(wrapper.find('PlaceholderImage').length).toBe(1);
+    expect(wrapper.find('Image').length).toBe(0);
+    wrapper.unmount();
   });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,9 +8,9 @@ module.exports = {
   coverageDirectory: '<rootDir>/coverage',
   coverageThreshold: {
     global: {
-      branches: 70,
-      functions: 70,
-      lines: 70,
+      branches: 85,
+      functions: 85,
+      lines: 85,
     },
   },
   collectCoverageFrom: [


### PR DESCRIPTION
## Description
If an image override url custom field is passed to a promo block, the image is not shown properly.  This is because the resize params for the image to show always uses that from the promo items resize params - whether or not the promo item image is used or the override image url is used. Then when an image override is used, there was a mismatch between resize params - image override url was used for image url, but then promo image resize params was used for resize params.  Logic was added so that in the case of an image override url being used, a call to   'resize-image-api' is made to get the resize params for that image and then those resize params are passed as props to the image component, and the image renders sucessfully.

## Jira Ticket
- [PEN-1388](https://arcpublishing.atlassian.net/browse/PEN-1388)

## Acceptance Criteria
When plugging in the "Path in Photo Center" URL for an image override in the Promo Blocks, the new image should appear properly in the preview.

Note: The user may be required to refresh their page window in order to see the image. If this is the case, we will address this in a follow-up ticket (this would be an Editor/Engine change). However, the image should be run through the resizer.

## Test Steps
For each Promo block (Extra-Large, Large, Medium, Small) verify that if the showImage custom field is checked, that an image is shown for both cases with and without image override URL provided in custom fields.

## Effect Of Changes
### Before
When image override url is provided in any Promo Block custom field, the image for that promo block is broken:
<img width="1339" alt="Screen Shot 2020-10-19 at 10 49 21 AM" src="https://user-images.githubusercontent.com/2664083/96467435-e9fa7900-11f8-11eb-8cb0-3f25f20fbf9f.png">


### After
When image override url is provided in any Promo Block custom field, the image for that promo block is shown successfully:

<img width="1026" alt="Screen Shot 2020-10-14 at 2 31 31 PM" src="https://user-images.githubusercontent.com/2664083/96467528-01d1fd00-11f9-11eb-8cdd-d6b012acdefc.png">



## Dependencies or Side Effects
None

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x ] Confirmed all the test steps above are working
- [ x] Confirmed there are no linter errors
- [ x] Confirmed this PR has reasonable code coverage
  - [ x] Confirmed this PR has unit test files
  - [x ] Ran `npm test`, made sure all tests are passing
  - [ x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x ] Confirmed relevant documentation has been updated/added.
