### PR TITLE
PEN-1430: 1.4.0 – Add Swedish and Norwegian translations for Gallery/Video labels

### DIFF
--- a/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.jsx
@@ -4,6 +4,22 @@ import getThemeStyle from 'fusion:themes';
 import styled from 'styled-components';
 import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
 import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
+import getTranslatedPhrases from 'fusion:intl';
+import getProperties from 'fusion:properties';
+
+export const getLabelText = (phrases, type) => {
+  if (phrases && type) {
+    switch (type) {
+      case 'Video':
+        return phrases.t('extra-large-promo-block.video-label');
+      case 'Gallery':
+        return phrases.t('extra-large-promo-block.gallery-label');
+      default:
+        return null;
+    }
+  }
+  return null;
+};
 
 const LabelBoxLarge = styled.div`
   align-items: center;
@@ -54,10 +70,10 @@ const Icon = ({ type }) => {
   }
 };
 
-const LabelLarge = ({ arcSite, type }) => (
+const LabelLarge = ({ arcSite, type, labelText }) => (
   <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
-    <Label>{type}</Label>
+    <Label>{labelText}</Label>
   </LabelBoxLarge>
 );
 
@@ -79,7 +95,9 @@ const PromoLabel = ({ type, size }) => {
     return <LabelSmall type={type} arcSite={arcSite} />;
   }
 
-  return <LabelLarge type={type} arcSite={arcSite} />;
+  const phrases = getTranslatedPhrases(getProperties(arcSite).locale || 'en');
+
+  return <LabelLarge type={type} arcSite={arcSite} labelText={getLabelText(phrases, type)} />;
 };
 
 export default PromoLabel;

--- a/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.test.jsx
@@ -1,83 +1,114 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import getProperties from 'fusion:properties';
+import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getTranslatedPhrases from 'fusion:intl';
+import PromoLabel, { getLabelText } from './promo_label';
 
 describe('the promo label', () => {
   beforeAll(() => {
-    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
-    jest.mock('fusion:context', () => ({
-      useFusionContext: jest.fn(() => ({ arcSite: 'the-sun' })),
-    }));
-    jest.mock('fusion:themes', () => (
-      jest.fn(() => ({ 'primary-color': '#ff0000' }))
-    ));
+    useFusionContext.mockReturnValue({ arcSite: 'the-sun' });
+    getProperties.mockReturnValue({ locale: 'en' });
+    getThemeStyle.mockReturnValue({ 'primary-color': '#ff0000' });
   });
+
+  jest.mock('fusion:intl', () => ({
+    __esModule: true,
+    default: jest.fn((locale) => ({ t: jest.fn((phrase) => require('../../../intl.json')[phrase][locale]) })),
+  }));
 
   afterAll(() => {
     jest.resetModules();
   });
 
   it('should not render when the promo type is missing', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel />);
     expect(wrapper.find('div.promo-label').length).toBe(0);
+    wrapper.unmount();
   });
 
   it('should not render when the promo type is "other"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="other" />);
     expect(wrapper.find('div.promo-label').length).toBe(0);
+    wrapper.unmount();
   });
 
   it('should render when type is "video"', () => {
-    const { default: PromoLabel } = require('./promo_label');
+    getTranslatedPhrases.mockReturnValue({ t: jest.fn().mockReturnValue('Video') });
     const wrapper = mount(<PromoLabel type="Video" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('Video');
+    wrapper.unmount();
   });
 
   it('should render when type is "gallery"', () => {
-    const { default: PromoLabel } = require('./promo_label');
+    getTranslatedPhrases.mockReturnValue({ t: jest.fn().mockReturnValue('Gallery') });
     const wrapper = mount(<PromoLabel type="Gallery" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('Gallery');
+    wrapper.unmount();
   });
 
   it('should be rendered using the color of the site', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Video" />);
     expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
     expect(wrapper.find('PlayIcon').length).toBe(1);
+    wrapper.unmount();
   });
 
   it('should render only the Play icon when the label is Video and size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Video" size="small" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').length).toBe(0);
     expect(wrapper.find('PlayIcon').length).toBe(1);
+    wrapper.unmount();
   });
 
   it('should render only the Camera icon when the label is Gallery and size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').length).toBe(0);
     expect(wrapper.find('CameraIcon').length).toBe(1);
+    wrapper.unmount();
   });
 
   it('should render small and using the color of the site when size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
     expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
     expect(wrapper.find('div.promo-label span').length).toBe(0);
     expect(wrapper.find('CameraIcon').length).toBe(1);
+    wrapper.unmount();
   });
 
   it('should not render an icon if label type is not recognized', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="PromoType" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
-    expect(wrapper.find('div.promo-label span').text()).toBe('PromoType');
+    expect(wrapper.find('div.promo-label span').text()).toBe('');
     expect(wrapper.find('Icon').html()).toBeFalsy();
+    wrapper.unmount();
+  });
+
+  it('getLabelText should return null if no phrases passed ', () => {
+    const result = getLabelText(null, 'type');
+    expect(result).toBe(null);
+  });
+
+  it('getLabelText should return null if no type passed ', () => {
+    const result = getLabelText({}, null);
+    expect(result).toBe(null);
+  });
+
+  it('getLabelText should return null if type is not gallery nor video ', () => {
+    const result = getLabelText({}, 'other');
+    expect(result).toBe(null);
+  });
+
+  it('should not render icon when the promo type not "other", "Video", or "Gallery"', () => {
+    const wrapper = mount(<PromoLabel type="none" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('CameraIcon').length).toEqual(0);
+    expect(wrapper.find('PlayIcon').length).toEqual(0);
+    wrapper.unmount();
   });
 });

--- a/blocks/extra-large-promo-block/intl.json
+++ b/blocks/extra-large-promo-block/intl.json
@@ -1,0 +1,12 @@
+{
+   "extra-large-promo-block.gallery-label":{
+      "en":"Gallery",
+      "sv":"Bildspel",
+      "no":"Bildegalleri"
+   },
+   "extra-large-promo-block.video-label":{
+      "en":"Video",
+      "sv":"Video",
+      "no":"Video"
+   }
+}

--- a/blocks/large-promo-block/features/large-promo/_children/promo_label.jsx
+++ b/blocks/large-promo-block/features/large-promo/_children/promo_label.jsx
@@ -4,6 +4,22 @@ import getThemeStyle from 'fusion:themes';
 import styled from 'styled-components';
 import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
 import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
+import getTranslatedPhrases from 'fusion:intl';
+import getProperties from 'fusion:properties';
+
+export const getLabelText = (phrases, type) => {
+  if (phrases && type) {
+    switch (type) {
+      case 'Video':
+        return phrases.t('extra-large-promo-block.video-label');
+      case 'Gallery':
+        return phrases.t('extra-large-promo-block.gallery-label');
+      default:
+        return null;
+    }
+  }
+  return null;
+};
 
 const LabelBoxLarge = styled.div`
   align-items: center;
