### PR TITLE
PEN-1497: Fix for auto-play custom field not working

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -71,7 +71,7 @@ class LeadArt extends Component {
       isOpen, buttonPosition, content, buttonLabel,
     } = this.state;
 
-    const { arcSite } = this.props;
+    const { arcSite, customFields } = this.props;
 
     if (content.promo_items && (content.promo_items.lead_art || content.promo_items.basic)) {
       const lead_art = (content.promo_items.lead_art || content.promo_items.basic);
@@ -109,7 +109,12 @@ class LeadArt extends Component {
           </LeadArtWrapperDiv>
         );
       } if (lead_art.type === 'video') {
-        return <VideoPlayer embedMarkup={lead_art.embed_html} enableAutoplay />;
+        return (
+          <VideoPlayer
+            embedMarkup={lead_art?.embed_html}
+            enableAutoplay={!!(customFields?.enableAutoplay)}
+          />
+        );
       } if (lead_art.type === 'image') {
         if (buttonPosition !== 'hidden') {
           lightbox = (

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -54,7 +54,7 @@ describe('LeadArt', () => {
     expect(wrapper.find('ReactImageLightbox').length).toEqual(1);
   });
 
-  it('renders video lead art type', () => {
+  it('renders video lead art type without auto-play', () => {
     const globalContent = {
       promo_items: {
         lead_art: {
@@ -63,8 +63,38 @@ describe('LeadArt', () => {
       },
     };
 
-    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
-    expect(wrapper.find('VideoPlayer').length).toEqual(1);
+    const wrapper = shallow(
+      <LeadArt
+        arcSite="the-sun"
+        globalContent={globalContent}
+        customFields={{ enableAutoplay: false }}
+      />,
+    );
+    const vidPlayer = wrapper.find('VideoPlayer');
+    expect(vidPlayer.length).toEqual(1);
+    expect(vidPlayer.prop('enableAutoplay')).toBeFalsy();
+  });
+
+  it('renders video lead art type with auto-play', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'video',
+        },
+      },
+    };
+
+    const wrapper = shallow(
+      <LeadArt
+        arcSite="the-sun"
+        globalContent={globalContent}
+        customFields={{ enableAutoplay: true }}
+      />,
+    );
+    const vidPlayer = wrapper.find('VideoPlayer');
+    expect(vidPlayer.length).toEqual(1);
+    expect(vidPlayer.prop('enableAutoplay')).toBeDefined();
+    expect(vidPlayer.prop('enableAutoplay')).toEqual(true);
   });
 
   it('renders image type', () => {


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Fixed issue where `VideoPlayer` inside `LeadArt` block was always auto-playing regardless of the custom field selection for `Autoplay`. This is now fixed

## Jira Ticket
- [PEN-](https://arcpublishing.atlassian.net/browse/PEN-)

## Acceptance Criteria
1. A new Custom Field is introduced to the Lead Art Block called Autoplay under a group named Video
a. Default behavior is autoplay: disabled (including for Lead Art Blocks already placed on PB pages/templates) and customers can choose to enable it on a per-block basis in PageBuilder. 
i. If autoplay is enabled, video autoplays, but is always muted by default.
2. Tests and documentation are updated to cover this functionality

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. After checking out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/lead-art-block,@wpmedia/video-player-block` in `Fusion-News-Theme`
4. Open **Article Right Rail** template and ensure that there is a `Lead Art` block placed on the page. Open the custom field panel for the `Lead Art` block and set the `Autoplay` custom field to "unchecked". Stage & publish this page.
5. Open http://localhost/pf/news/2020/02/10/video-test/?_website=dagen in a new tab
6. The video on this page should _not_ auto-play (should require you to actually click on the video player in order to start the video).
7. Go back to the `Lead Art` block custom fields in PB editor and set the `Autoplay` custom field to "checked". Stage & publish.
8. Go back to http://localhost/pf/news/2020/02/10/video-test/?_website=dagen and you should see upon page load that the video player starts playing by itself (with no need for user interaction)


## Effect Of Changes
### Before
Auto-play custom field on `Lead Art` block was not working

### After
Auto-play custom field on `Lead Art` block should now work as expected

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.
