### PR TITLE
Pen 861 comscore integration

### DIFF
--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -298,3 +298,41 @@ describe('chartbeat render conditions', () => {
     expect(wrapper.find('script[data-integration="chartbeat"]').length).toBe(1);
   });
 });
+
+describe('comscore render conditions', () => {
+  beforeAll(() => {
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({
+        globalContent: {},
+        arcSite: 'the-sun',
+      })),
+    }));
+
+    jest.mock('react-dom/server', () => ({
+      renderToString: jest.fn().mockReturnValue('<meta />'),
+    }));
+  });
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  it('must not render comscore code when property is missing', () => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+
+    const { default: DefaultOutputType } = require('../default');
+    const wrapper = shallow(<DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} />);
+    expect(wrapper.find('script[data-integration="comscore"]').length).toBe(0);
+    expect(wrapper.find('noscript[data-integration="comscore"]').length).toBe(0);
+  });
+
+  it('must render comscore code when comscoreID site property is present', () => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({
+      comscoreID: 88776655,
+    }))));
+
+    const { default: DefaultOutputType } = require('../default');
+    const wrapper = shallow(<DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} />);
+    expect(wrapper.find('script[data-integration="comscore"]').length).toBe(1);
+    expect(wrapper.find('noscript[data-integration="comscore"]').length).toBe(1);
+  });
+});

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -38,6 +38,36 @@ const chartBeatCode = (accountId, domain) => {
   `;
 };
 
+const comscoreScript = (accountId) => {
+  if (!accountId) {
+    return null;
+  }
+  const scriptCode = `
+    var _comscore = _comscore || [];
+    _comscore.push({ c1: "2", c2: "${accountId}" });
+    (function() {
+      var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+      s.src = (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js";
+      el.parentNode.insertBefore(s, el);
+    })();
+  `;
+
+  return (
+    <script data-integration="comscore" dangerouslySetInnerHTML={{ __html: scriptCode }} />
+  );
+};
+
+const comscoreNoScript = (accountId) => {
+  if (!accountId) {
+    return null;
+  }
+  return (
+    <noscript data-integration="comscore">
+      <img alt="comscore" src={`http://b.scorecardresearch.com/p?c1=2&c2=${accountId}&cv=2.0&cj=1`} />
+    </noscript>
+  );
+};
+
 const SampleOutputType = ({
   children,
   contextPath,
@@ -62,6 +92,7 @@ const SampleOutputType = ({
     facebookAdmins,
     chartBeatAccountId,
     chartBeatDomain,
+    comscoreID,
   } = getProperties(arcSite);
 
   const googleFonts = () => {
@@ -159,8 +190,10 @@ const SampleOutputType = ({
         <link rel="preload" as="script" href={powaDrive} />
         {googleFonts()}
         {chartBeat && <script data-integration="chartbeat" dangerouslySetInnerHTML={{ __html: chartBeat }} /> }
+        {comscoreScript(comscoreID)}
       </head>
       <body>
+        {comscoreNoScript(comscoreID)}
         {gtmID
           ? (
             <noscript>

--- a/blocks/small-promo-block/features/small-promo/_children/__snapshots__/promo_image.test.jsx.snap
+++ b/blocks/small-promo-block/features/small-promo/_children/__snapshots__/promo_image.test.jsx.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`PromoImage render placeholder image while imageUrl is empty 1`] = `""`;


### PR DESCRIPTION
## Description
Added Comscore script integration

## Jira Ticket
- [PEN-861](https://arcpublishing.atlassian.net/browse/PEN-861)

## Acceptance Criteria
- A new Theme Setting comscoreID is created. If this value is present for a given website, then the Comscore tag should be placed in the <head> of all pages on that website. 
- The value of comscoreID should be plugged into the tag as described above
- If comscoreID is not present for a given website, then the Comscore tag should not be included on pages on that website. 

## Test Steps
Once it’s deployed to Core Components, check in the Network tab on pages for The Sun and Dagen to verify that the call goes out to Comscore. You can filter for `scorecard` – then check that the given ID matches the value sent in. 
Next, validate that on a website that does not have a Comscore ID set (e.g. The Gazette website), no Comscore tag is included on the page
Next, disable javascript on the Developers tools config page, reload the page, and filter the request by `scorecard` and verify the pixel is loaded.


## Effect Of Changes
### Before
nothing, is new

### After
html code
<img width="853" alt=" 2020-11-04-19 44 43" src="https://user-images.githubusercontent.com/9757/98177451-6cfa1f80-1ed9-11eb-9053-76d76aafcc95.png">

script request
<img width="1122" alt=" 2020-11-04-19 44 12" src="https://user-images.githubusercontent.com/9757/98177502-83a07680-1ed9-11eb-9e41-96e8937d057e.png">

pixel request, with javascript disabled
<img width="1064" alt=" 2020-11-04-19 43 34" src="https://user-images.githubusercontent.com/9757/98177548-a29f0880-1ed9-11eb-82ca-170df6130c6a.png">

## Dependencies or Side Effects
- need to setup `comscoreID` on blocks.json

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
