### PR TITLE
Hotfix image compression opt out

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -73,12 +73,7 @@ function parseArticleItem(item, index, arcSite, phrases) {
             resizerURL={getProperties(arcSite)?.resizerURL}
           />
           <figcaption>
-            <Image
-              compressedThumborParamsMetadata
-              subtitle={subtitle}
-              caption={caption}
-              credits={credits}
-            />
+            <ImageMetadata subtitle={subtitle} caption={caption} credits={credits} />
           </figcaption>
         </figure>
       ) : null;

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -59,6 +59,7 @@ function parseArticleItem(item, index, arcSite, phrases) {
       return (url && url.length > 0) ? (
         <figure key={key}>
           <Image
+            compressedThumborParams
             resizedImageOptions={resizedImageOptions}
             url={url}
             alt={altText}
@@ -72,7 +73,12 @@ function parseArticleItem(item, index, arcSite, phrases) {
             resizerURL={getProperties(arcSite)?.resizerURL}
           />
           <figcaption>
-            <ImageMetadata subtitle={subtitle} caption={caption} credits={credits} />
+            <Image
+              compressedThumborParamsMetadata
+              subtitle={subtitle}
+              caption={caption}
+              credits={credits}
+            />
           </figcaption>
         </figure>
       ) : null;

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -19,6 +19,8 @@ import Pullquote from './_children/pullquote';
 import Table from './_children/table';
 import './_articlebody.scss';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const StyledText = styled.p`
   a {
     color: ${(props) => props.primaryColor};
@@ -59,7 +61,7 @@ function parseArticleItem(item, index, arcSite, phrases) {
       return (url && url.length > 0) ? (
         <figure key={key}>
           <Image
-            compressedThumborParams
+            compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
             resizedImageOptions={resizedImageOptions}
             url={url}
             alt={altText}

--- a/blocks/author-bio-block/features/author-bio/default.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.jsx
@@ -30,6 +30,8 @@ import './author-bio.scss';
 Testing: Unit tests are written to cover this block
 */
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const AuthorBioStyled = styled.section`
   font-family: ${(props) => props.primaryFont};
 
@@ -57,7 +59,7 @@ const renderAuthorInfo = (author, arcSite) => {
     image && url
       ? (
         <Image
-          compressedThumborParams
+          compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
           url={url}
           alt={(altText || name)}
           smallWidth={84}

--- a/blocks/author-bio-block/features/author-bio/default.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.jsx
@@ -57,6 +57,7 @@ const renderAuthorInfo = (author, arcSite) => {
     image && url
       ? (
         <Image
+          compressedThumborParams
           url={url}
           alt={(altText || name)}
           smallWidth={84}

--- a/blocks/author-content-source-block/sources/author-api.js
+++ b/blocks/author-content-source-block/sources/author-api.js
@@ -8,10 +8,12 @@ export default {
     slug: 'text',
   },
   transform: (data, query) => {
+    const { isCompressedImageParams = false } = query;
+
     const authors = !data?.authors ? [] : data.authors.map((authorObject) => ({
       ...authorObject,
       // other options null use default functionality, such as filter quality
-      resized_params: authorObject.image ? getResizedImageData(authorObject.image, null, true, null, query['arc-site'], undefined, true) : {},
+      resized_params: authorObject.image ? getResizedImageData(authorObject.image, null, true, null, query['arc-site'], undefined, isCompressedImageParams) : {},
     }));
 
     return ({

--- a/blocks/author-content-source-block/sources/author-api.test.js
+++ b/blocks/author-content-source-block/sources/author-api.test.js
@@ -48,7 +48,8 @@ describe('the author api content source block', () => {
     });
 
     it('should return object with blank authors array', () => {
-      expect(contentSource.transform(null)).toEqual({ authors: [] });
+      // as far as I know we can always assume an empty obj for query
+      expect(contentSource.transform(null, {})).toEqual({ authors: [] });
     });
 
     it('should return author with resized params populated', () => {

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -43,6 +43,8 @@ const Title = styled.div`
   font-family: ${(props) => props.primaryFont};
 `;
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 @Consumer
 class CardList extends React.Component {
   constructor(props) {
@@ -143,7 +145,7 @@ class CardList extends React.Component {
                   {
                    extractImage(contentElements[0].promo_items) ? (
                      <Image
-                       compressedThumborParams
+                       compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                        url={extractImage(contentElements[0].promo_items)}
                        alt={contentElements[0].headlines.basic}
                        smallWidth={377}
@@ -158,7 +160,7 @@ class CardList extends React.Component {
                      />
                    ) : (
                      <Image
-                       compressedThumborParams
+                       compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                        smallWidth={377}
                        smallHeight={283}
                        mediumWidth={377}
@@ -237,7 +239,7 @@ class CardList extends React.Component {
                             extractImage(element.promo_items)
                               ? (
                                 <Image
-                                  compressedThumborParams
+                                  compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                                   url={extractImage(element.promo_items)}
                                   alt={headlineText}
                                   // small, matches numbered list, is 3:2 aspect ratio
@@ -254,7 +256,7 @@ class CardList extends React.Component {
                               )
                               : (
                                 <Image
-                                  compressedThumborParams
+                                  compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                                   smallWidth={105}
                                   smallHeight={70}
                                   mediumWidth={105}

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -144,7 +144,6 @@ class CardList extends React.Component {
                    extractImage(contentElements[0].promo_items) ? (
                      <Image
                        compressedThumborParams
-
                        url={extractImage(contentElements[0].promo_items)}
                        alt={contentElements[0].headlines.basic}
                        smallWidth={377}

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -143,6 +143,8 @@ class CardList extends React.Component {
                   {
                    extractImage(contentElements[0].promo_items) ? (
                      <Image
+                       compressedThumborParams
+
                        url={extractImage(contentElements[0].promo_items)}
                        alt={contentElements[0].headlines.basic}
                        smallWidth={377}
@@ -157,6 +159,7 @@ class CardList extends React.Component {
                      />
                    ) : (
                      <Image
+                       compressedThumborParams
                        smallWidth={377}
                        smallHeight={283}
                        mediumWidth={377}
@@ -168,7 +171,6 @@ class CardList extends React.Component {
                        breakpoints={getProperties(arcSite)?.breakpoints}
                        resizedImageOptions={placeholderResizedImageOptions}
                        resizerURL={getProperties(arcSite)?.resizerURL}
-
                      />
                    )
                   }
@@ -236,6 +238,7 @@ class CardList extends React.Component {
                             extractImage(element.promo_items)
                               ? (
                                 <Image
+                                  compressedThumborParams
                                   url={extractImage(element.promo_items)}
                                   alt={headlineText}
                                   // small, matches numbered list, is 3:2 aspect ratio
@@ -252,6 +255,7 @@ class CardList extends React.Component {
                               )
                               : (
                                 <Image
+                                  compressedThumborParams
                                   smallWidth={105}
                                   smallHeight={70}
                                   mediumWidth={105}

--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -23,13 +23,17 @@ export default {
   resolve,
   schemaName: 'ans-feed',
   // other options null use default functionality, such as filter quality
-  transform: (data, query) => getResizedImageData(
-    data,
-    null,
-    null,
-    null,
-    query['arc-site'],
-    undefined,
-    true,
-  ),
+  transform: (data, query) => {
+    const { isCompressedImageParams = false } = query;
+
+    return getResizedImageData(
+      data,
+      null,
+      null,
+      null,
+      query['arc-site'],
+      undefined,
+      isCompressedImageParams,
+    );
+  },
 };

--- a/blocks/content-api-source-block/sources/content-api.js
+++ b/blocks/content-api-source-block/sources/content-api.js
@@ -11,15 +11,19 @@ const resolve = (key = {}) => {
   return `/content/v4/?${id ? `_id=${id}` : `website_url=${websiteUrl}`}${site ? `&website=${site}` : ''}`;
 };
 
-const transform = (data, query) => getResizedImageData(
-  data,
-  null,
-  null,
-  null,
-  query['arc-site'],
-  undefined,
-  true,
-);
+const transform = (data, query) => {
+  const { isCompressedImageParams = false } = query;
+
+  return getResizedImageData(
+    data,
+    null,
+    null,
+    null,
+    query['arc-site'],
+    undefined,
+    isCompressedImageParams,
+  );
+};
 
 export default {
   schemaName: 'ans-item',

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -9,6 +9,8 @@ import '@wpmedia/shared-styles/scss/_extra-large-promo.scss';
 import { Image } from '@wpmedia/engine-theme-sdk';
 import { useContent } from 'fusion:content';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
 `;
@@ -90,7 +92,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
                   rel={customFields.newTab ? 'noreferrer' : ''}
                 >
                   <Image
-                    compressedThumborParams
+                    compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                     url={customFields.imageURL}
                     alt={customFields.headline}
                     smallWidth={400}

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -90,6 +90,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
                   rel={customFields.newTab ? 'noreferrer' : ''}
                 >
                   <Image
+                    compressedThumborParams
                     url={customFields.imageURL}
                     alt={customFields.headline}
                     smallWidth={400}

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -160,6 +160,7 @@ const ExtraLargePromo = ({ customFields }) => {
                   {customFields.imageOverrideURL || extractImageFromStory(content)
                     ? (
                       <Image
+                        compressedThumborParams
                         url={customFields.imageOverrideURL
                           ? customFields.imageOverrideURL : extractImageFromStory(content)}
                         alt={content && content.headlines ? content.headlines.basic : ''}
@@ -172,7 +173,6 @@ const ExtraLargePromo = ({ customFields }) => {
                         breakpoints={getProperties(arcSite)?.breakpoints}
                         resizerURL={getProperties(arcSite)?.resizerURL}
                         resizedImageOptions={extractResizedParams(content)}
-                        // todo: this should have resized params
                       />
                     )
                     : (

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -22,6 +22,8 @@ import {
 import PromoLabel from './_children/promo_label';
 import discoverPromoType from './_children/discover';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
 `;
@@ -160,7 +162,7 @@ const ExtraLargePromo = ({ customFields }) => {
                   {customFields.imageOverrideURL || extractImageFromStory(content)
                     ? (
                       <Image
-                        compressedThumborParams
+                        compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                         url={customFields.imageOverrideURL
                           ? customFields.imageOverrideURL : extractImageFromStory(content)}
                         alt={content && content.headlines ? content.headlines.basic : ''}

--- a/blocks/full-author-bio-block/features/full-author-bio/default.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.jsx
@@ -109,19 +109,20 @@ const FullAuthorBio = () => {
         <div className="image-container">
           {
             (content.authors[0].image) && (
-              <Image
-                url={content.authors[0].image}
-                alt="Author photo"
-                smallWidth={158}
-                smallHeight={158}
-                mediumWidth={158}
-                mediumHeight={158}
-                largeWidth={158}
-                largeHeight={158}
-                resizedImageOptions={content.authors[0].resized_params}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-                breakpoints={getProperties(arcSite)?.breakpoints}
-              />
+            <Image
+              compressedThumborParams
+              url={content.authors[0].image}
+              alt="Author photo"
+              smallWidth={158}
+              smallHeight={158}
+              mediumWidth={158}
+              mediumHeight={158}
+              largeWidth={158}
+              largeHeight={158}
+              resizedImageOptions={content.authors[0].resized_params}
+              resizerURL={getProperties(arcSite)?.resizerURL}
+              breakpoints={getProperties(arcSite)?.breakpoints}
+            />
             )
           }
         </div>

--- a/blocks/full-author-bio-block/features/full-author-bio/default.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.jsx
@@ -25,6 +25,8 @@ import {
 import './full-author-bio.scss';
 import constructSocialURL from './shared/constructSocialURL';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const StyledAuthorContent = styled.div`
   font-family: ${(props) => props.primaryFont};
 
@@ -110,7 +112,7 @@ const FullAuthorBio = () => {
           {
             (content.authors[0].image) && (
             <Image
-              compressedThumborParams
+              compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
               url={content.authors[0].image}
               alt="Author photo"
               smallWidth={158}

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -52,6 +52,7 @@ const LargeManualPromo = ({ customFields }) => {
                 rel={customFields.newTab ? 'noreferrer noopener' : ''}
               >
                 <Image
+                  compressedThumborParams
                   url={customFields.imageURL}
                   alt={customFields.headline}
                   // large promo has 4:3

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -9,6 +9,8 @@ import { useContent } from 'fusion:content';
 
 import '@wpmedia/shared-styles/scss/_large-promo.scss';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
 `;
@@ -52,7 +54,7 @@ const LargeManualPromo = ({ customFields }) => {
                 rel={customFields.newTab ? 'noreferrer noopener' : ''}
               >
                 <Image
-                  compressedThumborParams
+                  compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                   url={customFields.imageURL}
                   alt={customFields.headline}
                   // large promo has 4:3

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -22,6 +22,8 @@ import {
 import PromoLabel from './_children/promo_label';
 import discoverPromoType from './_children/discover';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
 `;
@@ -158,7 +160,7 @@ const LargePromo = ({ customFields }) => {
                   customFields.imageOverrideURL || extractImageFromStory(content)
                     ? (
                       <Image
-                        compressedThumborParams
+                        compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                         url={customFields.imageOverrideURL
                           ? customFields.imageOverrideURL : extractImageFromStory(content)}
                         alt={content && content.headlines ? content.headlines.basic : ''}

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -158,6 +158,7 @@ const LargePromo = ({ customFields }) => {
                   customFields.imageOverrideURL || extractImageFromStory(content)
                     ? (
                       <Image
+                        compressedThumborParams
                         url={customFields.imageOverrideURL
                           ? customFields.imageOverrideURL : extractImageFromStory(content)}
                         alt={content && content.headlines ? content.headlines.basic : ''}
@@ -171,7 +172,6 @@ const LargePromo = ({ customFields }) => {
                         breakpoints={getProperties(arcSite)?.breakpoints}
                         resizerURL={getProperties(arcSite)?.resizerURL}
                         resizedImageOptions={extractResizedParams(content)}
-                        // todo: should have resized params
                       />
                     )
                     : (

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -121,7 +121,8 @@ class LeadArt extends Component {
         }
 
         caption = (
-          <ImageMetadata
+          <Image
+            compressedThumborParamsMetadata
             subtitle={lead_art.subtitle}
             caption={lead_art.caption}
             credits={lead_art.credits}
@@ -143,6 +144,7 @@ class LeadArt extends Component {
             </button>
             <div ref={this.imgRef}>
               <Image
+                compressedThumborParams
                 url={lead_art.url}
                 alt={lead_art.alt_text}
                 smallWidth={800}

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -13,6 +13,8 @@ import {
 import './leadart.scss';
 import FullscreenIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/FullscreenIcon';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const LeadArtWrapperDiv = styled.div`
   figcaption {
     font-family: ${(props) => props.primaryFont};
@@ -143,7 +145,7 @@ class LeadArt extends Component {
             </button>
             <div ref={this.imgRef}>
               <Image
-                compressedThumborParams
+                compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                 url={lead_art.url}
                 alt={lead_art.alt_text}
                 smallWidth={800}

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -121,8 +121,7 @@ class LeadArt extends Component {
         }
 
         caption = (
-          <Image
-            compressedThumborParamsMetadata
+          <ImageMetadata
             subtitle={lead_art.subtitle}
             caption={lead_art.caption}
             credits={lead_art.credits}

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -9,6 +9,8 @@ import { useContent } from 'fusion:content';
 
 import '@wpmedia/shared-styles/scss/_medium-promo.scss';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
 `;
@@ -43,7 +45,7 @@ const MediumManualPromo = ({ customFields }) => {
               rel={customFields.newTab ? 'noreferrer noopener' : ''}
             >
               <Image
-                compressedThumborParams
+                compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                 // medium is 16:9
                 url={customFields.imageURL}
                 alt={customFields.headline}

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -43,6 +43,7 @@ const MediumManualPromo = ({ customFields }) => {
               rel={customFields.newTab ? 'noreferrer noopener' : ''}
             >
               <Image
+                compressedThumborParams
                 // medium is 16:9
                 url={customFields.imageURL}
                 alt={customFields.headline}

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -21,6 +21,8 @@ import {
 import PromoLabel from './_children/promo_label';
 import discoverPromoType from './_children/discover';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
 `;
@@ -149,7 +151,7 @@ const MediumPromo = ({ customFields }) => {
                 customFields.imageOverrideURL || extractImageFromStory(content)
                   ? (
                     <Image
-                      compressedThumborParams
+                      compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                       url={customFields.imageOverrideURL
                         ? customFields.imageOverrideURL : extractImageFromStory(content)}
                       alt={content && content.headlines ? content.headlines.basic : ''}

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -149,6 +149,7 @@ const MediumPromo = ({ customFields }) => {
                 customFields.imageOverrideURL || extractImageFromStory(content)
                   ? (
                     <Image
+                      compressedThumborParams
                       url={customFields.imageOverrideURL
                         ? customFields.imageOverrideURL : extractImageFromStory(content)}
                       alt={content && content.headlines ? content.headlines.basic : ''}

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -132,6 +132,7 @@ class NumberedList extends Component {
                 >
                   {extractImage(promoItems) ? (
                     <Image
+                      compressedThumborParams
                       resizedImageOptions={extractResizedParams(element)}
                       url={extractImage(promoItems)}
                       alt={headlineText}
@@ -147,6 +148,7 @@ class NumberedList extends Component {
                     />
                   ) : (
                     <Image
+                      compressedThumborParams
                       smallWidth={105}
                       smallHeight={70}
                       mediumWidth={105}

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -10,6 +10,8 @@ import { Image } from '@wpmedia/engine-theme-sdk';
 import './numbered-list.scss';
 import { extractResizedParams } from '@wpmedia/resizer-image-block';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 function extractImage(promo) {
   return promo && promo.basic && promo.basic.type === 'image' && promo.basic.url;
 }
@@ -132,7 +134,7 @@ class NumberedList extends Component {
                 >
                   {extractImage(promoItems) ? (
                     <Image
-                      compressedThumborParams
+                      compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                       resizedImageOptions={extractResizedParams(element)}
                       url={extractImage(promoItems)}
                       alt={headlineText}
@@ -148,7 +150,7 @@ class NumberedList extends Component {
                     />
                   ) : (
                     <Image
-                      compressedThumborParams
+                      compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                       smallWidth={105}
                       smallHeight={70}
                       mediumWidth={105}

--- a/blocks/placeholder-image-block/features/placeholder-image/default.jsx
+++ b/blocks/placeholder-image-block/features/placeholder-image/default.jsx
@@ -5,6 +5,8 @@ import getProperties from 'fusion:properties';
 import { Image } from '@wpmedia/engine-theme-sdk';
 import withFusionContext from 'fusion:context';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 @Consumer
 class PlaceholderImage extends React.Component {
   constructor(props) {
@@ -53,7 +55,7 @@ class PlaceholderImage extends React.Component {
     return (
       <>
         <Image
-          compressedThumborParams
+          compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
           url={this.getTargetFallbackImageUrl()}
           alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
           smallWidth={smallWidth}

--- a/blocks/placeholder-image-block/features/placeholder-image/default.jsx
+++ b/blocks/placeholder-image-block/features/placeholder-image/default.jsx
@@ -53,6 +53,7 @@ class PlaceholderImage extends React.Component {
     return (
       <>
         <Image
+          compressedThumborParams
           url={this.getTargetFallbackImageUrl()}
           alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
           smallWidth={smallWidth}

--- a/blocks/related-content-content-source-block/sources/related-content.js
+++ b/blocks/related-content-content-source-block/sources/related-content.js
@@ -20,6 +20,8 @@ export default {
     _id: 'text',
   },
   transform: (data, query) => {
+    const { isCompressedImageParams = false } = query;
+
     if (data && data.basic && typeof Array.isArray(data.basic)) {
       return {
         content_elements: data.basic.map((ele) => (
@@ -30,7 +32,7 @@ export default {
             null,
             query['arc-site'],
             undefined,
-            true,
+            isCompressedImageParams,
           )
         )),
       };

--- a/blocks/resizer-image-block/index.js
+++ b/blocks/resizer-image-block/index.js
@@ -335,7 +335,7 @@ const getResizedImageData = (
   respectAspectRatio = false,
   arcSite,
   imageWidths = getProperties(arcSite).imageWidths,
-  compressedParams,
+  compressedParams = false,
 ) => {
   // resizer url is only arcSite specific option
   const { aspectRatios, resizerURL } = getProperties(arcSite);

--- a/blocks/resizer-image-content-source-block/sources/resize-image-api.js
+++ b/blocks/resizer-image-content-source-block/sources/resize-image-api.js
@@ -8,7 +8,11 @@ const params = {
 // input: raw image url
 // output: object with dimensions and image keys
 const fetch = (query) => {
-  const { raw_image_url: rawImageUrl, respect_aspect_ratio: respectAspectRatio = false } = query;
+  const {
+    raw_image_url: rawImageUrl,
+    respect_aspect_ratio: respectAspectRatio = false,
+    isCompressedImageParams = false,
+  } = query;
 
   // last param designates only url -- not data ans object
   return getResizedImageData(
@@ -18,7 +22,7 @@ const fetch = (query) => {
     respectAspectRatio,
     query['arc-site'],
     undefined,
-    true,
+    isCompressedImageParams,
   );
 };
 

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -19,6 +19,8 @@ import '@wpmedia/shared-styles/scss/_results-list.scss';
 import '@wpmedia/shared-styles/scss/_results-list-desktop.scss';
 import '@wpmedia/shared-styles/scss/_results-list-mobile.scss';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 function extractImage(promo) {
   return promo && promo.basic && promo.basic.type === 'image' && promo.basic.url;
 }
@@ -177,7 +179,7 @@ class ResultsList extends Component {
                   >
                     {extractImage(promoItems) ? (
                       <Image
-                        compressedThumborParams
+                        compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                         // results list is 16:9 by default
                         resizedImageOptions={extractResizedParams(element)}
                         url={extractImage(element.promo_items)}
@@ -193,7 +195,7 @@ class ResultsList extends Component {
                       />
                     ) : (
                       <Image
-                        compressedThumborParams
+                        compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                         smallWidth={158}
                         smallHeight={89}
                         mediumWidth={274}

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -177,6 +177,7 @@ class ResultsList extends Component {
                   >
                     {extractImage(promoItems) ? (
                       <Image
+                        compressedThumborParams
                         // results list is 16:9 by default
                         resizedImageOptions={extractResizedParams(element)}
                         url={extractImage(element.promo_items)}
@@ -192,6 +193,7 @@ class ResultsList extends Component {
                       />
                     ) : (
                       <Image
+                        compressedThumborParams
                         smallWidth={158}
                         smallHeight={89}
                         mediumWidth={274}
@@ -203,7 +205,6 @@ class ResultsList extends Component {
                         breakpoints={getProperties(arcSite)?.breakpoints}
                         resizedImageOptions={placeholderResizedImageOptions}
                         resizerURL={getProperties(arcSite)?.resizerURL}
-
                       />
                     )}
                   </a>

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
@@ -51,6 +51,7 @@ const SearchResult = ({
           >
             {extractImage(promoItems) ? (
               <Image
+                compressedThumborParams
                 url={extractImage(promoItems)}
                 alt={headlineText}
                 smallWidth={274}
@@ -65,6 +66,7 @@ const SearchResult = ({
               />
             ) : (
               <Image
+                compressedThumborParams
                 smallWidth={274}
                 smallHeight={154}
                 mediumWidth={274}

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
@@ -9,6 +9,8 @@ import getProperties from 'fusion:properties';
 import { HeadlineText, DescriptionText } from './styled-components';
 import { extractImage } from './helpers';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const SearchResult = ({
   element,
   arcSite,
@@ -51,7 +53,7 @@ const SearchResult = ({
           >
             {extractImage(promoItems) ? (
               <Image
-                compressedThumborParams
+                compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                 url={extractImage(promoItems)}
                 alt={headlineText}
                 smallWidth={274}
@@ -66,7 +68,7 @@ const SearchResult = ({
               />
             ) : (
               <Image
-                compressedThumborParams
+                compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                 smallWidth={274}
                 smallHeight={154}
                 mediumWidth={274}

--- a/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
+++ b/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
@@ -4,6 +4,8 @@ import getProperties from 'fusion:properties';
 
 import Title from './title';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const StoryItem = (props) => {
   const {
     itemTitle = '',
@@ -29,7 +31,7 @@ const StoryItem = (props) => {
         >
           {imageURL !== '' ? (
             <Image
-              compressedThumborParams
+              compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
               resizedImageOptions={resizedImageOptions}
               url={imageURL}
               alt={itemTitle}
@@ -47,7 +49,7 @@ const StoryItem = (props) => {
             />
           ) : (
             <Image
-              compressedThumborParams
+              compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
               smallWidth={274}
               smallHeight={183}
               mediumWidth={274}

--- a/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
+++ b/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
@@ -29,6 +29,7 @@ const StoryItem = (props) => {
         >
           {imageURL !== '' ? (
             <Image
+              compressedThumborParams
               resizedImageOptions={resizedImageOptions}
               url={imageURL}
               alt={itemTitle}
@@ -46,6 +47,7 @@ const StoryItem = (props) => {
             />
           ) : (
             <Image
+              compressedThumborParams
               smallWidth={274}
               smallHeight={183}
               mediumWidth={274}

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -9,6 +9,8 @@ import { useContent } from 'fusion:content';
 
 import '@wpmedia/shared-styles/scss/_small-promo.scss';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
 `;
@@ -55,7 +57,7 @@ const SmallManualPromo = ({ customFields }) => {
                 rel={customFields.newTab ? 'noreferrer noopener' : ''}
               >
                 <Image
-                  compressedThumborParams
+                  compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                   url={customFields.imageURL}
                   alt={customFields.headline}
                   // small should be 3:2 aspect ratio

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -55,6 +55,7 @@ const SmallManualPromo = ({ customFields }) => {
                 rel={customFields.newTab ? 'noreferrer noopener' : ''}
               >
                 <Image
+                  compressedThumborParams
                   url={customFields.imageURL}
                   alt={customFields.headline}
                   // small should be 3:2 aspect ratio

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -79,6 +79,7 @@ const SmallPromo = ({ customFields }) => {
                 {customFields.imageOverrideURL || extractImageFromStory(content)
                   ? (
                     <Image
+                      compressedThumborParams
                       url={customFields.imageOverrideURL
                         ? customFields.imageOverrideURL : extractImageFromStory(content)}
                       alt={content && content.headlines ? content.headlines.basic : ''}

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -19,6 +19,8 @@ import {
 import PromoLabel from './_children/promo_label';
 import discoverPromoType from './_children/discover';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const HeadlineText = styled.h1`
   font-family: ${(props) => props.primaryFont};
 `;
@@ -79,7 +81,7 @@ const SmallPromo = ({ customFields }) => {
                 {customFields.imageOverrideURL || extractImageFromStory(content)
                   ? (
                     <Image
-                      compressedThumborParams
+                      compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                       url={customFields.imageOverrideURL
                         ? customFields.imageOverrideURL : extractImageFromStory(content)}
                       alt={content && content.headlines ? content.headlines.basic : ''}

--- a/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
+++ b/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
@@ -11,13 +11,17 @@ export default {
     feedOffset: 'number',
   },
   // other options null use default functionality, such as filter quality
-  transform: (data, query) => getResizedImageData(
-    data,
-    null,
-    null,
-    null,
-    query['arc-site'],
-    undefined,
-    true,
-  ),
+  transform: (data, query) => {
+    const { isCompressedImageParams = false } = query;
+
+    return getResizedImageData(
+      data,
+      null,
+      null,
+      null,
+      query['arc-site'],
+      undefined,
+      isCompressedImageParams,
+    );
+  },
 };

--- a/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
+++ b/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
@@ -9,13 +9,16 @@ export default {
     offset: 'number',
   },
   // other options null use default functionality, such as filter quality
-  transform: (data, query) => getResizedImageData(
-    data,
-    null,
-    null,
-    null,
-    query['arc-site'],
-    undefined,
-    true,
-  ),
+  transform: (data, query) => {
+    const { isCompressedImageParams = false } = query;
+    return getResizedImageData(
+      data,
+      null,
+      null,
+      null,
+      query['arc-site'],
+      undefined,
+      isCompressedImageParams,
+    );
+  },
 };

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
@@ -6,13 +6,17 @@ export default {
   schemaName: source.schemaName,
   params: source.params,
   // other options null use default functionality, such as filter quality
-  transform: (data, query) => getResizedImageData(
-    data,
-    null,
-    null,
-    null,
-    query['arc-site'],
-    undefined,
-    true,
-  ),
+  transform: (data, query) => {
+    const { isCompressedImageParams = false } = query;
+
+    return getResizedImageData(
+      data,
+      null,
+      null,
+      null,
+      query['arc-site'],
+      undefined,
+      isCompressedImageParams,
+    );
+  },
 };

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
@@ -7,13 +7,17 @@ export default {
   schemaName: source.schemaName,
   params: source.params,
   // other options null use default functionality, such as filter quality
-  transform: (data, query) => getResizedImageData(
-    data,
-    null,
-    null,
-    null,
-    query['arc-site'],
-    undefined,
-    true,
-  ),
+  transform: (data, query) => {
+    const { isCompressedImageParams = false } = query;
+
+    return getResizedImageData(
+      data,
+      null,
+      null,
+      null,
+      query['arc-site'],
+      undefined,
+      isCompressedImageParams,
+    );
+  },
 };

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -11,6 +11,8 @@ import checkObjectEmpty from '../shared/checkObjectEmpty';
 import PromoLabel from './promo_label';
 import discoverPromoType from './discover';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const HorizontalOverlineImageStoryItem = (props) => {
   const {
     websiteURL,
@@ -142,7 +144,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
               {imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>
                   <Image
-                    compressedThumborParams
+                    compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                     resizedImageOptions={resizedImageOptions}
                     url={imageURL}
                     alt={
@@ -164,7 +166,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
               ) : (
                 <div className="image-wrapper">
                   <Image
-                    compressedThumborParams
+                    compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                     smallWidth={ratios.smallWidth}
                     smallHeight={ratios.smallHeight}
                     mediumWidth={ratios.mediumWidth}

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -142,6 +142,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
               {imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>
                   <Image
+                    compressedThumborParams
                     resizedImageOptions={resizedImageOptions}
                     url={imageURL}
                     alt={
@@ -163,6 +164,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
               ) : (
                 <div className="image-wrapper">
                   <Image
+                    compressedThumborParams
                     smallWidth={ratios.smallWidth}
                     smallHeight={ratios.smallHeight}
                     mediumWidth={ratios.mediumWidth}

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -55,6 +55,7 @@ const ItemTitleWithRightImage = (props) => {
             {imageURL !== '' ? (
               <a href={websiteURL} title={itemTitle}>
                 <Image
+                  compressedThumborParams
                   resizedImageOptions={resizedImageOptions}
                   url={imageURL}
                   alt={itemTitle}
@@ -72,6 +73,7 @@ const ItemTitleWithRightImage = (props) => {
             ) : (
               <div className="image-wrapper">
                 <Image
+                  compressedThumborParams
                   smallWidth={ratios.smallWidth}
                   smallHeight={ratios.smallHeight}
                   mediumWidth={ratios.mediumWidth}

--- a/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/item-title-with-right-image.jsx
@@ -6,6 +6,8 @@ import Title from './title';
 import PromoLabel from './promo_label';
 import discoverPromoType from './discover';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const ItemTitleWithRightImage = (props) => {
   const {
     itemTitle,
@@ -55,7 +57,7 @@ const ItemTitleWithRightImage = (props) => {
             {imageURL !== '' ? (
               <a href={websiteURL} title={itemTitle}>
                 <Image
-                  compressedThumborParams
+                  compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                   resizedImageOptions={resizedImageOptions}
                   url={imageURL}
                   alt={itemTitle}
@@ -73,7 +75,7 @@ const ItemTitleWithRightImage = (props) => {
             ) : (
               <div className="image-wrapper">
                 <Image
-                  compressedThumborParams
+                  compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                   smallWidth={ratios.smallWidth}
                   smallHeight={ratios.smallHeight}
                   mediumWidth={ratios.mediumWidth}

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -111,6 +111,7 @@ const MediumListItem = (props) => {
             <a className="image-link" href={websiteURL} title={itemTitle}>
               {imageURL !== '' ? (
                 <Image
+                  compressedThumborParams
                   resizedImageOptions={resizedImageOptions}
                   url={imageURL}
                   // todo: get the proper alt tag for this image
@@ -127,6 +128,7 @@ const MediumListItem = (props) => {
                 />
               ) : (
                 <Image
+                  compressedThumborParams
                   smallWidth={ratios.smallWidth}
                   smallHeight={ratios.smallHeight}
                   mediumWidth={ratios.mediumWidth}

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -10,6 +10,8 @@ import checkObjectEmpty from '../shared/checkObjectEmpty';
 import PromoLabel from './promo_label';
 import discoverPromoType from './discover';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 // via results list
 const MediumListItem = (props) => {
   const {
@@ -111,7 +113,7 @@ const MediumListItem = (props) => {
             <a className="image-link" href={websiteURL} title={itemTitle}>
               {imageURL !== '' ? (
                 <Image
-                  compressedThumborParams
+                  compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                   resizedImageOptions={resizedImageOptions}
                   url={imageURL}
                   // todo: get the proper alt tag for this image
@@ -128,7 +130,7 @@ const MediumListItem = (props) => {
                 />
               ) : (
                 <Image
-                  compressedThumborParams
+                  compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                   smallWidth={ratios.smallWidth}
                   smallHeight={ratios.smallHeight}
                   mediumWidth={ratios.mediumWidth}

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -126,6 +126,7 @@ const VerticalOverlineImageStoryItem = (props) => {
               {customFields.showImageXL && /*! videoUUID && */ imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>
                   <Image
+                    compressedThumborParams
                     resizedImageOptions={resizedImageOptions}
                     url={imageURL}
                     // todo: get the proper alt tag for this image
@@ -143,6 +144,7 @@ const VerticalOverlineImageStoryItem = (props) => {
               ) : (
                 /*! videoUUID && */ (
                   <Image
+                    compressedThumborParams
                     smallWidth={ratios.smallWidth}
                     smallHeight={ratios.smallHeight}
                     mediumWidth={ratios.mediumWidth}

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -9,6 +9,8 @@ import Title from './title';
 import DescriptionText from './description-text';
 import checkObjectEmpty from '../shared/checkObjectEmpty';
 
+const HANDLE_COMPRESSED_IMAGE_PARAMS = false;
+
 const VerticalOverlineImageStoryItem = (props) => {
   const {
     websiteURL,
@@ -126,7 +128,7 @@ const VerticalOverlineImageStoryItem = (props) => {
               {customFields.showImageXL && /*! videoUUID && */ imageURL !== '' ? (
                 <a href={websiteURL} title={itemTitle}>
                   <Image
-                    compressedThumborParams
+                    compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                     resizedImageOptions={resizedImageOptions}
                     url={imageURL}
                     // todo: get the proper alt tag for this image
@@ -144,7 +146,7 @@ const VerticalOverlineImageStoryItem = (props) => {
               ) : (
                 /*! videoUUID && */ (
                   <Image
-                    compressedThumborParams
+                    compressedThumborParams={HANDLE_COMPRESSED_IMAGE_PARAMS}
                     smallWidth={ratios.smallWidth}
                     smallHeight={ratios.smallHeight}
                     mediumWidth={ratios.mediumWidth}

--- a/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
+++ b/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
@@ -8,13 +8,16 @@ export default {
   params: {
     _id: 'text',
   },
-  transform: (data, query) => getResizedImageData(
-    data,
-    null,
-    null,
-    null,
-    query['arc-site'],
-    undefined,
-    true,
-  ),
+  transform: (data, query) => {
+    const { isCompressedImageParams = false } = query;
+    return getResizedImageData(
+      data,
+      null,
+      null,
+      null,
+      query['arc-site'],
+      undefined,
+      isCompressedImageParams,
+    );
+  },
 };


### PR DESCRIPTION
update: 

opt out by default working on rc tag on https://corecomponents.arcpublishing.com/pf/all-blocks/?_website=washpost&d=547
- can do a simple find and replace to getproperties to pass in opt in property 
- this, like I said, goes with engine theme sdk bugfixes https://github.com/WPMedia/engine-theme-sdk/pull/122 

---------
- content sources opted into image compression
- opted the blocks' image engine theme sdk into it as well after looking at that implementation https://github.com/WPMedia/engine-theme-sdk/pull/122 

- published as rc tag and in cc https://corecomponents.arcpublishing.com/pf/all-blocks/?_website=washpost&d=543

![Screen Shot 2020-11-17 at 18 57 23](https://user-images.githubusercontent.com/5950956/99468672-aa61a280-2906-11eb-8b85-ff0dfa1f0729.png)

- deployed as rc https://corecomponents.arcpublishing.com/pf/all-blocks/?_website=washpost&d=542
- in beta env I see compressed params 

![Screen Shot 2020-11-17 at 18 26 25](https://user-images.githubusercontent.com/5950956/99468191-a5502380-2905-11eb-9f0a-d5e86f8fce13.png)

```js
content source example:
  transform: (data, query) => getResizedImageData(
    data,
    null,
    null,
    null,
    query['arc-site'],
    undefined,
// opt into compression
    true,
  ),
};

// in resizer
      if (compressedParams) {
        output[key] = output[key].replace(':format(jpg):quality(70)', ':cm=t');
      }
