### PR TITLE
PEN-1328 update sharebar hide breakpoint

### DIFF
--- a/blocks/share-bar-block/features/share-bar/share-bar.scss
+++ b/blocks/share-bar-block/features/share-bar/share-bar.scss
@@ -10,7 +10,7 @@
   top: 200px;
   width: 44px;
 
-  @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+  @media screen and (max-width: #{map-get($grid-breakpoints, 'lg') - 1rem}) {
     visibility: hidden;
   }
 


### PR DESCRIPTION
## Description
update the breakpoint where the ShareBar component start showing up.

## Jira Ticket
- [PEN-1328](https://arcpublishing.atlassian.net/browse/PEN-1328)

## Acceptance Criteria
The share bar should not appear at all on breakpoints smaller than 1024px
(check the comments on the ticket, was updated to 1009px)

## Test Steps
- load an article and verify that the ShareBar do not show on viewport sizes lower than 1009px

## Effect Of Changes
### Before
![image-20200916-202358](https://user-images.githubusercontent.com/9757/97628001-eb068400-1a0a-11eb-81c0-c710a42eba69.png)

### After
<img width="1062" alt=" 2020-10-29-16 48 18" src="https://user-images.githubusercontent.com/9757/97627923-ce6a4c00-1a0a-11eb-85d7-2627a1c41409.png">
<img width="1049" alt=" 2020-10-29-16 40 40" src="https://user-images.githubusercontent.com/9757/97627932-d0cca600-1a0a-11eb-8bc2-73a63f337b00.png">

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
