### PR TITLE
PEN-1497: lead art video autoplay option

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -46,6 +46,15 @@ class LeadArt extends Component {
     };
 
     this.imgRef = React.createRef();
+    this.setIsOpenToFalse = this.setIsOpenToFalse.bind(this);
+  }
+
+  setIsOpenToFalse() {
+    this.setState({ isOpen: false });
+  }
+
+  setIsOpenToTrue() {
+    this.setState({ isOpen: true });
   }
 
   lightboxImgHandler() {
@@ -83,8 +92,8 @@ class LeadArt extends Component {
               {isOpen && (
                 <Lightbox
                   mainSrc={mainContent}
-                  onCloseRequest={() => this.setState({ isOpen: false })}
-                  showImageCaption="false"
+                  onCloseRequest={this.setIsOpenToFalse}
+                  showImageCaption={false}
                   enableZoom={enableZoom}
                 />
               )}
@@ -102,7 +111,7 @@ class LeadArt extends Component {
           </LeadArtWrapperDiv>
         );
       } if (lead_art.type === 'video') {
-        return <VideoPlayer embedMarkup={lead_art.embed_html} />;
+        return <VideoPlayer embedMarkup={lead_art.embed_html} enableAutoplay />;
       } if (lead_art.type === 'image') {
         if (buttonPosition !== 'hidden') {
           lightbox = (
@@ -110,7 +119,7 @@ class LeadArt extends Component {
               {isOpen && (
                 <Lightbox
                   mainSrc={this.lightboxImgHandler()}
-                  onCloseRequest={() => this.setState({ isOpen: false })}
+                  onCloseRequest={this.setIsOpenToFalse}
                   showImageCaption={showCredit}
                   imageCaption={lead_art.caption}
                   enableZoom={enableZoom}
@@ -136,7 +145,7 @@ class LeadArt extends Component {
             <button
               type="button"
               className="btn-full-screen"
-              onClick={() => this.setState({ isOpen: true })}
+              onClick={this.setIsOpenToTrue}
             >
               <FullscreenIcon width="100%" height="100%" fill="#6B6B6B" />
               {buttonLabel}
@@ -203,6 +212,11 @@ LeadArt.propTypes = {
     enableZoom: PropTypes.bool,
     showCredit: PropTypes.bool,
     inheritGlobalContent: PropTypes.bool,
+    enableAutoplay: PropTypes.bool.tag({
+      label: 'Autoplay',
+      defaultValue: false,
+      group: 'Video',
+    }),
   }),
 };
 

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -1,5 +1,282 @@
-// adding test so it's included in test coverage
-// https://github.com/WPMedia/fusion-news-theme-blocks/issues/426
-describe('lead art', () => {
-  xit('has a test', () => {});
+import getProperties from 'fusion:properties';
+import getThemeStyle from 'fusion:themes';
+import getTranslatedPhrases from 'fusion:intl';
+import { useAppContext } from 'fusion:context';
+import LeadArt from './default';
+
+const React = require('react');
+const { mount, shallow } = require('enzyme');
+
+describe('LeadArt', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    getThemeStyle.mockImplementation(() => (
+      {
+        'primary-font-family': 'Arial',
+      }));
+
+    getProperties.mockImplementation(() => (
+      { locale: [] }));
+  });
+
+  it('renders html lead art type', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'raw_html',
+        },
+      },
+    };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    expect(wrapper.find('.lead-art-wrapper').length).toEqual(1);
+  });
+
+  it('renders html lead art type lightbox if button pos is not hidden', () => {
+    const globalContent = {
+      promo_items: {
+        basic: {
+          type: 'raw_html',
+        },
+      },
+    };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    wrapper.setState({ buttonPosition: 'true', isOpen: true });
+    wrapper.update();
+    expect(wrapper.find('ReactImageLightbox').length).toEqual(1);
+  });
+
+  it('renders video lead art type', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'video',
+        },
+      },
+    };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    expect(wrapper.find('VideoPlayer').length).toEqual(1);
+  });
+
+  it('renders image type', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'image',
+        },
+      },
+    };
+
+    LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    expect(wrapper.find('ImageMetadata').length).toEqual(1);
+  });
+
+  it('renders gallery lead image type', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'gallery',
+          headlines: { basic: 'test headline' },
+        },
+      },
+    };
+
+    LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    expect(wrapper.find('Gallery').length).toEqual(1);
+  });
+
+  it('returns null if invalid lead art type', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'film',
+          headlines: { basic: 'test headline' },
+        },
+      },
+    };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    expect(wrapper).toEqual({});
+  });
+
+  it('returns null if no content promo items', () => {
+    const globalContent = { promo_items: null };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    expect(wrapper).toEqual({});
+  });
+
+  it('if raw html type has buttonPosition as hidden return null lightbox', () => {
+    const globalContent = {
+      promo_items: {
+        basic: {
+          type: 'raw_html',
+        },
+      },
+    };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    wrapper.setState({ buttonPosition: 'hidden', isOpen: true });
+    wrapper.update();
+    expect(wrapper.find('ReactImageLightbox').length).toEqual(0);
+  });
+
+  it('if image type has buttonPosition as hidden return null lightbox', () => {
+    const globalContent = {
+      promo_items: {
+        basic: {
+          type: 'image',
+        },
+      },
+    };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    wrapper.setState({ buttonPosition: 'hidden', isOpen: true });
+    wrapper.update();
+    expect(wrapper.find('ReactImageLightbox').length).toEqual(0);
+  });
+
+  it('uses english phrases if no locale available', () => {
+    getProperties.mockImplementation(() => (
+      { locale: undefined }));
+
+    getTranslatedPhrases.mockImplementation(() => (
+      {}));
+
+    const globalContent = {
+      promo_items: {
+        basic: {
+          type: 'raw_html',
+        },
+      },
+    };
+
+    // eslint-disable-next-line no-unused-vars
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    expect(getTranslatedPhrases).toHaveBeenLastCalledWith('en');
+    getTranslatedPhrases.mockReset();
+  });
+
+  it('uses translated gallery phrase if no custom field value provided', () => {
+    getTranslatedPhrases.mockImplementation(() => (
+      { t: jest.fn().mockReturnValue('gallery-expand') }));
+
+    const globalContent = {
+      promo_items: {
+        basic: {
+          type: 'raw_html',
+        },
+      },
+    };
+
+    const customFieldNullButton = { buttonLabel: null };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} customFields={customFieldNullButton} />);
+    expect(wrapper.state('buttonLabel')).toEqual('gallery-expand');
+    getTranslatedPhrases.mockReset();
+  });
+
+  it('creates lightbox', () => {
+    const globalContent = {
+      promo_items: {
+        basic: {
+          type: 'raw_html',
+        },
+      },
+    };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+
+    wrapper.instance().imgRef = { current: { querySelector: jest.fn().mockReturnValue({ dataset: { lightbox: 'testLightbox' } }) } };
+    const result = wrapper.instance().lightboxImgHandler();
+    expect(result).toEqual('testLightbox');
+  });
+
+  it(' lightbox returns empty string if no imgElm ', () => {
+    const globalContent = {
+      promo_items: {
+        basic: {
+          type: 'raw_html',
+        },
+      },
+    };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+
+    wrapper.instance().imgRef = { current: { querySelector: jest.fn().mockReturnValue(null) } };
+    const result = wrapper.instance().lightboxImgHandler();
+    expect(result).toEqual('');
+  });
+
+  it('raw html type returns styled component  LeadArtWrapperDiv', () => {
+    const globalContent = {
+      promo_items: {
+        basic: {
+          type: 'raw_html',
+        },
+      },
+    };
+
+    const wrapper = mount(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    expect(wrapper.find('StyledComponent').at(0).prop('className')).toEqual('lead-art-wrapper');
+    wrapper.unmount();
+  });
+
+  it('image type returns styled component  LeadArtWrapperFigure', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'image',
+        },
+      },
+    };
+
+    useAppContext.mockImplementation(() => (
+      {
+        arcSite: {},
+      }));
+
+    LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
+    const wrapper = mount(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    expect(wrapper.find('ImageMetadata').length).toEqual(1);
+    wrapper.unmount();
+  });
+
+  it('setIsOpenToFalse sets isOpen to false', () => {
+    const globalContent = {
+      promo_items: {
+        basic: {
+          type: 'raw_html',
+        },
+      },
+    };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    wrapper.instance().setIsOpenToFalse();
+    wrapper.update();
+    expect(wrapper.state('isOpen')).toBeFalsy();
+  });
+
+  it('setIsOpenToTrue sets isOpen to true', () => {
+    const globalContent = {
+      promo_items: {
+        basic: {
+          type: 'raw_html',
+        },
+      },
+    };
+
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    wrapper.instance().setIsOpenToTrue();
+    wrapper.update();
+    expect(wrapper.state('isOpen')).toBeTruthy();
+  });
 });