@@ -54,10 +70,10 @@ const Icon = ({ type }) => {
   }
 };
 
-const LabelLarge = ({ arcSite, type }) => (
+const LabelLarge = ({ arcSite, type, labelText }) => (
   <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
-    <Label>{type}</Label>
+    <Label>{labelText}</Label>
   </LabelBoxLarge>
 );
 
@@ -79,7 +95,9 @@ const PromoLabel = ({ type, size }) => {
     return <LabelSmall type={type} arcSite={arcSite} />;
   }
 
-  return <LabelLarge type={type} arcSite={arcSite} />;
+  const phrases = getTranslatedPhrases(getProperties(arcSite).locale || 'en');
+
+  return <LabelLarge type={type} arcSite={arcSite} labelText={getLabelText(phrases, type)} />;
 };
 
 export default PromoLabel;

--- a/blocks/large-promo-block/features/large-promo/_children/promo_label.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/_children/promo_label.test.jsx
@@ -1,56 +1,54 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import getProperties from 'fusion:properties';
+import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getTranslatedPhrases from 'fusion:intl';
+import PromoLabel, { getLabelText } from './promo_label';
 
 describe('the promo label', () => {
   beforeAll(() => {
-    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
-    jest.mock('fusion:context', () => ({
-      useFusionContext: jest.fn(() => ({ arcSite: 'the-sun' })),
-    }));
-    jest.mock('fusion:themes', () => (
-      jest.fn(() => ({ 'primary-color': '#ff0000' }))
-    ));
+    useFusionContext.mockReturnValue({ arcSite: 'the-sun' });
+    getProperties.mockReturnValue({ locale: 'en' });
+    getThemeStyle.mockReturnValue({ 'primary-color': '#ff0000' });
   });
 
   afterAll(() => {
     jest.resetModules();
+    jest.clearAllMocks();
   });
 
   it('should not render when the promo type is missing', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel />);
     expect(wrapper.find('div.promo-label').length).toBe(0);
   });
 
   it('should not render when the promo type is "other"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="other" />);
     expect(wrapper.find('div.promo-label').length).toBe(0);
   });
 
   it('should render when type is "video"', () => {
-    const { default: PromoLabel } = require('./promo_label');
+    getTranslatedPhrases.mockReturnValue({ t: jest.fn().mockReturnValue('Video') });
     const wrapper = mount(<PromoLabel type="Video" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('Video');
   });
 
   it('should render when type is "gallery"', () => {
-    const { default: PromoLabel } = require('./promo_label');
+    getTranslatedPhrases.mockReturnValue({ t: jest.fn().mockReturnValue('Gallery') });
     const wrapper = mount(<PromoLabel type="Gallery" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('Gallery');
   });
 
   it('should be rendered using the color of the site', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Video" />);
     expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
     expect(wrapper.find('PlayIcon').length).toBe(1);
   });
 
   it('should render only the Play icon when the label is Video and size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Video" size="small" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').length).toBe(0);
