### PR TITLE
fix: Odd cache issues between deployments with different params were …

### DIFF
--- a/blocks/resizer-image-content-source-block/sources/resize-image-api.js
+++ b/blocks/resizer-image-content-source-block/sources/resize-image-api.js
@@ -35,4 +35,9 @@ export default {
   params,
   http: false,
   fetch,
+  // not making any network requests anyway
+  // so this won't be too big of a performance hit
+  // and, resizing the image would change between deployments
+  // with caching the same image if params change
+  cache: false,
 };


### PR DESCRIPTION
…due to cache

Full issue: ok figured out how to replicate. go to a currently stable version of blocks. the base deployment of all-blocks: https://corecomponents.arcpublishing.com/pf/all-blocks/?_website=washpost. scroll down to see the large manual promos. you’ll see the images there. then empty cache and hard reload. and make sure your network tab has Disable cache unchecked (uses cache). then go to deployment 565 of all blocks. scroll down to see the large manual promos. you’ll notice broken images with the cm=t param in the source similar to before. now go to d=566 with the backward compatibility cache fix. you’ll see the the manual promos work as expected. you will still see the cm=t in the source (cached). now, go back to 565 and do a full cache clear. you will not see the cm=t in the source (cached from stable version). and the images will work

will test it out with rc