### PR TITLE
Pen 1386 overline content editable xl l promo blocks

### DIFF
--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -61,12 +61,6 @@ const ExtraLargePromo = ({ customFields }) => {
   const overlineDisplay = (content?.label?.basic?.display ?? null)
     || (content?.websites?.[arcSite] && websiteSection)
     || false;
-  const overlineUrl = (content?.label?.basic?.url ?? null)
-    || (content?.websites?.[arcSite] && websiteSection && websiteSection._id)
-    || '';
-  const overlineText = (content?.label?.basic?.text ?? null)
-    || (content?.websites?.[arcSite] && websiteSection && websiteSection.name)
-    || '';
   const promoType = discoverPromoType(content);
 
   const overlineTmpl = () => {
@@ -74,9 +68,8 @@ const ExtraLargePromo = ({ customFields }) => {
       return (
         (
           <Overline
-            customUrl={overlineUrl}
-            customText={overlineText}
             className="overline"
+            story={content}
             editable
           />
         )

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -197,8 +197,8 @@ describe('the extra large promo feature', () => {
     const wrapperOverline = wrapper.find('Overline');
     expect(wrapperOverline.length).toBe(1);
 
-    expect(wrapperOverline.props().customUrl).toEqual('the-sun-ID');
-    expect(wrapperOverline.props().customText).toEqual('the-sun-name');
+    expect(wrapperOverline.find('a.overline').text()).toEqual('the-sun-name');
+    expect(wrapperOverline.find('a.overline').prop('href')).toEqual('the-sun-ID/');
     wrapper.unmount();
   });
 

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -62,12 +62,6 @@ const LargePromo = ({ customFields }) => {
   const overlineDisplay = (content?.label?.basic?.display ?? null)
       || (content?.websites?.[arcSite] && websiteSection)
       || false;
-  const overlineUrl = (content?.label?.basic?.url ?? null)
-      || (content?.websites?.[arcSite] && websiteSection && websiteSection._id)
-      || '';
-  const overlineText = (content?.label?.basic?.text ?? null)
-      || (content?.websites?.[arcSite] && websiteSection && websiteSection.name)
-      || '';
   const textClass = customFields.showImage ? 'col-sm-12 col-md-xl-6 flex-col' : 'col-sm-xl-12 flex-col';
   const promoType = discoverPromoType(content);
 
@@ -76,9 +70,8 @@ const LargePromo = ({ customFields }) => {
       return (
         (
           <Overline
-            customUrl={overlineUrl}
-            customText={overlineText}
             className="overline"
+            story={content}
             editable
           />
         )

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -289,8 +289,8 @@ describe('the large promo feature', () => {
     const wrapperOverline = wrapper.find('Overline');
     expect(wrapperOverline.length).toBe(1);
 
-    expect(wrapperOverline.props().customUrl).toEqual('the-sun-ID');
-    expect(wrapperOverline.props().customText).toEqual('the-sun-name');
+    expect(wrapperOverline.find('a.overline').text()).toEqual('the-sun-name');
+    expect(wrapperOverline.find('a.overline').prop('href')).toEqual('the-sun-ID/');
     wrapper.unmount();
   });
 

--- a/blocks/overline-block/README.md
+++ b/blocks/overline-block/README.md
@@ -1,18 +1,13 @@
 # `@wpmedia/overline-block`
-_Fusion News Theme overline block. Please provide a 1-2 sentence description of what the block is and what it does._
-
-## Acceptance Criteria
-- Add AC relevant to the block
+_Fusion News Theme Overline block. Text usually displayed over the headline. By default will use the ANS fields Label or Web Site Section if they exist or optionally a custom text and url can be used._
 
 ## Props
 | **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
-| **required prop** | yes | | |
-| **optional prop** | no | | |
-| **contentConfig example** | | | Please specify which content sources are compatible |
-
-## ANS Schema
-Outline any schema information requirements necessary to know for ths block
+| **customText** | no | string | Text to use for the overline, if **customUrl** parameter do not exists, will be an span element |
+| **customUrl** | no | string | If exists, the **customText** will be wrapped with an anchor and this url used to link to |
+| **editable** | no | boolean | if the content of the overline **do not** came from the previous __customXXX__ params, the overline text can be flagged as editable and used on PageBuilder |
+| **story** | no | object | story object to use to extract overline values instead of GlobalContent |
 
 ### ANS Fields
 - `globalContent.label.basic.display`
@@ -21,23 +16,7 @@ Outline any schema information requirements necessary to know for ths block
 - `content.websites[arcSite].website_section._id`
 - `content.websites[arcSite].website_section.name`
 
-## Internationalization fields
-| Phrase key | Default (English) |
-|---|---|
-|`key`|`english translation`|
-
-## Events
-Blocks can emit events. The following is a list of events that are emitted by this block.
-
-| **Event Name** | **Description** |
-|---|---|
-| **eventName** | Describe the event |
-
 ### Event Listening
-Include block specific instructions for event listening.
-
-OR
-
 This block does not emit any events.
 
 ## Additional Considerations

--- a/blocks/overline-block/features/overline/default.jsx
+++ b/blocks/overline-block/features/overline/default.jsx
@@ -52,27 +52,39 @@ function fixTrailingSlash(item) {
 const Overline = (props) => {
   const { globalContent: content = {}, arcSite } = useFusionContext();
   const { editableContent } = useEditableContent();
-  const { customText, customUrl, editable } = props;
+  const {
+    customText,
+    customUrl,
+    editable,
+    story,
+  } = props;
+  const sourceContent = story || (Object.prototype.hasOwnProperty.call(content, '_id') && content) || {};
 
   const {
     display: labelDisplay,
     url: labelUrl,
     text: labelText,
-  } = (content.label && content.label.basic) || {};
+  } = (sourceContent.label && sourceContent.label.basic) || {};
   const shouldUseLabel = !!(labelDisplay);
 
   const {
     _id: sectionUrl,
     name: sectionText,
-  } = (content.websites
-    && content.websites[arcSite]
-    && content.websites[arcSite].website_section) || {};
+  } = (sourceContent.websites
+    && sourceContent.websites[arcSite]
+    && sourceContent.websites[arcSite].website_section) || {};
 
-  const shouldUseProps = !!((customText && customUrl));
+  const shouldUseProps = !!(customText && customUrl); // ? true : sourceContent._id ? false : false;
   const useGlobalContent = shouldUseLabel ? [labelText, labelUrl] : [sectionText, sectionUrl];
-
+  const editableContentPath = shouldUseLabel ? 'headlines.basic' : `websites.${arcSite}.website_section.name`;
   const [text, url] = shouldUseProps ? [customText, customUrl] : useGlobalContent;
-  const edit = editable ? { ...editableContent(content, text) } : {};
+
+  let edit = {};
+  if (editable) {
+    if (sourceContent._id) {
+      edit = { ...editableContent(sourceContent, editableContentPath) };
+    }
+  }
 
   if (url) {
     return (

--- a/blocks/overline-block/features/overline/default.test.jsx
+++ b/blocks/overline-block/features/overline/default.test.jsx
@@ -6,6 +6,7 @@ import Overline from './default';
 const mockContextObj = {
   arcSite: 'site',
   globalContent: {
+    _id: '12345',
     websites: {
       site: {
         website_section: {
@@ -24,7 +25,7 @@ jest.mock('fusion:context', () => ({
 
 jest.mock('fusion:content', () => ({
   useEditableContent: jest.fn(() => ({
-    editableContent: {},
+    editableContent: jest.fn(() => {}),
   })),
 }));
 
@@ -52,6 +53,34 @@ describe('overline feature for default output type', () => {
       const wrapper = shallow(<Overline />);
 
       expect(wrapper.at(0).prop('href')).toStrictEqual('/news/');
+    });
+
+    it('should render only text if label do not have url', () => {
+      const mockStory = {
+        arcSite: 'site',
+        globalContent: {
+          _id: '123456',
+          label: {
+            basic: {
+              display: true,
+              text: 'label',
+            },
+          },
+          websites: {
+            site: {
+              website_section: {
+                _id: '/mock/',
+                name: 'Mock',
+              },
+            },
+          },
+        },
+      };
+      useFusionContext.mockImplementation(() => mockStory);
+      const wrapper = mount(<Overline />);
+
+      expect(wrapper.find('span')).toHaveClassName('overline');
+      expect(wrapper.find('span').text()).toEqual(mockStory.globalContent.label.basic.text);
     });
   });
 
@@ -188,6 +217,7 @@ describe('overline feature for default output type', () => {
       const mockTrailingSlash = {
         arcSite: 'site',
         globalContent: {
+          _id: '123456',
           websites: {
             site: {
               website_section: {
@@ -208,6 +238,7 @@ describe('overline feature for default output type', () => {
       const mockTrailingSlash = {
         arcSite: 'site',
         globalContent: {
+          _id: '123456',
           websites: {
             site: {
               website_section: {
@@ -228,6 +259,7 @@ describe('overline feature for default output type', () => {
       const mockTrailingSlash = {
         arcSite: 'site',
         globalContent: {
+          _id: '123456',
           websites: {
             site: {
               website_section: {
@@ -248,6 +280,7 @@ describe('overline feature for default output type', () => {
       const mockTrailingSlash = {
         arcSite: 'site',
         globalContent: {
+          _id: '123456',
           websites: {
             site: {
               website_section: {
@@ -262,6 +295,92 @@ describe('overline feature for default output type', () => {
       const wrapper = shallow(<Overline />);
 
       expect(wrapper.at(0).prop('href')).toStrictEqual('/test/page#section');
+    });
+  });
+
+  describe('when custom values are send throw param must be used instead of globalContent', () => {
+    it('should render an anchor with correct values', () => {
+      const wrapper = mount(<Overline customText="hello" customUrl="http://example.com" />);
+
+      expect(wrapper.find('a')).toHaveClassName('overline');
+      expect(wrapper.find('a').text()).toEqual('hello');
+      expect(wrapper.find('a').prop('href')).toEqual('http://example.com/');
+    });
+  });
+
+  describe('when a story is send throw param must be used instead of globalContent', () => {
+    it('should render an anchor with correct values', () => {
+      const mockStory = {
+        _id: '123456',
+        websites: {
+          site: {
+            website_section: {
+              _id: '/mock/',
+              name: 'Mock',
+            },
+          },
+        },
+      };
+      useFusionContext.mockImplementation(() => mockContextObj);
+      const wrapper = mount(<Overline story={mockStory} />);
+
+      expect(wrapper.find('a')).toHaveClassName('overline');
+      expect(wrapper.find('a').text()).toEqual('Mock');
+      expect(wrapper.find('a').prop('href')).toEqual('/mock/');
+    });
+
+    it('should render an anchor using the label values if exists', () => {
+      const mockStory = {
+        _id: '123456',
+        label: {
+          basic: {
+            display: true,
+            url: 'http://label_url',
+            text: 'label',
+          },
+        },
+        websites: {
+          site: {
+            website_section: {
+              _id: '/mock/',
+              name: 'Mock',
+            },
+          },
+        },
+      };
+      useFusionContext.mockImplementation(() => mockContextObj);
+      const wrapper = mount(<Overline story={mockStory} />);
+
+      expect(wrapper.find('a')).toHaveClassName('overline');
+      expect(wrapper.find('a').text()).toEqual(mockStory.label.basic.text);
+      expect(wrapper.find('a').prop('href')).toEqual(`${mockStory.label.basic.url}/`);
+    });
+
+    it('should render an anchor using the story values if label display is false', () => {
+      const mockStory = {
+        _id: '123456',
+        label: {
+          basic: {
+            display: false,
+            url: 'http://label_url',
+            text: 'label',
+          },
+        },
+        websites: {
+          site: {
+            website_section: {
+              _id: '/mock/',
+              name: 'Mock',
+            },
+          },
+        },
+      };
+      useFusionContext.mockImplementation(() => mockContextObj);
+      const wrapper = mount(<Overline story={mockStory} />);
+
+      expect(wrapper.find('a')).toHaveClassName('overline');
+      expect(wrapper.find('a').text()).toEqual(mockStory.websites.site.website_section.name);
+      expect(wrapper.find('a').prop('href')).toEqual(mockStory.websites.site.website_section._id);
     });
   });
 });


### PR DESCRIPTION
## Description
Updated `overline-block` to support editable content inside page builder and updated `top-table-list-block` XL and L blocks.

## Jira Ticket
- [PEN-1386](https://arcpublishing.atlassian.net/browse/PEN-1386)

## Acceptance Criteria
When I overwrite the Overline field in an XL or L Promo Block, this field should persist until it is edited.

## Test Steps
- on a Top-Table-List-block pick the story displayed as Extra Large promo block
- try to edit it inside PageBuilder
- after change the text, click outside the edit block and the content must persist
- reload the page, and the content must persis

## Effect Of Changes

### After

<img width="944" alt=" 2020-11-02-18 21 07" src="https://user-images.githubusercontent.com/9757/97920431-35a03d00-1d38-11eb-818d-6b2a16f952df.png">

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
