### PR TITLE
Pen 1530 backport deps

### DIFF
--- a/blocks/story-feed-sections-content-source-block/package.json
+++ b/blocks/story-feed-sections-content-source-block/package.json
@@ -25,5 +25,8 @@
   "peerDependencies": {
     "@wpmedia/resizer-image-block": "canary"
   },
+  "dependencies": {
+    "@arc-core-components/content-source_story-feed_sections-v4": "^1.0.6-beta.0"
+  },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -25,5 +25,8 @@
   "peerDependencies": {
     "@wpmedia/resizer-image-block": "canary"
   },
+  "dependencies": {
+    "@arc-core-components/content-source_story-feed_tag-v4": "^1.0.6-beta.0"
+  },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }


### PR DESCRIPTION
## Description
This broke in beta without the associated dependency in feature pack

## Jira Ticket
- [PEN-1530](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=545&projectKey=PEN&modal=detail&selectedIssue=PEN-1530&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
- add dependency for corecomponents content sources

## Test Steps
- none (possibly make sure those npm resolutions resolve)

## Dependencies or Side Effects

- PR for fusion-news-theme ... https://github.com/WPMedia/Fusion-News-Theme/pull/142
