### PR TITLE
PEN-1430: TEMPORARY Debugging console log statements 

### DIFF
--- a/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.jsx
@@ -8,7 +8,12 @@ import getTranslatedPhrases from 'fusion:intl';
 import getProperties from 'fusion:properties';
 
 export const getLabelText = (phrases, type) => {
+  console.log("XL  promo - getLabelText phrases", phrases);
+  
   if (phrases && type) {
+    console.log("getLabelText video label = ", phrases.t('extra-large-promo-block.video-label'));
+    console.log("getLabelText video label = ", phrases.t('extra-large-promo-block.gallery-label'));
+
     switch (type) {
       case 'Video':
         return phrases.t('extra-large-promo-block.video-label');

--- a/blocks/large-promo-block/features/large-promo/_children/promo_label.jsx
+++ b/blocks/large-promo-block/features/large-promo/_children/promo_label.jsx
@@ -8,7 +8,12 @@ import getTranslatedPhrases from 'fusion:intl';
 import getProperties from 'fusion:properties';
 
 export const getLabelText = (phrases, type) => {
+  console.log("getLabelText phrases", phrases);
+  
   if (phrases && type) {
+    console.log("getLabelText video label = ", phrases.t('extra-large-promo-block.video-label'));
+    console.log("getLabelText video label = ", phrases.t('extra-large-promo-block.gallery-label'));
+
     switch (type) {
       case 'Video':
         return phrases.t('extra-large-promo-block.video-label');

--- a/blocks/medium-promo-block/features/medium-promo/_children/promo_label.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/_children/promo_label.jsx
@@ -8,7 +8,12 @@ import getTranslatedPhrases from 'fusion:intl';
 import getProperties from 'fusion:properties';
 
 export const getLabelText = (phrases, type) => {
+  console.log("M promo - getLabelText phrases", phrases);
+  
   if (phrases && type) {
+    console.log("getLabelText video label = ", phrases.t('extra-large-promo-block.video-label'));
+    console.log("getLabelText video label = ", phrases.t('extra-large-promo-block.gallery-label'));
+
     switch (type) {
       case 'Video':
         return phrases.t('extra-large-promo-block.video-label');


### PR DESCRIPTION
## Description
Translation phrases for promo blocks  on core components env has been broken and instead of showing the translated phrases, it shows the name of the phrase contained in intl.json:
<img width="912" alt="Screen Shot 2020-10-30 at 2 25 45 PM" src="https://user-images.githubusercontent.com/2664083/97893699-a5460600-1cff-11eb-8180-7259a9df7b23.png">

The purpose of these changes is to log the value of 'phrases' to glean clues on a root cause for this change. When running locally the translated phrases appear as expected - it seems that this issue arises when the changes are deployed onto core components env.

This commit will be reverted once root cause is identified. 



## Jira Ticket
- [PEN-1430](https://arcpublishing.atlassian.net/browse/PEN-1430)

## Acceptance Criteria
_copy from ticket_

## Test Steps
- Add test steps a reviewer must complete to test this PR

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
