### PR TITLE
ci: Add test blocks feature on pr

### DIFF
--- a/.github/workflows/test-coverage-blocks.yml
+++ b/.github/workflows/test-coverage-blocks.yml
@@ -28,13 +28,13 @@ jobs:
 
       - name: Install dependencies if lockfile changed
         if: steps.cache.outputs.cache-hit != 'true'
-        run: npm install
+        run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 
       # Remove nested modules to prevent multiple react versions
       - name: Run tests with coverage
-        run: npx lerna clean -y && npm run test:coverage
+        run: npm run test:coverage
 
       - name: Check linting
         run: npm run lint

--- a/.github/workflows/test-coverage-blocks.yml
+++ b/.github/workflows/test-coverage-blocks.yml
@@ -32,7 +32,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 
-      # Remove nested modules to prevent multiple react versions
       - name: Run tests with coverage
         run: npm run test:coverage
 

--- a/.github/workflows/test-coverage-blocks.yml
+++ b/.github/workflows/test-coverage-blocks.yml
@@ -19,15 +19,15 @@ jobs:
           node-version: "12"
           registry-url: "https://npm.pkg.github.com"
 
-      - name: Cache NPM files
+      - name: Cache Node Modules
+        id: cache
         uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
 
-      - name: Install dependencies with clean slate
+      - name: Clean install (CI) dependencies if lockfile (above) changed
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/test-coverage-blocks.yml
+++ b/.github/workflows/test-coverage-blocks.yml
@@ -1,0 +1,40 @@
+name: Test News Theme Blocks
+
+on:
+  pull_request:
+    # synchronize	commit(s) pushed to the pull request
+    types: [synchronize, opened]
+
+jobs:
+  ensure_minimum_test_coverage_linting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node with 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: Cache Node Modules
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies if lockfile changed
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+
+      # Remove nested modules to prevent multiple react versions
+      - name: Run tests with coverage
+        run: npx lerna clean -y && npm run test:coverage
+
+      - name: Check linting
+        run: npm run lint

--- a/.github/workflows/test-coverage-blocks.yml
+++ b/.github/workflows/test-coverage-blocks.yml
@@ -19,15 +19,15 @@ jobs:
           node-version: "12"
           registry-url: "https://npm.pkg.github.com"
 
-      - name: Cache Node Modules
-        id: cache
+      - name: Cache NPM files
         uses: actions/cache@v2
         with:
-          path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
-      - name: Install dependencies if lockfile changed
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Install dependencies with clean slate
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/test-coverage-blocks.yml
+++ b/.github/workflows/test-coverage-blocks.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   ensure_minimum_test_coverage_linting:
     runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
     steps:
       - name: Checkout repo
@@ -37,3 +39,9 @@ jobs:
 
       - name: Check linting
         run: npm run lint
+
+      - name: Check failure status
+        uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+        if: failure()

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -1,0 +1,5 @@
+// adding test so it's included in test coverage
+// https://github.com/WPMedia/fusion-news-theme-blocks/issues/426
+describe('lead art', () => {
+  xit('has a test', () => {});
+});

--- a/blocks/placeholder-image-block/features/placeholder-image/default.test.jsx
+++ b/blocks/placeholder-image-block/features/placeholder-image/default.test.jsx
@@ -1,0 +1,5 @@
+// adding test so it's included in test coverage
+
+describe('place holder image block', () => {
+  xit('has a test', () => {});
+});

--- a/blocks/video-player-block/features/video-player/default.test.jsx
+++ b/blocks/video-player-block/features/video-player/default.test.jsx
@@ -1,0 +1,5 @@
+// adding test so it's included in test coverage
+
+describe('video player', () => {
+  xit('has a test', () => {});
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,14 +12,14 @@ module.exports = {
   coverageDirectory: '<rootDir>/coverage',
   coverageThreshold: {
     global: {
-      statements: 88,
-      branches: 88,
-      functions: 87,
-      lines: 88,
+      statements: 85,
+      branches: 85,
+      functions: 85,
+      lines: 85,
     },
     // if an output type breaks, the page doesn't load
     // this should be higher, really
-    'default-output-block': {
+    'default-output-block/output-types': {
       statements: 86,
       branches: 80,
       functions: 100,

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,8 +8,17 @@ module.exports = {
   coverageDirectory: '<rootDir>/coverage',
   coverageThreshold: {
     global: {
-      branches: 85,
-      functions: 85,
+      statements: 88,
+      branches: 88,
+      functions: 87,
+      lines: 88,
+    },
+    // if an output type breaks, the page doesn't load
+    // this should be higher, really
+    'default-output-block': {
+      statements: 86,
+      branches: 80,
+      functions: 100,
       lines: 85,
     },
   },
@@ -18,5 +27,6 @@ module.exports = {
     '!**/node_modules/**',
     '!**/vendor/**',
     '!**/images/*.svg',
+    '!**/mock*.js',
   ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,8 @@
 module.exports = {
+  transformIgnorePatterns: [
+    '//node_modules/(?!@wpmedia/.*-block).*/',
+    '//node_modules/(?!(@wpmedia)).*/',
+  ],
   projects: [
     '<rootDir>/blocks/*/jest.config.js',
     // '<rootDir>/components/*/jest.config.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
     },
     // if an output type breaks, the page doesn't load
     // this should be higher, really
-    'default-output-block/output-types': {
+    'blocks/default-output-block/output-types': {
       statements: 86,
       branches: 80,
       functions: 100,

--- a/package.json
+++ b/package.json
@@ -144,12 +144,6 @@
     "@wpmedia/video-player-block": "file:blocks/video-player-block",
     "@wpmedia/video-promo-block": "file:blocks/video-promo-block"
   },
-  "jest": {
-    "transformIgnorePatterns": [
-      "//node_modules/(?!@wpmedia/.*-block).*/",
-      "//node_modules/(?!(@wpmedia)).*/"
-    ]
-  },
   "browserslist": [
     "defaults"
   ]


### PR DESCRIPTION
## Description
Test coverage and linting on pr 

## Jira Ticket
- [PEN-1339](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=545&projectKey=PEN&modal=detail&selectedIssue=PEN-1370&assignee=5e387d6a1b1d910e5dfd7a9b-)

## Acceptance Criteria
Run tests with coverage https://github.com/WPMedia/fusion-news-theme-blocks/blob/stable/package.json#L22

there are already github actions that you can base your implementation off of https://github.com/WPMedia/fusion-news-theme-blocks/actions?query=workflow%3A"Canary+block"

the tests should also be seen in the prs against these branches as well as a check

if all the tests do not pass, the pr should not be able to be merged 

additionally, if the tests do not pass, the publish action should not happen on push to canary and stable branches

Make sure you run npm i not `npx lerna bootstrap -y` because the tests rely on top-level node modules. You will get a rule of hooks error if there are nested dependencies

You may need to use secrets in github ui to run the github actions for npm i

make sure the minimum coverage check command is run as well https://github.com/WPMedia/fusion-news-theme-blocks/blob/stable/package.json#L22

the packages should not be published if the coverage check doesn’t pass

the pr should not be able to merged without the coverage check

## Test Steps
- Make sure tests pass on this branch (meta, right?)

