### PR TITLE
PEN-1368: Manual promo blocks should not require Link URL to be set

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from '@arc-fusion/prop-types';
 import styled from 'styled-components';
 import getThemeStyle from 'fusion:themes';
@@ -37,7 +37,22 @@ const ExtraLargeManualPromo = ({ customFields }) => {
     query: { raw_image_url: customFields.imageURL, 'arc-site': arcSite },
   });
 
-  return (customFields.linkURL ? (
+  const renderWithLink = useCallback((element, props) => (
+    <a
+      href={customFields.linkURL || '#'}
+      className={(props && props.className) || ''}
+      title={customFields.headline}
+      target={customFields.newTab ? '_blank' : '_self'}
+      rel={customFields.newTab ? 'noreferrer' : ''}
+      onClick={!customFields.linkURL ? (evt) => {
+        evt.preventDefault();
+      } : undefined}
+    >
+      {element}
+    </a>
+  ), [customFields.linkURL, customFields.headline, customFields.newTab]);
+
+  return (
     <>
       <article className="container-fluid xl-large-promo xl-large-manual-promo">
         <div className="row">
@@ -65,44 +80,30 @@ const ExtraLargeManualPromo = ({ customFields }) => {
                 </OverlineHeader>
               )}
               {(customFields.showHeadline && customFields.headline)
-              && (
-                <a
-                  href={customFields.linkURL}
+              && renderWithLink(
+                <HeadlineText
+                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
                   className="xl-promo-headline"
-                  title={customFields.headline}
-                  target={customFields.newTab ? '_blank' : '_self'}
-                  rel={customFields.newTab ? 'noreferrer' : ''}
                 >
-                  <HeadlineText
-                    primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
-                    className="xl-promo-headline"
-                  >
-                    {customFields.headline}
-                  </HeadlineText>
-                </a>
+                  {customFields.headline}
+                </HeadlineText>,
+                { className: 'xl-promo-headline' },
               )}
               {(customFields.showImage && customFields.imageURL)
-              && (
-                <a
-                  href={customFields.linkURL}
-                  title={customFields.headline}
-                  target={customFields.newTab ? '_blank' : '_self'}
-                  rel={customFields.newTab ? 'noreferrer' : ''}
-                >
-                  <Image
-                    url={customFields.imageURL}
-                    alt={customFields.headline}
-                    smallWidth={400}
-                    smallHeight={300}
-                    mediumWidth={600}
-                    mediumHeight={450}
-                    largeWidth={800}
-                    largeHeight={600}
-                    breakpoints={getProperties(arcSite)?.breakpoints}
-                    resizerURL={getProperties(arcSite)?.resizerURL}
-                    resizedImageOptions={resizedImageOptions}
-                  />
-                </a>
+              && renderWithLink(
+                <Image
+                  url={customFields.imageURL}
+                  alt={customFields.headline}
+                  smallWidth={400}
+                  smallHeight={300}
+                  mediumWidth={600}
+                  mediumHeight={450}
+                  largeWidth={800}
+                  largeHeight={600}
+                  breakpoints={getProperties(arcSite)?.breakpoints}
+                  resizerURL={getProperties(arcSite)?.resizerURL}
+                  resizedImageOptions={resizedImageOptions}
+                />,
               )}
               {(customFields.showDescription && customFields.description)
               && (
@@ -119,7 +120,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
       </article>
       <hr />
     </>
-  ) : null);
+  );
 };
 
 ExtraLargeManualPromo.propTypes = {

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import getThemeStyle from 'fusion:themes';
@@ -38,19 +38,29 @@ const LargeManualPromo = ({ customFields }) => {
     query: { raw_image_url: customFields.imageURL, 'arc-site': arcSite },
   });
 
-  return customFields.linkURL ? (
+  const renderWithLink = useCallback((element, props) => (
+    <a
+      href={customFields.linkURL || '#'}
+      className={(props && props.className) || ''}
+      title={customFields.headline}
+      target={customFields.newTab ? '_blank' : '_self'}
+      rel={customFields.newTab ? 'noreferrer noopener' : ''}
+      onClick={!customFields.linkURL ? (evt) => {
+        evt.preventDefault();
+      } : undefined}
+    >
+      {element}
+    </a>
+  ), [customFields.linkURL, customFields.headline, customFields.newTab]);
+
+  return (
     <>
       <article className="container-fluid large-promo">
         <div className="row lg-promo-padding-bottom">
           {(customFields.showImage && customFields.imageURL)
           && (
             <div className="col-sm-12 col-md-xl-6">
-              <a
-                href={customFields.linkURL}
-                title={customFields.headline}
-                target={customFields.newTab ? '_blank' : '_self'}
-                rel={customFields.newTab ? 'noreferrer noopener' : ''}
-              >
+              { renderWithLink(
                 <Image
                   url={customFields.imageURL}
                   alt={customFields.headline}
@@ -64,8 +74,8 @@ const LargeManualPromo = ({ customFields }) => {
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                   resizedImageOptions={resizedImageOptions}
-                />
-              </a>
+                />,
+              )}
             </div>
           )}
           {(customFields.showHeadline || customFields.showDescription
@@ -92,21 +102,14 @@ const LargeManualPromo = ({ customFields }) => {
                 </OverlineHeader>
               )}
               {(customFields.showHeadline && customFields.headline)
-              && (
-                <a
-                  href={customFields.linkURL}
+              && renderWithLink(
+                <HeadlineText
+                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
                   className="lg-promo-headline"
-                  title={customFields.headline}
-                  target={customFields.newTab ? '_blank' : '_self'}
-                  rel={customFields.newTab ? 'noreferrer' : ''}
                 >
-                  <HeadlineText
-                    primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
-                    className="lg-promo-headline"
-                  >
-                    {customFields.headline}
-                  </HeadlineText>
-                </a>
+                  {customFields.headline}
+                </HeadlineText>,
+                { className: 'lg-promo-headline' },
               )}
               {(customFields.showDescription && customFields.description)
               && (
@@ -123,7 +126,7 @@ const LargeManualPromo = ({ customFields }) => {
       </article>
       <hr />
     </>
-  ) : null;
+  );
 };
 
 LargeManualPromo.propTypes = {

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import getThemeStyle from 'fusion:themes';
@@ -30,53 +30,54 @@ const MediumManualPromo = ({ customFields }) => {
   } = getProperties(arcSite);
 
   const hasImage = customFields.showImage && customFields.imageURL;
-  return customFields.linkURL ? (
+
+  const renderWithLink = useCallback((element, props) => (
+    <a
+      href={customFields.linkURL || '#'}
+      className={(props && props.className) || ''}
+      title={customFields.headline}
+      target={customFields.newTab ? '_blank' : '_self'}
+      rel={customFields.newTab ? 'noreferrer noopener' : ''}
+      onClick={!customFields.linkURL ? (evt) => {
+        evt.preventDefault();
+      } : undefined}
+    >
+      {element}
+    </a>
+  ), [customFields.linkURL, customFields.headline, customFields.newTab]);
+
+  return (
     <>
       <article className="container-fluid medium-promo">
         <div className={`medium-promo-wrapper ${hasImage ? 'md-promo-image' : ''}`}>
-          {hasImage && (
-            <a
-              className="image-link"
-              href={customFields.linkURL}
-              title={customFields.headline}
-              target={customFields.newTab ? '_blank' : '_self'}
-              rel={customFields.newTab ? 'noreferrer noopener' : ''}
-            >
-              <Image
-                // medium is 16:9
-                url={customFields.imageURL}
-                alt={customFields.headline}
-                smallWidth={274}
-                smallHeight={154}
-                mediumWidth={274}
-                mediumHeight={154}
-                largeWidth={400}
-                largeHeight={225}
-                breakpoints={breakpoints}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-                resizedImageOptions={resizedImageOptions}
-              />
-            </a>
+          {hasImage && renderWithLink(
+            <Image
+              // medium is 16:9
+              url={customFields.imageURL}
+              alt={customFields.headline}
+              smallWidth={274}
+              smallHeight={154}
+              mediumWidth={274}
+              mediumHeight={154}
+              largeWidth={400}
+              largeHeight={225}
+              breakpoints={breakpoints}
+              resizerURL={getProperties(arcSite)?.resizerURL}
+              resizedImageOptions={resizedImageOptions}
+            />, { className: 'image-link' },
           )}
           {(customFields.showHeadline || customFields.showDescription)
           && (
             <>
               {(customFields.showHeadline && customFields.headline)
-              && (
-                <a
-                  href={customFields.linkURL}
-                  className="md-promo-headline"
-                  title={customFields.headline}
-                  target={customFields.newTab ? '_blank' : '_self'}
-                  rel={customFields.newTab ? 'noreferrer' : ''}
+              && renderWithLink(
+                <HeadlineText
+                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+                  className="md-promo-headline-text"
                 >
-                  <HeadlineText
-                    primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
-                    className="md-promo-headline-text"
-                  >
-                    {customFields.headline}
-                  </HeadlineText>
-                </a>
+                  {customFields.headline}
+                </HeadlineText>,
+                { className: 'md-promo-headline' },
               )}
               {(customFields.showDescription && customFields.description)
               && (
@@ -93,7 +94,7 @@ const MediumManualPromo = ({ customFields }) => {
       </article>
       <hr />
     </>
-  ) : null;
+  );
 };
 
 MediumManualPromo.propTypes = {

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import getThemeStyle from 'fusion:themes';
@@ -22,38 +22,42 @@ const SmallManualPromo = ({ customFields }) => {
   });
   const headlineClass = customFields.showImage ? 'col-sm-xl-8' : 'col-sm-xl-12 no-image-padding';
 
-  return customFields.linkURL ? (
+  const renderWithLink = useCallback((element, props) => (
+    <a
+      href={customFields.linkURL || '#'}
+      className={(props && props.className) || ''}
+      title={customFields.headline}
+      target={customFields.newTab ? '_blank' : '_self'}
+      rel={customFields.newTab ? 'noreferrer noopener' : ''}
+      onClick={!customFields.linkURL ? (evt) => {
+        evt.preventDefault();
+      } : undefined}
+    >
+      {element}
+    </a>
+  ), [customFields.linkURL, customFields.headline, customFields.newTab]);
+
+  return (
     <>
       <article className="container-fluid small-promo">
         <div className="row sm-promo-padding-btm">
           {(customFields.showHeadline && customFields.headline)
           && (
             <div className={headlineClass}>
-              <a
-                href={customFields.linkURL}
-                className="sm-promo-headline"
-                title={customFields.headline}
-                target={customFields.newTab ? '_blank' : '_self'}
-                rel={customFields.newTab ? 'noreferrer noopener' : ''}
-              >
+              { renderWithLink((
                 <HeadlineText
                   primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
                   className="sm-promo-headline"
                 >
                   {customFields.headline}
                 </HeadlineText>
-              </a>
+              ), { className: 'sm-promo-headline' }) }
             </div>
           )}
           {(customFields.showImage && customFields.imageURL)
           && (
             <div className="col-sm-xl-4 right-aligned-container">
-              <a
-                href={customFields.linkURL}
-                title={customFields.headline}
-                target={customFields.newTab ? '_blank' : '_self'}
-                rel={customFields.newTab ? 'noreferrer noopener' : ''}
-              >
+              { renderWithLink(
                 <Image
                   url={customFields.imageURL}
                   alt={customFields.headline}
@@ -67,15 +71,15 @@ const SmallManualPromo = ({ customFields }) => {
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                   resizedImageOptions={resizedImageOptions}
-                />
-              </a>
+                />,
+              )}
             </div>
           )}
         </div>
       </article>
       <hr />
     </>
-  ) : null;
+  );
 };
 
 SmallManualPromo.propTypes = {


### PR DESCRIPTION
## Description
Modified 'Small', 'Medium', 'Large' and 'Extra Large' Manual Promo blocks so they still render when a 'linkURL' is not provided

## Jira Ticket
- [PEN-1368](https://arcpublishing.atlassian.net/browse/PEN-1368)

## Acceptance Criteria
Users should not have to enter a Link URL for the Manual Promo Blocks to render.

## Test Steps
1. Add one of each `Manual Promo` block (`Small`, `Medium`, `Large`, `Extra Large`) to a test page
2. Fill out all fields in `Custom Fields` for each block instance except `Link URL` - which should be left blank
3. After filling out all custom fields, stage & publish page. Open page in new tab.
4. Ensure that all `Manual Promo` blocks render with the data supplied in custom fields. Try clicking on each of the block headlines and they should not cause the page to navigate or refresh (they should do nothing when no `Link URL` supplied
5. Go back to PageBuilder editor and add a `Link URL` for each of the `Manual Promo` block instances
6. Stage, publish, view page in separate tab again
7. Now try clicking on each of the `Manual Promo` block "headline" elements and it should navigate to the provided `Link URL`
8. Ensure that all styling still looks correct across breakpoints

## Effect Of Changes
### Before
When no `Link URL` was provided in custom fields, the manual promo blocks would _not_ render

### After
When no `Link URL` is provided in custom fields, the manual promo blocks should still render

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
