### PR TITLE
style: Style linting fixes

### DIFF
--- a/blocks/ads-block/features/ads/_children/ArcAdminAd/index.scss
+++ b/blocks/ads-block/features/ads/_children/ArcAdminAd/index.scss
@@ -1,5 +1,5 @@
 .pb-ad-admin {
   background-color: $ui-medium-gray;
-  color: #FFF;
   border-radius: 6px;
+  color: #fff;
 }

--- a/blocks/ads-block/features/ads/ads.scss
+++ b/blocks/ads-block/features/ads/ads.scss
@@ -25,7 +25,7 @@
     .arcad {
       text-align: center;
 
-      div[id^="google_ads_iframe"] {
+      div[id^='google_ads_iframe'] {
         text-align: center;
       }
     }

--- a/blocks/header-nav-block/features/navigation/header-nav.scss
+++ b/blocks/header-nav-block/features/navigation/header-nav.scss
@@ -67,12 +67,12 @@ $submenu-link-color: $ui-dark-gray;
 .nav-block-sections {
   background: rgba(25, 25, 25, 0.5);
   flex-direction: column;
-  position: absolute;
-  transition: transform 300ms ease-in-out;
-  top: 0;
-  width: 100%;
   -ms-overflow-style: none;
+  position: absolute;
   scrollbar-width: none;
+  top: 0;
+  transition: transform 300ms ease-in-out;
+  width: 100%;
 
   &::-webkit-scrollbar {
     display: none;
@@ -111,10 +111,10 @@ $submenu-link-color: $ui-dark-gray;
   }
 
   .inner-drawer-nav {
-    width: $section-width;
     background-color: $section-bg;
     display: flex;
     flex-direction: column;
+    width: $section-width;
   }
 
   .nav-block-search {

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -199,13 +199,14 @@ body.nav-open {
 
     &.nav-logo-hidden {
       opacity: 0;
-      visibility: hidden;
       transition: opacity 800ms ease, visibility 0s ease 800ms;
+      visibility: hidden;
     }
+
     &.nav-logo-show {
       opacity: 1;
-      visibility: visible;
       transition: opacity 800ms ease, visibility 0s ease 0s;
+      visibility: visible;
     }
   }
 }
@@ -352,6 +353,7 @@ body.nav-open {
       svg {
         transform: rotate(-90deg);
       }
+
       path {
         fill: #fff;
       }


### PR DESCRIPTION
Noticed some odd stylesheets in another pr. Updated styles elsewhere using `npm run lint:styles:fix`: 

We can probably start to decide what's a warning vs what's an error (preventing a push) among this:

looks like alphabetical order is one of them `order/properties-alphabetical-order: 24`

# before: 

621 problems found
 severity level "warning": 332
  plugin/no-unsupported-browser-features: 332
 severity level "error": 289
  max-nesting-depth: 98
  no-descending-specificity: 22
  selector-max-compound-selectors: 37
  order/properties-alphabetical-order: 24
  rule-empty-line-before: 3
  selector-no-qualifying-type: 23
  scss/selector-no-redundant-nesting-selector: 7
  selector-class-pattern: 11
  color-named: 11
  string-quotes: 1
  declaration-property-value-disallowed-list: 14
  selector-max-id: 16
  no-duplicate-selectors: 2
  indentation: 5
  scss/at-import-no-partial-leading-underscore: 2
  declaration-block-semicolon-newline-after: 2
  no-extra-semicolons: 1
  block-opening-brace-space-before: 1
  declaration-colon-space-after: 2
  selector-list-comma-newline-after: 1
  color-hex-case: 3
  color-hex-length: 1
  no-missing-end-of-source-newline: 2

# after: 

610 problems found
 severity level "warning": 332
  plugin/no-unsupported-browser-features: 332
 severity level "error": 278
  max-nesting-depth: 98
  no-descending-specificity: 22
  selector-max-compound-selectors: 37
  selector-no-qualifying-type: 23
  scss/selector-no-redundant-nesting-selector: 7
  selector-class-pattern: 11
  color-named: 11
  declaration-property-value-disallowed-list: 14
  selector-max-id: 16
  no-duplicate-selectors: 2
  order/properties-alphabetical-order: 18
  indentation: 5
  scss/at-import-no-partial-leading-underscore: 2
  declaration-block-semicolon-newline-after: 2
  no-extra-semicolons: 1
  block-opening-brace-space-before: 1
  declaration-colon-space-after: 2
  rule-empty-line-before: 1
  selector-list-comma-newline-after: 1
  color-hex-case: 2
  color-hex-length: 1
  no-missing-end-of-source-newline: 1