### PR TITLE
Hotfix peer deps blocks to beta 

### DIFF
--- a/blocks/alert-bar-block/package.json
+++ b/blocks/alert-bar-block/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "cookie": "^0.4.1",
-    "@wpmedia/engine-theme-sdk": "stable"
+    "@wpmedia/engine-theme-sdk": "beta"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }

--- a/blocks/alert-bar-block/package.json
+++ b/blocks/alert-bar-block/package.json
@@ -22,10 +22,12 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
-    "@wpmedia/engine-theme-sdk": "^2.2.0",
-    "cookie": "^0.4.1",
+  "peerDependencies": {
     "styled-components": "^4.4.0"
+  },
+  "dependencies": {
+    "cookie": "^0.4.1",
+    "@wpmedia/engine-theme-sdk": "stable"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }

--- a/blocks/alert-bar-content-source-block/package.json
+++ b/blocks/alert-bar-content-source-block/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/article-body-block/package.json
+++ b/blocks/article-body-block/package.json
@@ -25,12 +25,14 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/video-player-block": "beta",
-    "react-oembed-container": "^0.3.0",
     "styled-components": "^4.4.0"
+  },
+  "dependencies": {
+    "react-oembed-container": "^0.3.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }

--- a/blocks/article-tag-block/package.json
+++ b/blocks/article-tag-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/author-bio-block/package.json
+++ b/blocks/author-bio-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/author-content-source-block/package.json
+++ b/blocks/author-content-source-block/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/byline-block/package.json
+++ b/blocks/byline-block/package.json
@@ -26,9 +26,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/card-list-block/package.json
+++ b/blocks/card-list-block/package.json
@@ -22,11 +22,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/byline-block": "beta",
     "@wpmedia/date-block": "beta",
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/collections-content-source-block/package.json
+++ b/blocks/collections-content-source-block/package.json
@@ -22,7 +22,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
     "@wpmedia/resizer-image-block": "beta"
   },

--- a/blocks/content-api-source-block/package.json
+++ b/blocks/content-api-source-block/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint --ext js --ext jsx sources"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/date-block/package.json
+++ b/blocks/date-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/default-output-block/package.json
+++ b/blocks/default-output-block/package.json
@@ -26,9 +26,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx output-types"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable"
+    "@wpmedia/news-theme-css": "beta"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }

--- a/blocks/double-chain-block/package.json
+++ b/blocks/double-chain-block/package.json
@@ -21,9 +21,9 @@
     "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
     "directory": "blocks/double-chain-block"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable"
+    "@wpmedia/news-theme-css": "beta"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/blocks/event-tester-block/package.json
+++ b/blocks/event-tester-block/package.json
@@ -24,7 +24,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/extra-large-manual-promo-block/package.json
+++ b/blocks/extra-large-manual-promo-block/package.json
@@ -25,9 +25,11 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "dependencies": {
-    "@arc-fusion/prop-types": "^0.1.5",
+    "@arc-fusion/prop-types": "^0.1.5"
+  },
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/shared-styles": "beta",
     "styled-components": "^4.4.0"
   },

--- a/blocks/extra-large-promo-block/package.json
+++ b/blocks/extra-large-promo-block/package.json
@@ -25,12 +25,12 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/byline-block": "beta",
     "@wpmedia/date-block": "beta",
     "@wpmedia/engine-theme-sdk": "beta",
     "@wpmedia/global-phrases-block": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/overline-block": "beta",
     "@wpmedia/shared-styles": "beta",
     "styled-components": "^4.4.0"

--- a/blocks/footer-block/package.json
+++ b/blocks/footer-block/package.json
@@ -25,10 +25,12 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "dependencies": {
-    "@arc-fusion/prop-types": "^0.1.5",
+    "@arc-fusion/prop-types": "^0.1.5"
+  },
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
     "@wpmedia/links-bar-block": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/full-author-bio-block/package.json
+++ b/blocks/full-author-bio-block/package.json
@@ -23,9 +23,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "bugs": {

--- a/blocks/gallery-block/package.json
+++ b/blocks/gallery-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable"
+    "@wpmedia/news-theme-css": "beta"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }

--- a/blocks/global-phrases-block/package.json
+++ b/blocks/global-phrases-block/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/header-block/package.json
+++ b/blocks/header-block/package.json
@@ -22,9 +22,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable"
+    "@wpmedia/news-theme-css": "beta"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"

--- a/blocks/header-nav-block/package.json
+++ b/blocks/header-nav-block/package.json
@@ -28,9 +28,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/shared-styles": "beta",
     "styled-components": "^4.4.0"
   },

--- a/blocks/header-nav-chain-block/package.json
+++ b/blocks/header-nav-chain-block/package.json
@@ -26,11 +26,13 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
-    "@wpmedia/shared-styles": "beta",
-    "styled-components": "^4.4.0",
     "use-debounce": "^3.4.3"
