### PR TITLE
REVERT SENG-66 changes

### DIFF
--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -20,7 +20,6 @@ import {
 } from '@wpmedia/resizer-image-block';
 import PromoLabel from './_children/promo_label';
 import discoverPromoType from './_children/discover';
-import './default.scss';
 
 const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
@@ -51,13 +50,11 @@ const MediumPromo = ({ customFields }) => {
     query: { raw_image_url: customFields.imageOverrideURL },
   }) || undefined;
 
-  const headlinePosition = customFields.headlinePosition === 'below' ? 'below' : 'above';
   const headlineText = content && content.headlines ? content.headlines.basic : null;
   const descriptionText = content && content.description ? content.description.basic : null;
   const showSeparator = content?.credits?.by && content.credits.by.length !== 0;
   const byLineArray = content?.credits?.by
-    && content.credits.by.length !== 0 ? content.credits.by : null;
-  /* eslint-disable camelcase */
+  && content.credits.by.length !== 0 ? content.credits.by : null;
   const dateText = content?.display_date || null;
 
   const promoType = discoverPromoType(content);
@@ -67,7 +64,8 @@ const MediumPromo = ({ customFields }) => {
       return (
         <a
           href={content.website_url}
-          className={`md-promo-headline headline-${headlinePosition} ${headlinePosition === 'below' ? '' : 'margin-left-zero'}`}
+          className="md-promo-headline"
+          // className={`md-promo-headline headline-${customFields.headlinePosition}`}
           title={headlineText}
         >
           <HeadlineText
@@ -133,26 +131,11 @@ const MediumPromo = ({ customFields }) => {
   return content ? (
     <>
       <article className="container-fluid medium-promo">
-        <div className={`medium-promo-wrapper ${customFields.showImage ? 'md-promo-image' : ''} ${headlinePosition === 'below' ? '' : 'flex'}`}>
-          {headlinePosition === 'above'
-            && (customFields.showHeadline
-              || customFields.showDescription
-              || customFields.showByline
-              || customFields.showDate) && (
-              <div>
-                {headlineTmpl()}
-                {descriptionTmpl()}
-                <div className={`article-meta ${headlinePosition === 'below' ? '' : 'margin-left-zero'}`}>
-                  {byLineTmpl()}
-                  {dateTmpl()}
-                </div>
-              </div>
-          )}
-
+        <div className={`medium-promo-wrapper ${customFields.showImage ? 'md-promo-image' : ''}`}>
           {customFields.showImage
           && (
             <a
-              className={`image-link ${headlinePosition === 'below' ? '' : 'float-right'}`}
+              className="image-link"
               href={content.website_url}
               title={content && content.headlines ? content.headlines.basic : ''}
             >
@@ -184,23 +167,24 @@ const MediumPromo = ({ customFields }) => {
                       largeHeight={ratios.largeHeight}
                     />
                   )
-                }
+              }
               <PromoLabel type={promoType} />
             </a>
           )}
-          {headlinePosition === 'below'
-          && (customFields.showHeadline || customFields.showDescription
-            || customFields.showByline || customFields.showDate)
-          && (
-            <>
-              {headlineTmpl()}
-              {descriptionTmpl()}
-              <div className="article-meta">
-                {byLineTmpl()}
-                {dateTmpl()}
-              </div>
-            </>
-          )}
+          {/* customFields.headlinePosition === 'below' && */
+            (customFields.showHeadline || customFields.showDescription
+              || customFields.showByline || customFields.showDate)
+            && (
+              <>
+                {headlineTmpl()}
+                {descriptionTmpl()}
+                <div className="article-meta">
+                  {byLineTmpl()}
+                  {dateTmpl()}
+                </div>
+              </>
+            )
+          }
         </div>
       </article>
       <hr />
@@ -218,11 +202,6 @@ MediumPromo.propTypes = {
       label: 'Show headline',
       defaultValue: true,
       group: 'Show promo elements',
-    }),
-    headlinePosition: PropTypes.oneOf(['above', 'below']).tag({
-      label: 'Headline Position',
-      group: 'Show promo elements',
-      defaultValue: 'above',
     }),
     showImage: PropTypes.bool.tag({
       label: 'Show image',

--- a/blocks/medium-promo-block/features/medium-promo/default.scss
+++ b/blocks/medium-promo-block/features/medium-promo/default.scss
@@ -1,14 +1,14 @@
-.medium-promo {
-  .md-promo-image .md-promo-headline.margin-left-zero,
-  .md-promo-image .article-meta.margin-left-zero {
-    margin-left: 0;
-  }
-
-  .float-right {
-    float: right;
-  }
-
-  .flex {
-    display: flex;
-  }
-}
+//.medium-promo {
+//  .md-promo-image .md-promo-headline.margin-left-zero,
+//  .md-promo-image .article-meta.margin-left-zero {
+//    margin-left: 0;
+//  }
+//
+//  .float-right {
+//    float: right;
+//  }
+//
+//  .flex {
+//    display: flex;
+//  }
+//}

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -24,14 +24,7 @@ jest.mock('fusion:content', () => ({
 const config = {
   itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
   showHeadline: true,
-  headlinePosition: 'above',
-  showImage: true,
-};
-
-const headlineBelowConfig = {
-  itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
-  showHeadline: true,
-  headlinePosition: 'below',
+  // headlinePosition: 'below',
   showImage: true,
 };
 
@@ -80,18 +73,6 @@ describe('the medium promo feature', () => {
   it('should have class .md-promo-image when show image is true', () => {
     const wrapper = mount(<MediumPromo customFields={config} />);
     expect(wrapper.find('.md-promo-image')).toHaveLength(1);
-  });
-
-  it('should have class .headline-above when headline position is above', () => {
-    const wrapper = mount(<MediumPromo customFields={config} />);
-    expect(wrapper.find('.headline-above')).toHaveLength(1);
-    expect(wrapper.find('.headline-below')).toHaveLength(0);
-  });
-
-  it('should have class .headline-below when headline position is below', () => {
-    const wrapper = mount(<MediumPromo customFields={headlineBelowConfig} />);
-    expect(wrapper.find('.headline-above')).toHaveLength(0);
-    expect(wrapper.find('.headline-below')).toHaveLength(1);
   });
 
   it('should have no Image when show image is false', () => {

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -71,7 +71,7 @@ const SmallPromo = ({ customFields }) => {
                   primaryFont={
                     getThemeStyle(getProperties(arcSite))[
                       'primary-font-family'
-                      ]
+                    ]
                   }
                   className="sm-promo-headline"
                   {...editableContent(content, 'headlines.basic')}

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -60,9 +60,8 @@ const SmallPromo = ({ customFields }) => {
     <>
       <article className="container-fluid small-promo">
         <div className="row">
-          {customFields.showHeadline
-          && (customFields.headlinePosition === 'above' || customFields.headlinePosition === undefined) && (
-            <div className={`headline-above ${headlineClass}`}>
+          {customFields.showHeadline && (
+            <div className={headlineClass}>
               <a
                 href={content.website_url}
                 className="sm-promo-headline"
@@ -70,10 +69,10 @@ const SmallPromo = ({ customFields }) => {
               >
                 <HeadlineText
                   primaryFont={
-                        getThemeStyle(getProperties(arcSite))[
-                          'primary-font-family'
-                        ]
-                      }
+                    getThemeStyle(getProperties(arcSite))[
+                      'primary-font-family'
+                      ]
+                  }
                   className="sm-promo-headline"
                   {...editableContent(content, 'headlines.basic')}
                   suppressContentEditableWarning
@@ -120,7 +119,7 @@ const SmallPromo = ({ customFields }) => {
               </a>
             </div>
           )}
-          {customFields.showHeadline
+          {/* customFields.showHeadline
             && customFields.headlinePosition === 'below' && (
               <div className={`headline-below ${headlineClass}`}>
                 <a
@@ -142,7 +141,7 @@ const SmallPromo = ({ customFields }) => {
                   </HeadlineText>
                 </a>
               </div>
-          )}
+          ) */}
         </div>
       </article>
       <hr />
@@ -160,11 +159,6 @@ SmallPromo.propTypes = {
       label: 'Show headline',
       defaultValue: true,
       group: 'Show promo elements',
-    }),
-    headlinePosition: PropTypes.oneOf(['above', 'below']).tag({
-      label: 'Headline Position',
-      group: 'Show promo elements',
-      defaultValue: 'above',
     }),
     showImage: PropTypes.bool.tag({
       label: 'Show image',

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image/* , Video */ } from '@wpmedia/engine-theme-sdk';
+import { Image /* , Video */ } from '@wpmedia/engine-theme-sdk';
 import ArticleDate from '@wpmedia/date-block';
 import Byline from '@wpmedia/byline-block';
 import Overline from '@wpmedia/overline-block';
@@ -38,8 +38,6 @@ const HorizontalOverlineImageStoryItem = (props) => {
     ? 'col-sm-12 col-md-xl-6 flex-col'
     : 'col-sm-xl-12 flex-col';
 
-  const headlinePositionLG = customFields.headlinePositionLG === 'below' ? 'below' : 'above';
-
   const overlineTmpl = () => {
     if (customFields.showOverlineLG && overlineDisplay) {
       return (
@@ -57,7 +55,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineLG && itemTitle) {
       return (
-        <a href={websiteURL} title={itemTitle} className={`lg-promo-headline headline-${headlinePositionLG}`}>
+        <a href={websiteURL} title={itemTitle} className="lg-promo-headline">
           <Title primaryFont={primaryFont} className="lg-promo-headline">
             {itemTitle}
           </Title>
@@ -115,7 +113,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
     <>
       <article key={id} className="container-fluid large-promo">
         <div className="row lg-promo-padding-bottom">
-          {(headlinePositionLG === 'above')
+          {/* {customFields.headlinePositionLG === 'above'
             && (customFields.showHeadlineLG
               || customFields.showDescriptionLG
               || customFields.showBylineLG
@@ -129,8 +127,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
                   {dateTmpl()}
                 </div>
               </div>
-          )}
-          {/* videoUUID && (
+          )} */}
+          {/* {videoUUID && (
             <Video
               uuid={videoUUID}
               autoplay={false}
@@ -138,8 +136,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
               org="arcbrands"
               env="sandbox"
             />
-          ) */}
-          {customFields.showImageLG /* && !videoUUID */ && (
+          )} */}
+          {customFields.showImageLG && /*! videoUUID && */ (
             <div className="col-sm-12 col-md-xl-6 flex-col">
               {imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>
@@ -186,8 +184,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
               )}
             </div>
           )}
-          {headlinePositionLG === 'below'
-            && (customFields.showHeadlineLG
+          {/* customFields.headlinePositionLG === 'below' && */
+            (customFields.showHeadlineLG
               || customFields.showDescriptionLG
               || customFields.showBylineLG
               || customFields.showDateLG) && (
@@ -200,7 +198,8 @@ const HorizontalOverlineImageStoryItem = (props) => {
                   {dateTmpl()}
                 </div>
               </div>
-          )}
+            )
+          }
         </div>
       </article>
       <hr />

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
@@ -10,7 +10,7 @@ const config = {
   showDateXL: true,
   showOverlineLG: true,
   showHeadlineLG: true,
-  headlinePositionLG: 'above',
+  // headlinePositionLG: 'above',
   showImageLG: true,
   showDescriptionLG: true,
   showBylineLG: true,
@@ -24,28 +24,28 @@ const config = {
   showImageSM: true,
 };
 
-const headBelowConfig = {
-  showOverlineXL: true,
-  showHeadlineXL: true,
-  showImageXL: true,
-  showDescriptionXL: true,
-  showBylineXL: true,
-  showDateXL: true,
-  showOverlineLG: true,
-  showHeadlineLG: true,
-  headlinePositionLG: 'below',
-  showImageLG: true,
-  showDescriptionLG: true,
-  showBylineLG: true,
-  showDateLG: true,
-  showHeadlineMD: true,
-  showImageMD: true,
-  showDescriptionMD: true,
-  showBylineMD: true,
-  showDateMD: true,
-  showHeadlineSM: true,
-  showImageSM: true,
-};
+// const headBelowConfig = {
+//   showOverlineXL: true,
+//   showHeadlineXL: true,
+//   showImageXL: true,
+//   showDescriptionXL: true,
+//   showBylineXL: true,
+//   showDateXL: true,
+//   showOverlineLG: true,
+//   showHeadlineLG: true,
+//   headlinePositionLG: 'below',
+//   showImageLG: true,
+//   showDescriptionLG: true,
+//   showBylineLG: true,
+//   showDateLG: true,
+//   showHeadlineMD: true,
+//   showImageMD: true,
+//   showDescriptionMD: true,
+//   showBylineMD: true,
+//   showDateMD: true,
+//   showHeadlineSM: true,
+//   showImageSM: true,
+// };
 
 describe('horizontal overline image story item', () => {
   beforeAll(() => {
@@ -183,81 +183,81 @@ describe('horizontal overline image story item', () => {
     expect(wrapper.find('HorizontalOverlineImageStoryItem > hr').length).toBe(1);
   });
 
-  it('headline div has class headline-above when headline is above', () => {
-    const imageURL = 'pic';
-    const websiteURL = 'url';
-    const itemTitle = 'title';
-    const descriptionText = 'description';
-    const primaryFont = 'arial';
-    const secondaryFont = 'Georgia';
-    const by = ['jack'];
-    const element = { credits: { by: [] } };
-    const displayDate = '';
-    const { default: HorizontalOverlineImageStoryItem } = require('./horizontal-overline-image-story-item');
-    const id = 'test';
-    const overlineUrl = '/news';
-    const overlineText = 'News';
-    const overlineDisplay = true;
+  // it('headline div has class headline-above when headline is above', () => {
+  //   const imageURL = 'pic';
+  //   const websiteURL = 'url';
+  //   const itemTitle = 'title';
+  //   const descriptionText = 'description';
+  //   const primaryFont = 'arial';
+  //   const secondaryFont = 'Georgia';
+  //   const by = ['jack'];
+  //   const element = { credits: { by: [] } };
+  //   const displayDate = '';
+  //   const { default: HorizontalOverlineImageStoryItem } = require('./horizontal-overline-image-story-item');
+  //   const id = 'test';
+  //   const overlineUrl = '/news';
+  //   const overlineText = 'News';
+  //   const overlineDisplay = true;
 
-    const wrapper = mount(
-      <HorizontalOverlineImageStoryItem
-        imageURL={imageURL}
-        websiteURL={websiteURL}
-        itemTitle={itemTitle}
-        descriptionText={descriptionText}
-        primaryFont={primaryFont}
-        secondaryFont={secondaryFont}
-        by={by}
-        element={element}
-        displayDate={displayDate}
-        id={id}
-        overlineDisplay={overlineDisplay}
-        overlineUrl={overlineUrl}
-        overlineText={overlineText}
-        customFields={config}
-      />,
-    );
+  //   const wrapper = mount(
+  //     <HorizontalOverlineImageStoryItem
+  //       imageURL={imageURL}
+  //       websiteURL={websiteURL}
+  //       itemTitle={itemTitle}
+  //       descriptionText={descriptionText}
+  //       primaryFont={primaryFont}
+  //       secondaryFont={secondaryFont}
+  //       by={by}
+  //       element={element}
+  //       displayDate={displayDate}
+  //       id={id}
+  //       overlineDisplay={overlineDisplay}
+  //       overlineUrl={overlineUrl}
+  //       overlineText={overlineText}
+  //       customFields={config}
+  //     />,
+  //   );
 
-    expect(wrapper.find('.headline-above').length).toBe(1);
-    expect(wrapper.find('.headline-below').length).toBe(0);
-  });
+  //   expect(wrapper.find('.headline-above').length).toBe(2);
+  //   expect(wrapper.find('.headline-below').length).toBe(0);
+  // });
 
-  it('headline div has class headline-below when headline is below', () => {
-    const imageURL = 'pic';
-    const websiteURL = 'url';
-    const itemTitle = 'title';
-    const descriptionText = 'description';
-    const primaryFont = 'arial';
-    const secondaryFont = 'Georgia';
-    const by = ['jack'];
-    const element = { credits: { by: [] } };
-    const displayDate = '';
-    const { default: HorizontalOverlineImageStoryItem } = require('./horizontal-overline-image-story-item');
-    const id = 'test';
-    const overlineUrl = '/news';
-    const overlineText = 'News';
-    const overlineDisplay = true;
+  // it('headline div has class headline-below when headline is below', () => {
+  //   const imageURL = 'pic';
+  //   const websiteURL = 'url';
+  //   const itemTitle = 'title';
+  //   const descriptionText = 'description';
+  //   const primaryFont = 'arial';
+  //   const secondaryFont = 'Georgia';
+  //   const by = ['jack'];
+  //   const element = { credits: { by: [] } };
+  //   const displayDate = '';
+  //   const { default: HorizontalOverlineImageStoryItem } = require('./horizontal-overline-image-story-item');
+  //   const id = 'test';
+  //   const overlineUrl = '/news';
+  //   const overlineText = 'News';
+  //   const overlineDisplay = true;
 
-    const wrapper = mount(
-      <HorizontalOverlineImageStoryItem
-        imageURL={imageURL}
-        websiteURL={websiteURL}
-        itemTitle={itemTitle}
-        descriptionText={descriptionText}
-        primaryFont={primaryFont}
-        secondaryFont={secondaryFont}
-        by={by}
-        element={element}
-        displayDate={displayDate}
-        id={id}
-        overlineDisplay={overlineDisplay}
-        overlineUrl={overlineUrl}
-        overlineText={overlineText}
-        customFields={headBelowConfig}
-      />,
-    );
+  //   const wrapper = mount(
+  //     <HorizontalOverlineImageStoryItem
+  //       imageURL={imageURL}
+  //       websiteURL={websiteURL}
+  //       itemTitle={itemTitle}
+  //       descriptionText={descriptionText}
+  //       primaryFont={primaryFont}
+  //       secondaryFont={secondaryFont}
+  //       by={by}
+  //       element={element}
+  //       displayDate={displayDate}
+  //       id={id}
+  //       overlineDisplay={overlineDisplay}
+  //       overlineUrl={overlineUrl}
+  //       overlineText={overlineText}
+  //       customFields={headBelowConfig}
+  //     />,
+  //   );
 
-    expect(wrapper.find('.headline-below').length).toBe(1);
-    expect(wrapper.find('.headline-above').length).toBe(0);
-  });
+  //   expect(wrapper.find('.headline-below').length).toBe(2);
+  //   expect(wrapper.find('.headline-above').length).toBe(0);
+  // });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
@@ -193,7 +193,8 @@ describe('horizontal overline image story item', () => {
   //   const by = ['jack'];
   //   const element = { credits: { by: [] } };
   //   const displayDate = '';
-  //   const { default: HorizontalOverlineImageStoryItem } = require('./horizontal-overline-image-story-item');
+  //   const { default: HorizontalOverlineImageStoryItem }
+  //   = require('./horizontal-overline-image-story-item');
   //   const id = 'test';
   //   const overlineUrl = '/news';
   //   const overlineText = 'News';
@@ -232,7 +233,8 @@ describe('horizontal overline image story item', () => {
   //   const by = ['jack'];
   //   const element = { credits: { by: [] } };
   //   const displayDate = '';
-  //   const { default: HorizontalOverlineImageStoryItem } = require('./horizontal-overline-image-story-item');
+  //   const { default: HorizontalOverlineImageStoryItem }
+  //   = require('./horizontal-overline-image-story-item');
   //   const id = 'test';
   //   const overlineUrl = '/news';
   //   const overlineText = 'News';

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -34,22 +34,23 @@ const ItemTitleWithRightImage = (props) => {
       className={`${promoClasses} ${paddingRight ? 'small-promo-padding' : ''}`}
     >
       <div className="row sm-promo-padding-btm">
-        {(customFields.headlinePositionSM === 'above' || customFields.headlinePositionSM === undefined)
-          && customFields.showHeadlineSM && itemTitle !== '' ? (
+        {/* customFields.headlinePositionSM === 'above' && */
+          customFields.showHeadlineSM && itemTitle !== '' ? (
             <div className="col-sm-8 col-md-xl-8">
               <a
                 href={websiteURL}
                 title={itemTitle}
-                className="sm-promo-headline headline-above"
+                className="sm-promo-headline"
               >
                 <Title primaryFont={primaryFont} className="sm-promo-headline">
                   {itemTitle}
                 </Title>
               </a>
             </div>
-          ) : null}
+          ) : null
+        }
         {customFields.showImageSM
-          && (
+        && (
           <div className="col-sm-4 col-md-xl-4 flex-col">
             {imageURL !== '' ? (
               <a href={websiteURL} title={itemTitle}>
@@ -87,9 +88,9 @@ const ItemTitleWithRightImage = (props) => {
               </div>
             )}
           </div>
-          )}
+        )}
       </div>
-      {customFields.headlinePositionSM === 'below'
+      {/* {customFields.headlinePositionSM === 'below'
       && customFields.showHeadlineSM
       && itemTitle !== '' ? (
         <div className="col-sm-8 col-md-xl-8">
@@ -99,7 +100,7 @@ const ItemTitleWithRightImage = (props) => {
             </Title>
           </a>
         </div>
-        ) : null}
+        ) : null} */}
       <hr />
     </article>
   );

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
@@ -20,32 +20,32 @@ const config = {
   showBylineMD: true,
   showDateMD: true,
   showHeadlineSM: true,
-  headlinePositionSM: 'above',
+  // headlinePositionSM: 'above',
   showImageSM: true,
 };
 
-const headBelowConfig = {
-  showOverlineXL: true,
-  showHeadlineXL: true,
-  showImageXL: true,
-  showDescriptionXL: true,
-  showBylineXL: true,
-  showDateXL: true,
-  showOverlineLG: true,
-  showHeadlineLG: true,
-  showImageLG: true,
-  showDescriptionLG: true,
-  showBylineLG: true,
-  showDateLG: true,
-  showHeadlineMD: true,
-  showImageMD: true,
-  showDescriptionMD: true,
-  showBylineMD: true,
-  showDateMD: true,
-  showHeadlineSM: true,
-  headlinePositionSM: 'below',
-  showImageSM: true,
-};
+// const headBelowConfig = {
+//   showOverlineXL: true,
+//   showHeadlineXL: true,
+//   showImageXL: true,
+//   showDescriptionXL: true,
+//   showBylineXL: true,
+//   showDateXL: true,
+//   showOverlineLG: true,
+//   showHeadlineLG: true,
+//   showImageLG: true,
+//   showDescriptionLG: true,
+//   showBylineLG: true,
+//   showDateLG: true,
+//   showHeadlineMD: true,
+//   showImageMD: true,
+//   showDescriptionMD: true,
+//   showBylineMD: true,
+//   showDateMD: true,
+//   showHeadlineSM: true,
+//   headlinePositionSM: 'below',
+//   showImageSM: true,
+// };
 
 describe('item title with right image block', () => {
   beforeAll(() => {
@@ -118,117 +118,119 @@ describe('item title with right image block', () => {
     // expect(wrapper.find('.simple-list-img').length).toBe(0);
   });
 
-  it('headline has class headline-above when headline position is above', () => {
-    const imageURL = 'pic';
-    const itemTitle = 'title';
-    const primaryFont = 'arial';
-    const id = 'test';
-    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+  //   it('headline has class headline-above when headline position is above', () => {
+  //     const imageURL = 'pic';
+  //     const itemTitle = 'title';
+  //     const primaryFont = 'arial';
+  //     const id = 'test';
+  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-    const wrapper = mount(
-      <ItemTitleWithRightImage
-        imageURL={imageURL}
-        itemTitle={itemTitle}
-        primaryFont={primaryFont}
-        id={id}
-        customFields={config}
-        resizedImageOptions={{ '400x267': '' }}
-      />,
-    );
+  //     // eslint-disable-next-line no-unused-vars
+  //     const wrapper = mount(
+  //       <ItemTitleWithRightImage
+  //         imageURL={imageURL}
+  //         itemTitle={itemTitle}
+  //         primaryFont={primaryFont}
+  //         id={id}
+  //         customFields={config}
+  //         resizedImageOptions={{ '400x267': '' }}
+  //       />,
+  //     );
 
-    expect(wrapper.find('.headline-above').length).toBe(1);
-    expect(wrapper.find('.headline-below').length).toBe(0);
-  });
+  //     expect(wrapper.find('.headline-above').length).toBe(1);
+  //     expect(wrapper.find('.headline-below').length).toBe(0);
+  //   });
 
-  it('headline has class headline-below when headline position is below', () => {
-    const imageURL = 'pic';
-    const itemTitle = 'title';
-    const primaryFont = 'arial';
-    const id = 'test';
-    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+  //   it('headline has class headline-below when headline position is below', () => {
+  //     const imageURL = 'pic';
+  //     const itemTitle = 'title';
+  //     const primaryFont = 'arial';
+  //     const id = 'test';
+  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-    const wrapper = mount(
-      <ItemTitleWithRightImage
-        imageURL={imageURL}
-        itemTitle={itemTitle}
-        primaryFont={primaryFont}
-        id={id}
-        customFields={headBelowConfig}
-        resizedImageOptions={{ '400x267': '' }}
-      />,
-    );
+  //     // eslint-disable-next-line no-unused-vars
+  //     const wrapper = mount(
+  //       <ItemTitleWithRightImage
+  //         imageURL={imageURL}
+  //         itemTitle={itemTitle}
+  //         primaryFont={primaryFont}
+  //         id={id}
+  //         customFields={headBelowConfig}
+  //         resizedImageOptions={{ '400x267': '' }}
+  //       />,
+  //     );
 
-    expect(wrapper.find('.headline-below').length).toBe(1);
-    expect(wrapper.find('.headline-above').length).toBe(0);
-  });
-});
+  //     expect(wrapper.find('.headline-below').length).toBe(1);
+  //     expect(wrapper.find('.headline-above').length).toBe(0);
+  //   });
+  // });
 
-describe('small promo display', () => {
-  it('when storiesPerRowSM is undefined must not add class small-promo-one', () => {
-    const imageURL = 'pic';
-    const itemTitle = 'title';
-    const primaryFont = 'arial';
-    const id = 'test';
-    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+  // describe('small promo display', () => {
+  //   it('when storiesPerRowSM is undefined must not add class small-promo-one', () => {
+  //     const imageURL = 'pic';
+  //     const itemTitle = 'title';
+  //     const primaryFont = 'arial';
+  //     const id = 'test';
+  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-    const wrapper = mount(
-      <ItemTitleWithRightImage
-        imageURL={imageURL}
-        itemTitle={itemTitle}
-        primaryFont={primaryFont}
-        id={id}
-        customFields={config}
-        resizedImageOptions={{ '400x267': '' }}
-      />,
-    );
+  //     const wrapper = mount(
+  //       <ItemTitleWithRightImage
+  //         imageURL={imageURL}
+  //         itemTitle={itemTitle}
+  //         primaryFont={primaryFont}
+  //         id={id}
+  //         customFields={config}
+  //         resizedImageOptions={{ '400x267': '' }}
+  //       />,
+  //     );
 
-    expect(wrapper.find('.small-promo-one').length).toBe(0);
-    expect(wrapper.find('article.wrap-bottom').length).toBe(1);
-  });
+  //     expect(wrapper.find('.small-promo-one').length).toBe(0);
+  //     expect(wrapper.find('article.wrap-bottom').length).toBe(1);
+  //   });
 
-  it('when storiesPerRowSM is 2 must not add class small-promo-one', () => {
-    const imageURL = 'pic';
-    const itemTitle = 'title';
-    const primaryFont = 'arial';
-    const id = 'test';
-    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
-    const setup = Object.assign(config, { storiesPerRowSM: 2 });
+  //   it('when storiesPerRowSM is 2 must not add class small-promo-one', () => {
+  //     const imageURL = 'pic';
+  //     const itemTitle = 'title';
+  //     const primaryFont = 'arial';
+  //     const id = 'test';
+  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+  //     const setup = Object.assign(config, { storiesPerRowSM: 2 });
 
-    const wrapper = mount(
-      <ItemTitleWithRightImage
-        imageURL={imageURL}
-        itemTitle={itemTitle}
-        primaryFont={primaryFont}
-        id={id}
-        customFields={setup}
-        resizedImageOptions={{ '400x267': '' }}
-      />,
-    );
+  //     const wrapper = mount(
+  //       <ItemTitleWithRightImage
+  //         imageURL={imageURL}
+  //         itemTitle={itemTitle}
+  //         primaryFont={primaryFont}
+  //         id={id}
+  //         customFields={setup}
+  //         resizedImageOptions={{ '400x267': '' }}
+  //       />,
+  //     );
 
-    expect(wrapper.find('.small-promo-one').length).toBe(0);
-    expect(wrapper.find('article.wrap-bottom').length).toBe(1);
-  });
+  //     expect(wrapper.find('.small-promo-one').length).toBe(0);
+  //     expect(wrapper.find('article.wrap-bottom').length).toBe(1);
+  //   });
 
-  it('when storiesPerRowSM is 1 must add class small-promo-one', () => {
-    const imageURL = 'pic';
-    const itemTitle = 'title';
-    const primaryFont = 'arial';
-    const id = 'test';
-    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
-    const setup = Object.assign(config, { storiesPerRowSM: 1 });
+  //   it('when storiesPerRowSM is 1 must add class small-promo-one', () => {
+  //     const imageURL = 'pic';
+  //     const itemTitle = 'title';
+  //     const primaryFont = 'arial';
+  //     const id = 'test';
+  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+  //     const setup = Object.assign(config, { storiesPerRowSM: 1 });
 
-    const wrapper = mount(
-      <ItemTitleWithRightImage
-        imageURL={imageURL}
-        itemTitle={itemTitle}
-        primaryFont={primaryFont}
-        id={id}
-        customFields={setup}
-        resizedImageOptions={{ '400x267': '' }}
-      />,
-    );
+  //     const wrapper = mount(
+  //       <ItemTitleWithRightImage
+  //         imageURL={imageURL}
+  //         itemTitle={itemTitle}
+  //         primaryFont={primaryFont}
+  //         id={id}
+  //         customFields={setup}
+  //         resizedImageOptions={{ '400x267': '' }}
+  //       />,
+  //     );
 
-    expect(wrapper.find('.small-promo-one').length).toBe(1);
-    expect(wrapper.find('article.wrap-bottom').length).toBe(0);
-  });
+//     expect(wrapper.find('.small-promo-one').length).toBe(1);
+//     expect(wrapper.find('article.wrap-bottom').length).toBe(0);
+//   });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -32,12 +32,10 @@ const MediumListItem = (props) => {
   } = props;
   const showSeparator = by && by.length !== 0 && customFields.showDateMD;
 
-  const headlinePositionMD = customFields.headlinePositionMD === 'below' ? 'below' : 'above';
-
   const headlineTmpl = () => {
     if (customFields.showHeadlineMD && itemTitle !== '') {
       return (
-        <a href={websiteURL} title={itemTitle} className={`md-promo-headline headline-${headlinePositionMD}`}>
+        <a href={websiteURL} title={itemTitle} className={`md-promo-headline headline-${customFields.headlinePositionMD || 'above'}`}>
           <Title className="md-promo-headline-text" primaryFont={primaryFont}>
             {itemTitle}
           </Title>
@@ -94,23 +92,23 @@ const MediumListItem = (props) => {
     <>
       <article className="container-fluid medium-promo" key={id}>
         <div className={`medium-promo-wrapper ${customFields.showImageMD ? 'md-promo-image' : ''}`}>
-          {(headlinePositionMD === 'above')
-            && (customFields.showHeadlineMD
-              || customFields.showDescriptionMD
-              || customFields.showBylineMD
-              || customFields.showDateMD) && (
-              <div className="float-left">
-                {headlineTmpl()}
-                {descriptionTmpl()}
-                <div className="article-meta">
-                  {byLineTmpl()}
-                  {dateTmpl()}
-                </div>
+          {(customFields.headlinePositionMD === 'above' || customFields.headlinePositionMD === undefined)
+          && (customFields.showHeadlineMD
+            || customFields.showDescriptionMD
+            || customFields.showBylineMD
+            || customFields.showDateMD) && (
+            <div style={{ float: 'left' }}>
+              {headlineTmpl()}
+              {descriptionTmpl()}
+              <div className="article-meta">
+                {byLineTmpl()}
+                {dateTmpl()}
               </div>
+            </div>
           )}
           {customFields.showImageMD
-            && (
-            <a className={`image-link${headlinePositionMD === 'below' ? '' : ' float-right'}`} href={websiteURL} title={itemTitle}>
+          && (
+            <a className="image-link" href={websiteURL} title={itemTitle} style={{ float: (customFields.headlinePositionMD === 'below' ? '' : 'right') }}>
               {imageURL !== '' ? (
                 <Image
                   resizedImageOptions={resizedImageOptions}
@@ -144,20 +142,20 @@ const MediumListItem = (props) => {
               )}
               <PromoLabel type={promoType} />
             </a>
-            )}
-          {headlinePositionMD === 'below'
-            && (customFields.showHeadlineMD
-              || customFields.showDescriptionMD
-              || customFields.showBylineMD
-              || customFields.showDateMD) && (
-              <>
-                {headlineTmpl()}
-                {descriptionTmpl()}
-                <div className="article-meta">
-                  {byLineTmpl()}
-                  {dateTmpl()}
-                </div>
-              </>
+          )}
+          {customFields.headlinePositionMD === 'below'
+          && (customFields.showHeadlineMD
+            || customFields.showDescriptionMD
+            || customFields.showBylineMD
+            || customFields.showDateMD) && (
+            <>
+              {headlineTmpl()}
+              {descriptionTmpl()}
+              <div className="article-meta">
+                {byLineTmpl()}
+                {dateTmpl()}
+              </div>
+            </>
           )}
         </div>
       </article>

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
@@ -4,54 +4,54 @@ import { mount } from 'enzyme';
 const config = {
   showOverlineXL: true,
   showHeadlineXL: true,
-  headlinePositionXL: 'below',
+  // headlinePositionXL: 'below',
   showImageXL: true,
   showDescriptionXL: true,
   showBylineXL: true,
   showDateXL: true,
   showOverlineLG: true,
   showHeadlineLG: true,
-  headlinePositionLG: 'below',
+  // headlinePositionLG: 'below',
   showImageLG: true,
   showDescriptionLG: true,
   showBylineLG: true,
   showDateLG: true,
   showHeadlineMD: true,
-  headlinePositionMD: 'above',
+  // headlinePositionMD: 'above',
   showImageMD: true,
   showDescriptionMD: true,
   showBylineMD: true,
   showDateMD: true,
   showHeadlineSM: true,
-  headlinePositionSM: 'below',
+  // headlinePositionSM: 'below',
   showImageSM: true,
 };
 
-const headBelowConfig = {
-  showOverlineXL: true,
-  showHeadlineXL: true,
-  headlinePositionXL: 'below',
-  showImageXL: true,
-  showDescriptionXL: true,
-  showBylineXL: true,
-  showDateXL: true,
-  showOverlineLG: true,
-  showHeadlineLG: true,
-  headlinePositionLG: 'below',
-  showImageLG: true,
-  showDescriptionLG: true,
-  showBylineLG: true,
-  showDateLG: true,
-  showHeadlineMD: true,
-  headlinePositionMD: 'below',
-  showImageMD: true,
-  showDescriptionMD: true,
-  showBylineMD: true,
-  showDateMD: true,
-  showHeadlineSM: true,
-  headlinePositionSM: 'below',
-  showImageSM: true,
-};
+// const headBelowConfig = {
+//   showOverlineXL: true,
+//   showHeadlineXL: true,
+//   headlinePositionXL: 'below',
+//   showImageXL: true,
+//   showDescriptionXL: true,
+//   showBylineXL: true,
+//   showDateXL: true,
+//   showOverlineLG: true,
+//   showHeadlineLG: true,
+//   headlinePositionLG: 'below',
+//   showImageLG: true,
+//   showDescriptionLG: true,
+//   showBylineLG: true,
+//   showDateLG: true,
+//   showHeadlineMD: true,
+//   headlinePositionMD: 'below',
+//   showImageMD: true,
+//   showDescriptionMD: true,
+//   showBylineMD: true,
+//   showDateMD: true,
+//   showHeadlineSM: true,
+//   headlinePositionSM: 'below',
+//   showImageSM: true,
+// };
 
 describe('medium list item', () => {
   beforeAll(() => {
@@ -87,6 +87,7 @@ describe('medium list item', () => {
     const id = 'test';
     const { default: MediumListItem } = require('./medium-list-item');
 
+    // eslint-disable-next-line no-unused-vars
     const wrapper = mount(<MediumListItem
       imageURL={imageURL}
       constructedURL={constructedURL}
@@ -113,67 +114,69 @@ describe('medium list item', () => {
     expect(wrapper.find('MediumListItem > hr').length).toBe(1);
   });
 
-  it('headline has class headline-above when headline position is above', () => {
-    const imageURL = 'pic';
-    const constructedURL = 'url';
-    const itemTitle = 'title';
-    const descriptionText = 'description';
-    const primaryFont = 'arial';
-    const secondaryFont = 'Georgia';
-    const by = ['jack'];
-    const element = { credits: { by: [] } };
-    const displayDate = '';
-    const id = 'test';
-    const { default: MediumListItem } = require('./medium-list-item');
+  // it('headline has class headline-above when headline position is above', () => {
+  //   const imageURL = 'pic';
+  //   const constructedURL = 'url';
+  //   const itemTitle = 'title';
+  //   const descriptionText = 'description';
+  //   const primaryFont = 'arial';
+  //   const secondaryFont = 'Georgia';
+  //   const by = ['jack'];
+  //   const element = { credits: { by: [] } };
+  //   const displayDate = '';
+  //   const id = 'test';
+  //   const { default: MediumListItem } = require('./medium-list-item');
 
-    const wrapper = mount(<MediumListItem
-      imageURL={imageURL}
-      constructedURL={constructedURL}
-      itemTitle={itemTitle}
-      descriptionText={descriptionText}
-      primaryFont={primaryFont}
-      secondaryFont={secondaryFont}
-      by={by}
-      element={element}
-      displayDate={displayDate}
-      id={id}
-      customFields={config}
-    />);
+  //   // eslint-disable-next-line no-unused-vars
+  //   const wrapper = mount(<MediumListItem
+  //     imageURL={imageURL}
+  //     constructedURL={constructedURL}
+  //     itemTitle={itemTitle}
+  //     descriptionText={descriptionText}
+  //     primaryFont={primaryFont}
+  //     secondaryFont={secondaryFont}
+  //     by={by}
+  //     element={element}
+  //     displayDate={displayDate}
+  //     id={id}
+  //     customFields={config}
+  //   />);
 
-    expect(wrapper.find('.headline-above').length).toBe(1);
-    expect(wrapper.find('.headline-below').length).toBe(0);
-  });
+  //   expect(wrapper.find('.headline-above').length).toBe(1);
+  //   expect(wrapper.find('.headline-below').length).toBe(0);
+  // });
 
-  it('headline has class headline-below when headline position is below', () => {
-    const imageURL = 'pic';
-    const constructedURL = 'url';
-    const itemTitle = 'title';
-    const descriptionText = 'description';
-    const primaryFont = 'arial';
-    const secondaryFont = 'Georgia';
-    const by = ['jack'];
-    const element = { credits: { by: [] } };
-    const displayDate = '';
-    const id = 'test';
-    const { default: MediumListItem } = require('./medium-list-item');
+  // it('headline has class headline-below when headline position is below', () => {
+  //   const imageURL = 'pic';
+  //   const constructedURL = 'url';
+  //   const itemTitle = 'title';
+  //   const descriptionText = 'description';
+  //   const primaryFont = 'arial';
+  //   const secondaryFont = 'Georgia';
+  //   const by = ['jack'];
+  //   const element = { credits: { by: [] } };
+  //   const displayDate = '';
+  //   const id = 'test';
+  //   const { default: MediumListItem } = require('./medium-list-item');
 
-    const wrapper = mount(<MediumListItem
-      imageURL={imageURL}
-      constructedURL={constructedURL}
-      itemTitle={itemTitle}
-      descriptionText={descriptionText}
-      primaryFont={primaryFont}
-      secondaryFont={secondaryFont}
-      by={by}
-      element={element}
-      displayDate={displayDate}
-      id={id}
-      customFields={headBelowConfig}
-    />);
+  //   // eslint-disable-next-line no-unused-vars
+  //   const wrapper = mount(<MediumListItem
+  //     imageURL={imageURL}
+  //     constructedURL={constructedURL}
+  //     itemTitle={itemTitle}
+  //     descriptionText={descriptionText}
+  //     primaryFont={primaryFont}
+  //     secondaryFont={secondaryFont}
+  //     by={by}
+  //     element={element}
+  //     displayDate={displayDate}
+  //     id={id}
+  //     customFields={headBelowConfig}
+  //   />);
 
-    expect(wrapper.find('.headline-below').length).toBe(1);
-    expect(wrapper.find('.headline-above').length).toBe(0);
-  });
+  //   expect(wrapper.find('.headline-below').length).toBe(1);
+  //   expect(wrapper.find('.headline-above').length).toBe(0);
+  // });
 
   it('renders image placeholder with empty props', () => {
     const { default: MediumListItem } = require('./medium-list-item');
@@ -189,6 +192,7 @@ describe('medium list item', () => {
     const displayDate = '';
     const id = 'test';
 
+    // eslint-disable-next-line no-unused-vars
     const wrapper = mount(<MediumListItem
       imageURL={imageURL}
       constructedURL={constructedURL}

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, Video } from '@wpmedia/engine-theme-sdk';
+import { Image /* , Video */ } from '@wpmedia/engine-theme-sdk';
 import ArticleDate from '@wpmedia/date-block';
 import Byline from '@wpmedia/byline-block';
 import Overline from '@wpmedia/overline-block';
@@ -33,8 +33,6 @@ const VerticalOverlineImageStoryItem = (props) => {
   } = props;
   const showSeparator = by && by.length !== 0 && customFields.showDateXL;
 
-  const headlinePositionXL = customFields.headlinePositionXL === 'below' ? 'below' : 'above';
-
   const overlineTmpl = () => {
     if (customFields.showOverlineXL && overlineDisplay) {
       return (
@@ -52,7 +50,7 @@ const VerticalOverlineImageStoryItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineXL && itemTitle) {
       return (
-        <a href={websiteURL} title={itemTitle} className={`xl-promo-headline headline-${headlinePositionXL}`}>
+        <a href={websiteURL} title={itemTitle} className="xl-promo-headline">
           <Title primaryFont={primaryFont} className="xl-promo-headline">
             {itemTitle}
           </Title>
@@ -103,8 +101,7 @@ const VerticalOverlineImageStoryItem = (props) => {
   };
 
   const ratios = ratiosFor('XL', imageRatio);
-  /* eslint-disable camelcase */
-  const videoUUID = element?.promo_items?.basic?.additional_properties?.videoId;
+  // const videoUUID = element?.promo_items?.basic?.additional_properties?.videoId;
 
   return (
     <>
@@ -116,8 +113,8 @@ const VerticalOverlineImageStoryItem = (props) => {
             || customFields.showDateXL) && (
             <div className="col-sm-xl-12 flex-col">
               {overlineTmpl()}
-              {headlinePositionXL === 'above' && headlineTmpl()}
-              {videoUUID && (
+              {/* customFields.headlinePositionXL === 'above' && */ headlineTmpl()}
+              {/* {videoUUID && (
                 <Video
                   uuid={videoUUID}
                   autoplay={false}
@@ -125,8 +122,8 @@ const VerticalOverlineImageStoryItem = (props) => {
                   org="arcbrands"
                   env="sandbox"
                 />
-              )}
-              {customFields.showImageXL && !videoUUID && imageURL !== '' ? (
+              )} */}
+              {customFields.showImageXL && /*! videoUUID && */ imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>
                   <Image
                     resizedImageOptions={resizedImageOptions}
@@ -144,7 +141,7 @@ const VerticalOverlineImageStoryItem = (props) => {
                   />
                 </a>
               ) : (
-                !videoUUID && (
+                /*! videoUUID && */ (
                   <Image
                     smallWidth={ratios.smallWidth}
                     smallHeight={ratios.smallHeight}
@@ -163,7 +160,7 @@ const VerticalOverlineImageStoryItem = (props) => {
                   />
                 )
               )}
-              {headlinePositionXL === 'below' && headlineTmpl()}
+              {/* customFields.headlinePositionXL === 'below' && headlineTmpl() */}
               {descriptionTmpl()}
               <div className="article-meta">
                 {byLineTmpl()}

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
@@ -4,54 +4,54 @@ import { mount } from 'enzyme';
 const config = {
   showOverlineXL: true,
   showHeadlineXL: true,
-  headlinePositionXL: 'above',
+  // headlinePositionXL: 'above',
   showImageXL: true,
   showDescriptionXL: true,
   showBylineXL: true,
   showDateXL: true,
   showOverlineLG: true,
   showHeadlineLG: true,
-  headlinePositionLG: 'below',
+  // headlinePositionLG: 'below',
   showImageLG: true,
   showDescriptionLG: true,
   showBylineLG: true,
   showDateLG: true,
   showHeadlineMD: true,
-  headlinePositionMD: 'below',
+  // headlinePositionMD: 'below',
   showImageMD: true,
   showDescriptionMD: true,
   showBylineMD: true,
   showDateMD: true,
   showHeadlineSM: true,
-  headlinePositionSM: 'below',
+  // headlinePositionSM: 'below',
   showImageSM: true,
 };
 
-const headBelowConfig = {
-  showOverlineXL: true,
-  showHeadlineXL: true,
-  headlinePositionXL: 'below',
-  showImageXL: true,
-  showDescriptionXL: true,
-  showBylineXL: true,
-  showDateXL: true,
-  showOverlineLG: true,
-  showHeadlineLG: true,
-  headlinePositionLG: 'below',
-  showImageLG: true,
-  showDescriptionLG: true,
-  showBylineLG: true,
-  showDateLG: true,
-  showHeadlineMD: true,
-  headlinePositionMD: 'below',
-  showImageMD: true,
-  showDescriptionMD: true,
-  showBylineMD: true,
-  showDateMD: true,
-  showHeadlineSM: true,
-  headlinePositionSM: 'below',
-  showImageSM: true,
-};
+// const headBelowConfig = {
+//   showOverlineXL: true,
+//   showHeadlineXL: true,
+//   headlinePositionXL: 'below',
+//   showImageXL: true,
+//   showDescriptionXL: true,
+//   showBylineXL: true,
+//   showDateXL: true,
+//   showOverlineLG: true,
+//   showHeadlineLG: true,
+//   headlinePositionLG: 'below',
+//   showImageLG: true,
+//   showDescriptionLG: true,
+//   showBylineLG: true,
+//   showDateLG: true,
+//   showHeadlineMD: true,
+//   headlinePositionMD: 'below',
+//   showImageMD: true,
+//   showDescriptionMD: true,
+//   showBylineMD: true,
+//   showDateMD: true,
+//   showHeadlineSM: true,
+//   headlinePositionSM: 'below',
+//   showImageSM: true,
+// };
 
 describe('vertical overline image story item', () => {
   beforeAll(() => {
@@ -126,81 +126,83 @@ describe('vertical overline image story item', () => {
     expect(wrapper.find('VerticalOverlineImageStoryItem > hr').length).toBe(1);
   });
 
-  it('headline has class headline-above when headline position is above', () => {
-    const imageURL = 'pic';
-    const websiteURL = 'url';
-    const itemTitle = 'title';
-    const descriptionText = 'description';
-    const primaryFont = 'arial';
-    const by = ['jack'];
-    const element = { credits: { by: [] } };
-    const displayDate = '';
-    const id = 'test';
-    const overlineUrl = '/news';
-    const overlineText = 'News';
-    const overlineDisplay = true;
+  // it('headline has class headline-above when headline position is above', () => {
+  //   const imageURL = 'pic';
+  //   const websiteURL = 'url';
+  //   const itemTitle = 'title';
+  //   const descriptionText = 'description';
+  //   const primaryFont = 'arial';
+  //   const by = ['jack'];
+  //   const element = { credits: { by: [] } };
+  //   const displayDate = '';
+  //   const id = 'test';
+  //   const overlineUrl = '/news';
+  //   const overlineText = 'News';
+  //   const overlineDisplay = true;
 
-    const { default: VerticalOverlineImageStoryItem } = require('./vertical-overline-image-story-item');
+  //   const { default: VerticalOverlineImageStoryItem } =
+  // require('./vertical-overline-image-story-item');
 
-    const wrapper = mount(
-      <VerticalOverlineImageStoryItem
-        imageURL={imageURL}
-        websiteURL={websiteURL}
-        itemTitle={itemTitle}
-        descriptionText={descriptionText}
-        primaryFont={primaryFont}
-        by={by}
-        element={element}
-        displayDate={displayDate}
-        overlineUrl={overlineUrl}
-        overlineText={overlineText}
-        id={id}
-        overlineDisplay={overlineDisplay}
-        customFields={config}
-      />,
-    );
+  //   const wrapper = mount(
+  //     <VerticalOverlineImageStoryItem
+  //       imageURL={imageURL}
+  //       websiteURL={websiteURL}
+  //       itemTitle={itemTitle}
+  //       descriptionText={descriptionText}
+  //       primaryFont={primaryFont}
+  //       by={by}
+  //       element={element}
+  //       displayDate={displayDate}
+  //       overlineUrl={overlineUrl}
+  //       overlineText={overlineText}
+  //       id={id}
+  //       overlineDisplay={overlineDisplay}
+  //       customFields={config}
+  //     />,
+  //   );
 
-    expect(wrapper.find('.headline-above').length).toBe(1);
-    expect(wrapper.find('.headline-below').length).toBe(0);
-  });
+  //   expect(wrapper.find('.headline-above').length).toBe(1);
+  //   expect(wrapper.find('.headline-below').length).toBe(0);
+  // });
 
-  it('headline has class headline-below when headline position is below', () => {
-    const imageURL = 'pic';
-    const websiteURL = 'url';
-    const itemTitle = 'title';
-    const descriptionText = 'description';
-    const primaryFont = 'arial';
-    const by = ['jack'];
-    const element = { credits: { by: [] } };
-    const displayDate = '';
-    const id = 'test';
-    const overlineUrl = '/news';
-    const overlineText = 'News';
-    const overlineDisplay = true;
+  // it('headline has class headline-below when headline position is below', () => {
+  //   const imageURL = 'pic';
+  //   const websiteURL = 'url';
+  //   const itemTitle = 'title';
+  //   const descriptionText = 'description';
+  //   const primaryFont = 'arial';
+  //   const by = ['jack'];
+  //   const element = { credits: { by: [] } };
+  //   const displayDate = '';
+  //   const id = 'test';
+  //   const overlineUrl = '/news';
+  //   const overlineText = 'News';
+  //   const overlineDisplay = true;
 
-    const { default: VerticalOverlineImageStoryItem } = require('./vertical-overline-image-story-item');
+  //   const { default: VerticalOverlineImageStoryItem } =
+  // require('./vertical-overline-image-story-item');
 
-    const wrapper = mount(
-      <VerticalOverlineImageStoryItem
-        imageURL={imageURL}
-        websiteURL={websiteURL}
-        itemTitle={itemTitle}
-        descriptionText={descriptionText}
-        primaryFont={primaryFont}
-        by={by}
-        element={element}
-        displayDate={displayDate}
-        overlineUrl={overlineUrl}
-        overlineText={overlineText}
-        id={id}
-        overlineDisplay={overlineDisplay}
-        customFields={headBelowConfig}
-      />,
-    );
+  //   const wrapper = mount(
+  //     <VerticalOverlineImageStoryItem
+  //       imageURL={imageURL}
+  //       websiteURL={websiteURL}
+  //       itemTitle={itemTitle}
+  //       descriptionText={descriptionText}
+  //       primaryFont={primaryFont}
+  //       by={by}
+  //       element={element}
+  //       displayDate={displayDate}
+  //       overlineUrl={overlineUrl}
+  //       overlineText={overlineText}
+  //       id={id}
+  //       overlineDisplay={overlineDisplay}
+  //       customFields={headBelowConfig}
+  //     />,
+  //   );
 
-    expect(wrapper.find('.headline-below').length).toBe(1);
-    expect(wrapper.find('.headline-above').length).toBe(0);
-  });
+  //   expect(wrapper.find('.headline-below').length).toBe(1);
+  //   expect(wrapper.find('.headline-above').length).toBe(0);
+  // });
 
   it('does not render image, overline and byline with empty props', () => {
     const imageURL = '';

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -31,9 +31,9 @@ const overlineData = (storyObject, arcSite) => {
   const shouldUseLabel = !!labelDisplay;
 
   const { _id: sectionUrl, name: sectionText } = (storyObject.websites
-      && storyObject.websites[arcSite]
-      && storyObject.websites[arcSite].website_section)
-    || {};
+    && storyObject.websites[arcSite]
+    && storyObject.websites[arcSite].website_section)
+  || {};
 
   return shouldUseLabel ? [labelText, labelUrl] : [sectionText, sectionUrl];
 };
@@ -247,11 +247,11 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Extra Large story settings',
     }),
-    headlinePositionXL: PropTypes.oneOf(['above', 'below']).tag({
-      label: 'Headline Position',
-      group: 'Extra Large story settings',
-      defaultValue: 'above',
-    }),
+    // headlinePositionXL: PropTypes.oneOf(['above', 'below']).tag({
+    //   label: 'Headline Position',
+    //   group: 'Extra Large story settings',
+    //   defaultValue: 'above',
+    // }),
     showImageXL: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,
@@ -288,11 +288,11 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Large story settings',
     }),
-    headlinePositionLG: PropTypes.oneOf(['above', 'below']).tag({
-      label: 'Headline Position',
-      group: 'Large story settings',
-      defaultValue: 'above',
-    }),
+    // headlinePositionLG: PropTypes.oneOf(['above', 'below']).tag({
+    //   label: 'Headline Position',
+    //   group: 'Large story settings',
+    //   defaultValue: 'above',
+    // }),
     showImageLG: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,
@@ -320,11 +320,11 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Medium story settings',
     }),
-    headlinePositionMD: PropTypes.oneOf(['above', 'below']).tag({
-      label: 'Headline Position',
-      group: 'Medium story settings',
-      defaultValue: 'above',
-    }),
+    // headlinePositionMD: PropTypes.oneOf(['above', 'below']).tag({
+    //   label: 'Headline Position',
+    //   group: 'Medium story settings',
+    //   defaultValue: 'above',
+    // }),
     showImageMD: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,
@@ -352,18 +352,18 @@ TopTableListWrapper.propTypes = {
       defaultValue: true,
       group: 'Small story settings',
     }),
-    headlinePositionSM: PropTypes.oneOf(['above', 'below']).tag({
-      label: 'Headline Position',
-      group: 'Small story settings',
-      defaultValue: 'above',
-    }),
+    // headlinePositionSM: PropTypes.oneOf(['above', 'below']).tag({
+    //   label: 'Headline Position',
+    //   group: 'Small story settings',
+    //   defaultValue: 'above',
+    // }),
     showImageSM: PropTypes.bool.tag({
       label: 'Show image',
       defaultValue: true,
       group: 'Small story settings',
     }),
     ...imageRatioCustomField('imageRatioSM', 'Small story settings', '3:2'),
-    storiesPerRowSM: PropTypes.oneOf([1, 2, 3, 4]).tag({
+    storiesPerRowSM: PropTypes.oneOf([1, 2]).tag({
       name: 'Stories per row',
       defaultValue: 2,
       group: 'Small story settings',

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -1,14 +1,4 @@
 .top-table-list-container {
-  .medium-promo {
-    .float-left {
-      float: left;
-    }
-
-    .float-right {
-      float: right;
-    }
-  }
-
   .small-promo {
     @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
       .row.sm-promo-padding-btm {


### PR DESCRIPTION
## Description
- revert changes on https://github.com/WPMedia/fusion-news-theme-blocks/pull/509/
- duplicated ticket https://arcpublishing.atlassian.net/browse/SENG-66 
https://arcpublishing.atlassian.net/browse/PEN-802

## Jira Ticket
- [PEN-](https://arcpublishing.atlassian.net/browse/PEN-)

## Acceptance Criteria
_copy from ticket_

## Test Steps
- compare PR changes from https://github.com/WPMedia/fusion-news-theme-blocks/pull/509
- test against the toptable list, small promo, middle promo and large promo that working as is

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