@@ -58,7 +56,6 @@ describe('the promo label', () => {
   });
 
   it('should render only the Camera icon when the label is Gallery and size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').length).toBe(0);
@@ -66,7 +63,6 @@ describe('the promo label', () => {
   });
 
   it('should render small and using the color of the site when size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
     expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
     expect(wrapper.find('div.promo-label span').length).toBe(0);
@@ -74,10 +70,31 @@ describe('the promo label', () => {
   });
 
   it('should not render an icon if label type is not recognized', () => {
-    const { default: PromoLabel } = require('./promo_label');
-    const wrapper = mount(<PromoLabel type="PromoType" />);
+    const wrapper = mount(<PromoLabel type="other" />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+    wrapper.unmount();
+  });
+
+  it('getLabelText should return null if no phrases passed ', () => {
+    const result = getLabelText(null, 'type');
+    expect(result).toBe(null);
+  });
+
+  it('getLabelText should return null if no type passed ', () => {
+    const result = getLabelText({}, null);
+    expect(result).toBe(null);
+  });
+
+  it('getLabelText should return null if type is not gallery nor video ', () => {
+    const result = getLabelText({}, 'other');
+    expect(result).toBe(null);
+  });
+
+  it('should not render icon when the promo type not "other", "Video", or "Gallery"', () => {
+    const wrapper = mount(<PromoLabel type="none" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
-    expect(wrapper.find('div.promo-label span').text()).toBe('PromoType');
-    expect(wrapper.find('Icon').html()).toBeFalsy();
+    expect(wrapper.find('CameraIcon').length).toEqual(0);
+    expect(wrapper.find('PlayIcon').length).toEqual(0);
+    wrapper.unmount();
   });
 });

--- a/blocks/large-promo-block/intl.json
+++ b/blocks/large-promo-block/intl.json
@@ -1,0 +1,12 @@
+{
+   "large-promo-block.gallery-label":{
+      "en":"Gallery",
+      "sv":"Bildspel",
+      "no":"Bildegalleri"
+   },
+   "large-promo-block.video-label":{
+      "en":"Video",
+      "sv":"Video",
+      "no":"Video"
+   }
+}

--- a/blocks/medium-promo-block/features/medium-promo/_children/promo_label.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/_children/promo_label.jsx
@@ -4,6 +4,22 @@ import getThemeStyle from 'fusion:themes';
 import styled from 'styled-components';
 import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
 import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
+import getTranslatedPhrases from 'fusion:intl';
+import getProperties from 'fusion:properties';
+
+export const getLabelText = (phrases, type) => {
+  if (phrases && type) {
+    switch (type) {
+      case 'Video':
+        return phrases.t('extra-large-promo-block.video-label');
+      case 'Gallery':
+        return phrases.t('extra-large-promo-block.gallery-label');
+      default:
+        return null;
+    }
+  }
+  return null;
+};
 
 const LabelBoxLarge = styled.div`
   align-items: center;
@@ -54,10 +70,10 @@ const Icon = ({ type }) => {
   }
 };
 
-const LabelLarge = ({ arcSite, type }) => (
+const LabelLarge = ({ arcSite, type, labelText }) => (
   <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
-    <Label>{type}</Label>
+    <Label>{labelText}</Label>
   </LabelBoxLarge>
 );
 
@@ -79,7 +95,9 @@ const PromoLabel = ({ type, size }) => {
     return <LabelSmall type={type} arcSite={arcSite} />;
   }
 
-  return <LabelLarge type={type} arcSite={arcSite} />;
+  const phrases = getTranslatedPhrases(getProperties(arcSite).locale || 'en');
+
+  return <LabelLarge type={type} arcSite={arcSite} labelText={getLabelText(phrases, type)} />;
 };
 
 export default PromoLabel;

--- a/blocks/medium-promo-block/features/medium-promo/_children/promo_label.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/_children/promo_label.test.jsx
@@ -1,56 +1,54 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import getProperties from 'fusion:properties';
+import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getTranslatedPhrases from 'fusion:intl';
+import PromoLabel, { getLabelText } from './promo_label';
 
 describe('the promo label', () => {
   beforeAll(() => {
-    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
-    jest.mock('fusion:context', () => ({
-      useFusionContext: jest.fn(() => ({ arcSite: 'the-sun' })),
-    }));
-    jest.mock('fusion:themes', () => (
-      jest.fn(() => ({ 'primary-color': '#ff0000' }))
-    ));
+    useFusionContext.mockReturnValue({ arcSite: 'the-sun' });
+    getProperties.mockReturnValue({ locale: 'en' });
+    getThemeStyle.mockReturnValue({ 'primary-color': '#ff0000' });
   });
 
   afterAll(() => {
     jest.resetModules();
+    jest.clearAllMocks();
   });
 
   it('should not render when the promo type is missing', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel />);
     expect(wrapper.find('div.promo-label').length).toBe(0);
   });
 
   it('should not render when the promo type is "other"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="other" />);
     expect(wrapper.find('div.promo-label').length).toBe(0);
   });
 
   it('should render when type is "video"', () => {
-    const { default: PromoLabel } = require('./promo_label');
+    getTranslatedPhrases.mockReturnValue({ t: jest.fn().mockReturnValue('Video') });
     const wrapper = mount(<PromoLabel type="Video" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('Video');
   });
 
   it('should render when type is "gallery"', () => {
-    const { default: PromoLabel } = require('./promo_label');
+    getTranslatedPhrases.mockReturnValue({ t: jest.fn().mockReturnValue('Gallery') });
     const wrapper = mount(<PromoLabel type="Gallery" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('Gallery');
   });
 
   it('should be rendered using the color of the site', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Video" />);
     expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
     expect(wrapper.find('PlayIcon').length).toBe(1);
   });
 
   it('should render only the Play icon when the label is Video and size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Video" size="small" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').length).toBe(0);
@@ -58,7 +56,6 @@ describe('the promo label', () => {
   });
 
   it('should render only the Camera icon when the label is Gallery and size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').length).toBe(0);
@@ -66,7 +63,6 @@ describe('the promo label', () => {
   });
 
   it('should render small and using the color of the site when size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
     expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
     expect(wrapper.find('div.promo-label span').length).toBe(0);
@@ -74,10 +70,31 @@ describe('the promo label', () => {
   });
 
   it('should not render an icon if label type is not recognized', () => {
-    const { default: PromoLabel } = require('./promo_label');
-    const wrapper = mount(<PromoLabel type="PromoType" />);
+    const wrapper = mount(<PromoLabel type="other" />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+    wrapper.unmount();
+  });
+
+  it('getLabelText should return null if no phrases passed ', () => {
+    const result = getLabelText(null, 'type');
+    expect(result).toBe(null);
+  });
+
+  it('getLabelText should return null if no type passed ', () => {
+    const result = getLabelText({}, null);
+    expect(result).toBe(null);
+  });
+
+  it('getLabelText should return null if type is not gallery nor video ', () => {
+    const result = getLabelText({}, 'other');
+    expect(result).toBe(null);
+  });
+
+  it('should not render icon when the promo type not "other", "Video", or "Gallery"', () => {
+    const wrapper = mount(<PromoLabel type="none" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
-    expect(wrapper.find('div.promo-label span').text()).toBe('PromoType');
-    expect(wrapper.find('Icon').html()).toBeFalsy();
+    expect(wrapper.find('CameraIcon').length).toEqual(0);
+    expect(wrapper.find('PlayIcon').length).toEqual(0);
+    wrapper.unmount();
   });
 });

--- a/blocks/medium-promo-block/intl.json
+++ b/blocks/medium-promo-block/intl.json
@@ -1,0 +1,12 @@
+{
+   "medium-promo-block.gallery-label":{
+      "en":"Gallery",
+      "sv":"Bildspel",
+      "no":"Bildegalleri"
+   },
+   "medium-promo-block.video-label":{
+      "en":"Video",
+      "sv":"Video",
+      "no":"Video"
+   }
+}

--- a/blocks/small-promo-block/features/small-promo/_children/promo_label.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_label.test.jsx
@@ -1,56 +1,54 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import getProperties from 'fusion:properties';
+import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getTranslatedPhrases from 'fusion:intl';
+import PromoLabel from './promo_label';
 
 describe('the promo label', () => {
   beforeAll(() => {
-    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
-    jest.mock('fusion:context', () => ({
-      useFusionContext: jest.fn(() => ({ arcSite: 'the-sun' })),
-    }));
-    jest.mock('fusion:themes', () => (
-      jest.fn(() => ({ 'primary-color': '#ff0000' }))
-    ));
+    useFusionContext.mockReturnValue({ arcSite: 'the-sun' });
+    getProperties.mockReturnValue({ locale: 'en' });
+    getThemeStyle.mockReturnValue({ 'primary-color': '#ff0000' });
   });
 
   afterAll(() => {
     jest.resetModules();
+    jest.clearAllMocks();
   });
 
   it('should not render when the promo type is missing', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel />);
     expect(wrapper.find('div.promo-label').length).toBe(0);
   });
 
   it('should not render when the promo type is "other"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="other" />);
     expect(wrapper.find('div.promo-label').length).toBe(0);
   });
 
   it('should render when type is "video"', () => {
-    const { default: PromoLabel } = require('./promo_label');
+    getTranslatedPhrases.mockReturnValue({ t: jest.fn().mockReturnValue('Video') });
     const wrapper = mount(<PromoLabel type="Video" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('Video');
   });
 
   it('should render when type is "gallery"', () => {
-    const { default: PromoLabel } = require('./promo_label');
+    getTranslatedPhrases.mockReturnValue({ t: jest.fn().mockReturnValue('Gallery') });
     const wrapper = mount(<PromoLabel type="Gallery" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('Gallery');
   });
 
   it('should be rendered using the color of the site', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Video" />);
     expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
     expect(wrapper.find('PlayIcon').length).toBe(1);
   });
 
   it('should render only the Play icon when the label is Video and size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Video" size="small" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').length).toBe(0);
@@ -58,7 +56,6 @@ describe('the promo label', () => {
   });
 
   it('should render only the Camera icon when the label is Gallery and size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').length).toBe(0);
@@ -66,7 +63,6 @@ describe('the promo label', () => {
   });
 
   it('should render small and using the color of the site when size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
     expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
     expect(wrapper.find('div.promo-label span').length).toBe(0);
@@ -74,10 +70,23 @@ describe('the promo label', () => {
   });
 
   it('should not render an icon if label type is not recognized', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="PromoType" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('PromoType');
     expect(wrapper.find('Icon').html()).toBeFalsy();
+  });
+
+  it('should not render an icon if label type is not recognized', () => {
+    const wrapper = mount(<PromoLabel type="other" />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+    wrapper.unmount();
+  });
+
+  it('should not render icon when the promo type not "other", "Video", or "Gallery"', () => {
+    const wrapper = mount(<PromoLabel type="none" />);
+    expect(wrapper.find('div.promo-label').length).toBe(1);
+    expect(wrapper.find('CameraIcon').length).toEqual(0);
+    expect(wrapper.find('PlayIcon').length).toEqual(0);
+    wrapper.unmount();
   });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/promo_label.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/promo_label.jsx
@@ -4,6 +4,22 @@ import getThemeStyle from 'fusion:themes';
 import styled from 'styled-components';
 import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
 import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
+import getTranslatedPhrases from 'fusion:intl';
+import getProperties from 'fusion:properties';
+
+export const getLabelText = (phrases, type) => {
+  if (phrases) {
+    switch (type) {
+      case 'Video':
+        return phrases.t('extra-large-promo-block.video-label');
+      case 'Gallery':
+        return phrases.t('extra-large-promo-block.gallery-label');
+      default:
+        return null;
+    }
+  }
+  return null;
+};
 
 const LabelBoxLarge = styled.div`
   align-items: center;
@@ -54,10 +70,10 @@ const Icon = ({ type }) => {
   }
 };
 