+  },
+  "peerDependencies": {
+    "@wpmedia/engine-theme-sdk": "beta",
+    "@wpmedia/news-theme-css": "beta",
+    "@wpmedia/shared-styles": "beta",
+    "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }

--- a/blocks/headline-block/package.json
+++ b/blocks/headline-block/package.json
@@ -22,9 +22,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/htmlbox-block/package.json
+++ b/blocks/htmlbox-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/large-manual-promo-block/package.json
+++ b/blocks/large-manual-promo-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/shared-styles": "beta",
     "styled-components": "^4.4.0"
   },

--- a/blocks/large-promo-block/package.json
+++ b/blocks/large-promo-block/package.json
@@ -25,11 +25,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/byline-block": "beta",
     "@wpmedia/date-block": "beta",
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/overline-block": "beta",
     "@wpmedia/shared-styles": "beta",
     "styled-components": "^4.4.0"

--- a/blocks/lead-art-block/package.json
+++ b/blocks/lead-art-block/package.json
@@ -20,9 +20,9 @@
     "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
     "directory": "blocks/lead-art-block"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/video-player-block": "beta",
     "styled-components": "^4.4.0"
   },

--- a/blocks/links-bar-block/package.json
+++ b/blocks/links-bar-block/package.json
@@ -25,9 +25,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/masthead-block/package.json
+++ b/blocks/masthead-block/package.json
@@ -13,10 +13,10 @@
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
-    "styled-components": "^5.0.1"
+    "@wpmedia/news-theme-css": "beta",
+    "styled-components": "^4.4.0"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/blocks/medium-manual-promo-block/package.json
+++ b/blocks/medium-manual-promo-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/shared-styles": "beta",
     "styled-components": "^4.4.0"
   },

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -24,11 +24,11 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/byline-block": "beta",
     "@wpmedia/date-block": "beta",
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/shared-styles": "beta",
     "styled-components": "^4.4.0"
   },

--- a/blocks/numbered-list-block/package.json
+++ b/blocks/numbered-list-block/package.json
@@ -26,9 +26,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/overline-block/package.json
+++ b/blocks/overline-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable"
+    "@wpmedia/news-theme-css": "beta"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"

--- a/blocks/placeholder-image-block/package.json
+++ b/blocks/placeholder-image-block/package.json
@@ -24,7 +24,7 @@
   ],
   "author": "Jack Howard <jack.howard@washpost.com>",
   "license": "CC-BY-NC-ND-4.0",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/quad-chain-block/package.json
+++ b/blocks/quad-chain-block/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint --ext js --ext jsx chains"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/related-content-content-source-block/package.json
+++ b/blocks/related-content-content-source-block/package.json
@@ -22,7 +22,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/resizer-image-block/package.json
+++ b/blocks/resizer-image-block/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
   },
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
     "thumbor-lite": "^0.1.8"
   },

--- a/blocks/resizer-image-content-source-block/package.json
+++ b/blocks/resizer-image-content-source-block/package.json
@@ -29,7 +29,7 @@
   "author": "Jack Howard <jack.howard@washpost.com>",
   "license": "CC-BY-NC-ND-4.0",
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/results-list-block/package.json
+++ b/blocks/results-list-block/package.json
@@ -27,12 +27,12 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/byline-block": "beta",
     "@wpmedia/date-block": "beta",
     "@wpmedia/engine-theme-sdk": "beta",
     "@wpmedia/global-phrases-block": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/shared-styles": "beta",
     "styled-components": "^4.4.0"
   },

--- a/blocks/right-rail-advanced-block/package.json
+++ b/blocks/right-rail-advanced-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/right-rail-block/package.json
+++ b/blocks/right-rail-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/search-content-source-block/package.json
+++ b/blocks/search-content-source-block/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --ext js --ext jsx sources"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/search-results-list-block/package.json
+++ b/blocks/search-results-list-block/package.json
@@ -23,7 +23,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/date-block": "beta",
     "@wpmedia/engine-theme-sdk": "beta",
     "@wpmedia/global-phrases-block": "beta",

--- a/blocks/section-title-block/package.json
+++ b/blocks/section-title-block/package.json
@@ -22,9 +22,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable"
+    "@wpmedia/news-theme-css": "beta"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"

--- a/blocks/share-bar-block/package.json
+++ b/blocks/share-bar-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/shared-styles/package.json
+++ b/blocks/shared-styles/package.json
@@ -18,9 +18,9 @@
     "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
     "directory": "blocks/shared-styles"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable"
+    "@wpmedia/news-theme-css": "beta"
   },
   "scripts": {},
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/simple-list-block/package.json
+++ b/blocks/simple-list-block/package.json
@@ -21,9 +21,9 @@
     "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
     "directory": "blocks/simple-list-block"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "scripts": {

--- a/blocks/single-chain-block/package.json
+++ b/blocks/single-chain-block/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/site-hierarchy-content-block/package.json
+++ b/blocks/site-hierarchy-content-block/package.json
@@ -29,9 +29,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx sources"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/small-manual-promo-block/package.json
+++ b/blocks/small-manual-promo-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/shared-styles": "beta",
     "styled-components": "^4.4.0"
   },

