### PR TITLE
PEN-1594 Ability to use See More button when using Collections conten…

### DIFF
--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -40,18 +40,17 @@ const ReadMoreButton = styled.button`
   }
 `;
 
+function fetchStoriesTransform(data, storedList) {
+  const result = storedList;
+  if (data) {
+    // Add new data to previous list
+    result.content_elements = storedList.content_elements.concat(data.content_elements);
+    result.next = data.next;
+  }
+  return result;
+}
 @Consumer
 class ResultsList extends Component {
-  static fetchStoriesTransform(data, storedList) {
-    const result = storedList;
-    if (data) {
-      // Add new data to previous list
-      result.content_elements = storedList.content_elements.concat(data.content_elements);
-      result.next = data.next;
-    }
-    return result;
-  }
-
   constructor(props) {
     super(props);
     this.arcSite = props.arcSite;
@@ -120,7 +119,7 @@ class ResultsList extends Component {
           resultList: {
             source: contentService,
             query: contentConfigValues,
-            transform: (data) => ResultsList.fetchStoriesTransform(data, storedList),
+            transform: (data) => fetchStoriesTransform(data, storedList),
           },
         });
         // Hide button if no more stories to load

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -120,7 +120,7 @@ class ResultsList extends Component {
           resultList: {
             source: contentService,
             query: contentConfigValues,
-            transform: (data) => this.fetchStoriesTransform(data, storedList),
+            transform: (data) => ResultsList.fetchStoriesTransform(data, storedList),
           },
         });
         // Hide button if no more stories to load

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -11,7 +11,7 @@ import getTranslatedPhrases from 'fusion:intl';
 
 import { Image } from '@wpmedia/engine-theme-sdk';
 import { extractResizedParams } from '@wpmedia/resizer-image-block';
-import { resolveDefaultPromoElements } from './helpers';
+import { resolveDefaultPromoElements, fetchStoriesTransform } from './helpers';
 
 // shared with search results list
 // to modify, go to the shared styles block
@@ -40,15 +40,6 @@ const ReadMoreButton = styled.button`
   }
 `;
 
-function fetchStoriesTransform(data, storedList) {
-  const result = storedList;
-  if (data) {
-    // Add new data to previous list
-    result.content_elements = storedList.content_elements.concat(data.content_elements);
-    result.next = data.next;
-  }
-  return result;
-}
 @Consumer
 class ResultsList extends Component {
   constructor(props) {

--- a/blocks/results-list-block/features/results-list/helpers.jsx
+++ b/blocks/results-list-block/features/results-list/helpers.jsx
@@ -17,5 +17,14 @@ const resolveDefaultPromoElements = (customFields = {}) => {
   }, fields);
 };
 
-// eslint-disable-next-line import/prefer-default-export
-export { resolveDefaultPromoElements };
+const fetchStoriesTransform = (data, storedList) => {
+  const result = storedList;
+  if (data) {
+    // Add new data to previous list
+    result.content_elements = storedList.content_elements.concat(data.content_elements);
+    result.next = data.next;
+  }
+  return result;
+};
+
+export { resolveDefaultPromoElements, fetchStoriesTransform };

--- a/blocks/results-list-block/features/results-list/internalTests.test.jsx
+++ b/blocks/results-list-block/features/results-list/internalTests.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import ResultsList from './default';
 import mockData, { oneListItem } from './mock-data';
+import { fetchStoriesTransform } from './helpers';
 
 const mockReturnData = mockData;
 
@@ -213,14 +214,14 @@ describe('fetchStoriesTransform', () => {
   it('if has no data, return storedList', () => {
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
 
-    const result = ResultsList.fetchStoriesTransform(null, 'storedList');
+    const result = fetchStoriesTransform(null, 'storedList');
     expect(result).toEqual('storedList');
   });
 
   it('if has  data, return concatenated data with storedList', () => {
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
 
-    const result = ResultsList.fetchStoriesTransform({ content_elements: ['A', 'B'], next: 10 }, { content_elements: ['C', 'D'] });
+    const result = fetchStoriesTransform({ content_elements: ['A', 'B'], next: 10 }, { content_elements: ['C', 'D'] });
     expect(result).toEqual({ content_elements: ['C', 'D', 'A', 'B'], next: 10 });
   });
 });


### PR DESCRIPTION
…t source

**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
_Information about what you changed for this PR_
Fix typo issue for @wpmedia/results-list-block

## Jira Ticket
- [PEN-1594](https://arcpublishing.atlassian.net/browse/PEN-1594)

## Acceptance Criteria
_copy from ticket_

What should be happening
Clicking the read more button portion of the results-list block should load more stories when that block is configured with the content-api-collections content source.

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. In Fusion-News-Theme repo, checkout master & git pull
2. After checking out this feature branch in fusion-news-theme-blocks, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run npx fusion start -f -l @wpmedia/results-list-block in Fusion-News-Theme
Create a page then add Result List for testing purpose


## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._

### What's Happening
The content source provides the data to the results-list block fine on render, however when the read more button is displayed, clicking that button does nothing

[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._

### What should be happening
Clicking the read more button portion of the results-list block should load more stories when that block is configured with the content-api-collections content source.

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
