### PR TITLE
add new mixin to select affected blocks (WIP)

### DIFF
--- a/blocks/card-list-block/features/card-list/card-list.scss
+++ b/blocks/card-list-block/features/card-list/card-list.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable max-nesting-depth */
+
 .card-list-container {
   @include block-margin-bottom;
   @include block-internal-spacing;
@@ -7,9 +9,8 @@
   .card-list-title {
     margin-bottom: 0;
   }
-  .simple-results-list-container {
-   
 
+  .simple-results-list-container {
     .list-item-simple {
       margin-bottom: map-get($spacers, 'md');
     }

--- a/blocks/card-list-block/features/card-list/card-list.scss
+++ b/blocks/card-list-block/features/card-list/card-list.scss
@@ -1,6 +1,19 @@
 .card-list-container {
   @include block-margin-bottom;
+  @include block-internal-spacing;
+
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 2px 2px 0 rgba(0, 0, 0, 0.12), 0 1px 3px 0 rgba(0, 0, 0, 0.14);
+
+  .card-list-title {
+    margin-bottom: 0;
+  }
+  .simple-results-list-container {
+   
+
+    .list-item-simple {
+      margin-bottom: map-get($spacers, 'md');
+    }
+  }
 }
 
 .list-item-simple:nth-child(2) > a > .image-placeholder-sm {

--- a/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
+++ b/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
@@ -1,5 +1,6 @@
 .numbered-list-container {
   @include block-margin-bottom;
+  @include block-internal-spacing;
 }
 
 .numbered-list-item {

--- a/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
+++ b/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable max-nesting-depth */
+
 .numbered-list-container {
   @include block-margin-bottom;
   @include block-internal-spacing;

--- a/blocks/simple-list-block/features/simple-list/simple-list.scss
+++ b/blocks/simple-list-block/features/simple-list/simple-list.scss
@@ -1,5 +1,6 @@
 .list-container {
   @include block-margin-bottom;
+  @include block-internal-spacing;
   padding-left: 0;
   padding-right: 0;
   padding-top: 0;

--- a/blocks/simple-list-block/features/simple-list/simple-list.scss
+++ b/blocks/simple-list-block/features/simple-list/simple-list.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors */
+
 .list-container {
   @include block-margin-bottom;
   @include block-internal-spacing;


### PR DESCRIPTION
## Description
This PR is the companion PR that applies the new mix-in proposed in https://github.com/WPMedia/news-theme-css/pull/46

## Affected blocks noticed so far
- Simple List
- Numbered List
- Card List