### PR TITLE
remove warnings from tests

### DIFF
--- a/blocks/numbered-list-block/features/numbered-list/default.test.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.test.jsx
@@ -10,18 +10,12 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
 }));
 const { default: mockData } = require('./mock-data');
 
-jest.mock('fusion:themes', () => jest.fn(() => ({})));
-
-jest.mock('styled-components', () => ({
-  p: jest.fn(),
-  h2: jest.fn(),
-}));
-
-jest.mock('prop-types', () => ({
-  shape: jest.fn(),
-  contentConfig: jest.fn(),
-  customFields: jest.fn(),
-}));
+jest.mock('fusion:themes', () => (
+  () => ({
+    'primary-font-family': 'fontPrimary',
+    'secondary-font-family': 'fontSecondary',
+  })
+));
 
 describe('The numbered-list-block', () => {
   describe('render a list of numbered-list-items', () => {


### PR DESCRIPTION
## Description
removed warnings from default-output-block tests

## Effect Of Changes
### Before
lots and lots of 
<img width="1272" alt=" 2020-11-05-21 24 32" src="https://user-images.githubusercontent.com/9757/98312057-a43b0000-1faf-11eb-9048-fc9b74a2c45b.png">

### After
none !

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
