### PR TITLE
PEN-1422: [SM] | Black border displaying on .socialBtn-container class when no social is present

### DIFF
--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -17,7 +17,7 @@ const FooterSection = styled.ul`
 `;
 
 const StyledSocialContainer = styled.div`
-  border: 1px solid ${(props) => props.primaryColor}; 
+  border: ${(props) => (props.hasSocialLinks ? '1px' : '0')} solid ${(props) => props.primaryColor}; 
   fill: ${(props) => props.primaryColor};
 
   a {
@@ -105,7 +105,11 @@ const Footer = ({ customFields: { navigationConfig } }) => {
         <section className="footer-header">
           <div className="footer-row">
             <div className="social-column">
-              <StyledSocialContainer className="socialBtn-container" primaryColor={getThemeStyle(arcSite)['primary-color']}>
+              <StyledSocialContainer
+                className="socialBtn-container"
+                primaryColor={getThemeStyle(arcSite)['primary-color']}
+                hasSocialLinks={facebookPage || twitterUsername || rssUrl}
+              >
                 {socialButtons}
               </StyledSocialContainer>
             </div>

--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -16,7 +16,7 @@ const FooterSection = styled.ul`
   font-family: ${(props) => props.primaryFont};
 `;
 
-const StyledSocialContainer = styled.div`
+export const StyledSocialContainer = styled.div`
   border: ${(props) => (props.hasSocialLinks ? '1px' : '0')} solid ${(props) => props.primaryColor}; 
   fill: ${(props) => props.primaryColor};
 
@@ -108,7 +108,7 @@ const Footer = ({ customFields: { navigationConfig } }) => {
               <StyledSocialContainer
                 className="socialBtn-container"
                 primaryColor={getThemeStyle(arcSite)['primary-color']}
-                hasSocialLinks={facebookPage || twitterUsername || rssUrl}
+                hasSocialLinks={!!(facebookPage || twitterUsername || rssUrl)}
               >
                 {socialButtons}
               </StyledSocialContainer>

--- a/blocks/footer-block/features/footer/default.test.jsx
+++ b/blocks/footer-block/features/footer/default.test.jsx
@@ -391,5 +391,22 @@ describe('the footer feature for the default output type', () => {
         expect(wrapper.find({ title: 'RSS feed' })).toHaveLength(0);
       });
     });
+
+    describe('when no social site properties are provided', () => {
+      it('should render no social buttons and no border on container', () => {
+        getProperties.mockImplementation(() => ({
+          facebookPage: '',
+          twitterUsername: '',
+          rssUrl: '',
+        }));
+        const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+        expect(wrapper.find({ title: 'Facebook page' })).toHaveLength(0);
+        expect(wrapper.find({ title: 'Twitter feed' })).toHaveLength(0);
+        expect(wrapper.find({ title: 'RSS feed' })).toHaveLength(0);
+        const container = wrapper.find('.socialBtn-container');
+        expect(container).toBeDefined();
+        expect(container.get(0).props.hasSocialLinks).toBeFalsy();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description
Modified `footer-block` so that social container doesn't render a border when no social site properties are configured.

## Jira Ticket
- [PEN-1422](https://arcpublishing.atlassian.net/browse/PEN-1422)

## Acceptance Criteria
Social icon container no longer displays a border (appearing as a "dot" when collapsed and no child content) when a site has no social site properties configured in their `blocks.json`.

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. In `Fusion-News-Theme/blocks.json` - under `the-gazette` `siteProperties`, set `facebookPage`, `twitterUsername` and `rssUrl` to blank strings
3. After checking out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
4. Run `npx fusion start -f -l @wpmedia/footer-block` in `Fusion-News-Theme`
5. Open http://localhost/pf/homepage/?_website=the-sun , scroll down to the footer and you should see all social button/links in the site primary color with a border surrounding the entire button group
6. Open http://localhost/pf/homepage/?_website=the-gazette , scroll down to the footer and you should see no social buttons and no "dot"/border remaining on the collapsed social container. Contrast with the example from the ticket http://shawmedia-shaw-media-sandbox.cdn.arcpublishing.com/ where you can see a small "dot" in the footer (which is the container border)

## Effect Of Changes
### Before
When the current site has no `facebookPage`, `twitterUsername` or `rssUrl` properties setup in `blocks.json` for the current site, a small "dot"/border would display inside the footer section

### After
When the current site has no `facebookPage`, `twitterUsername` or `rssUrl` properties setup in `blocks.json` for the current site, **no** "dot"/border displays inside the footer section

## Dependencies or Side Effects
Add to `siteProperties` for `the-gazette` (in `blocks.json`):
- `"facebookPage": ""`
- `"twitterUsername": ""`
- `"rssUrl": ""`

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
