### PR TITLE
PEN-1500: Clean up Custom Fields + tests in the Lead Art Block

### DIFF
--- a/blocks/lead-art-block/README.md
+++ b/blocks/lead-art-block/README.md
@@ -7,6 +7,7 @@ _Fusion News Theme lead art block. Please provide a 1-2 sentence description of 
 ## Props
 | **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
+|customFields.enableAutoplay|no|boolean|If the lead art type is video, configures the video to autoplay on page load. If value is true it will autoplay the video.  If value is false, it will not autoplay the video.  |
 | **required prop** | yes | | |
 | **optional prop** | no | | |
 | **contentConfig example** | | | Please specify which content sources are compatible |

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -35,18 +35,17 @@ const LeadArtWrapperFigure = styled.figure`
 class LeadArt extends Component {
   constructor(props) {
     super(props);
-    const { globalContent: content, customFields, arcSite } = this.props;
+    const { globalContent: content, arcSite } = this.props;
     this.phrases = getTranslatedPhrases(getProperties(arcSite).locale || 'en');
     this.state = {
       isOpen: false,
-      enableZoom: customFields.enableZoom || false,
-      buttonLabel: customFields.buttonLabel || this.phrases.t('global.gallery-expand-button'),
-      showCredit: customFields.showCredit || false,
+      buttonLabel: this.phrases.t('global.gallery-expand-button'),
       content,
     };
 
     this.imgRef = React.createRef();
     this.setIsOpenToFalse = this.setIsOpenToFalse.bind(this);
+    this.setIsOpenToTrue = this.setIsOpenToTrue.bind(this);
   }
 
   setIsOpenToFalse() {
@@ -69,7 +68,7 @@ class LeadArt extends Component {
 
   render() {
     const {
-      enableZoom, isOpen, buttonPosition, buttonLabel, showCredit, content,
+      isOpen, buttonPosition, content, buttonLabel,
     } = this.state;
 
     const { arcSite } = this.props;
@@ -94,7 +93,6 @@ class LeadArt extends Component {
                   mainSrc={mainContent}
                   onCloseRequest={this.setIsOpenToFalse}
                   showImageCaption={false}
-                  enableZoom={enableZoom}
                 />
               )}
             </>
@@ -104,7 +102,7 @@ class LeadArt extends Component {
         return (
           <LeadArtWrapperDiv className="lead-art-wrapper" primaryFont={getThemeStyle(arcSite)['primary-font-family']}>
             <div
-              className="innerContent"
+              className="inner-content"
               dangerouslySetInnerHTML={{ __html: lead_art.content }}
             />
             {lightbox}
@@ -120,9 +118,7 @@ class LeadArt extends Component {
                 <Lightbox
                   mainSrc={this.lightboxImgHandler()}
                   onCloseRequest={this.setIsOpenToFalse}
-                  showImageCaption={showCredit}
                   imageCaption={lead_art.caption}
-                  enableZoom={enableZoom}
                 />
               )}
             </>
@@ -200,18 +196,12 @@ LeadArt.label = 'Lead Art – Arc Block';
 
 LeadArt.defaultProps = {
   customFields: {
-    enableZoom: false,
-    buttonLabel: 'Full Screen',
-    showCredit: false,
+    enableAutoplay: false,
   },
 };
 
 LeadArt.propTypes = {
   customFields: PropTypes.shape({
-    buttonLabel: PropTypes.string,
-    enableZoom: PropTypes.bool,
-    showCredit: PropTypes.bool,
-    inheritGlobalContent: PropTypes.bool,
     enableAutoplay: PropTypes.bool.tag({
       label: 'Autoplay',
       defaultValue: false,

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -21,6 +21,9 @@ describe('LeadArt', () => {
 
     getProperties.mockImplementation(() => (
       { locale: [] }));
+
+    getTranslatedPhrases.mockImplementation(() => (
+      { t: jest.fn().mockReturnValue('gallery-expand') }));
   });
 
   it('renders html lead art type', () => {
@@ -147,9 +150,6 @@ describe('LeadArt', () => {
   it('uses english phrases if no locale available', () => {
     getProperties.mockImplementation(() => (
       { locale: undefined }));
-
-    getTranslatedPhrases.mockImplementation(() => (
-      {}));
 
     const globalContent = {
       promo_items: {

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -30,7 +30,7 @@ const VideoPlayer = (props) => {
 
   // In all other scenarios, fetch from the provided url and content api
   const fetchSource = doFetch ? 'content-api' : null;
-  // const { embed_html: fetchedEmbedMarkup = '' } =
+
   const fetchedData = useContent({
     source: fetchSource,
     query: {


### PR DESCRIPTION
## Description
Removed unused custom fields (Enable zoom, button label, show credit, inherit global content), ensure functionality is still in place, update tests/linting as needed for these changes.

## Jira Ticket
- [PEN-1500](https://arcpublishing.atlassian.net/browse/PEN-1500)

## Acceptance Criteria
Remove the following Custom Fields from the Lead Art Block: 

buttonLabel
enableZoom
showCredit
inheritGlobalContent

The functionality of the Lead Art Block should not change (the removal of these fields should not actually change how the block works) 
Tests and documentation are updated as necessary – specifically, tests should be added to cover the Lead Art (during grooming, Nelson mentioned that it didn’t have any tests, and ideally it should have at least 85% coverage) 



## Test Steps
Verify that existing instances of LeadArtBlock are not adversely affected by these changes - feature should still render successfully and functionality should remain unchanged.
Verify that when adding a new Lead Art Block, that the custom fields presented do not include any of the following:
buttonLabel
enableZoom
showCredit
inheritGlobalContent
Yet the functionality remains as is required - images are rendered successfully, videos play, zoom/full screen views are available. 

Example stories that can be used for testing:

Image
http://localhost//pf//news/2020/05/15/video-promo-test-story/?_website=the-prophet

Video
http://localhost//pf/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/?_website=the-prophet

Gallery
http://localhost//pf//news/2020/10/20/gallery-promo-item-with-festive-dishes-gallery/?_website=the-prophet


## Effect Of Changes
### Before
Custom Fields for buttonLabel, enableZoom, showCredit, inheritGlobalContent are shown when adding a new Lead Art Block.  

<img width="294" alt="Screen Shot 2020-11-18 at 10 35 26 AM" src="https://user-images.githubusercontent.com/2664083/99553040-ae83d380-298b-11eb-9efe-f293758854bc.png">


### After
Custom Fields for buttonLabel, enableZoom, showCredit, inheritGlobalContent are NOT shown when adding a new Lead Art Block.  
<img width="354" alt="Screen Shot 2020-11-18 at 10 48 41 AM" src="https://user-images.githubusercontent.com/2664083/99553049-b2175a80-298b-11eb-80b4-3f3d11af096f.png">


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
