### PR TITLE
Pen 1304 404 support tags content source

### DIFF
--- a/blocks/tags-content-source-block/sources/tags-api.js
+++ b/blocks/tags-content-source-block/sources/tags-api.js
@@ -1,8 +1,26 @@
+const make404 = () => {
+  const error = new Error('Not found');
+  error.statusCode = 404;
+  throw error;
+};
+
 export default {
   resolve({ slug }) {
     return `/tags/v2/slugs?slugs=${slug}`;
   },
   params: {
     slug: 'text',
+  },
+  transform: (data) => {
+    if (!data || !data.Payload) {
+      make404();
+    }
+
+    const hasValues = data.Payload.some((ele) => !!ele);
+    if (hasValues) {
+      return data;
+    }
+
+    return make404();
   },
 };

--- a/blocks/tags-content-source-block/sources/tags-api.test.js
+++ b/blocks/tags-content-source-block/sources/tags-api.test.js
@@ -23,3 +23,54 @@ describe('the tags content source block', () => {
     });
   });
 });
+
+describe('the transform', () => {
+  const error = new Error('Not found');
+  error.statusCode = 404;
+
+  it('must return the original data if something found', () => {
+    const data = {
+      StatusCode: 200,
+      Payload: [
+        {
+          slug: '/foo',
+        },
+      ],
+    };
+    expect(contentSource.transform({ ...data })).toEqual(data);
+  });
+
+  it('must throw error if api returns nothing', () => {
+    expect(() => contentSource.transform()).toThrow(error);
+  });
+
+  it('must throw error if api returns empty', () => {
+    expect(() => contentSource.transform({})).toThrow(error);
+  });
+
+  it('must throw error if slug not found', () => {
+    const data = {
+      StatusCode: 200,
+      Payload: [
+        null,
+      ],
+    };
+    expect(() => {
+      contentSource.transform({ ...data });
+    }).toThrow(error);
+  });
+
+  it('must return data if one of the slugs returns data', () => {
+    const data = {
+      StatusCode: 200,
+      Payload: [
+        null,
+        {
+          slug: '/bar',
+        },
+        null,
+      ],
+    };
+    expect(contentSource.transform({ ...data })).toEqual(data);
+  });
+});


### PR DESCRIPTION
## Description
throw 404 error on content source when tag not found

## Jira Ticket
- [PEN-1304](https://arcpublishing.atlassian.net/browse/PEN-1304)

## Acceptance Criteria
If a Tags page is requested with a tag slug that does not exist, the page redirects to a 404 Not Found page

## Test Steps
- go to `localhost/tag/food` and verify that renders correctly
- then go to `localhost/tag/nonsense` and verify that the content source throw 404 error

## Effect Of Changes

### After
<img width="1692" alt="Screen Shot 2020-10-29 at 11 41 29" src="https://user-images.githubusercontent.com/9757/97599112-686bcd80-19e6-11eb-9543-90d211529370.png">

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
