### PR TITLE
PEN-1505 Card List Card-Headline is not h1/h2 tag

### DIFF
--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -39,6 +39,8 @@ const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 
+HeadlineText.displayName = 'h2';
+
 const Title = styled.div`
   font-family: ${(props) => props.primaryFont};
 `;
@@ -183,7 +185,7 @@ class CardList extends React.Component {
                   </Title>
                   )}
                 <div>
-                  <Title
+                  <HeadlineText
                     primaryFont={getThemeStyle(arcSite)['primary-font-family']}
                     className="card-list-headline"
                   >
@@ -194,7 +196,7 @@ class CardList extends React.Component {
                     >
                       {contentElements[0].headlines.basic}
                     </a>
-                  </Title>
+                  </HeadlineText>
                   <div className="author-date">
                     <Byline story={contentElements[0]} stylesFor="list" />
                     {/* separator will only be shown if there is at least one author */}

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -39,7 +39,7 @@ const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 
-HeadlineText.displayName = 'h2';
+HeadlineText.displayName = 'HeadlineText';
 
 const Title = styled.div`
   font-family: ${(props) => props.primaryFont};

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -103,7 +103,7 @@ describe('Card list', () => {
       it('should render two anchor tags - one around image one for the title', () => {
         expect(wrapper.find('.list-item-simple').find('.list-anchor').length).toEqual(2);
         expect(wrapper.find('#card-list--link-container').find('Image').length).toEqual(1);
-        expect(wrapper.find('.card-list-headline #card-list--headline-link').length).toEqual(1);
+        expect(wrapper.find('h2.card-list-headline #card-list--headline-link').length).toEqual(1);
       });
 
       it('should render one image wrapped in an anchor tag', () => {
@@ -129,7 +129,7 @@ describe('Card list', () => {
       });
 
       it('should render a main headline', () => {
-        expect(wrapper.find('.card-list-headline').length).toEqual(1);
+        expect(wrapper.find('h2.card-list-headline').length).toEqual(1);
       });
 
       it('should render an author and a publish date section', () => {
@@ -149,11 +149,11 @@ describe('Card list', () => {
       });
 
       it('should set the primary font for the headline', () => {
-        expect(wrapper.find('.card-list-headline')).toHaveProp('primaryFont', 'Papyrus');
+        expect(wrapper.find('h2.card-list-headline')).toHaveProp('primaryFont', 'Papyrus');
       });
 
       it('should set the primary font for the title', () => {
-        expect(wrapper.find('.card-list-headline')).toHaveProp('primaryFont', 'Papyrus');
+        expect(wrapper.find('h2.card-list-headline')).toHaveProp('primaryFont', 'Papyrus');
       });
 
       it('should not add the line divider', () => {
@@ -252,7 +252,7 @@ describe('Card list', () => {
         expect(wrapper.find('.overline').length).toBe(0);
       });
       it('should render headline', () => {
-        expect(wrapper.find('.card-list-headline').length).toBe(1);
+        expect(wrapper.find('h2.card-list-headline').length).toBe(1);
       });
       it('should render author-date', () => {
         expect(wrapper.find('.author-date').length).toBe(1);

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -103,7 +103,7 @@ describe('Card list', () => {
       it('should render two anchor tags - one around image one for the title', () => {
         expect(wrapper.find('.list-item-simple').find('.list-anchor').length).toEqual(2);
         expect(wrapper.find('#card-list--link-container').find('Image').length).toEqual(1);
-        expect(wrapper.find('h2.card-list-headline #card-list--headline-link').length).toEqual(1);
+        expect(wrapper.find('HeadlineText.card-list-headline #card-list--headline-link').length).toEqual(1);
       });
 
       it('should render one image wrapped in an anchor tag', () => {
@@ -129,7 +129,7 @@ describe('Card list', () => {
       });
 
       it('should render a main headline', () => {
-        expect(wrapper.find('h2.card-list-headline').length).toEqual(1);
+        expect(wrapper.find('HeadlineText.card-list-headline').length).toEqual(1);
       });
 
       it('should render an author and a publish date section', () => {
@@ -149,11 +149,11 @@ describe('Card list', () => {
       });
 
       it('should set the primary font for the headline', () => {
-        expect(wrapper.find('h2.card-list-headline')).toHaveProp('primaryFont', 'Papyrus');
+        expect(wrapper.find('HeadlineText.card-list-headline')).toHaveProp('primaryFont', 'Papyrus');
       });
 
       it('should set the primary font for the title', () => {
-        expect(wrapper.find('h2.card-list-headline')).toHaveProp('primaryFont', 'Papyrus');
+        expect(wrapper.find('HeadlineText.card-list-headline')).toHaveProp('primaryFont', 'Papyrus');
       });
 
       it('should not add the line divider', () => {
@@ -252,7 +252,7 @@ describe('Card list', () => {
         expect(wrapper.find('.overline').length).toBe(0);
       });
       it('should render headline', () => {
-        expect(wrapper.find('h2.card-list-headline').length).toBe(1);
+        expect(wrapper.find('HeadlineText.card-list-headline').length).toBe(1);
       });
       it('should render author-date', () => {
         expect(wrapper.find('.author-date').length).toBe(1);


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
_Information about what you changed for this PR_

## Jira Ticket
- [PEN-1505](https://arcpublishing.atlassian.net/browse/PEN-1505)

## Acceptance Criteria
_copy from ticket_
Expected Behavior
Card Headline should be a link and an h1/h2 tag

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. In Fusion-News-Theme repo, checkout master & git pull
2. After checking out this feature branch in fusion-news-theme-blocks, run rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..
3. Run npx fusion start -f -l @wpmedia/card-list-block in Fusion-News-Theme
4. Create a page then add Card Headline for testing purpose
5. Inspect the html element in card title, we assume Headline should be a link and an h2 tag


## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._
Headline showing a link without h2 tag
[include screenshot or gif or link to video, storybook would be awesome]
![image](https://user-images.githubusercontent.com/61674931/102587859-24bc5700-413f-11eb-889c-e56303af8054.png)

### After
_Example: When I clicked the search button, the button turned green._
Headline showing a link with h2 tag
[include screenshot or gif or link to video, storybook would be awesome]
![image](https://user-images.githubusercontent.com/61674931/102588561-35b99800-4140-11eb-9ba3-78b4a2b4c50d.png)

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
