### PR TITLE
PEN-1440: overlap fix for nav chain horizontal links

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
@@ -4,6 +4,7 @@
   flex: 0 1 auto;
   overflow: hidden;
   text-align: left;
+  margin-left: 20px;
  
   @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
     text-align: center;


### PR DESCRIPTION
## Description
Fixed overlap for horizontal links in the nav chain - at narrow widths it would overlap the logo. Added 20 px left margin to fi. All other nav bar horizontal links styling will be addressed in another ticket.( PEN-1546: [CMG] Updates to Horizontal Links styling in nav barPO GROOMING ))

## Jira Ticket
- [PEN-1440](https://arcpublishing.atlassian.net/browse/PEN-1440)

## Acceptance Criteria
Per Saras comment: it looks like the margin isn’t applied to the right and left side of the logo as expected in The Gazette’s logo.

## Test Steps
Add a nav bar chain to a page with Horizontal Links hierarchy custom field as links-bar and logo alignment custom field as left - confirm that as you drag the window narrower and wider that the horizontal links never overlap the logo.


## Effect Of Changes
### Before
<img width="1087" alt="Screen Shot 2020-11-23 at 12 09 18 PM" src="https://user-images.githubusercontent.com/2664083/99992836-df497b80-2d84-11eb-8018-38c1e696d3ff.png">


### After
<img width="813" alt="Screen Shot 2020-11-23 at 11 45 21 AM" src="https://user-images.githubusercontent.com/2664083/99992861-e6708980-2d84-11eb-9826-28b717fe50a9.png">
<img width="1816" alt="Screen Shot 2020-11-23 at 11 45 34 AM" src="https://user-images.githubusercontent.com/2664083/99992864-e7092000-2d84-11eb-8eea-324c2a0e8239.png">

## Dependencies or Side Effects
_Examples of dependencies or side effects are: NONE
- Additional settings that will be required in the blocks.json NONE
- Changes to the custom fields which will require users to reconfigure features NONE
- Update to css framework or SDK NONE
- Dependency on another PR that needs to be merged first NONE

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ x] Confirmed all the test steps above are working
- [x ] Confirmed there are no linter errors
- [ x] Confirmed this PR has reasonable code coverage
  - [ x] Confirmed this PR has unit test files
  - [ x] Ran `npm test`, made sure all tests are passing
  - [x ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ x] Confirmed relevant documentation has been updated/added.