-const LabelLarge = ({ arcSite, type }) => (
+const LabelLarge = ({ arcSite, type, labelText }) => (
   <LabelBoxLarge className="promo-label" primaryColor={getThemeStyle(arcSite)['primary-color']}>
     <Icon type={type} />
-    <Label>{type}</Label>
+    <Label>{labelText}</Label>
   </LabelBoxLarge>
 );
 
@@ -79,7 +95,9 @@ const PromoLabel = ({ type, size }) => {
     return <LabelSmall type={type} arcSite={arcSite} />;
   }
 
-  return <LabelLarge type={type} arcSite={arcSite} />;
+  const phrases = getTranslatedPhrases(getProperties(arcSite).locale || 'en');
+  const translatedLabelText = getLabelText(phrases, type);
+  return <LabelLarge type={type} arcSite={arcSite} labelText={translatedLabelText} />;
 };
 
 export default PromoLabel;

--- a/blocks/top-table-list-block/features/top-table-list/_children/promo_label.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/promo_label.test.jsx
@@ -1,83 +1,108 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import getProperties from 'fusion:properties';
+import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getTranslatedPhrases from 'fusion:intl';
+import PromoLabel, { getLabelText } from './promo_label';
 
 describe('the promo label', () => {
   beforeAll(() => {
-    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
-    jest.mock('fusion:context', () => ({
-      useFusionContext: jest.fn(() => ({ arcSite: 'the-sun' })),
-    }));
-    jest.mock('fusion:themes', () => (
-      jest.fn(() => ({ 'primary-color': '#ff0000' }))
-    ));
+    useFusionContext.mockReturnValue({ arcSite: 'the-sun' });
+    getProperties.mockReturnValue({ locale: 'en' });
+    getThemeStyle.mockReturnValue({ 'primary-color': '#ff0000' });
   });
 
   afterAll(() => {
     jest.resetModules();
+    jest.clearAllMocks();
   });
 
   it('should not render when the promo type is missing', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel />);
     expect(wrapper.find('div.promo-label').length).toBe(0);
+    wrapper.unmount();
   });
 
   it('should not render when the promo type is "other"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="other" />);
     expect(wrapper.find('div.promo-label').length).toBe(0);
+    wrapper.unmount();
   });
 
   it('should render when type is "video"', () => {
-    const { default: PromoLabel } = require('./promo_label');
+    getTranslatedPhrases.mockReturnValue({ t: jest.fn().mockReturnValue('Video') });
     const wrapper = mount(<PromoLabel type="Video" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('Video');
+    wrapper.unmount();
   });
 
   it('should render when type is "gallery"', () => {
-    const { default: PromoLabel } = require('./promo_label');
+    getTranslatedPhrases.mockReturnValue({ t: jest.fn().mockReturnValue('Gallery') });
     const wrapper = mount(<PromoLabel type="Gallery" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').text()).toBe('Gallery');
+    wrapper.unmount();
   });
 
   it('should be rendered using the color of the site', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Video" />);
     expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
     expect(wrapper.find('PlayIcon').length).toBe(1);
+    wrapper.unmount();
   });
 
   it('should render only the Play icon when the label is Video and size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Video" size="small" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').length).toBe(0);
     expect(wrapper.find('PlayIcon').length).toBe(1);
