### PR TITLE
PEN-1434: Mobile styling for results and search results list blocks

### DIFF
--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -179,7 +179,7 @@ class ResultsList extends Component {
           return (
             <div className="list-item" key={`result-card-${url}`}>
               { promoElements.showImage && (
-                <div className="results-list--image-container">
+                <div className="results-list--image-container mobile-order-2 mobile-image">
                   <a
                     href={url}
                     title={headlineText}
@@ -219,7 +219,7 @@ class ResultsList extends Component {
                 </div>
               )}
               { promoElements.showHeadline && (
-                <div className="results-list--headline-container">
+                <div className="results-list--headline-container mobile-order-1">
                   <a
                     href={url}
                     title={headlineText}
@@ -238,7 +238,7 @@ class ResultsList extends Component {
                   || promoElements.showDate
                   || promoElements.showByline
               ) && (
-                <div className="results-list--description-author-container">
+                <div className="results-list--description-author-container mobile-order-3">
                   {promoElements.showDescription && descriptionText && (
                     <a
                       href={url}

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
@@ -43,7 +43,7 @@ const SearchResult = ({
   return (
     <div className="list-item" key={`result-card-${url}`}>
       { showImage && (
-        <div className="results-list--image-container">
+        <div className="results-list--image-container mobile-order-2 mobile-image">
           <a
             href={url}
             title={headlineText}
@@ -82,7 +82,7 @@ const SearchResult = ({
         </div>
       )}
       { showHeadline && (
-        <div className="results-list--headline-container">
+        <div className="results-list--headline-container mobile-order-1">
           <a
             href={url}
             title={headlineText}
@@ -98,7 +98,7 @@ const SearchResult = ({
         </div>
       )}
       { (showDescription || showDate || showByline) && (
-        <div className="results-list--description-author-container">
+        <div className="results-list--description-author-container mobile-order-3">
           { showDescription && (
             <DescriptionText
               secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}

--- a/blocks/shared-styles/scss/_results-list-mobile.scss
+++ b/blocks/shared-styles/scss/_results-list-mobile.scss
@@ -7,22 +7,22 @@
       'description description';
     grid-template-columns: 1fr minmax(0, max-content);
     grid-template-rows: auto;
+    padding: map-get($spacers, 'md') 0 map-get($spacers, 'md') 0;
 
     .description-text {
       font-size: calculateRem(18px);
-      line-height: calculateRem(32px);
-      margin-bottom: map-get($spacers, 'xs');
+      line-height: 1.78;
+      margin-bottom: map-get($spacers, 'sm');
     }
 
     .headline-text {
-      font-size: calculateRem(16px);
+      font-size: calculateRem(19px);
       font-weight: bold;
-      line-height: calculateRem(24px);
-      margin-bottom: map-get($spacers, 'xs');
+      line-height: 1.26;
+      margin-bottom: map-get($spacers, 'sm');
     }
 
     .results-list--author-date {
-      display: flex;
       font-size: calculateRem(14px);
       line-height: calculateRem(16px);
 
@@ -41,5 +41,29 @@
         line-height: calculateRem(16px);
       }
     }
+
+    .mobile {
+      &-order {
+        &-1 {
+          order: 1;
+        }
+    
+        &-2 {
+          order: 2;
+        }
+    
+        &-3 {
+          order: 3;
+        }
+      }
+
+      &-image {
+        height: 60px;
+        width: 99px;
+      }
+        
+    }
+    
+
   }
 }


### PR DESCRIPTION
## Description
update styles for results list block and search results list blocks so that they match zeplin designs.

## Jira Ticket
- [PEN-1434](https://arcpublishing.atlassian.net/browse/PEN-1434)

## Acceptance Criteria
Update the Results List and Search Results List display on mobile, so that it matches the design specs 

## Test Steps
add Results list block and search results list block to a page - inspect the page on mobile view and ensure that the appearance matches the designs specified in zeplin:
https://app.zeplin.io/project/5ea04773df4e1b7ae81167f8/screen/5ea04bf90d82a4545e5db990

## Effect Of Changes
### Before
Results list block and search results list block do not match mobile zeplin designs. 
<img width="732" alt="Screen Shot 2020-10-28 at 4 32 45 PM" src="https://user-images.githubusercontent.com/2664083/97493430-52ed9980-193b-11eb-9207-1f6e6807e282.png">
<img width="630" alt="Screen Shot 2020-10-28 at 4 33 11 PM" src="https://user-images.githubusercontent.com/2664083/97493434-53863000-193b-11eb-860f-c82310846f84.png">

### After
Results list block and search results list block do match mobile zeplin designs. 

<img width="440" alt="Screen Shot 2020-10-28 at 3 29 21 PM" src="https://user-images.githubusercontent.com/2664083/97493228-073af000-193b-11eb-8808-1f1cd864d1f3.png">
<img width="456" alt="Screen Shot 2020-10-28 at 3 37 58 PM" src="https://user-images.githubusercontent.com/2664083/97493240-0bffa400-193b-11eb-816b-016dfc7317b6.png">


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ x] Confirmed all the test steps above are working
- [x ] Confirmed there are no linter errors
- [x ] Confirmed this PR has reasonable code coverage
  - [ x] Confirmed this PR has unit test files
  - [x ] Ran `npm test`, made sure all tests are passing
  - [ x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x ] Confirmed relevant documentation has been updated/added.
