### PR TITLE
PEN-1457: [CMG] Updates to existing Navigation chain

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -214,11 +214,15 @@ const Nav = (props) => {
 
 Nav.propTypes = {
   customFields: PropTypes.shape({
-    hierarchy: PropTypes.string,
+    hierarchy: PropTypes.string.tag({
+      label: 'Sections Menu hierarchy',
+      defaultValue: '',
+      group: 'Configure content',
+    }),
     signInOrder: PropTypes.number,
   }),
 };
 
-Nav.label = 'Header Nav Chain – Arc Block';
+Nav.label = 'Navigation - Arc Chain';
 
 export default Nav;


### PR DESCRIPTION
## Description
Changed 'header-nav-chain-block' Display Name to 'Navigation - Arc Chain. Modified 'hierarchy' custom field to have 'Section Menu hierarchy' label and 'Configure content' group.

## Jira Ticket
- [PEN-1457](https://arcpublishing.atlassian.net/browse/PEN-1457)

## Acceptance Criteria
1. Update the Display Name of the navigation to be Navigation – Arc Chain but do not update its ID  (so that it does not break existing placements)
(By ID, I mean the value stored here under Chain Type – @wpmedia/header-nav-chain-block/header-nav-chain-block – should not change. Only the value under Display Name should change.) 
![image](https://user-images.githubusercontent.com/26662906/97467613-60425e00-1912-11eb-9653-b4fd6a83773e.png)
2. The Display Name for the field currently called hierarchy should be Sections Menu hierarchy, and it should go under a group called Configure content
The ID of this Custom Field should not change, so that we don’t break existing navigation chains on Theme websites

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. After checking out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/header-nav-chain-block` in `Fusion-News-Theme`
4. Open 'Homepage' in PB editor and also open http://localhost/pf/homepage/?_website=the-sun in a new tab
5. In PB editor, click on the nav chain feature and you should see that there is now a 'Configure content' section. Expand this and there should be a custom field labeled `Section Menu hierarchy`.
6. NOTE: The label of the feature instance itself doesn't appear to change automatically when a code change is made to the `Nav.label`.
7. In order to see that the feature label has changed, remove and re-add the `header-nav-chain-block`. When clicking to 'Add Feature', under `Chain Library` you should now see a chain labeled 'Navigation - Arc Chain'. Click this to add it to the page.
8. The newly re-added nav chain block should have the expected custom fields configuration outlined in the previous steps.

## Effect Of Changes
### Before
The `header-nav-chain-block` feature had a `hierarchy` custom field with no label and no grouping.
The `header-nav-chain-block` had a label of `Header Nav Chain – Arc Block`

### After
The `header-nav-chain-block` feature now has a `hierarchy` custom field with a label of `Section Menu hierarchy` and should be contained within the 'Configure content' group.
The `header-nav-chain-block` now has a label of `Navigation - Arc Chain`.

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