+    wrapper.unmount();
   });
 
   it('should render only the Camera icon when the label is Gallery and size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
     expect(wrapper.find('div.promo-label span').length).toBe(0);
     expect(wrapper.find('CameraIcon').length).toBe(1);
+    wrapper.unmount();
   });
 
   it('should render small and using the color of the site when size is "small"', () => {
-    const { default: PromoLabel } = require('./promo_label');
     const wrapper = mount(<PromoLabel type="Gallery" size="small" />);
     expect(wrapper.find('StyledComponent').at(0).prop('primaryColor')).toEqual('#ff0000');
     expect(wrapper.find('div.promo-label span').length).toBe(0);
     expect(wrapper.find('CameraIcon').length).toBe(1);
+    wrapper.unmount();
   });
 
   it('should not render an icon if label type is not recognized', () => {
-    const { default: PromoLabel } = require('./promo_label');
-    const wrapper = mount(<PromoLabel type="PromoType" />);
+    const wrapper = mount(<PromoLabel type="other" />);
+    expect(wrapper.find('div.promo-label').length).toBe(0);
+    wrapper.unmount();
+  });
+
+  it('getLabelText should return null if no phrases passed ', () => {
+    const result = getLabelText(null, 'type');
+    expect(result).toBe(null);
+  });
+
+  it('getLabelText should return null if no type passed ', () => {
+    const result = getLabelText({}, null);
+    expect(result).toBe(null);
+  });
+
+  it('getLabelText should return null if type is not gallery nor video ', () => {
+    const result = getLabelText({}, 'other');
+    expect(result).toBe(null);
+  });
+
+  it('should not render icon when the promo type not "other", "Video", or "Gallery"', () => {
+    const wrapper = mount(<PromoLabel type="none" />);
     expect(wrapper.find('div.promo-label').length).toBe(1);
-    expect(wrapper.find('div.promo-label span').text()).toBe('PromoType');
-    expect(wrapper.find('Icon').html()).toBeFalsy();
+    expect(wrapper.find('CameraIcon').length).toEqual(0);
+    expect(wrapper.find('PlayIcon').length).toEqual(0);
+    wrapper.unmount();
   });
 });

