### PR TITLE
PEN-1529: Fixed backwards-compatibility issue with Video Center Player block when "Display Content Info" was set before changes

### DIFF
--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -38,6 +38,7 @@ const VideoPlayer = (props) => {
     alertBadge,
     title,
     description,
+    websiteURL,
   } = customFields;
 
   const { id, globalContent = {}, arcSite } = useFusionContext();
@@ -57,13 +58,19 @@ const VideoPlayer = (props) => {
 
   // In all other scenarios, fetch from the provided url and content api
   const customFieldSource = customFields?.itemContentConfig?.contentService ?? null;
-  const fetchSource = doFetch ? customFieldSource : null;
+  const contentConfigValues = customFields?.itemContentConfig?.contentConfigValues;
+  // Support for deprecated 'websiteURL' custom field (use 'content-api' & URL for fetch)
+  const fetchSource = doFetch ? (
+    (!!websiteURL && 'content-api') || customFieldSource
+  ) : null;
+  const fetchDataQuery = websiteURL ? {
+    website_url: websiteURL,
+    site: arcSite,
+  } : (contentConfigValues && { 'arc-site': arcSite, ...contentConfigValues }) || null;
 
   const fetchedData = useContent({
     source: fetchSource,
-    query: customFields?.itemContentConfig?.contentConfigValues
-      ? { 'arc-site': arcSite, ...customFields.itemContentConfig.contentConfigValues }
-      : null,
+    query: fetchDataQuery,
   });
 
   embedHTML = doFetch ? fetchedData && fetchedData.embed_html : embedHTML;

--- a/blocks/video-player-block/features/video-player/default.test.jsx
+++ b/blocks/video-player-block/features/video-player/default.test.jsx
@@ -1,4 +1,5 @@
 import { useFusionContext } from 'fusion:context';
+import { useContent } from 'fusion:content';
 import getThemeStyle from 'fusion:themes';
 import getProperties from 'fusion:properties';
 import VideoPlayer from './default';
@@ -24,6 +25,23 @@ describe('VideoPlayer', () => {
   it('renders ', () => {
     const wrapper = shallow(<VideoPlayer />);
     expect(wrapper.find('.embed-video').length).toEqual(1);
+  });
+
+  it('renders with deprecated "websiteURL" custom field', () => {
+    const mockFusionContext = { arcSite: 'dagen' };
+    useFusionContext.mockReturnValueOnce(mockFusionContext);
+    const websiteURL = '/some/website/url';
+    const mockFetchParam = {
+      query: {
+        site: mockFusionContext.arcSite,
+        website_url: websiteURL,
+      },
+      source: 'content-api',
+    };
+    const wrapper = shallow(<VideoPlayer customFields={{ websiteURL }} />);
+    expect(wrapper.find('.embed-video').length).toEqual(1);
+    expect(useContent).toHaveBeenCalledTimes(1);
+    expect(useContent).toHaveBeenCalledWith(mockFetchParam);
   });
 
   it('if inheritGlobalContent do not fetch data and use gc ', () => {


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Added support for deprecated 'websiteURL' custom field to <VideoPlayer/> (for backwards compatibility)

## Jira Ticket
- [PEN-1529](https://arcpublishing.atlassian.net/browse/PEN-1529)

## Acceptance Criteria
![image](https://user-images.githubusercontent.com/26662906/101101415-23f7c280-358e-11eb-8af4-910e1a261c2f.png)

## Test Steps
1. Checkout commit `7f8716f9acdca256c3e378d2fd4dd6eb1b0918e1` (before the initial batch of `PEN-1529` changes were added to the repo)
2. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
3. In `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
4. Run `npx fusion start -f -l @wpmedia/video-player-block` in `Fusion-News-Theme`
5. Set global content for the page to `content-api` source with a `websiteURL` of `/video/2019/12/17/a-snowy-waterfall/` and make sure you are using `The Sun` website (`the-sun` site ID)
6. Open a test page, add a `Video Center Player` block to the `main` section and make sure the `Inherit Global Content` checkbox is checked
7. Add another `Video Center Player` block to the `main` section and make sure the `Inherit Global Content` checkbox is _unchecked_. Set the `Display Content Info` custom field to `/video/2020/11/17/video-in-a-vineyard/`;
8. Make sure the video players are both rendering and then stage & publish page
9. Open page in separate tab
10. Make sure that video players both render on separate page and are playable
11. Now stop Fusion, checkout this branch `PEN-1529`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..` in `fusion-news-theme-blocks`, and start Fusion again with `npx fusion start -f -l @wpmedia/video-player-block`
12. If you open `Video Center Player` block in PB editor, you'll notice that `Display Content Info` custom field is gone and there are other new custom fields
13. However, the video player that was configured with a `Display Content Info` value (`Inherit Global Content` unchecked) should still render properly and should no longer be displaying this error on PB admin:
![image](https://user-images.githubusercontent.com/26662906/101103994-c5cbdf00-358f-11eb-84ca-9d6232277be7.png)
14. The video players should also render when opening the test page in a new tab

## Effect Of Changes
### Before
`<VideoPlayer/>` block was not properly backwards-compatible and any instance of this block that had a `Display Content Info` custom field set before deploying these changes was throwing an error.

### After
`<VideoPlayer/>` block is now fully backwards-compatible when an instance was previously setup with a value for `Display Content Info` custom field and will no longer throw an error (and should play the previously-defined video corresponding to the `Display Content Info` custom field).

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.
