### PR TITLE
Ads UAT fixes, refactoring & clean-up (removed 'lodash.get' dependency)

### DIFF
--- a/blocks/ads-block/features/ads/_children/AdUnitLog/index.js
+++ b/blocks/ads-block/features/ads/_children/AdUnitLog/index.js
@@ -1,0 +1,34 @@
+export default class AdUnitLog {
+  static instance;
+
+  static getInstance() {
+    if (!AdUnitLog.instance) {
+      AdUnitLog.instance = new AdUnitLog();
+    }
+    return this.instance;
+  }
+
+  constructor() {
+    this.add = this.add.bind(this);
+    this.getPosition = this.getPosition.bind(this);
+    this.log = {};
+  }
+
+  add(adCfg) {
+    const { id, adType: adKey } = adCfg;
+    if (!this.log[adKey]) this.log[adKey] = [];
+    const cfgExists = this.log[adKey].reduce((exists, next) => !!(
+      next && next.id === id ? true : exists
+    ), false);
+    if (!cfgExists) this.log[adKey].push(adCfg);
+  }
+
+  getPosition({ adType, id }) {
+    const adCfgs = this.log[adType] || [];
+    let adCfg = null;
+    adCfgs.forEach((cfg) => {
+      if (cfg.id === id) adCfg = cfg;
+    });
+    return !adCfg ? 0 : (adCfgs.indexOf(adCfg) + 1);
+  }
+}

--- a/blocks/ads-block/features/ads/_children/AdUnitLog/index.test.js
+++ b/blocks/ads-block/features/ads/_children/AdUnitLog/index.test.js
@@ -1,0 +1,107 @@
+import AdUnitLog from './index';
+
+const MOCK_ADUNIT_1 = {
+  id: 'arcad_9071',
+  slotName: 'news',
+  adType: 'leaderboard_large',
+  adClass: '728x90',
+  display: 'all',
+};
+
+const MOCK_ADUNIT_2 = {
+  id: 'arcad_5530',
+  slotName: 'news',
+  adType: 'right_rail_cube',
+  adClass: '300x250',
+  display: 'desktop',
+};
+
+const MOCK_ADUNIT_3 = {
+  id: 'arcad_3055',
+  slotName: 'news',
+  adType: 'right_rail_cube',
+  adClass: '300x250',
+  display: 'desktop',
+};
+
+describe('AdUnitLog', () => {
+  beforeEach(() => {
+    AdUnitLog.instance = undefined;
+  });
+
+  it('uses same instance for each initialization', () => {
+    const log1 = AdUnitLog.getInstance();
+    const log2 = AdUnitLog.getInstance();
+    expect(AdUnitLog.instance).toBeDefined();
+    expect(log1).toBeDefined();
+    expect(log2).toBeDefined();
+    expect(log1).toEqual(log2);
+  });
+
+  it('has empty log upon initialization', () => {
+    const log = AdUnitLog.getInstance();
+    expect(log).toBeDefined();
+    expect(AdUnitLog.instance).toBeDefined();
+    expect(typeof log.log).toEqual('object');
+    expect(Object.keys(log.log)).toEqual([]);
+  });
+
+  it('adds single ad instances to log', () => {
+    const log = AdUnitLog.getInstance();
+    log.add(MOCK_ADUNIT_1);
+    log.add(MOCK_ADUNIT_2);
+    expect(Object.keys(log.log)).toHaveLength(2);
+  });
+
+  it('adds duplicate ad instances to log', () => {
+    const log = AdUnitLog.getInstance();
+    log.add(MOCK_ADUNIT_1);
+    log.add(MOCK_ADUNIT_2);
+    log.add(MOCK_ADUNIT_2);
+    expect(Object.keys(log.log)).toHaveLength(2);
+  });
+
+  it('adds two of same type ad unit to log', () => {
+    const log = AdUnitLog.getInstance();
+    log.add(MOCK_ADUNIT_1);
+    log.add(MOCK_ADUNIT_2);
+    log.add(MOCK_ADUNIT_3);
+    expect(Object.keys(log.log)).toHaveLength(2);
+    expect(log.log[MOCK_ADUNIT_1.adType]).toHaveLength(1);
+    expect(log.log[MOCK_ADUNIT_2.adType]).toHaveLength(2);
+  });
+
+  it('returns correct ad position', () => {
+    const log = AdUnitLog.getInstance();
+    expect(Object.keys(log.log)).toHaveLength(0);
+    log.add(MOCK_ADUNIT_1);
+    const adUnitPosition1 = log.getPosition({
+      adType: MOCK_ADUNIT_1.adType,
+      id: MOCK_ADUNIT_1.id,
+    });
+    expect(adUnitPosition1).toEqual(1);
+    log.add(MOCK_ADUNIT_2);
+    const adUnitPosition2 = log.getPosition({
+      adType: MOCK_ADUNIT_2.adType,
+      id: MOCK_ADUNIT_2.id,
+    });
+    expect(adUnitPosition2).toEqual(1);
+    log.add(MOCK_ADUNIT_3);
+    const adUnitPosition3 = log.getPosition({
+      adType: MOCK_ADUNIT_3.adType,
+      id: MOCK_ADUNIT_3.id,
+    });
+    expect(adUnitPosition3).toEqual(2);
+    expect(Object.keys(log.log)).toHaveLength(2);
+  });
+
+  it('returns ad position of zero when no matching config added', () => {
+    const log = AdUnitLog.getInstance();
+    expect(Object.keys(log.log)).toHaveLength(0);
+    const adUnitPosition1 = log.getPosition({
+      adType: MOCK_ADUNIT_1.adType,
+      id: MOCK_ADUNIT_1.id,
+    });
+    expect(adUnitPosition1).toEqual(0);
+  });
+});

