### PR TITLE
1530 remove feature pack deps, put in blocks

### DIFF
--- a/blocks/story-feed-author-content-source-block/package.json
+++ b/blocks/story-feed-author-content-source-block/package.json
@@ -25,5 +25,8 @@
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e",
   "peerDependencies": {
     "@wpmedia/resizer-image-block": "canary"
+  },
+  "dependencies": {
+    "@arc-core-components/content-source_story-feed_author-v4": "^1.0.6-beta.0"
   }
 }


### PR DESCRIPTION
## Description
Add dependencies for content sources removed now from feature pack

## Jira Ticket
https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=545&projectKey=PEN&modal=detail&selectedIssue=PEN-1530&assignee=5e387d6a1b1d910e5dfd7a9b

## Acceptance Criteria

- Remove dependencies that exist in feature pack deps and put in blocks more explicitly
- Will help clients with custom block dev and so we know the blocks have what they need

## Test Steps

Run all blocks and see content source 
- `npx fusion start -f -l @wpmedia/content-story-feed-author-block`

![Screen Shot 2020-11-20 at 09 29 33](https://user-images.githubusercontent.com/5950956/99817892-203a5980-2b13-11eb-8794-5125ad6286ce.png)
![Screen Shot 2020-11-20 at 09 29 01](https://user-images.githubusercontent.com/5950956/99817893-20d2f000-2b13-11eb-88c7-0905bfcae24d.png)

## Dependencies or Side Effects

- Goes with fp https://github.com/WPMedia/Fusion-News-Theme/pull/143