### PR TITLE
[UAT Fix] PEN-1486: Fix TopTableList errors

### DIFF
--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -108,7 +108,9 @@ const HorizontalOverlineImageStoryItem = (props) => {
 
   const ratios = ratiosFor('LG', imageRatio);
   const promoType = discoverPromoType(element);
-  const videoEmbed = customFields.playVideoInPlaceLG && extractVideoEmbedFromStory(element);
+  const videoEmbed = customFields.playVideoInPlaceLG
+    && !!extractVideoEmbedFromStory
+    && extractVideoEmbedFromStory(element);
 
   return (
     <>

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -102,7 +102,9 @@ const VerticalOverlineImageStoryItem = (props) => {
   };
 
   const ratios = ratiosFor('XL', imageRatio);
-  const videoEmbed = customFields.playVideoInPlaceXL && extractVideoEmbedFromStory(element);
+  const videoEmbed = customFields.playVideoInPlaceXL
+    && !!extractVideoEmbedFromStory
+    && extractVideoEmbedFromStory(element);
 
   return (
     <>

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -125,7 +125,7 @@ const TopTableList = (props) => {
       large = 0,
       medium = 0,
       small = 0,
-      storiesPerRowSM,
+      storiesPerRowSM = 2,
     } = {},
     id = '',
     placeholderResizedImageOptions,
@@ -166,10 +166,15 @@ const TopTableList = (props) => {
   const storyTypes = [...(new Set(storyTypeArray))];
   const storyList = siteContent.map(unserializeStory(arcSite));
   const storyTypeMap = {};
-  storyTypeArray.forEach((sType, index) => {
-    if (!storyTypeMap[sType]) storyTypeMap[sType] = [];
-    storyTypeMap[sType].push(storyList[index]);
-  });
+
+  if (storyList && storyTypeArray) {
+    storyTypeArray.forEach((sType, index) => {
+      if (index < storyList.length) {
+        if (!storyTypeMap[sType]) storyTypeMap[sType] = [];
+        storyTypeMap[sType].push(storyList[index]);
+      }
+    });
+  }
 
   return (
     <div
@@ -187,48 +192,51 @@ const TopTableList = (props) => {
             (storiesPerRowSM && storiesPerRowSM > 1 && storyType === SMALL ? 'row' : ''),
           ].join(' ')}
         >
-          {storyTypeMap[storyType].map((itemObject, index) => {
-            const {
-              id: itemId,
-              itemTitle,
-              imageURL,
-              displayDate,
-              description,
-              by,
-              element,
-              overlineDisplay,
-              overlineUrl,
-              overlineText,
-              resizedImageOptions,
-            } = itemObject;
-            const url = element?.websites[arcSite]?.website_url || '';
-            return (
-              <StoryItemContainer
-                id={itemId}
-                itemTitle={itemTitle}
-                imageURL={imageURL}
-                displayDate={displayDate}
-                description={description}
-                by={by}
-                websiteURL={url}
-                element={element}
-                overlineDisplay={overlineDisplay}
-                overlineUrl={overlineUrl}
-                overlineText={overlineText}
-                storySize={storyType}
-                index={index}
-                storySizeMap={storySizeMap}
-                primaryFont={primaryFont}
-                secondaryFont={secondaryFont}
-                key={itemId}
-                customFields={props.customFields}
-                resizedImageOptions={resizedImageOptions}
-                placeholderResizedImageOptions={placeholderResizedImageOptions}
-                targetFallbackImage={targetFallbackImage}
-                arcSite={arcSite}
-              />
-            );
-          })}
+          {
+            !!storyTypeMap[storyType]
+            && storyTypeMap[storyType].map((itemObject = {}, index) => {
+              const {
+                id: itemId,
+                itemTitle,
+                imageURL,
+                displayDate,
+                description,
+                by,
+                element,
+                overlineDisplay,
+                overlineUrl,
+                overlineText,
+                resizedImageOptions,
+              } = itemObject;
+              const url = element?.websites[arcSite]?.website_url || '';
+              return (
+                <StoryItemContainer
+                  id={itemId}
+                  itemTitle={itemTitle}
+                  imageURL={imageURL}
+                  displayDate={displayDate}
+                  description={description}
+                  by={by}
+                  websiteURL={url}
+                  element={element}
+                  overlineDisplay={overlineDisplay}
+                  overlineUrl={overlineUrl}
+                  overlineText={overlineText}
+                  storySize={storyType}
+                  index={index}
+                  storySizeMap={storySizeMap}
+                  primaryFont={primaryFont}
+                  secondaryFont={secondaryFont}
+                  key={itemId}
+                  customFields={props.customFields}
+                  resizedImageOptions={resizedImageOptions}
+                  placeholderResizedImageOptions={placeholderResizedImageOptions}
+                  targetFallbackImage={targetFallbackImage}
+                  arcSite={arcSite}
+                />
+              );
+            })
+          }
         </div>
       ))}
     </div>


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Put in fix for the scenario where the cumulative total of the 'Number of [SIZE] Stories' exceeds the number of stories retrieved through the content feed. When this occurred previously, the `Top Table List Block` was throwing and error and failing to render. This should no longer be the case. Also setup the `storiesPerRowSM` custom field to have a default value of `2`.

For further information, see Poorva & Sara's comments on the ticket below. This is the video of the error that Poorva provided https://share.getcloudapp.com/llunNAym .

## Jira Ticket
- [PEN-1486](https://arcpublishing.atlassian.net/browse/PEN-1486)

## Acceptance Criteria
Render Top Table List block without errors when number of stories setup through custom fields exceeds the number retrieved from the content feed.

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. After checking out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/top-table-list-block` in `Fusion-News-Theme` repo
4. Open a test page and add a `Top Table List Block` with the following configuration:
![image](https://user-images.githubusercontent.com/26662906/102403610-286ba480-3fac-11eb-83e9-1ee4e39de722.png)
5. Also ensure that when adding the `Top Table List Block` that the `Stories per row` custom field (under **Small story settings**) is set to `2` by default
6. Stage & publish, open page in new tab
7. In both the editor view and page in separate tab, the top table list should render properly and should _not_ throw this error anymore:
![image](https://user-images.githubusercontent.com/26662906/102403869-826c6a00-3fac-11eb-971d-7cb90fdaf978.png)
8. Also check console for any other errors


## Effect Of Changes
### Before
Top Table List block was breaking when cumulative number of stories setup through custom fields exceeds the amount of stories specified to return from the content feed.

### After
Top Table List block should no longer break when cumulative number of stories setup through custom fields exceeds the amount of stories specified to return from the content feed. It should render the number of stories specified through the feature content feed configuration.

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.
