### PR TITLE
PEN-1358 - update small promo blocks to display 3 and 4 items per row

### DIFF
--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -24,19 +24,56 @@ const ItemTitleWithRightImage = (props) => {
   } = props;
 
   const ratios = ratiosFor('SM', imageRatio);
-  const onePerLine = customFields.storiesPerRowSM === 1;
-  const promoClasses = `container-fluid small-promo layout-section ${onePerLine ? 'small-promo-one' : 'wrap-bottom'}`;
+  const storiesPerRow = (typeof customFields.storiesPerRowSM === 'undefined')
+    ? 2
+    : customFields.storiesPerRowSM;
+  const promoClasses = `small-promo layout-section small-promo-${storiesPerRow} wrap-bottom`;
   const promoType = discoverPromoType(element);
+  const showHeadline = customFields.showHeadlineSM && itemTitle !== '';
+  const showImage = customFields.showImageSM;
+  let showSize;
+  let layout;
+
+  if (storiesPerRow > 2) {
+    showSize = `${showHeadline ? 'vHead' : ''}${showImage ? 'vImage' : ''}`;
+    layout = 'vertical';
+  } else {
+    showSize = `${showHeadline ? 'hHead' : ''}${showImage ? 'hImage' : ''}`;
+    layout = 'horizontal';
+  }
+
+  const sizes = {
+    hHeadhImage: {
+      title: 'col-sm-8 col-md-8 col-lg-8 col-xl-8 headline-wrap-horizontal',
+      image: 'col-sm-4 col-md-4 col-lg-4 col-xl-4 flex-col',
+    },
+    hHead: {
+      title: 'col-sm-12 col-md-12 col-lg-12 col-xl-12 headline-wrap-horizontal',
+    },
+    hImage: {
+      image: 'col-sm-4 col-md-4 col-lg-4 col-xl-4 flex-col',
+    },
+    vHeadvImage: {
+      title: 'col-sm-8 col-md-12 col-lg-12 col-xl-12 headline-wrap-vertical',
+      image: 'col-sm-4 col-md-12 col-lg-12 col-xl-12 flex-col',
+    },
+    vHead: {
+      title: 'col-sm-8 col-md-12 col-lg-12 col-xl-12 headline-wrap-vertical',
+    },
+    vImage: {
+      image: 'col-sm-4 col-md-12 col-lg-12 col-xl-12 flex-col',
+    },
+  };
 
   return (
     <article
       key={id}
       className={`${promoClasses} ${paddingRight ? 'small-promo-padding' : ''}`}
     >
-      <div className="row sm-promo-padding-btm">
+      <div className={`row sm-promo-padding-btm ${layout}`}>
         {/* customFields.headlinePositionSM === 'above' && */
-          customFields.showHeadlineSM && itemTitle !== '' ? (
-            <div className="col-sm-8 col-md-xl-8">
+          showHeadline ? (
+            <div className={sizes[showSize].title}>
               <a
                 href={websiteURL}
                 title={itemTitle}
@@ -49,10 +86,9 @@ const ItemTitleWithRightImage = (props) => {
             </div>
           ) : null
         }
-        {customFields.showImageSM
-          && (
-          <div className="col-sm-4 col-md-xl-4 flex-col">
-            {imageURL !== '' ? (
+        {showImage && (
+          <div className={sizes[showSize].image}>
+            { imageURL !== '' ? (
               <a href={websiteURL} title={itemTitle}>
                 <Image
                   resizedImageOptions={resizedImageOptions}
@@ -88,7 +124,7 @@ const ItemTitleWithRightImage = (props) => {
               </div>
             )}
           </div>
-          )}
+        )}
       </div>
       {/* {customFields.headlinePositionSM === 'below'
       && customFields.showHeadlineSM

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.test.jsx
@@ -20,34 +20,10 @@ const config = {
   showBylineMD: true,
   showDateMD: true,
   showHeadlineSM: true,
-  // headlinePositionSM: 'above',
   showImageSM: true,
 };
 
-// const headBelowConfig = {
-//   showOverlineXL: true,
-//   showHeadlineXL: true,
-//   showImageXL: true,
-//   showDescriptionXL: true,
-//   showBylineXL: true,
-//   showDateXL: true,
-//   showOverlineLG: true,
-//   showHeadlineLG: true,
-//   showImageLG: true,
-//   showDescriptionLG: true,
-//   showBylineLG: true,
-//   showDateLG: true,
-//   showHeadlineMD: true,
-//   showImageMD: true,
-//   showDescriptionMD: true,
-//   showBylineMD: true,
-//   showDateMD: true,
-//   showHeadlineSM: true,
-//   headlinePositionSM: 'below',
-//   showImageSM: true,
-// };
-
-describe('item title with right image block', () => {
+describe('small image block', () => {
   beforeAll(() => {
     jest.mock('fusion:properties', () => (jest.fn(() => ({
       fallbackImage: 'placeholder.jpg',
@@ -65,14 +41,13 @@ describe('item title with right image block', () => {
     jest.resetModules();
   });
 
-  it('renders title and image with full props', () => {
+  it('must render title and image with full props', () => {
     const imageURL = 'pic';
     const itemTitle = 'title';
     const primaryFont = 'arial';
     const id = 'test';
     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-    // eslint-disable-next-line no-unused-vars
     const wrapper = mount(
       <ItemTitleWithRightImage
         imageURL={imageURL}
@@ -84,23 +59,23 @@ describe('item title with right image block', () => {
       />,
     );
 
-    // expect(wrapper.find('h2.simple-list-headline-text').length).toBe(1);
-    // expect(wrapper.find('h2.simple-list-headline-text').text()).toBe(itemTitle);
+    expect(wrapper.find('h2.sm-promo-headline').length).toBe(1);
+    expect(wrapper.find('h2.sm-promo-headline').text()).toBe(itemTitle);
 
-    // placeholder
-    // expect(wrapper.find('.simple-list-placeholder').length).toBe(0);
-    // expect(wrapper.find('.simple-list-img').length).toBe(1);
+    expect(wrapper.find('Image').length).toBe(1);
+    expect(wrapper.find('Image').prop('url')).toBe(imageURL);
 
     expect(wrapper.find('ItemTitleWithRightImage > article > hr').length).toBe(1);
   });
-  xit('renders neither title nor image with empty props, renders placeholder', () => {
+
+  it('must renders neither title nor image with empty props, renders placeholder image', () => {
     const imageURL = '';
+    const fallbackImage = 'fallback';
     const itemTitle = '';
     const primaryFont = 'arial';
     const id = 'test';
     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-    // eslint-disable-next-line no-unused-vars
     const wrapper = mount(
       <ItemTitleWithRightImage
         imageURL={imageURL}
@@ -108,129 +83,212 @@ describe('item title with right image block', () => {
         primaryFont={primaryFont}
         id={id}
         customFields={config}
+        placeholderResizedImageOptions={{ '400x267': '' }}
+        targetFallbackImage={fallbackImage}
       />,
     );
 
-    // expect(wrapper.find('h2.simple-list-headline-text').length).toBe(0);
+    expect(wrapper.find('h2.sm-promo-headline').length).toBe(0);
 
-    // placeholder
-    // expect(wrapper.find('.simple-list-placeholder').length).toBe(1);
-    // expect(wrapper.find('.simple-list-img').length).toBe(0);
+    expect(wrapper.find('Image').length).toBe(1);
+    expect(wrapper.find('Image').prop('url')).toBe(fallbackImage);
+
+    expect(wrapper.find('ItemTitleWithRightImage > article > hr').length).toBe(1);
   });
 
-  //   it('headline has class headline-above when headline position is above', () => {
-  //     const imageURL = 'pic';
-  //     const itemTitle = 'title';
-  //     const primaryFont = 'arial';
-  //     const id = 'test';
-  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+  it('must render only title if showImageSM false', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-  //     // eslint-disable-next-line no-unused-vars
-  //     const wrapper = mount(
-  //       <ItemTitleWithRightImage
-  //         imageURL={imageURL}
-  //         itemTitle={itemTitle}
-  //         primaryFont={primaryFont}
-  //         id={id}
-  //         customFields={config}
-  //         resizedImageOptions={{ '400x267': '' }}
-  //       />,
-  //     );
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        /* eslint-disable-next-line */
+        customFields={Object.assign({}, config, { showImageSM: false })}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
 
-  //     expect(wrapper.find('.headline-above').length).toBe(1);
-  //     expect(wrapper.find('.headline-below').length).toBe(0);
-  //   });
+    expect(wrapper.find('h2.sm-promo-headline').length).toBe(1);
+    expect(wrapper.find('h2.sm-promo-headline').text()).toBe(itemTitle);
 
-  //   it('headline has class headline-below when headline position is below', () => {
-  //     const imageURL = 'pic';
-  //     const itemTitle = 'title';
-  //     const primaryFont = 'arial';
-  //     const id = 'test';
-  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+    expect(wrapper.find('Image').length).toBe(0);
 
-  //     // eslint-disable-next-line no-unused-vars
-  //     const wrapper = mount(
-  //       <ItemTitleWithRightImage
-  //         imageURL={imageURL}
-  //         itemTitle={itemTitle}
-  //         primaryFont={primaryFont}
-  //         id={id}
-  //         customFields={headBelowConfig}
-  //         resizedImageOptions={{ '400x267': '' }}
-  //       />,
-  //     );
+    expect(wrapper.find('ItemTitleWithRightImage > article > hr').length).toBe(1);
+  });
 
-  //     expect(wrapper.find('.headline-below').length).toBe(1);
-  //     expect(wrapper.find('.headline-above').length).toBe(0);
-  //   });
-  // });
+  it('must render only image if showHeadlinesSM false', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-  // describe('small promo display', () => {
-  //   it('when storiesPerRowSM is undefined must not add class small-promo-one', () => {
-  //     const imageURL = 'pic';
-  //     const itemTitle = 'title';
-  //     const primaryFont = 'arial';
-  //     const id = 'test';
-  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        /* eslint-disable-next-line */
+        customFields={Object.assign({}, config, { showHeadlineSM: false })}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
 
-  //     const wrapper = mount(
-  //       <ItemTitleWithRightImage
-  //         imageURL={imageURL}
-  //         itemTitle={itemTitle}
-  //         primaryFont={primaryFont}
-  //         id={id}
-  //         customFields={config}
-  //         resizedImageOptions={{ '400x267': '' }}
-  //       />,
-  //     );
+    expect(wrapper.find('h2.sm-promo-headline').length).toBe(0);
 
-  //     expect(wrapper.find('.small-promo-one').length).toBe(0);
-  //     expect(wrapper.find('article.wrap-bottom').length).toBe(1);
-  //   });
+    expect(wrapper.find('Image').length).toBe(1);
 
-  //   it('when storiesPerRowSM is 2 must not add class small-promo-one', () => {
-  //     const imageURL = 'pic';
-  //     const itemTitle = 'title';
-  //     const primaryFont = 'arial';
-  //     const id = 'test';
-  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
-  //     const setup = Object.assign(config, { storiesPerRowSM: 2 });
+    expect(wrapper.find('ItemTitleWithRightImage > article > hr').length).toBe(1);
+  });
 
-  //     const wrapper = mount(
-  //       <ItemTitleWithRightImage
-  //         imageURL={imageURL}
-  //         itemTitle={itemTitle}
-  //         primaryFont={primaryFont}
-  //         id={id}
-  //         customFields={setup}
-  //         resizedImageOptions={{ '400x267': '' }}
-  //       />,
-  //     );
+  it('must render with layout horizontal if stories per row is less than 3', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-  //     expect(wrapper.find('.small-promo-one').length).toBe(0);
-  //     expect(wrapper.find('article.wrap-bottom').length).toBe(1);
-  //   });
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        /* eslint-disable-next-line */
+        customFields={Object.assign({}, config, { storiesPerRowSM: 2})}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
 
-  //   it('when storiesPerRowSM is 1 must add class small-promo-one', () => {
-  //     const imageURL = 'pic';
-  //     const itemTitle = 'title';
-  //     const primaryFont = 'arial';
-  //     const id = 'test';
-  //     const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
-  //     const setup = Object.assign(config, { storiesPerRowSM: 1 });
+    expect(wrapper.find('article > .horizontal').length).toBe(1);
+  });
 
-  //     const wrapper = mount(
-  //       <ItemTitleWithRightImage
-  //         imageURL={imageURL}
-  //         itemTitle={itemTitle}
-  //         primaryFont={primaryFont}
-  //         id={id}
-  //         customFields={setup}
-  //         resizedImageOptions={{ '400x267': '' }}
-  //       />,
-  //     );
+  it('must render with layout vertical if stories per row greater than 3', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
 
-//     expect(wrapper.find('.small-promo-one').length).toBe(1);
-//     expect(wrapper.find('article.wrap-bottom').length).toBe(0);
-//   });
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        /* eslint-disable-next-line */
+        customFields={Object.assign({}, config, { storiesPerRowSM: 3})}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
+
+    expect(wrapper.find('article > .vertical').length).toBe(1);
+  });
+
+  it('must render only title if showImageSM false in horizontal layuout', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        /* eslint-disable-next-line */
+        customFields={Object.assign({}, config, { storiesPerRowSM: 2, showImageSM: false })}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
+
+    expect(wrapper.find('h2.sm-promo-headline').length).toBe(1);
+    expect(wrapper.find('h2.sm-promo-headline').text()).toBe(itemTitle);
+
+    expect(wrapper.find('Image').length).toBe(0);
+    expect(wrapper.find('article > .horizontal').length).toBe(1);
+  });
+
+  it('must render only image if showHeadlineSM false in horizontal layuout', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        /* eslint-disable-next-line */
+        customFields={Object.assign({}, config, { storiesPerRowSM: 2, showHeadlineSM: false })}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
+
+    expect(wrapper.find('h2.sm-promo-headline').length).toBe(0);
+
+    expect(wrapper.find('Image').length).toBe(1);
+    expect(wrapper.find('article > .horizontal').length).toBe(1);
+  });
+
+  it('must render only image if showHeadlineSM false in vertical layout', () => {
+    const imageURL = 'pic';
+    const itemTitle = '';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        /* eslint-disable-next-line */
+        customFields={Object.assign({}, config, { storiesPerRowSM: 3, showHeadlineSM: false})}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
+
+    expect(wrapper.find('h2.sm-promo-headline').length).toBe(0);
+    expect(wrapper.find('article > .vertical').length).toBe(1);
+  });
+
+  it('must render only title if showImageSM false in vertical layout', () => {
+    const imageURL = 'pic';
+    const itemTitle = 'title';
+    const primaryFont = 'arial';
+    const id = 'test';
+    const { default: ItemTitleWithRightImage } = require('./item-title-with-right-image');
+
+    const wrapper = mount(
+      <ItemTitleWithRightImage
+        imageURL={imageURL}
+        itemTitle={itemTitle}
+        primaryFont={primaryFont}
+        id={id}
+        /* eslint-disable-next-line */
+        customFields={Object.assign({}, config, { storiesPerRowSM: 3, showImageSM: false})}
+        resizedImageOptions={{ '400x267': '' }}
+      />,
+    );
+
+    expect(wrapper.find('h2.sm-promo-headline').length).toBe(1);
+    expect(wrapper.find('h2.sm-promo-headline').text()).toBe(itemTitle);
+    expect(wrapper.find('Image').length).toBe(0);
+    expect(wrapper.find('article > .vertical').length).toBe(1);
+  });
 });

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -86,7 +86,7 @@ class TopTableListWrapper extends Component {
 
     // using the fetchContent seems both more reliable
     // and allows for conditional calls whereas useContent hook does not
-    if (targetFallbackImage && !targetFallbackImage.includes('/resources/')) {
+    if (targetFallbackImage && !targetFallbackImage.includes('resources/')) {
       this.fetchContent({
         placeholderResizedImageOptions: {
           source: 'resize-image-api',
@@ -363,7 +363,7 @@ TopTableListWrapper.propTypes = {
       group: 'Small story settings',
     }),
     ...imageRatioCustomField('imageRatioSM', 'Small story settings', '3:2'),
-    storiesPerRowSM: PropTypes.oneOf([1, 2]).tag({
+    storiesPerRowSM: PropTypes.oneOf([1, 2, 3, 4]).tag({
       name: 'Stories per row',
       defaultValue: 2,
       group: 'Small story settings',

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -5,23 +5,14 @@
         padding-top: 0;
       }
     }
-    display: block;
 
-    .col-md-xl-4 {
-      text-align: right;
-    }
-    @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      display: inline-block;
-      width: calc((100% - #{map-get($spacers, 'md')}) / 2);
-    }
+    display: inline-flex;
+    flex-direction: column;
+    vertical-align: top;
 
     .row {
       @media only screen and (min-width: map-get($grid-breakpoints, 'md')) and (max-width: map-get($grid-breakpoints-max, 'lg')) {
         grid-column-gap: 0;
-
-        img {
-          max-width: 90%;
-        }
       }
     }
 
@@ -32,22 +23,91 @@
         margin-bottom: inherit;
       }
     }
+
+    .vertical {
+      grid-auto-flow: column;
+      grid-row-gap: 0.5rem;
+      grid-column-gap: 0;
+
+      @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
+        grid-auto-flow: row;
+
+        & > div:first-child {
+          grid-row-start: 2;
+        }
+      }
+    }
+ 
+    .horizontal {
+      grid-auto-flow: column;
+    }
+  
+    hr {
+      width: 100%;
+    }
+
+    .headline-wrap-vertical {
+      height: 4.6em;
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+      -moz-box-oriented: vertical;
+      /* opera */
+      text-overflow: -o-ellipsis-lastline;
+    }
+
+    .headline-wrap-horizontal {
+      height: 50px;
+      overflow: hidden;
+    }
+
+    img {
+      width: 100%;
+    }
   }
 
-  .small-promo-padding {
-    padding-right: 0;
+  .small-promo-1 {
+    width: 100%;
+  }
+
+  .small-promo-2 {
+    width: 100%;
+
     @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding-right: map-get($spacers, 'md');
+      padding: 0 5px;
+      width: 50%;
+    }
+  }
+
+  .small-promo-2:nth-child(odd) {
+    padding-right: 0.75rem;
+  }
+
+  .small-promo-2:nth-child(even) {
+    padding-left: 0.75rem;
+  }
+
+  .small-promo-3 {
+    width: 100%;
+
+    @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
+      padding: 0 5px;
+      width: 33%;
+    }
+  }
+
+  .small-promo-4 {
+    width: 100%;
+
+    @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
+      padding: 0 5px;
+      width: 25%;
     }
   }
 
   &.wrap-bottom {
     margin-bottom: inherit !important;
-  }
-
-  .small-promo-one {
-    display: block;
-    width: 100%;
   }
 
   .image-wrapper {


### PR DESCRIPTION
## Description
Update small promo blocks on `top-table-list-block` to support 3 and 4 items per row, and update the layouts for they.

## Jira Ticket
- [PEN-1358](https://arcpublishing.atlassian.net/browse/PEN-1358)

## Acceptance Criteria
PageBuilder users can configure Small items in the Top Table List to display 3 or 4 stories per row by using the Stories per row custom field (in addition to 1 or 2 stories per row, which is already supported)

If 3 stories per row or 4 stories per row is selected, this should only display on the Desktop/Tablet breakpoints – on the mobile breakpoint, it should display 2 per row

## Test Steps
- add a `top-table-list-block` to a page
- setup it to show for example 10 small promo blocks
- update the custom fields to show different numbers of items per row
- verify that the layout change
- later setup the small promo blocks to show 4 items per row, and change browser viewport to mobile, and verify that the layout change to 1 item per row.

## Effect Of Changes
### 4 items per row
<img width="939" alt=" 2020-10-14-20 18 07" src="https://user-images.githubusercontent.com/9757/97449544-8bc44900-1910-11eb-8f73-55c710dd4400.png">

### 3 items per row
<img width="852" alt=" 2020-10-27-16 14 38" src="https://user-images.githubusercontent.com/9757/97449587-97b00b00-1910-11eb-8e13-fce75ac50b9b.png">

### 2 items per row
<img width="848" alt=" 2020-10-27-16 14 51" src="https://user-images.githubusercontent.com/9757/97449612-a0084600-1910-11eb-9d2b-0f130159d590.png">

### use case where the images are setup to 4:3 ratio and the fallback image is on 16:9 
a followup ticket will address this issue (send local images throw thumbor)

<img width="852" alt=" 2020-10-27-16 15 52" src="https://user-images.githubusercontent.com/9757/97449723-c0d09b80-1910-11eb-86dd-451ae6468b2f.png">


## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