--- a/blocks/ads-block/features/ads/_children/ArcAdsInstance/index.js
+++ b/blocks/ads-block/features/ads/_children/ArcAdsInstance/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 // istanbul ignore file
 import { ArcAds } from 'arcads';
-import get from 'lodash.get';
 
 export const logEvent = (evt, debug = false) => {
   if (debug) {
@@ -34,7 +33,7 @@ class ArcAdsInstance {
 
   initArcAds({ publisherIds, debug = false }) {
     if (!this.arcAds) {
-      const id = get(publisherIds, 'dfp_publisher_id');
+      const { dfp_publisher_id: id } = publisherIds;
       const arcAdsConfig = { dfp: { id } };
       this.arcAds = new ArcAds(arcAdsConfig, (evt) => {
         logEvent(evt, debug);

--- a/blocks/ads-block/features/ads/_children/ArcAdsInstance/index.test.js
+++ b/blocks/ads-block/features/ads/_children/ArcAdsInstance/index.test.js
@@ -93,7 +93,7 @@ describe('ArcAdsInstance', () => {
     it('registers ad', () => {
       const arcAds = ArcAdsInstance.getInstance(siteProperties);
       jest.spyOn(arcAds, 'registerAd');
-      arcAds.registerAd({ adRegisterProps });
+      arcAds.registerAd(adRegisterProps);
       expect(arcAds.registerAd).toHaveBeenCalledTimes(1);
     });
   });

--- a/blocks/ads-block/features/ads/ad-helper.test.js
+++ b/blocks/ads-block/features/ads/ad-helper.test.js
@@ -29,6 +29,7 @@ const SITE_PROPS_MOCK = {
     large: 992,
   },
   websiteAdPath: 'news',
+  dfpId: 701,
 };
 
 const STORY_MOCK = {

--- a/blocks/ads-block/features/ads/ad-mapping.js
+++ b/blocks/ads-block/features/ads/ad-mapping.js
@@ -14,7 +14,7 @@ const sz300x600 = [300, 600];
 const sz320x50 = [320, 50];
 const sz728x90 = [728, 90];
 const sz970x90 = [970, 90];
-const sz970x250 = [970, 90];
+const sz970x250 = [970, 250];
 
 const adMapping = {
   '1x1': {
@@ -61,7 +61,7 @@ const adMapping = {
     adLabel: 'Leaderboard - Large',
     adClass: '728x90',
     dimensionsArray: [
-      [sz728x90, sz970x90, sz970x250],
+      [sz970x250, sz970x90, sz728x90],
       sz728x90,
       sz320x50,
     ],

--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 /* eslint-disable comma-dangle */
 import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from '@arc-fusion/prop-types';
@@ -11,12 +12,16 @@ import './ads.scss';
 
 /** === ArcAd Component === */
 const ArcAd = (props) => {
+  if (typeof window === 'undefined') return null;
+  const [instanceId] = useState(Math.floor(Math.random() * 10000));
   const propsWithContext = {
     ...useAppContext(),
     ...useFusionContext(),
     ...props,
+    instanceId,
   };
   const { customFields } = props;
+  const { isAdmin } = propsWithContext;
   const [config] = useState(
     getAdObject({
       ...customFields,
@@ -49,17 +54,16 @@ const ArcAd = (props) => {
   }, [config]);
 
   useEffect(() => {
-    registerAd();
-  }, [registerAd]);
+    if (!isAdmin) registerAd();
+  }, [registerAd, isAdmin]);
 
   const {
     id, adClass, adType, dimensions, slotName, display,
   } = config;
-  const { isAdmin } = propsWithContext;
 
   return (
     <div
-      id={`arcad_feature-${id}`}
+      id={`arcad_feature-${instanceId}`}
       className="arcad_feature margin-md-bottom"
     >
       <div className="arcad_container">


### PR DESCRIPTION
## Description
UAT FIXES: Fix for `leaderboard_large` ad breakpoints, fix and refactoring of `pos` targeting functionality, removed `lodash.get` dependency, other clean-up and refactoring.

## Jira Ticket
This branch contains fixes for issues cited on:
- [PEN-425](https://arcpublishing.atlassian.net/browse/PEN-425)
- [PEN-436](https://arcpublishing.atlassian.net/browse/PEN-436)
- [PEN-1223](https://arcpublishing.atlassian.net/browse/PEN-1223)

## Acceptance Criteria
_copy from ticket_

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. After checking out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/header-nav-chain-block` in `Fusion-News-Theme`
4. Open 'Homepage' in PB editor, Chrome DevTools `Network` tab and filter by `dfp`. You should see that there are no requests being made to DFP when viewing page in PB Admin.
5. In PB editor, make sure two instances of `Google Ad` feature with a type of `leaderboard_large` are added to the page. Then stage & publish.
6. Open http://localhost/pf/homepage/?_website=the-sun in a new tab
7. Open Chrome DevTools `Network` tab and filter by `dfp`
8. Find the request for the `leaderboard_large` ad call
![image](https://user-images.githubusercontent.com/26662906/97904622-649dbb00-1d06-11eb-9c33-6c265a386f19.png)
9. You should see the `prev_iu_szs` param set to `970x250|970x90|728x90`
10. Now look through the rest of the requests under `Network` with `dfp` filter. Look at the `pos` value for each ad unit (under `prev_scp` query string param) and it should match the `position` value. Specifically take a look at the two `leaderboard_large` requests. The first one should have a `pos` of `1` and the second one should have a `pos` of `2`.

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
None

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps above are working
- [X] Confirmed there are no linter errors
- [X] Confirmed this PR has reasonable code coverage
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.