--- a/blocks/video-player-block/features/video-player/default.test.jsx
+++ b/blocks/video-player-block/features/video-player/default.test.jsx
@@ -1,5 +1,115 @@
-// adding test so it's included in test coverage
+import { useFusionContext } from 'fusion:context';
+import VideoPlayer from './default';
 
-describe('video player', () => {
-  xit('has a test', () => {});
+const React = require('react');
+const { mount, shallow } = require('enzyme');
+
+jest.mock('fusion:content', () => ({
+  useContent: jest.fn(() => ({})),
+}));
+
+describe('VideoPlayer', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    useFusionContext.mockImplementation(() => (
+      { id: '12345' }));
+  });
+
+  it('renders ', () => {
+    const wrapper = shallow(<VideoPlayer />);
+    expect(wrapper.find('.embed-video').length).toEqual(1);
+  });
+
+  it('if inheritGlobalContent do not fetch data and use gc ', () => {
+    const testEmbed = '<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943"'
+    + ' data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943"'
+    + ' data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/'
+    + 'prod/powaBoot.js?org=corecomponents"></script></div>';
+
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'raw_html',
+        },
+      },
+      embed_html: testEmbed,
+    };
+
+    useFusionContext.mockImplementation(() => (
+      {
+        id: '12345',
+        globalContent,
+      }));
+
+    const getElementMock = jest.fn();
+    getElementMock.mockReturnValue({ firstElementChild: {} });
+    document.getElementById = getElementMock;
+
+    const customFields = { inheritGlobalContent: true };
+    const wrapper = mount(<VideoPlayer customFields={customFields} />);
+
+    const expectedEmbed = {
+      __html: '<div class="powa" id="powa-e924e51b-db94-492e-8346-02283'
+    + 'a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346'
+    + '-02283a126943" data-aspect-ratio="0.562" data-api="prod"><!--script src="//d2w3jw6424abwq'
+    + '.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script--></div>',
+    };
+    expect(wrapper.find('#video-12345').prop('dangerouslySetInnerHTML')).toEqual(expectedEmbed);
+  });
+
+  it('if inheritGlobalContent is FALSE use markup passed as prop ', () => {
+    const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
+    + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
+    + 'src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
+
+    useFusionContext.mockImplementation(() => (
+      { id: '12345' }));
+
+    const getElementMock = jest.fn();
+    getElementMock.mockReturnValue({ firstElementChild: {} });
+    document.getElementById = getElementMock;
+
+    const customFields = { inheritGlobalContent: false };
+    const wrapper = mount(<VideoPlayer customFields={customFields} embedMarkup={testEmbed} />);
+
+    const expectedEmbed = {
+      __html: '<div class="powa" id="powa-e924" data-org="corecomponents"'
+      + ' data-env="prod" data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod">'
+      + '<!--script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents">'
+      + '</script--></div>',
+    };
+    expect(wrapper.find('#video-12345').prop('dangerouslySetInnerHTML')).toEqual(expectedEmbed);
+  });
+
+  it('if autplay is enabled, add autoplay props ', () => {
+    const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
+    + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
+    + 'src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
+
+    useFusionContext.mockImplementation(() => (
+      { id: '12345' }));
+
+    const getElementMock = jest.fn();
+    getElementMock.mockReturnValue({ firstElementChild: {} });
+    document.getElementById = getElementMock;
+
+    const customFields = { inheritGlobalContent: false };
+    const wrapper = mount(<VideoPlayer
+      customFields={customFields}
+      embedMarkup={testEmbed}
+      enableAutoplay
+    />);
+
+    const expectedEmbed = {
+      __html: '<div class="powa"  data-autoplay=true data-muted=true'
+      + ' id="powa-e924" data-org="corecomponents" data-env="prod" data-uuid="e924e51b" '
+      + 'data-aspect-ratio="0.562" data-api="prod"><!--script src="//d2w3jw6424abwq.cloud'
+      + 'front.net/prod/powaBoot.js?org=corecomponents"></script--></div>',
+    };
+    expect(wrapper.find('#video-12345').prop('dangerouslySetInnerHTML')).toEqual(expectedEmbed);
+  });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
   },
   collectCoverageFrom: [
     '**/(features|chains|layouts|sources|output-types)/**/*.{js,jsx}',
+    // for resizer image block
     '**/extractImageFromStory.js',
     '**/imageRatioCustomField.js',
     '**/ratioFor.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,9 @@ module.exports = {
   },
   collectCoverageFrom: [
     '**/(features|chains|layouts|sources|output-types)/**/*.{js,jsx}',
+    '**/extractImageFromStory.js',
+    '**/imageRatioCustomField.js',
+    '**/ratioFor.js',
     '!**/node_modules/**',
     '!**/vendor/**',
     '!**/images/*.svg',


### PR DESCRIPTION
## Description
Added option in lead art block for editor to select video auto play option - if selected and the lead art is a video, the video will auto-play. Wrote tests for lead art and video player blocks.

## Jira Ticket
- [PEN-1497](https://arcpublishing.atlassian.net/browse/PEN-1497)

## Acceptance Criteria
A new Custom Field is introduced to the Lead Art Block called Autoplay under a group named Video

Default behavior is autoplay: disabled (including for Lead Art Blocks already placed on PB pages/templates) and customers can choose to enable it on a per-block basis in PageBuilder. 

If autoplay is enabled, video autoplays, but is always muted by default.

Tests and documentation are updated to cover this functionality



## Test Steps
Add a lead art block to a page (with video as lead art) Verify that the enable autoplay custom field option is present. Verify that when the enable autoplay option is selected, that the lead art video auto-plays on page load.

## Effect Of Changes
### Before
no auto play option is. available, lead art video must be clicked to play.


### After
Lead art autoplay option is available, when autoplay is selected, the lead art video plays on page load.

<img width="1151" alt="Screen Shot 2020-11-09 at 2 01 50 PM" src="https://user-images.githubusercontent.com/2664083/98970033-7db02400-24dd-11eb-8c22-75c27c46fe85.png">
<img width="1243" alt="Screen Shot 2020-11-09 at 2 02 25 PM" src="https://user-images.githubusercontent.com/2664083/98970054-8274d800-24dd-11eb-92a1-5e9f6fb29045.png">


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ x] Confirmed all the test steps above are working
- [x ] Confirmed there are no linter errors (no new js lint warnings/errors, js style lint error/warnings have not increased)
- [x ] Confirmed this PR has reasonable code coverage
  - [ x] Confirmed this PR has unit test files
  - [ x] Ran `npm test`, made sure all tests are passing
  - [x ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ x] Confirmed relevant documentation has been updated/added.
