### PR TITLE
Pen 1547 reduce stylelint errors

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+**/*.test.jsx
+**/*.story.jsx

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -14,6 +14,7 @@
         "severity": "warning"
       }
     ],
-    "font-family-no-missing-generic-family-keyword": null
+    "font-family-no-missing-generic-family-keyword": null,
+    "order/properties-alphabetical-order": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -15,6 +15,14 @@
       }
     ],
     "font-family-no-missing-generic-family-keyword": null,
-    "order/properties-alphabetical-order": null
+    "order/properties-alphabetical-order": null,
+    "declaration-property-value-disallowed-list": [
+      true,
+      {
+        "border": [
+          "none"
+        ]
+      }
+    ]
   }
 }

--- a/blocks/ad-taboola-block/features/ad-taboola/default.jsx
+++ b/blocks/ad-taboola-block/features/ad-taboola/default.jsx
@@ -108,7 +108,7 @@ class AdTaboola extends Component {
           <div
             className="tbl-wrapper"
             style={{
-              backgroundColor: 'papayawhip',
+              backgroundColor: '#FFEFD5',
               padding: '20px',
             }}
           >

--- a/blocks/alert-bar-block/features/alert-bar/alert-bar.scss
+++ b/blocks/alert-bar-block/features/alert-bar/alert-bar.scss
@@ -15,7 +15,7 @@ $alert-bar-height: 56px;
 
   .article-link {
     align-items: center;
-    color: white;
+    color: #fff;
     display: flex;
     font-family: $theme-primary-font-family;
     font-size: calculateRem(16px);

--- a/blocks/article-body-block/chains/article-body/_articlebody.scss
+++ b/blocks/article-body-block/chains/article-body/_articlebody.scss
@@ -160,10 +160,6 @@
         border: 2px solid $border-rule-color;
       }
 
-      th {
-        white-space: nowrap;
-      }
-
       th,
       td {
         border: 1px solid $border-rule-color;

--- a/blocks/article-body-block/chains/article-body/_children/heading.jsx
+++ b/blocks/article-body-block/chains/article-body/_children/heading.jsx
@@ -8,6 +8,7 @@ const Heading = ({ element, primaryColor }) => {
     a {
       color: ${(props) => props.primaryColor};
     }
+    /* stylelint-disable-next-line no-missing-end-of-source-newline */
   `;
 
   return (

--- a/blocks/article-body-block/chains/article-body/_children/heading.test.jsx
+++ b/blocks/article-body-block/chains/article-body/_children/heading.test.jsx
@@ -12,14 +12,18 @@ describe('the article body Heading component', () => {
         inline_comments: [],
         _id: 1563473120776,
       },
-      content: 'Heading 3 - <b>bold</b> <i>italic</i> <u>underline</u> <a href="https://www.washingtonpost.com/" target=_blank>hyperlink</a>',
+      content:
+        'Heading 3 - <b>bold</b> <i>italic</i> <u>underline</u> <a href="https://www.washingtonpost.com/" target=_blank>hyperlink</a>',
     };
     const { default: Heading } = require('./heading');
     const wrapper = mount(<Heading element={headingData} />);
     expect(wrapper.find('h3').length).toBe(1);
-    expect(wrapper.find('h3').text()).toMatch('Heading 3 - bold italic underline hyperlink');
-    // eslint-disable-next-line no-useless-escape
-    expect(wrapper.find('h3').html()).toMatch('<h3 class=\"sc-bdVaJa glstMe\">Heading 3 - <b>bold</b> <i>italic</i> <u>underline</u> <a href="https://www.washingtonpost.com/" target=\"_blank\">hyperlink</a></h3>');
+    expect(wrapper.find('h3').text()).toMatch(
+      'Heading 3 - bold italic underline hyperlink',
+    );
+    expect(wrapper.find('h3').html()).toMatchInlineSnapshot(
+      '"<h3 class=\\"sc-bdVaJa cGOhgh\\">Heading 3 - <b>bold</b> <i>italic</i> <u>underline</u> <a href=\\"https://www.washingtonpost.com/\\" target=\\"_blank\\">hyperlink</a></h3>"',
+    );
   });
 
   it('should default to h2 if no heading level is given', () => {
@@ -31,13 +35,17 @@ describe('the article body Heading component', () => {
         inline_comments: [],
         _id: 1563473120776,
       },
-      content: 'Heading 3 - <b>bold</b> <i>italic</i> <u>underline</u> <a href="https://www.washingtonpost.com/" target=_blank>hyperlink</a>',
+      content:
+        'Heading 3 - <b>bold</b> <i>italic</i> <u>underline</u> <a href="https://www.washingtonpost.com/" target=_blank>hyperlink</a>',
     };
     const { default: Heading } = require('./heading');
     const wrapper = mount(<Heading element={headingData} />);
     expect(wrapper.find('h2').length).toBe(1);
-    // eslint-disable-next-line no-useless-escape
-    expect(wrapper.find('h2').html()).toMatch('<h2 class=\"sc-bdVaJa glstMe\">Heading 3 - <b>bold</b> <i>italic</i> <u>underline</u> <a href="https://www.washingtonpost.com/" target=\"_blank\">hyperlink</a></h2>');
-    expect(wrapper.find('h2').text()).toMatch('Heading 3 - bold italic underline hyperlink');
+    expect(wrapper.find('h2').html()).toMatchInlineSnapshot(
+      '"<h2 class=\\"sc-bdVaJa cGOhgh\\">Heading 3 - <b>bold</b> <i>italic</i> <u>underline</u> <a href=\\"https://www.washingtonpost.com/\\" target=\\"_blank\\">hyperlink</a></h2>"',
+    );
+    expect(wrapper.find('h2').text()).toMatch(
+      'Heading 3 - bold italic underline hyperlink',
+    );
   });
 });

--- a/blocks/byline-block/features/byline/default.jsx
+++ b/blocks/byline-block/features/byline/default.jsx
@@ -16,7 +16,7 @@ const BylineSection = styled.section`
     display: inline;
     font-size: .875rem;
     line-height: 1rem;
-`}
+  `}
 `;
 
 const By = styled.span`

--- a/blocks/default-output-block/output-types/styles/_partials/_colors.scss
+++ b/blocks/default-output-block/output-types/styles/_partials/_colors.scss
@@ -5,7 +5,7 @@ $white: #fff;
 $black: #000;
 $light-blue: #f4f7fb;
 $dark-blue: #1955a5;
-$gray: gray;
+$gray: #808080;
 $medium-grey: #b8c1cb;
 $light-gray: #f9f9f9;
 $black-70: rgba(0, 0, 0, 0.7);

--- a/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/_children/promo_label.jsx
@@ -48,7 +48,7 @@ const LabelBoxSmall = styled.div`
 `;
 
 const Label = styled.span`
-  color: white;
+  color: #fff;
   font-family: Arial;
   font-size: 12px;
   font-weight: bold;

--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -17,11 +17,11 @@ const FooterSection = styled.ul`
 `;
 
 export const StyledSocialContainer = styled.div`
-  border: ${(props) => (props.hasSocialLinks ? '1px' : '0')} solid ${(props) => props.primaryColor}; 
+  border: ${(props) => (props.hasSocialLinks ? '1px' : '0')} solid ${(props) => props.primaryColor};
   fill: ${(props) => props.primaryColor};
 
   a {
-    border-right: 1px solid ${(props) => props.primaryColor};;
+    border-right: 1px solid ${(props) => props.primaryColor};
   }
 `;
 

--- a/blocks/header-nav-block/features/navigation/header-nav.scss
+++ b/blocks/header-nav-block/features/navigation/header-nav.scss
@@ -145,7 +145,7 @@ $submenu-link-color: $ui-dark-gray;
 
       a {
         align-items: center;
-        color: white;
+        color: #fff;
         flex: 1;
         justify-content: space-between;
         padding: 14px 0;
@@ -175,7 +175,7 @@ $submenu-link-color: $ui-dark-gray;
 
     .arrow-left {
       border-bottom: $arrow-size solid transparent;
-      border-right: $arrow-size solid white;
+      border-right: $arrow-size solid #fff;
       border-top: $arrow-size solid transparent;
       height: 0;
       left: -$arrow-size;
@@ -187,7 +187,7 @@ $submenu-link-color: $ui-dark-gray;
   }
 
   ul.subsection-menu {
-    background: white;
+    background: #fff;
     border-radius: 2px;
     box-shadow: 0 0 20px 0 rgba(42, 42, 42, 0.5);
     left: 0;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -46,7 +46,7 @@ const StyledSectionDrawer = styled.div`
 `;
 
 const StyledWarning = styled.div`
-  background-color: #cc3300;
+  background-color: #c30;
   color: #fff;
   display: flex;
   align-self: flex-start;

--- a/blocks/large-promo-block/features/large-promo/_children/promo_label.jsx
+++ b/blocks/large-promo-block/features/large-promo/_children/promo_label.jsx
@@ -48,7 +48,7 @@ const LabelBoxSmall = styled.div`
 `;
 
 const Label = styled.span`
-  color: white;
+  color: #fff;
   font-family: Arial;
   font-size: 12px;
   font-weight: bold;

--- a/blocks/masthead-block/features/masthead-block/_children/MastheadItemsContainer.jsx
+++ b/blocks/masthead-block/features/masthead-block/_children/MastheadItemsContainer.jsx
@@ -10,16 +10,13 @@ const MastheadItemsContainer = styled.div`
     flex: 1;
     padding-bottom: 9px;
     padding-top: 5px;
+    justify-content: center;
 
     > p {
       color: #191919;
       font-family: ${(props) => props.primaryFont};
       margin: 0;
     }
-  }
-
-  > div {
-    justify-content: center;
   }
 
   > div:first-child {

--- a/blocks/medium-promo-block/features/medium-promo/_children/promo_label.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/_children/promo_label.jsx
@@ -48,7 +48,7 @@ const LabelBoxSmall = styled.div`
 `;
 
 const Label = styled.span`
-  color: white;
+  color: #fff;
   font-family: Arial;
   font-size: 12px;
   font-weight: bold;

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -32,9 +32,11 @@ const DescriptionText = styled.p`
 `;
 
 const ReadMoreButton = styled.button`
-  background-color:${(props) => props.primaryColor}; 
-  &:not(:disabled):not(.disabled):active:hover, &:not(:disabled):not(.disabled):hover:hover{
-    background-color:${(props) => props.primaryColor}; 
+  background-color: ${(props) => props.primaryColor};
+
+  &:not(:disabled):not(.disabled):active:hover,
+  &:not(:disabled):not(.disabled):hover:hover {
+    background-color: ${(props) => props.primaryColor}; 
   }
 `;
 

--- a/blocks/shared-styles/scss/_extra-large-promo.scss
+++ b/blocks/shared-styles/scss/_extra-large-promo.scss
@@ -5,6 +5,7 @@
     color: $ui-primary-font-color;
     position: relative;
   }
+
   a > picture > img {
     vertical-align: middle;
   }

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -187,10 +187,11 @@ body.nav-open {
     }
 
     &.nav-right:not(:empty) {
-      margin-left:10px
+      margin-left: 10px;
     }
 
-    &.nav-logo, & > .nav-logo {
+    &.nav-logo,
+    & > .nav-logo {
       justify-content: center;
 
       img {
@@ -202,7 +203,7 @@ body.nav-open {
 
       &.nav-logo-left {
         justify-content: flex-start;
-        margin: 0 24px 0 24px;
+        margin: 0 24px;
       }
     }
 

--- a/blocks/shared-styles/scss/_small-promo.scss
+++ b/blocks/shared-styles/scss/_small-promo.scss
@@ -5,6 +5,7 @@
   a {
     color: $ui-primary-font-color;
     position: relative;
+
     h2 {
       display: inline;
     }

--- a/blocks/small-promo-block/features/small-promo/_children/promo_label.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_label.jsx
@@ -32,7 +32,7 @@ const LabelBoxSmall = styled.div`
 `;
 
 const Label = styled.span`
-  color: white;
+  color: #fff;
   font-family: Arial;
   font-size: 12px;
   font-weight: bold;

--- a/blocks/top-table-list-block/features/top-table-list/_children/promo_label.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/promo_label.jsx
@@ -48,7 +48,7 @@ const LabelBoxSmall = styled.div`
 `;
 
 const Label = styled.span`
-  color: white;
+  color: #fff;
   font-family: Arial;
   font-size: 12px;
   font-weight: bold;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "lint": "eslint --ext js --ext jsx blocks components --no-error-on-unmatched-pattern",
     "lint:styles": "stylelint '**/*.(scss|jsx)' --formatter verbose",
-    "lint:styles:fix": "stylelint '**/*.scss' -- --fix",
+    "lint:styles:fix": "stylelint '**/*.scss' --fix",
     "lint:fix": "npm run lint -- --fix",
     "storybook": "start-storybook",
     "test": "jest",


### PR DESCRIPTION
- Reduced many low-hanging fruit for stylelint errors
- Remove alphabetical order as a warning
- Also removed border:none as an issue 
- Again, no effectual changes here. Will need to setup snapshots in order to test output of scss with nesting depth and other output-based changes

before: 

317 problems found
 severity level "error": 301
  max-nesting-depth: 103
  no-descending-specificity: 22
  rule-empty-line-before: 2
  selector-max-compound-selectors: 38
  order/properties-alphabetical-order: 25
  scss/selector-no-redundant-nesting-selector: 9
  declaration-block-trailing-semicolon: 1
  declaration-colon-space-after: 3
  selector-list-comma-newline-after: 2
  selector-no-qualifying-type: 26
  shorthand-property-no-redundant-values: 1
  selector-class-pattern: 11
  color-named: 11
  declaration-property-value-disallowed-list: 14
  selector-max-id: 16
  no-duplicate-selectors: 2
  indentation: 5
  scss/at-import-no-partial-leading-underscore: 2
  declaration-block-semicolon-newline-after: 2
  no-extra-semicolons: 1
  color-hex-length: 1
  block-opening-brace-space-before: 1
  property-no-vendor-prefix: 1
  value-no-vendor-prefix: 1
  no-missing-end-of-source-newline: 1
 severity level "warning": 16
  plugin/no-unsupported-browser-features: 16


after: 

243 problems found
 severity level "error": 227
  max-nesting-depth: 102
  no-descending-specificity: 22
  selector-max-compound-selectors: 37
  scss/selector-no-redundant-nesting-selector: 9
  selector-no-qualifying-type: 26
  selector-class-pattern: 11
  selector-max-id: 16
  scss/at-import-no-partial-leading-underscore: 2
  property-no-vendor-prefix: 1
  value-no-vendor-prefix: 1
 severity level "warning": 16
  plugin/no-unsupported-browser-features: 16