--- a/blocks/top-table-list-block/intl.json
+++ b/blocks/top-table-list-block/intl.json
@@ -1,0 +1,12 @@
+{
+   "top-table-list-block.gallery-label":{
+      "en":"Gallery",
+      "sv":"Bildspel",
+      "no":"Bildegalleri"
+   },
+   "top-table-list-block.video-label":{
+      "en":"Video",
+      "sv":"Video",
+      "no":"Video"
+   }
+}


### PR DESCRIPTION
## Description
internationalization for promo blocks, XL, L M (not small bc small never displays the text label for type video/gallery)

## Jira Ticket
- [PEN-1430](https://arcpublishing.atlassian.net/browse/PEN-1430)

## Acceptance Criteria
The labels for Gallery and Video (as developed in ) have translations for Swedish and Norwegian. If a website’s language is set to Swedish or to Norwegian, the respective translations should be used on these labels. 

Tests and documentation are updated for this new functionality 

## Test Steps
For each promo type, XL, L, M, create a new promo block on a page/template for each case video and Gallery, and visit pages for sites using languages Swedish, Norwegian and English ( Dagen website is set up to use Swedish and The Prophet website is set up to use Norwegian) Confirm that the label in the proper language is displayed for promo blocks.

Swedish:

"promo-blocks.video-text":"Video",
"promo-blocks.gallery-text":"Bildspel",

Norwegian:

   "promo-blocks.video-text":"Video",
   "promo-blocks.gallery-text":"Bildegalleri",

## Effect Of Changes
### Before
Gallery and Video promo labels are shown English, regardless of site locale.
<img width="940" alt="Screen Shot 2020-10-22 at 11 39 08 AM" src="https://user-images.githubusercontent.com/2664083/96896442-7f954300-145b-11eb-8840-c27281d874af.png">
<img width="916" alt="Screen Shot 2020-10-22 at 11 39 26 AM" src="https://user-images.githubusercontent.com/2664083/96896490-8f148c00-145b-11eb-92b1-7ae7536acd10.png">


### After
Gallery and Video promo labels are shown in Norwegian/Swedish/English as per the site locale.

<img width="1136" alt="Screen Shot 2020-10-20 at 2 49 05 PM" src="https://user-images.githubusercontent.com/2664083/96892216-6d190a80-1457-11eb-947a-ba3f57809891.png">
<img width="1054" alt="Screen Shot 2020-10-20 at 2 49 12 PM" src="https://user-images.githubusercontent.com/2664083/96892222-6e4a3780-1457-11eb-8b0b-12fc822e7eb2.png">
<img width="1920" alt="Screen Shot 2020-10-20 at 2 49 15 PM" src="https://user-images.githubusercontent.com/2664083/96892227-6f7b6480-1457-11eb-8bde-4d75a6977c27.png">
<img width="1003" alt="Screen Shot 2020-10-20 at 2 49 20 PM" src="https://user-images.githubusercontent.com/2664083/96892235-70ac9180-1457-11eb-85f4-63bb1f54ebf2.png">
<img width="1016" alt="Screen Shot 2020-10-20 at 2 49 26 PM" src="https://user-images.githubusercontent.com/2664083/96892236-71452800-1457-11eb-9319-1bd5e1471194.png">

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x ] Confirmed all the test steps above are working
- [x ] Confirmed there are no linter errors
- [ x] Confirmed this PR has reasonable code coverage
  - [ x] Confirmed this PR has unit test files
  - [x ] Ran `npm test`, made sure all tests are passing
  - [ x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x ] Confirmed relevant documentation has been updated/added.
