### PR TITLE
Pen 1597 playtrough on lead art block

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -114,6 +114,9 @@ class LeadArt extends Component {
           <VideoPlayer
             embedMarkup={lead_art?.embed_html}
             enableAutoplay={!!(customFields?.enableAutoplay)}
+            customFields={{
+              playthrough: !!(customFields?.playthrough)
+            }}
           />
         );
       } if (lead_art.type === 'image') {
@@ -223,6 +226,7 @@ LeadArt.label = 'Lead Art – Arc Block';
 LeadArt.defaultProps = {
   customFields: {
     enableAutoplay: false,
+    playthrough: false,
   },
 };
 
@@ -230,6 +234,11 @@ LeadArt.propTypes = {
   customFields: PropTypes.shape({
     enableAutoplay: PropTypes.bool.tag({
       label: 'Autoplay',
+      defaultValue: false,
+      group: 'Video',
+    }),
+    playthrough: PropTypes.bool.tag({
+      label: 'Playthrough',
       defaultValue: false,
       group: 'Video',
     }),

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -115,7 +115,7 @@ class LeadArt extends Component {
             embedMarkup={lead_art?.embed_html}
             enableAutoplay={!!(customFields?.enableAutoplay)}
             customFields={{
-              playthrough: !!(customFields?.playthrough)
+              playthrough: !!(customFields?.playthrough),
             }}
           />
         );

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -54,6 +54,49 @@ describe('LeadArt', () => {
     expect(wrapper.find('ReactImageLightbox').length).toEqual(1);
   });
 
+  it('renders video lead art type without playthrough', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'video',
+        },
+      },
+    };
+
+    const wrapper = shallow(
+      <LeadArt
+        arcSite="the-sun"
+        globalContent={globalContent}
+        customFields={{ playthrough: false }}
+      />,
+    );
+    const vidPlayer = wrapper.find('VideoPlayer');
+    expect(vidPlayer.length).toEqual(1);
+    expect(vidPlayer.props().customFields.playthrough).toBeFalsy();
+  });
+
+  it('renders video lead art type with playthrough', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'video',
+        },
+      },
+    };
+
+    const wrapper = shallow(
+      <LeadArt
+        arcSite="the-sun"
+        globalContent={globalContent}
+        customFields={{ playthrough: true }}
+      />,
+    );
+    const vidPlayer = wrapper.find('VideoPlayer');
+    expect(vidPlayer.length).toEqual(1);
+    expect(vidPlayer.props().customFields.playthrough).toBeDefined();
+    expect(vidPlayer.props().customFields.playthrough).toEqual(true);
+  });
+
   it('renders video lead art type without auto-play', () => {
     const globalContent = {
       promo_items: {


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
As a PageBuilder editor, I can configure Playthrough for videos that appear in the Lead Art Block, so that I can control whether or not videos playthrough in this position 

## Jira Ticket
- [PEN-1597](https://arcpublishing.atlassian.net/browse/PEN-1597)

## Acceptance Criteria
A new Custom Field is introduced to the Lead Art Block called Playthrough under a group named Video

Default behavior is playthrough: disabled (including for Lead Art Blocks already placed on PB pages/templates) and customers can choose to enable it on a per-block basis in PageBuilder. 

Tests and documentation are updated to cover this functionality

## Test Steps

1. In Fusion-News-Theme repo, checkout master & git pull
2. After checking out this feature branch in fusion-news-theme-blocks, run rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/lead-art-block && npm i && cd ../..
3. Run npx fusion start -f -l  in Fusion-News-Theme
4. Create a page then add Lead Art Block

## Effect Of Changes
### Before
Didn't have this functionality

### After
![image](https://user-images.githubusercontent.com/47773457/102504365-512a9180-40b3-11eb-8786-f7b542e0da79.png)

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
