### PR TITLE
Pen 1547 reduce linting errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,7 @@ module.exports = {
     'jsx-a11y/role-supports-aria-props': 2,
     'jsx-a11y/scope': 2,
     'jsx-a11y/tabindex-no-positive': 2,
-    "react-hooks/rules-of-hooks": "warn", // todo: this should be an error
+    "react-hooks/rules-of-hooks": "error", 
     "react-hooks/exhaustive-deps": "warn"
   },
 };

--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
@@ -4,7 +4,7 @@ import { useAppContext } from 'fusion:context';
 import { framework } from '@wpmedia/news-theme-css/js/framework';
 import './default.scss';
 
-const getFeatureList = () => {
+const useFeatureList = () => {
   const { renderables } = useAppContext();
   const featureList = {};
   renderables.forEach((renderable) => {
@@ -28,7 +28,7 @@ const RightRailAdvancedLayout = ({ children }) => {
     fullWidth2,
     footer,
   ] = children;
-  const featureList = getFeatureList();
+  const featureList = useFeatureList();
 
   useEffect(() => {
     let mounted = true;

--- a/blocks/right-rail-block/layouts/right-rail/default.jsx
+++ b/blocks/right-rail-block/layouts/right-rail/default.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useAppContext } from 'fusion:context';
 import './default.scss';
 
-const getFeatureList = () => {
+const useFeatueList = () => {
   const { renderables } = useAppContext();
   const featureList = {};
   renderables.forEach((renderable) => {
@@ -16,7 +16,7 @@ const getFeatureList = () => {
 
 const RightRailLayout = ({ children }) => {
   const [navigation, fullWidth1, main, rightRail, fullWidth2, footer] = children;
-  const featureList = getFeatureList();
+  const featureList = useFeatueList();
 
   return (
     <>


### PR DESCRIPTION
## Description
- rule-of-hooks should be an error

## Jira Ticket
- [PEN-1547](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=545&projectKey=PEN&modal=detail&selectedIssue=PEN-1547&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
- rule-of-hooks is an error

## Test Steps
- should see fewer npm run lint errors 

## Effect Of Changes


/Users/howardj/sites/fusion-news-theme-blocks/blocks/ads-block/features/ads/default.jsx
  54:6  warning  React Hook useCallback has missing dependencies: 'debug', 'propsWithContext', and 'siteVars'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

/Users/howardj/sites/fusion-news-theme-blocks/blocks/header-nav-block/features/navigation/_children/search-box.jsx
  17:23  warning  Assignments to the 'disabledBtn' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect  react-hooks/exhaustive-deps

/Users/howardj/sites/fusion-news-theme-blocks/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/search-box.jsx
  17:23  warning  Assignments to the 'disabledBtn' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect  react-hooks/exhaustive-deps

/Users/howardj/sites/fusion-news-theme-blocks/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
  8:27  warning  React Hook "useAppContext" is called in function "getFeatureList" that is neither a React function component nor a custom React Hook function  react-hooks/rules-of-hooks

/Users/howardj/sites/fusion-news-theme-blocks/blocks/right-rail-block/layouts/right-rail/default.jsx
  7:27  warning  React Hook "useAppContext" is called in function "getFeatureList" that is neither a React function component nor a custom React Hook function  react-hooks/rules-of-hooks

✖ 5 problems (0 errors, 5 warnings)


before 




after 

howardj@it-20750 fusion-news-theme-blocks % npm run lint

> fusion-news-theme-blocks@ lint /Users/howardj/sites/fusion-news-theme-blocks
> eslint --ext js --ext jsx blocks components --no-error-on-unmatched-pattern


/Users/howardj/sites/fusion-news-theme-blocks/blocks/ads-block/features/ads/default.jsx
  54:6  warning  React Hook useCallback has missing dependencies: 'debug', 'propsWithContext', and 'siteVars'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

/Users/howardj/sites/fusion-news-theme-blocks/blocks/header-nav-block/features/navigation/_children/search-box.jsx
  17:23  warning  Assignments to the 'disabledBtn' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect  react-hooks/exhaustive-deps

/Users/howardj/sites/fusion-news-theme-blocks/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/search-box.jsx
  17:23  warning  Assignments to the 'disabledBtn' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect  react-hooks/exhaustive-deps

✖ 3 problems (0 errors, 3 warnings)

## Dependencies or Side Effects
- none, simply renaming funcs to be in line with linting 

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x ] Confirmed all the test steps a reviewer will follow above are working. 
- [ x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings. - ish
- [x ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x ] Confirmed this PR has unit test files
  - [x ] Ran `npm run test`, made sure all tests are passing
  - [x ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ x] Confirmed relevant documentation has been updated/added.
