### PR TITLE
Pen 1529

### DIFF
--- a/blocks/video-player-block/README.md
+++ b/blocks/video-player-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/video-player-block`
-_Fusion News Theme video player block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion News Theme video player block. Provides a feature to play videos._
 
 ## Acceptance Criteria
 - Add AC relevant to the block
@@ -7,8 +7,17 @@ _Fusion News Theme video player block. Please provide a 1-2 sentence description
 ## Props
 | **Prop** | **Required** | **Type** | **Description** |
 |---|---|---|---|
-| **required prop** | yes | | |
-| **optional prop** | no | | |
+|customFields.websiteURL|No|String|website URL of the video that should be played in this instance of the video player.|
+|customFields.itemContentConfig|No|Object|Content configuration. Must be a content source that supports the ans-item schema, as well as the necessary parameters needed to make the content source call.|
+|customFields.inheritGlobalContent|No|Boolean|Indicates whether this feature should pull video data from global content.|
+|customFields.autoplay|No|Boolean|Indicates whether the video should autoplay on load.|
+|customFields.playthrough|No|Boolean|If your Goldfish instance is configured to provide recommended videos a value of "true" will result in the player continuing to "play through" recommended videos after the specified video has completed.|
+|customFields.title|No|String|A title to display above the video player.|
+|customFields.description|No|String|A description to display below the video player.|
+|embedMarkup|No|String|The video embed of the video to play. |
+|enableAutoplay|No|String|Indicates whether the video should autoplay on load.|
+| **required prop** | Yes | | |
+| **optional prop** | No | | |
 | **contentConfig example** | | | Please specify which content sources are compatible |
 
 ## ANS Schema

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -4,6 +4,25 @@ import { useContent } from 'fusion:content';
 import PropTypes from 'prop-types';
 import EmbedContainer from 'react-oembed-container';
 import './default.scss';
+import styled from 'styled-components';
+import getThemeStyle from 'fusion:themes';
+import getProperties from 'fusion:properties';
+
+const TitleText = styled.h2`
+  font-family: ${(props) => props.primaryFont};
+`;
+
+const DescriptionText = styled.p`
+  font-family: ${(props) => props.secondaryFont};
+`;
+
+const AlertBadge = styled.span`
+  background-color: #db0a07;
+  border-radius: 5px;
+  color: #fff;
+  display: inline-block;
+  padding: 0.3rem 0.8rem;
+`;
 
 const VideoPlayer = (props) => {
   const {
@@ -12,15 +31,23 @@ const VideoPlayer = (props) => {
     enableAutoplay = false,
   } = props;
 
-  const { inheritGlobalContent = false, websiteURL = '' } = customFields;
-  const { id, globalContent: { embed_html: globalContentHTML = '' } = {}, arcSite } = useFusionContext();
+  const {
+    autoplay,
+    inheritGlobalContent,
+    playthrough,
+    alertBadge,
+    title,
+    description,
+  } = customFields;
+
+  const { id, globalContent = {}, arcSite } = useFusionContext();
   const videoRef = useRef(id);
   let embedHTML = '';
   let doFetch = false;
 
   // If it's inheriting from global content, use the html from the content
   if (inheritGlobalContent) {
-    embedHTML = globalContentHTML;
+    embedHTML = globalContent?.embed_html;
   } else if (embedMarkup) {
     // If there is an embed html being passed in from a parent, use that
     embedHTML = embedMarkup;
@@ -29,21 +56,26 @@ const VideoPlayer = (props) => {
   }
 
   // In all other scenarios, fetch from the provided url and content api
-  const fetchSource = doFetch ? 'content-api' : null;
+  const customFieldSource = customFields?.itemContentConfig?.contentService ?? null;
+  const fetchSource = doFetch ? customFieldSource : null;
 
   const fetchedData = useContent({
     source: fetchSource,
-    query: {
-      website_url: websiteURL,
-      site: arcSite,
-    },
+    query: customFields?.itemContentConfig?.contentConfigValues
+      ? { 'arc-site': arcSite, ...customFields.itemContentConfig.contentConfigValues }
+      : null,
   });
 
   embedHTML = doFetch ? fetchedData && fetchedData.embed_html : embedHTML;
 
-  if (enableAutoplay && embedHTML) {
+  if ((enableAutoplay || autoplay) && embedHTML) {
     const position = embedHTML.search('id=');
     embedHTML = [embedHTML.slice(0, position), ' data-autoplay=true data-muted=true ', embedHTML.slice(position)].join('');
+  }
+
+  if (playthrough && embedHTML) {
+    const position = embedHTML.search('id=');
+    embedHTML = [embedHTML.slice(0, position), ' data-playthrough=true ', embedHTML.slice(position)].join('');
   }
 
   // Make sure that the player does not render until after component is mounted
@@ -59,10 +91,35 @@ const VideoPlayer = (props) => {
   });
 
   return (
-    <div className="embed-video">
-      <EmbedContainer markup={embedHTML}>
-        <div id={`video-${videoRef.current}`} dangerouslySetInnerHTML={{ __html: embedHTML }} />
-      </EmbedContainer>
+    <div className="container-fluid video-promo">
+      <div className="row">
+        <div className="col-sm-xl-12">
+          {alertBadge && <AlertBadge>{alertBadge}</AlertBadge>}
+          {title
+          && (
+          <TitleText
+            primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+            className="xl-promo-headline"
+          >
+            {title}
+          </TitleText>
+          )}
+          <div className="embed-video">
+            <EmbedContainer markup={embedHTML}>
+              <div id={`video-${videoRef.current}`} dangerouslySetInnerHTML={{ __html: embedHTML }} />
+            </EmbedContainer>
+          </div>
+          {description
+            && (
+            <DescriptionText
+              secondaryFont={getThemeStyle(getProperties(arcSite))['secondary-font-family']}
+              className="description-text"
+            >
+              {description}
+            </DescriptionText>
+            )}
+        </div>
+      </div>
     </div>
   );
 };
@@ -72,9 +129,42 @@ VideoPlayer.propTypes = {
     websiteURL: PropTypes.string.tag({
       group: 'Configure Content',
       label: 'Display Content Info',
+      hidden: true,
     }),
+    itemContentConfig: PropTypes.contentConfig('ans-item').tag(
+      {
+        label: 'Video Content',
+        group: 'Configure Content',
+      },
+    ),
     inheritGlobalContent: PropTypes.bool.tag({
       group: 'Configure Content',
+      label: 'Inherit global content',
+      defaultValue: true,
+    }),
+    autoplay: PropTypes.bool.tag(
+      {
+        label: 'Autoplay',
+        defaultValue: false,
+        group: 'Video settings',
+      },
+    ),
+    playthrough: PropTypes.bool.tag({
+      label: 'Playthrough',
+      defaultValue: false,
+      group: 'Video settings',
+    }),
+    title: PropTypes.string.tag({
+      label: 'Title',
+      group: 'Display settings',
+    }),
+    description: PropTypes.string.tag({
+      label: 'Description',
+      group: 'Display settings',
+    }),
+    alertBadge: PropTypes.string.tag({
+      label: 'Alert Badge',
+      group: 'Display settings',
     }),
   }),
   embedMarkup: PropTypes.string,

--- a/blocks/video-player-block/features/video-player/default.test.jsx
+++ b/blocks/video-player-block/features/video-player/default.test.jsx
@@ -1,4 +1,6 @@
 import { useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+import getProperties from 'fusion:properties';
 import VideoPlayer from './default';
 
 const React = require('react');
@@ -97,6 +99,12 @@ describe('VideoPlayer', () => {
     getElementMock.mockReturnValue({ firstElementChild: {} });
     document.getElementById = getElementMock;
 
+    getThemeStyle.mockImplementation(() => (
+      { 'primary-font-family': 'Leopard' }));
+
+    getProperties.mockImplementation(() => (
+      'sampleSite'));
+
     const customFields = { inheritGlobalContent: false };
     const wrapper = mount(<VideoPlayer
       customFields={customFields}
@@ -111,5 +119,74 @@ describe('VideoPlayer', () => {
       + 'front.net/prod/powaBoot.js?org=corecomponents"></script--></div>',
     };
     expect(wrapper.find('#video-12345').prop('dangerouslySetInnerHTML')).toEqual(expectedEmbed);
+  });
+
+  it('if playthrough is enabled, add playthrough props ', () => {
+    const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
+    + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
+    + 'src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
+
+    useFusionContext.mockImplementation(() => (
+      { id: '12345' }));
+
+    const getElementMock = jest.fn();
+    getElementMock.mockReturnValue({ firstElementChild: {} });
+    document.getElementById = getElementMock;
+
+    const customFields = { inheritGlobalContent: false, playthrough: true };
+    const wrapper = mount(<VideoPlayer
+      customFields={customFields}
+      embedMarkup={testEmbed}
+      enableAutoplay
+    />);
+
+    const expectedEmbed = {
+      __html: '<div class="powa"  data-autoplay=true data-muted=true  data-playthrough=true'
+      + ' id="powa-e924" data-org="corecomponents" data-env="prod" data-uuid="e924e51b" '
+      + 'data-aspect-ratio="0.562" data-api="prod"><!--script src="//d2w3jw6424abwq.cloud'
+      + 'front.net/prod/powaBoot.js?org=corecomponents"></script--></div>',
+    };
+    expect(wrapper.find('#video-12345').prop('dangerouslySetInnerHTML')).toEqual(expectedEmbed);
+  });
+
+  it('if title, description, alert badge is provided then show those ', () => {
+    const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
+    + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
+    + 'src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
+
+    useFusionContext.mockImplementation(() => (
+      { id: '12345' }));
+
+    const getElementMock = jest.fn();
+    getElementMock.mockReturnValue({ firstElementChild: {} });
+    document.getElementById = getElementMock;
+
+    const titleText = 'Test Title';
+    const descriptionText = 'Test Description';
+    const alertBadgeText = 'Test Alert  Badge';
+
+    const customFields = {
+      inheritGlobalContent: false,
+      playthrough: true,
+      title: titleText,
+      description: descriptionText,
+      alertBadge: alertBadgeText,
+    };
+
+    const wrapper = mount(<VideoPlayer
+      customFields={customFields}
+      embedMarkup={testEmbed}
+      enableAutoplay
+    />);
+
+    const expectedAlertBadge = '<span class="sc-htpNat dgLZsB">Test Alert  Badge</span>';
+    const expectedTitle = '<h2 class="sc-bdVaJa jbIaBK xl-promo-headline">Test Title</h2>';
+    const expectedDescription = '<p class="sc-bwzfXH gfyHkX description-text">Test Description</p>';
+    const foundStyledComponents = wrapper.find('StyledComponent');
+
+    expect(foundStyledComponents.length).toEqual(3);
+    expect(foundStyledComponents.at(0).html()).toEqual(expectedAlertBadge);
+    expect(foundStyledComponents.at(1).html()).toEqual(expectedTitle);
+    expect(foundStyledComponents.at(2).html()).toEqual(expectedDescription);
   });
 });


### PR DESCRIPTION
## Description
carried over new options/functionality developed in Video Promo over to Video Player Feature.
## Jira Ticket
- [PEN-1529](https://arcpublishing.atlassian.net/browse/PEN-1529)

## Acceptance Criteria
All of the functionality that we’ve implemented in the Video Promo Block is transferred into the Video Center Player Block

All of the Custom Fields listed under Video Promo Block above should also be available on the Video Center Player Block, and the functionality should work as expected

The following existing functionality from the Video Center Player Block is preserved: 

Display Content Info: This Custom Field should be changed to hidden, so that editors can no longer access it in the Custom Fields UI. However, the functionality behind it should be preserved, so that if it is already on a page and filled out, it continues to populate the video content as expected

inheritGlobalContent: This Custom Field should continue to function as it currently does and should stay visible; you should just add a display name to it (Inherit Global Content) (but do not change the custom field ID, since that would break backwards compatibility) 



## Test Steps
Add a Video Player Feature to a page.  Verify the following:
1. Custom Field "Enable Global Content" pulls video data from global content and the feature does not make a content source call to fetch video data.
2.  If Playthrough is selected - the video plays and then begins to play recommended videos.
3.  if Autoplay is selected - the video begins to play automatically on page load.

## Effect Of Changes
### Before


### After
<img width="320" alt="Screen Shot 2020-11-25 at 12 18 23 PM" src="https://user-images.githubusercontent.com/2664083/100276429-836f2600-2f2f-11eb-9e6a-18304deb73dd.png">


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json NONE
- Changes to the custom fields which will require users to reconfigure features NONE
- Update to css framework or SDK NONE
- Dependency on another PR that needs to be merged first NONE

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x ] Confirmed all the test steps above are working
- [x ] Confirmed there are no linter errors
- [x ] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x ] Ran `npm test`, made sure all tests are passing
  - [x ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x ] Confirmed relevant documentation has been updated/added.