--- a/blocks/small-promo-block/package.json
+++ b/blocks/small-promo-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/shared-styles": "beta",
     "styled-components": "^4.4.0"
   },

--- a/blocks/story-feed-author-content-source-block/package.json
+++ b/blocks/story-feed-author-content-source-block/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --ext js --ext jsx sources"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/story-feed-query-content-source-block/package.json
+++ b/blocks/story-feed-query-content-source-block/package.json
@@ -22,8 +22,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx sources"
   },
-  "dependencies": {
-    "@arc-core-components/content-source_story-feed_sections-v4": "^1.0.6-beta.0",
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
     "@wpmedia/resizer-image-block": "beta"
   },

--- a/blocks/story-feed-sections-content-source-block/package.json
+++ b/blocks/story-feed-sections-content-source-block/package.json
@@ -22,8 +22,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx sources"
   },
-  "dependencies": {
-    "@arc-core-components/content-source_story-feed_sections-v4": "^1.0.6-beta.0",
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
     "@wpmedia/story-feed-tag-content-source-block": "beta"
   },

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -22,8 +22,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx sources"
   },
-  "dependencies": {
-    "@arc-core-components/content-source_story-feed_tag-v4": "^1.0.6-beta.0",
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/subheadline-block/package.json
+++ b/blocks/subheadline-block/package.json
@@ -24,9 +24,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/tag-title-block/package.json
+++ b/blocks/tag-title-block/package.json
@@ -22,9 +22,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable"
+    "@wpmedia/news-theme-css": "beta"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"

--- a/blocks/tags-content-source-block/package.json
+++ b/blocks/tags-content-source-block/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/text-output-block/package.json
+++ b/blocks/text-output-block/package.json
@@ -22,7 +22,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx output-types"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/textfile-block/package.json
+++ b/blocks/textfile-block/package.json
@@ -22,7 +22,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/top-table-list-block/package.json
+++ b/blocks/top-table-list-block/package.json
@@ -21,11 +21,11 @@
     "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
     "directory": "blocks/top-table-list-block"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/byline-block": "beta",
     "@wpmedia/date-block": "beta",
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@wpmedia/overline-block": "beta",
     "@wpmedia/placeholder-image-block": "beta",
     "@wpmedia/resizer-image-block": "beta",

--- a/blocks/triple-chain-block/package.json
+++ b/blocks/triple-chain-block/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --ext js --ext jsx chains"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/unpublished-content-source-block/package.json
+++ b/blocks/unpublished-content-source-block/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint --ext js --ext jsx sources"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
-  "dependencies": {
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta"
   }
 }

--- a/blocks/video-player-block/package.json
+++ b/blocks/video-player-block/package.json
@@ -25,9 +25,11 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "dependencies": {
+    "react-oembed-container": "^0.3.0"
+  },
+  "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "beta",
-    "@wpmedia/news-theme-css": "stable",
-    "react-oembed-container": "^0.3.0",
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/video-promo-block/package.json
+++ b/blocks/video-promo-block/package.json
@@ -22,11 +22,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "dependencies": {
-    "@wpmedia/engine-theme-sdk": "stable"
-  },
   "peerDependencies": {
     "@wpmedia/news-theme-css": "beta",
+    "@wpmedia/engine-theme-sdk": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/video-promo-block/package.json
+++ b/blocks/video-promo-block/package.json
@@ -23,8 +23,10 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "dependencies": {
-    "@wpmedia/engine-theme-sdk": "latest",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/engine-theme-sdk": "stable"
+  },
+  "peerDependencies": {
+    "@wpmedia/news-theme-css": "beta",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@storybook/addon-a11y": "^5.3.19",
     "@storybook/addon-docs": "^5.3.19",
     "@storybook/react": "^5.3.19",
-    "@wpmedia/news-theme-css": "stable",
+    "@wpmedia/news-theme-css": "beta",
     "@storybook/addon-knobs": "^5.3.19",
     "babel-eslint": "^10.0.2",
     "babel-jest": "^24.9.0",


### PR DESCRIPTION
https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=545&projectKey=PEN&modal=detail&selectedIssue=PEN-1520&assignee=5e387d6a1b1d910e5dfd7a9b

Use peerDependencies when we can rather than dependencies. As a note, this is already working in canary ... see rca https://github.com/WPMedia/fusion-news-theme-blocks/wiki/Bundle-Size-Internal-Service-Error-On-Corecomponents


prev explanation (I removed the non-peer deps experiment):

> - Similarly instrumenting peerDeps to https://github.com/WPMedia/fusion-news-theme-blocks/wiki/Bundle-Size-Internal-Service-Error-On-Corecomponents
> - except, we have designated deps (not peers) for showing that we can install a dependency version of engine theme sdk
> - I also removed content sources like I did previously for canary as they are installed by the fusion-news-theme and working as expected in corecomponents
> - Designated the correct news-theme-css version. But just because we will be installing the correct version at the top level of beta and want to make the peer dependencies match and not throw a warning
> - For Monday