### PR TITLE
PEN-1450 - removed title markup if value is missing

### DIFF
--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -114,9 +114,12 @@ const SimpleList = (props) => {
 
   return (
     <div key={id} className="list-container layout-section">
-      <Title className="list-title" primaryFont={primaryFont}>
-        {title}
-      </Title>
+      { title
+        && (
+        <Title className="list-title" primaryFont={primaryFont}>
+          {title}
+        </Title>
+        )}
       {
         contentElements.reduce(unserializeStory(arcSite), []).map(({
           id: listItemId, itemTitle, imageURL, websiteURL, resizedImageOptions,

--- a/blocks/simple-list-block/features/simple-list/default.test.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.test.jsx
@@ -125,7 +125,7 @@ describe('Simple list', () => {
     }));
     const wrapper = mount(<SimpleList deployment={jest.fn((path) => path)} />);
 
-    expect(wrapper.find('h2.list-title').text()).toBe('');
+    expect(wrapper.find('h2.list-title').length).toBe(0);
   });
   it('should fetch an array of data when content service is provided', () => {
     const { default: SimpleList } = require('./default.jsx');


### PR DESCRIPTION
## Description
removed title markup if value is missing

## Jira Ticket
- [PEN-1450](https://arcpublishing.atlassian.net/browse/PEN-1450)

## Acceptance Criteria
There should be no white space above the simple list block when the title custom field is not provided. In the screenshot above, the top picture in the card list and simple list should be aligned.

## Test Steps
- add a double chain to a page, as the first column a card-list-block and to the right a simple list
- the image from the simple-list must be top aligned with the image from the card-list
- add a title to the simple-list from the custom fields, and not the title must be top aligned with the image on the card-list
- remove the title, and the simple-list image will be again top aligned with the card-list

## Effect Of Changes
### Before
<img width="853" alt=" 2020-11-06-13 34 03" src="https://user-images.githubusercontent.com/9757/98409486-b8373e00-2051-11eb-9fd6-a5840ef9f17a.png">

### After
<img width="888" alt=" 2020-11-06-13 34 35" src="https://user-images.githubusercontent.com/9757/98409496-bec5b580-2051-11eb-9099-c2794836d4f5.png">
<img width="863" alt=" 2020-11-06-13 35 18" src="https://user-images.githubusercontent.com/9757/98409501-c2593c80-2051-11eb-98bb-9b2a459dacad.png">

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
