### PR TITLE
PEN-1430: adding intl.json to promo block package.json files

### DIFF
--- a/News Theme Development.md
+++ b/News Theme Development.md
@@ -126,6 +126,27 @@ To check if blocks are being properly linked, run:
 
   NOTE:  'npm fusion' will use the  globally available fusion, but using 'npx fusion' will use the local fusion available from within the folder
 
+
+### Internationalization
+
+Phrase translations may be added via an intl.json file for each block to contain the phrases that block needs. For example  this is the intl.json file for results list block:
+```sh
+{
+   "results-list-block.see-more-button":{
+      "en":"See More",
+      "sv":"Fler artiklar",
+      "no":"Se mer"
+   }
+}
+```
+Common phrases needed across multiple blocks are declared in global-phrases-block.  In order for the intl.json files to be included in a build, it must be included in the lists for a block in that blocks package.json file:
+```sh
+  "files": [
+    "features",
+    "intl.json"
+  ],
+```
+
 ### Development Process
 
 1. Pull the latest `canary` branch:

--- a/blocks/extra-large-promo-block/package.json
+++ b/blocks/extra-large-promo-block/package.json
@@ -10,7 +10,8 @@
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "features"
+    "features",
+    "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/blocks/large-promo-block/package.json
+++ b/blocks/large-promo-block/package.json
@@ -10,7 +10,8 @@
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "features"
+    "features",
+    "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -9,7 +9,8 @@
   "files": [
     "features",
     "chains",
-    "layouts"
+    "layouts",
+    "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",


### PR DESCRIPTION
## Description
Promo block intl.json files are not included in the promo block package.json files and so those translated phrases are not included in phrases on core components env and displaying phrase name instead of the translated phrase. These changes will test that theory.

If this change fixes the issue, the  previous PR adding in console log statements for debugging will be reverted via a follow-up PR.


## Jira Ticket
- [PEN-1430](https://arcpublishing.atlassian.net/browse/PEN-1430)

## Acceptance Criteria
_copy from ticket_

## Test Steps
- Add test steps a reviewer must complete to test this PR

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
