### PR TITLE
PEN-1497: bug fix for embed_html from null fetched data

### DIFF
--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -30,7 +30,8 @@ const VideoPlayer = (props) => {
 
   // In all other scenarios, fetch from the provided url and content api
   const fetchSource = doFetch ? 'content-api' : null;
-  const { embed_html: fetchedEmbedMarkup = '' } = useContent({
+  // const { embed_html: fetchedEmbedMarkup = '' } =
+  const fetchedData = useContent({
     source: fetchSource,
     query: {
       website_url: websiteURL,
@@ -38,7 +39,7 @@ const VideoPlayer = (props) => {
     },
   });
 
-  embedHTML = doFetch ? fetchedEmbedMarkup : embedHTML;
+  embedHTML = doFetch ? fetchedData && fetchedData.embed_html : embedHTML;
 
   if (enableAutoplay && embedHTML) {
     const position = embedHTML.search('id=');
@@ -46,7 +47,7 @@ const VideoPlayer = (props) => {
   }
 
   // Make sure that the player does not render until after component is mounted
-  embedHTML = embedHTML.replace('<script', '<!--script')
+  embedHTML = embedHTML && embedHTML.replace('<script', '<!--script')
     .replace('script>', 'script-->');
 
   useEffect(() => {


### PR DESCRIPTION
## Description
react hook error violation was fixed so the useContent hook is not called conditionally (content source is updated depending on if embedMarkup is coming in as a prop or global content or not ).  But this means the the fetched data may be null but the code still tries to access embed_html from a null object which throws errors and interferes with the rendering and playing of the video. Code hardening was added to check that the fetched data object is not null before trying to access parameters within it.  

## Jira Ticket
- [PEN-1497](https://arcpublishing.atlassian.net/browse/PEN-1497)

## Acceptance Criteria
The video should be visible and playable. Changes should reflect the original changes made for this ticket regarding enabling autoplay.



## Test Steps
Visit sites that has a video Lead Art Block, for example story: 
Z5YKJWNJ4JHMBJG7AM3UDT6NAE
 https://corecomponents.arcpublishing.com/pf/local/2020/01/14/these-fish-tacos-channel-the-best-beach-vacation-vibes/?_website=the-gazette


Verify that the custom field for autoplay can be turned on/off to control if the video autoplays or not upon page load.  In all cases, the video should be successfully shown and playable (either via a click or autoplay)

## Effect Of Changes
### Before
Autoplay can be specified in the lead art block custom fields, but the video may not render/play.  In addition, a console log error is seen:

<img width="1277" alt="Screen Shot 2020-11-17 at 1 54 49 PM" src="https://user-images.githubusercontent.com/2664083/99434215-85f0d080-28dc-11eb-9883-3c8d1cd43512.png">



### After
Video is shown and playable for all cases of autoplay on/off:
<img width="1233" alt="Screen Shot 2020-11-17 at 1 21 28 PM" src="https://user-images.githubusercontent.com/2664083/99434257-9143fc00-28dc-11eb-9f88-2aa265eb9811.png">


## Dependencies or Side Effects
NA

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x ] Confirmed all the test steps above are working
- [x ] Confirmed there are no linter errors
- [x ] Confirmed this PR has reasonable code coverage
  - [x ] Confirmed this PR has unit test files
  - [x ] Ran `npm test`, made sure all tests are passing
  - [x ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x ] Confirmed relevant documentation has been updated/added.
