### PR TITLE
PEN-1508 remove display customField

### DIFF
--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -58,8 +58,10 @@ const ArcAd = (props) => {
   }, [registerAd, isAdmin]);
 
   const {
-    id, adClass, adType, dimensions, slotName, display,
+    id, adClass, adType, dimensions, slotName,
   } = config;
+
+  const display = adType === 'right_rail_cube' ? 'desktop' : 'all';
 
   return (
     <div
@@ -101,19 +103,6 @@ ArcAd.propTypes = {
       labels: adTypeLabels,
       defaultValue: '1x1px',
       required: true,
-      hidden: false,
-    }),
-    display: PropTypes.oneOf([
-      'all', 'mobile', 'desktop',
-    ]).tag({
-      name: 'Display',
-      labels: {
-        all: 'All',
-        mobile: 'Mobile',
-        desktop: 'Desktop',
-      },
-      defaultValue: 'all',
-      required: false,
       hidden: false,
     }),
     displayAdLabel: PropTypes.boolean.tag({

--- a/blocks/ads-block/features/ads/default.test.jsx
+++ b/blocks/ads-block/features/ads/default.test.jsx
@@ -20,7 +20,6 @@ const AD_PROPS_MOCK = {
   id: '0fPdGkcOqEoaWyN',
   customFields: {
     adType: '300x250',
-    display: 'all',
     displayAdLabel: true,
   },
   displayProperties: {},
@@ -70,5 +69,17 @@ describe('<ArcAd>', () => {
   it('renders advertisement label when enabled', () => {
     const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
     expect(wrapper.find('div.advertisement-label')).toHaveLength(1);
+  });
+
+  it('should use "all" on wrapper for advertisement label', () => {
+    const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
+    expect(wrapper.find('div.advertisement-label--all')).toHaveLength(1);
+  });
+
+  it('should use "desktop" on wrapper for advertisement right_rail_cube', () => {
+    const mockData = { ...AD_PROPS_MOCK };
+    mockData.customFields.adType = '300x250|300x600_rightrail';
+    const wrapper = shallow(<ArcAd {...mockData} />);
+    expect(wrapper.find('div.advertisement-label--desktop')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Description
removed display customField and update Advertisement label logic

## Jira Ticket
- [PEN-1508](https://arcpublishing.atlassian.net/browse/PEN-1508)

## Acceptance Criteria
- Remove the Display custom field from the Google Ad block
  - Within the code, we may still use this because Arc Ads require it – all of the ads should be set to All except for Right Rail Cube, which should be set to Desktop – per Vinnie Olsen 

## Test Steps
- add a new Ad block, pick any ad type except Right Rail Cube, publish the page and check the local rendered page (outside PB)
- verify the advertisement label has the wrapper class `advertisement-label--all`
- change the Ad block to `Right Rail Cube`, publish and check the local rendered page
- verify the advertisement label has the wrapper class `advertisement-label--desktop`

## Effect Of Changes
### Before
<img width="305" alt="Screen Shot 2020-11-10 at 11 39 20 AM" src="https://user-images.githubusercontent.com/9757/98865792-b357fd00-244a-11eb-8e7c-c1e6c4b5a785.png">

### After
<img width="287" alt=" 2020-11-11-17 27 41" src="https://user-images.githubusercontent.com/9757/98865749-a3401d80-244a-11eb-9633-2533fce5c685.png">

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
