### PR TITLE
PEN-1494 updated advertisement label

### DIFF
--- a/blocks/ads-block/features/ads/ads.scss
+++ b/blocks/ads-block/features/ads/ads.scss
@@ -2,6 +2,7 @@
   color: $ui-medium-gray;
   font-size: calculateRem(12px);
   line-height: calculateRem(16px);
+  white-space: nowrap;
 
   &--mobile {
     @media only screen and (min-width: map-get($grid-breakpoints, md)) {

--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -70,9 +70,10 @@ const ArcAd = (props) => {
     >
       <div className="arcad_container">
         {!isAdmin && displayAdLabel && !isAMP() && (
-          <div className={`advertisement-label advertisement-label--${display}`}>
-            {siteVars.advertisementLabel || 'ADVERTISEMENT'}
-          </div>
+          <div
+            className={`advertisement-label advertisement-label--${display}`}
+            dangerouslySetInnerHTML={{ __html: siteVars.advertisementLabel || 'ADVERTISEMENT' }}
+          />
         )}
         {!isAdmin && !isAMP() && (
           <div id={id} className={`arcad ad-${adClass}`} />

--- a/blocks/ads-block/features/ads/default.test.jsx
+++ b/blocks/ads-block/features/ads/default.test.jsx
@@ -71,6 +71,12 @@ describe('<ArcAd>', () => {
     expect(wrapper.find('div.advertisement-label')).toHaveLength(1);
   });
 
+  it('renders the label with text ADVERTISEMENT when advertisementLabel property is missing', () => {
+    const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
+    /* eslint-disable-next-line no-underscore-dangle */
+    expect(wrapper.find('div.advertisement-label').prop('dangerouslySetInnerHTML').__html).toEqual('ADVERTISEMENT');
+  });
+
   it('should use "all" on wrapper for advertisement label', () => {
     const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
     expect(wrapper.find('div.advertisement-label--all')).toHaveLength(1);
@@ -81,5 +87,25 @@ describe('<ArcAd>', () => {
     mockData.customFields.adType = '300x250|300x600_rightrail';
     const wrapper = shallow(<ArcAd {...mockData} />);
     expect(wrapper.find('div.advertisement-label--desktop')).toHaveLength(1);
+  });
+});
+
+describe('ArcAd with custom advertisement label', () => {
+  const customLabel = {
+    advertisementLabel: "Advertisement / <a href='http://example.com' target='_blank'>Advertisement</a>",
+  };
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getProperties.mockReturnValue({ ...SITE_PROPS_MOCK, ...customLabel });
+    useFusionContext.mockReturnValue({ isAdmin: false });
+    useAppContext.mockReturnValue({});
+  });
+
+  it('renders the label using advertisementLabel property when present', () => {
+    const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
+    expect(
+      /* eslint-disable-next-line no-underscore-dangle */
+      wrapper.find('div.advertisement-label').prop('dangerouslySetInnerHTML').__html,
+    ).toEqual(customLabel.advertisementLabel);
   });
 });


### PR DESCRIPTION
## Description
updated advertisement label with a Themes property if is present

## Jira Ticket
- [PEN-1494](https://arcpublishing.atlassian.net/browse/PEN-1494)

## Acceptance Criteria
- A new Theme Setting called advertisementLabel is created. 
- If this setting is present for a given website, then the string contained in that setting should be used in place of ADVERTISEMENT above ads in the Google Ad Block
- This setting should allow for hyperlinks 
- If this setting is not present for a given website, then the fallback text ADVERTISEMENT should be used 
- Tests and documentation are updated to cover this functionality 

## Test Steps

- Add this new Advertisement Text Theme Setting to a website in the Fusion-News-Theme repo: 
- `Advertisement / <a href="https://www.washingtonpost.com/mediakit/">Advertise with us</a></p>`
- Verify that for this website, the string appearing above ads matches this ^ exactly
- Verify that for all other websites, the fallback string (ADVERTISEMENT) is used 

## Effect Of Changes
### Before
<img width="786" alt=" 2020-11-17-18 33 49" src="https://user-images.githubusercontent.com/9757/99456309-f4975380-2907-11eb-8957-1863b88659d5.png">

### After
<img width="796" alt=" 2020-11-17-18 31 48" src="https://user-images.githubusercontent.com/9757/99456275-e6e1ce00-2907-11eb-8793-efd5005b6969.png">

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
