### PR TITLE
PEN-1549: intl.json files are not included in promo components package.json files list

### DIFF
--- a/blocks/extra-large-promo-block/package.json
+++ b/blocks/extra-large-promo-block/package.json
@@ -10,7 +10,8 @@
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "features"
+    "features",
+    "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/blocks/large-promo-block/package.json
+++ b/blocks/large-promo-block/package.json
@@ -10,7 +10,8 @@
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "features"
+    "features",
+    "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -9,7 +9,8 @@
   "files": [
     "features",
     "chains",
-    "layouts"
+    "layouts",
+    "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/blocks/small-promo-block/package.json
+++ b/blocks/small-promo-block/package.json
@@ -9,7 +9,8 @@
   "files": [
     "features",
     "chains",
-    "layouts"
+    "layouts",
+    "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",


### PR DESCRIPTION
## Description
The intl.json file is not included in the promo components package.json file - so the name of the phrase is displayed in stead of the actual translated phrase. (For example shows "extra-large-promo-block.video-label" instead of the translated phrase value "Video")

## Jira Ticket
- [PEN-1549](https://arcpublishing.atlassian.net/browse/PEN-1549)

## Acceptance Criteria
These blocks should be displaying the correct internationalized text for the given language on that website when using the beta version. 



## Test Steps
Go to a page that has all the different promo block components (Large, Extra-Large, Medium, and Small).  Verify that for promo blocks show the translated labels for Gallery and Video, that it is the translated phrases that are displayed - not the name of the translated phrase.

## Effect Of Changes
### Before
<img width="408" alt="Screen Shot 2020-11-20 at 2 55 34 PM" src="https://user-images.githubusercontent.com/2664083/99844014-7a9ddf00-2b40-11eb-996d-cdf3278dd8bf.png">

### After
<img width="1082" alt="Screen Shot 2020-11-20 at 2 50 28 PM" src="https://user-images.githubusercontent.com/2664083/99844045-84bfdd80-2b40-11eb-9f3b-fd1bfce042a7.png">

## Dependencies or Side Effects
None

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ x] Confirmed all the test steps above are working
- [x ] Confirmed there are no linter errors
- [x ] Confirmed this PR has reasonable code coverage
  - [x ] Confirmed this PR has unit test files
  - [x ] Ran `npm test`, made sure all tests are passing
  - [x ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
