### PR TITLE
Pen 1480 rc documentation

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
       - name: Publish to beta tag with a short git SHA as the version
-        run: npx lerna publish 0.0.0-$(git rev-parse --short HEAD) --no-git-tag-version --no-push --dist-tag beta --yes
+        run: npx lerna publish 0.0.0-beta.$(git rev-parse --short HEAD) --no-git-tag-version --no-push --dist-tag beta --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check beta failure status

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -31,7 +31,7 @@ jobs:
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
-      - run: npx lerna publish 0.0.0-$(git rev-parse --short HEAD) --no-git-tag-version --no-push --dist-tag canary --yes
+      - run: npx lerna publish 0.0.0-canary.$(git rev-parse --short HEAD) --no-git-tag-version --no-push --dist-tag canary --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
       - name: Publish to rc tag with a short git SHA as the version
-        run: npx lerna publish 0.0.0-$(git rev-parse --short HEAD) --no-git-tag-version --no-push --dist-tag rc --yes
+        run: npx lerna publish 0.0.0-rc.$(git rev-parse --short HEAD) --no-git-tag-version --no-push --dist-tag rc --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check rc failure status

--- a/News Theme Development.md
+++ b/News Theme Development.md
@@ -136,6 +136,18 @@ WARNING: If you need help rolling back publish, please see the wiki [How A Dev C
 NOTE: Make sure to rebase onto beta branch if you hotfix stable, for instance.
 ---
 
+## Cut The `canary` development process for RC release 
+
+1. Ensure all tickets are in current canary branch ready. 
+2. `git push origin canary:rc`
+3. This will publish that version with the rc tag for testing. 
+4. Ensure the engine theme sdk and news-theme-css have also been published to the `rc` tag. (For the news-theme-css, that process is done locally. Engine theme sdk can be done by merging into rc branch.)
+5. Go to admin in Okta
+6. Go to themes internal site. Find the dev-sandbox environment. Then, in the deployer, deploy a feature pack that has the rc versions of the aforementioned repos. This can be done in the `environment/` folder using BLOCK_DIST_TAG (note: not the `.env` file).
+7. Make sure that version is designated as the version release. 
+8. After it's approved, merge `rc` tag into `beta` branch. 
+9. Then, make sure that `beta` branch is rebased onto canary `branch`.
+
 ## For stable releases, it remains manual process
 
 1. Pull the latest `beta` branch:


### PR DESCRIPTION
## Description
Note: This was supposed to be part of PEN-1406, but we broke it into its own ticket. 

## Jira Ticket
- [PEN-1480](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=545&projectKey=PEN&modal=detail&selectedIssue=PEN-1480&assignee=5e387d6a1b1d910e5dfd7a9b)


## Acceptance Criteria

dev-sandbox | Release Candidate regression testing 

Inherits all content from Sandbox (no standalone APIs/editorial apps in this environment)

The Themes platform team can create a Release Candidate 1 week before that release is scheduled to go to customer Sandbox. 

This Release Candidate is testable by Product and QA in a dedicated environment (dev-sandbox)

If regressions are found in the release candidate, they can be fixed and re-deployed to the Release Candidate environment (but new changes that have since gone to Canary should not be included) 


## Test Steps
- Add test steps a reviewer must complete to test this PR

## Effect Of Changes
### Before

- Clear canary -> beta -> stable path

### After

- Clear canary -> rc -> beta -> stable release process 


## Dependencies or Side Effects

- I updated the publish script so that rebasing on top of branches from another tag didn't cause same version issues. Essentially, beta and canary versions were overlapping if there was a rebase. Same with canary going into rc

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working. -> na
- [ x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- na [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - na [ ] Confirmed this PR has unit test files
  - [ x] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x ] Confirmed relevant documentation has been updated/added.
