### PR TITLE
PEN-1496: [CMG] Ability to configure components in navigation bar

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
@@ -31,11 +31,3 @@
     white-space: nowrap;
   }
 }
-
-// Re-adding temporary hack for SVG logo
-// Doesn't scale - only keeping until ticket for real SVG fix
-.news-theme-navigation-container.svg-logo  {
-  .horizontal-links-bar {
-    margin-left: calculateRem(32px);
-  }
-}

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
@@ -6,11 +6,10 @@ const NavLogo = ({ alignment, isVisible }) => {
   const { arcSite, deployment, contextPath } = useFusionContext();
   const { primaryLogo, primaryLogoAlt } = getProperties(arcSite);
   // Check if URL is absolute/base64
-  const primaryLogoPath = (
-    primaryLogo && (
-      primaryLogo.indexOf('http') === 0
-      || primaryLogo.indexOf('base64') === 0
-    ) ? primaryLogo : deployment(`${contextPath}/${primaryLogo}`)
+  const primaryLogoPath = primaryLogo && (
+    primaryLogo.indexOf('http') === 0
+    || primaryLogo.indexOf('base64') === 0
+      ? primaryLogo : deployment(`${contextPath}/${primaryLogo}`)
   );
   const isLogoSVG = (
     !!primaryLogoPath
@@ -19,7 +18,7 @@ const NavLogo = ({ alignment, isVisible }) => {
   return (
     <div className={`nav-logo nav-logo-${alignment} ${isVisible ? 'nav-logo-show' : 'nav-logo-hidden'} ${isLogoSVG ? 'svg-logo' : ''}`}>
       <a href="/" title={primaryLogoAlt}>
-        {!!primaryLogo && (
+        {!!primaryLogoPath && (
           <img
             src={primaryLogoPath}
             alt={primaryLogoAlt || 'Navigation bar logo'}

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useFusionContext } from 'fusion:context';
+import getProperties from 'fusion:properties';
+
+const NavLogo = ({ alignment, isVisible }) => {
+  const { arcSite, deployment, contextPath } = useFusionContext();
+  const { primaryLogo, primaryLogoAlt } = getProperties(arcSite);
+  // Check if URL is absolute/base64
+  const primaryLogoPath = (
+    primaryLogo && (
+      primaryLogo.indexOf('http') === 0
+      || primaryLogo.indexOf('base64') === 0
+    ) ? primaryLogo : deployment(`${contextPath}/${primaryLogo}`)
+  );
+  const isLogoSVG = (
+    !!primaryLogoPath
+    && String(primaryLogoPath).endsWith('.svg')
+  );
+  return (
+    <div className={`nav-logo nav-logo-${alignment} ${isVisible ? 'nav-logo-show' : 'nav-logo-hidden'} ${isLogoSVG ? 'svg-logo' : ''}`}>
+      <a href="/" title={primaryLogoAlt}>
+        {!!primaryLogo && (
+          <img
+            src={primaryLogoPath}
+            alt={primaryLogoAlt || 'Navigation bar logo'}
+          />
+        )}
+      </a>
+    </div>
+  );
+};
+
+export default NavLogo;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.test.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import getProperties from 'fusion:properties';
+import { useFusionContext } from 'fusion:context';
+import { mount } from 'enzyme';
+import NavLogo from './nav-logo';
+
+jest.mock('fusion:properties', () => (jest.fn(() => ({
+  primaryLogo: 'resources/images/logo.png',
+  primaryLogoAlt: 'NavBar logo',
+}))));
+jest.mock('fusion:context', () => ({
+  useFusionContext: jest.fn(() => ({
+    contextPath: 'pf',
+    deployment: jest.fn(() => ({})).mockReturnValue('resources/images/logo.png'),
+  })),
+}));
+
+describe('<NavLogo/>', () => {
+  it('renders left-aligned logo', () => {
+    const wrapper = mount(<NavLogo alignment="left" isVisible />);
+    const navLogo = wrapper.find('.nav-logo');
+    expect(navLogo).toHaveLength(1);
+    expect(navLogo.hasClass('nav-logo-left')).toBe(true);
+    expect(navLogo.hasClass('nav-logo-show')).toBe(true);
+    expect(navLogo.hasClass('nav-logo-hidden')).toBe(false);
+    expect(navLogo.hasClass('svg-logo')).toBe(false);
+
+    const navLogoLink = navLogo.find('a');
+    expect(navLogoLink.prop('href')).toEqual('/');
+    expect(navLogoLink.prop('title')).toEqual('NavBar logo');
+
+    const navLogoImg = navLogoLink.find('img');
+    expect(navLogoImg).toHaveLength(1);
+    expect(navLogoImg.prop('src')).toEqual('resources/images/logo.png');
+    expect(navLogoImg.prop('alt')).toEqual('NavBar logo');
+  });
+
+  it('renders right-aligned logo', () => {
+    const wrapper = mount(<NavLogo alignment="right" isVisible />);
+    const navLogo = wrapper.find('.nav-logo');
+    expect(navLogo).toHaveLength(1);
+    expect(navLogo.hasClass('nav-logo-right')).toBe(true);
+    expect(navLogo.hasClass('nav-logo-show')).toBe(true);
+    expect(navLogo.hasClass('nav-logo-hidden')).toBe(false);
+    expect(navLogo.hasClass('svg-logo')).toBe(false);
+
+    const navLogoLink = navLogo.find('a');
+    expect(navLogoLink.prop('href')).toEqual('/');
+    expect(navLogoLink.prop('title')).toEqual('NavBar logo');
+
+    const navLogoImg = navLogoLink.find('img');
+    expect(navLogoImg).toHaveLength(1);
+    expect(navLogoImg.prop('src')).toEqual('resources/images/logo.png');
+    expect(navLogoImg.prop('alt')).toEqual('NavBar logo');
+  });
+
+  it('renders SVG logo', () => {
+    getProperties.mockReturnValueOnce({
+      primaryLogo: 'resources/images/logo.svg',
+      primaryLogoAlt: 'NavBar SVG logo',
+    });
+    useFusionContext.mockReturnValueOnce({
+      contextPath: 'pf',
+      deployment: jest.fn(() => ({})).mockReturnValue('resources/images/logo.svg'),
+    });
+    const wrapper = mount(<NavLogo alignment="left" isVisible />);
+    const navLogo = wrapper.find('.nav-logo');
+    expect(navLogo).toHaveLength(1);
+    expect(navLogo.hasClass('nav-logo-left')).toBe(true);
+    expect(navLogo.hasClass('nav-logo-show')).toBe(true);
+    expect(navLogo.hasClass('nav-logo-hidden')).toBe(false);
+    expect(navLogo.hasClass('svg-logo')).toBe(true);
+
+    const navLogoLink = navLogo.find('a');
+    expect(navLogoLink.prop('href')).toEqual('/');
+    expect(navLogoLink.prop('title')).toEqual('NavBar SVG logo');
+
+    const navLogoImg = navLogoLink.find('img');
+    expect(navLogoImg).toHaveLength(1);
+    expect(navLogoImg.prop('src')).toEqual('resources/images/logo.svg');
+    expect(navLogoImg.prop('alt')).toEqual('NavBar SVG logo');
+  });
+
+  it('renders non-visible logo', () => {
+    const wrapper = mount(<NavLogo alignment="left" isVisible={false} />);
+    const navLogo = wrapper.find('.nav-logo');
+    expect(navLogo).toHaveLength(1);
+    expect(navLogo.hasClass('nav-logo-show')).toBe(false);
+    expect(navLogo.hasClass('nav-logo-hidden')).toBe(true);
+  });
+
+  it('renders logo with external link URL', () => {
+    getProperties.mockReturnValueOnce({
+      primaryLogo: 'http://www.example.com/logo.png',
+    });
+    useFusionContext.mockReturnValueOnce({
+      contextPath: 'pf',
+      deployment: jest.fn(() => ({})).mockReturnValue('resources/images/logo.png'),
+    });
+    const wrapper = mount(<NavLogo alignment="left" isVisible />);
+    const navLogoImg = wrapper.find('.nav-logo img');
+    expect(navLogoImg).toHaveLength(1);
+    expect(navLogoImg.prop('src')).toEqual('http://www.example.com/logo.png');
+  });
+});

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useFusionContext } from 'fusion:context';
+import getProperties from 'fusion:properties';
+import getTranslatedPhrases from 'fusion:intl';
+import HamburgerMenuIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/HamburgerMenuIcon';
+import SearchBox from './search-box';
+
+const ICON_SIZE = 16;
+
+const NavWidget = ({
+  type,
+  position = 0,
+  children = [],
+  customSearchAction,
+  menuButtonClickAction,
+}) => {
+  const { arcSite } = useFusionContext();
+  const { navColor, locale } = getProperties(arcSite);
+  const phrases = getTranslatedPhrases(locale);
+  if (!type || type === 'none') return null;
+
+  const predefinedWidget = (
+    (type === 'search' && (
+      <SearchBox
+        iconSize={ICON_SIZE}
+        navBarColor={navColor}
+        placeholderText={phrases.t('header-nav-chain-block.search-text')}
+        customSearchAction={customSearchAction}
+      />
+    )) || (type === 'menu' && (
+      <button
+        type="button"
+        onClick={menuButtonClickAction}
+        className={`nav-btn nav-sections-btn border transparent ${navColor === 'light' ? 'nav-btn-light' : 'nav-btn-dark'}`}
+      >
+        <span>{phrases.t('header-nav-chain-block.sections-button')}</span>
+        <HamburgerMenuIcon fill={null} height={ICON_SIZE} width={ICON_SIZE} />
+      </button>
+    ))
+  );
+
+  return predefinedWidget || (
+    children
+    && children.length > 0
+    && position
+    && position > 0
+    && Number.isInteger(position)
+    && position <= children.length
+      ? children[position - 1] : null
+  );
+};
+
+export default NavWidget;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.test.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+// import getProperties from 'fusion:properties';
+// import { useFusionContext } from 'fusion:context';
+import { mount } from 'enzyme';
+import NavWidget from './nav-widget';
+import SearchBox from './search-box';
+
+jest.mock('fusion:properties', () => (jest.fn(() => ({
+  navColor: 'dark', locale: 'somelocale',
+}))));
+jest.mock('fusion:context', () => ({
+  useFusionContext: jest.fn(() => ({
+    arcSite: 'dagen',
+  })),
+}));
+
+describe('<NavWidget/>', () => {
+  it('renders null when type "none"', () => {
+    const wrapper = mount(<NavWidget type="none" />);
+    expect(wrapper).toBeDefined();
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('renders nav widget - search', () => {
+    const customSearchAction = jest.fn(() => {});
+    const wrapper = mount(
+      <NavWidget
+        type="search"
+        customSearchAction={customSearchAction}
+      />,
+    );
+    expect(wrapper).toHaveLength(1);
+    const searchWidget = wrapper.find(SearchBox);
+    expect(searchWidget).toHaveLength(1);
+    expect(searchWidget.prop('customSearchAction')).toEqual(customSearchAction);
+    const searchEl = searchWidget.find('.nav-search');
+    expect(searchEl).toHaveLength(1);
+    expect(searchEl.hasClass('dark')).toBe(true);
+  });
+
+  it('renders nav widget - menu', () => {
+    const menuButtonClick = jest.fn(() => {});
+    const wrapper = mount(
+      <NavWidget
+        type="menu"
+        menuButtonClickAction={menuButtonClick}
+      />,
+    );
+    expect(wrapper).toHaveLength(1);
+    const menuWidget = wrapper.find('button.nav-sections-btn');
+    expect(menuWidget.hasClass('nav-btn-dark')).toBe(true);
+    expect(menuWidget).toHaveLength(1);
+    expect(menuWidget.prop('onClick')).toEqual(menuButtonClick);
+  });
+
+  it('renders nav widget - custom with child component', () => {
+    const ChildComponent = () => <div>something</div>;
+    const wrapper = mount(
+      <NavWidget
+        type="custom"
+        position={1}
+        // eslint-disable-next-line react/no-children-prop
+        children={[<ChildComponent />]}
+      />,
+    );
+    expect(wrapper).toBeDefined();
+    expect(wrapper.isEmptyRender()).toBe(false);
+    expect(wrapper.contains(<ChildComponent />)).toBe(true);
+  });
+
+  it('renders nav widget - custom without child component', () => {
+    const wrapper = mount(
+      <NavWidget
+        type="custom"
+        position={1}
+      />,
+    );
+    expect(wrapper).toBeDefined();
+    expect(wrapper.isEmptyRender()).toBe(true);
+    expect(wrapper.children()).toHaveLength(0);
+  });
+});

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.test.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-// import getProperties from 'fusion:properties';
-// import { useFusionContext } from 'fusion:context';
 import { mount } from 'enzyme';
 import NavWidget from './nav-widget';
 import SearchBox from './search-box';

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import getProperties from 'fusion:properties';
 import getThemeStyle from 'fusion:themes';
 import Navigation from './default';
 import SearchBox from './_children/search-box';
+import { DEFAULT_SELECTIONS } from './nav-helper';
 
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
@@ -19,34 +20,77 @@ jest.mock('fusion:content', () => ({
 }));
 
 describe('the header navigation feature for the default output type', () => {
-  it('should render a SearchBox component in the top navbar', () => {
-    const wrapper = mount(<Navigation />);
+  it('should render search and sections menu in the top-left navbar on desktop', () => {
+    const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+    const navLeftDesktop = wrapper.find('.nav-left > .nav-components--desktop');
+    expect(navLeftDesktop).toHaveLength(1);
+    const searchWidget = navLeftDesktop.find('.nav-search');
+    expect(searchWidget).toHaveLength(1);
+    const menuWidget = navLeftDesktop.find('.nav-sections-btn');
+    expect(menuWidget).toHaveLength(1);
+  });
 
-    expect(wrapper.find('.nav-left').find(SearchBox)).toHaveLength(1);
+  it('should render sections menu in the top-left navbar on mobile', () => {
+    const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+    const navLeftDesktop = wrapper.find('.nav-left > .nav-components--mobile');
+    expect(navLeftDesktop).toHaveLength(1);
+    const menuWidget = navLeftDesktop.find('.nav-sections-btn');
+    expect(menuWidget).toHaveLength(1);
   });
 
   it('should render a SearchBox component in the side navbar', () => {
-    const wrapper = mount(<Navigation />);
-
+    const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
     expect(wrapper.find('#nav-sections').find(SearchBox)).toHaveLength(1);
   });
 
-  it('should render nothing inside the .nav-right', () => {
-    const wrapper = mount(<Navigation />);
+  it('should render nothing inside the .nav-right on desktop', () => {
+    const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+    expect(wrapper.find('.nav-right > .nav-components--desktop').children()).toHaveLength(0);
+  });
 
-    expect(wrapper.find('.nav-right').children()).toHaveLength(0);
+  it('should render nothing inside the .nav-right on mobile', () => {
+    const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+    expect(wrapper.find('.nav-right > .nav-components--mobile').children()).toHaveLength(0);
+  });
+
+  it('should render horizontal links when "logoAlignment" is "left"', () => {
+    const cFields = {
+      ...DEFAULT_SELECTIONS,
+      logoAlignment: 'left',
+      horizontalLinksHierarchy: 'default',
+    };
+    const wrapper = mount(<Navigation customFields={cFields} />);
+    const navBar = wrapper.find('.news-theme-navigation-bar');
+    expect(navBar.hasClass('horizontal-links')).toBe(true);
+    expect(navBar.hasClass('logo-left')).toBe(true);
+    const linksBar = navBar.find('HorizontalLinksBar');
+    expect(linksBar).toHaveLength(1);
+    expect(linksBar.prop('hierarchy')).toEqual(cFields.horizontalLinksHierarchy);
+  });
+
+  it('should not render horizontal links when "logoAlignment" is "center"', () => {
+    const cFields = {
+      ...DEFAULT_SELECTIONS,
+      logoAlignment: 'center',
+      horizontalLinksHierarchy: 'default',
+    };
+    const wrapper = mount(<Navigation customFields={cFields} />);
+    const navBar = wrapper.find('.news-theme-navigation-bar');
+    expect(navBar.hasClass('horizontal-links')).toBe(false);
+    expect(navBar.hasClass('logo-center')).toBe(true);
+    expect(navBar.find('HorizontalLinksBar')).toHaveLength(0);
   });
 
   describe('when the signInOrder customField is set', () => {
     describe('when no child component exists at the signInOrder index', () => {
       it('should render nothing inside the .nav-right', () => {
         const wrapper = mount(
-          <Navigation customFields={{ signInOrder: 2 }}>
+          <Navigation customFields={{ ...DEFAULT_SELECTIONS, signInOrder: 2 }}>
             {[<button key={1} type="button">Sign In</button>]}
           </Navigation>,
         );
-
-        expect(wrapper.find('.nav-right').children()).toHaveLength(0);
+        expect(wrapper.find('.nav-right > .nav-components--desktop').children()).toHaveLength(0);
+        expect(wrapper.find('.nav-right > .nav-components--mobile').children()).toHaveLength(0);
       });
     });
 
@@ -57,101 +101,23 @@ describe('the header navigation feature for the default output type', () => {
             {[<button key={1} type="button">Sign In</button>]}
           </Navigation>,
         );
-
-        expect(wrapper.find('.nav-right').children()).toHaveLength(1);
-        expect(wrapper.find('.nav-right > button')).toHaveText('Sign In');
+        const navRightDesktop = wrapper.find('.nav-right > .nav-components--desktop');
+        const navRightMobile = wrapper.find('.nav-right > .nav-components--mobile');
+        expect(navRightDesktop.children()).toHaveLength(1);
+        expect(navRightMobile.children()).toHaveLength(1);
+        expect(navRightDesktop.find('button')).toHaveText('Sign In');
+        expect(navRightMobile.find('button')).toHaveText('Sign In');
       });
     });
   });
 
-  describe('the navigation bar image/logo', () => {
-    describe('when the theme manifest provides a logo url', () => {
-      it('should make the src of the logo the provided image', () => {
-        getProperties.mockImplementation(() => ({ primaryLogo: 'https://test.com/my-nav-logo.svg' }));
-        const wrapper = mount(<Navigation />);
-
-        expect(wrapper.find('div.nav-logo > a > img')).toHaveProp('src', 'https://test.com/my-nav-logo.svg');
-      });
-
-      it('should make the alt text of the logo the default text', () => {
-        const wrapper = mount(<Navigation />);
-
-        expect(wrapper.find('div.nav-logo > a > img')).toHaveProp('alt', 'Navigation bar logo');
-      });
-
-      describe('when the theme manifest provides alt text for the logo', () => {
-        it('should make the alt text of the logo the provided text', () => {
-          getProperties.mockImplementation(() => ({ primaryLogo: 'my-nav-logo.svg', primaryLogoAlt: 'My Nav Logo' }));
-          const wrapper = mount(<Navigation />);
-
-          expect(wrapper.find('div.nav-logo > a > img')).toHaveProp('alt', 'My Nav Logo');
-        });
-      });
-
-      describe('when the provided logo is a relative url', () => {
-        it('should create a url with a context path', () => {
-          getProperties.mockImplementation(() => ({ primaryLogo: 'image.svg' }));
-          const wrapper = mount(<Navigation />);
-          expect(wrapper.find('div.nav-logo > a > img')).toHaveProp('src', 'path/image.svg');
-        });
-      });
-    });
-
-    describe('when the theme does not provide a logo url', () => {
-      it('should not render a logo', () => {
-        getProperties.mockImplementation(() => ({}));
-        const wrapper = mount(<Navigation />);
-
-        expect(wrapper.find('div.nav-logo > a > img').length).toBe(0);
-      });
-    });
-
-    describe('when no "logoAlignment" custom field is provided to nav bar', () => {
-      it('should default nav logo to "center-aligned" (direct child of the nav bar container)', () => {
-        getProperties.mockImplementation(() => ({ primaryLogo: 'https://test.com/my-nav-logo.svg' }));
-        const wrapper = mount(<Navigation />);
-        expect(wrapper.props().customFields).not.toBeDefined();
-        expect(wrapper.find('.news-theme-navigation-bar > div.nav-left > NavLogo > div.nav-logo')).toHaveLength(0);
-        const navLogoEl = wrapper.find('.news-theme-navigation-bar > NavLogo > div.nav-logo');
-        expect(navLogoEl).toHaveLength(1);
-        expect(navLogoEl.hasClass('nav-logo-center')).toBe(true);
-      });
-    });
-
-    describe('when the nav logo is center-aligned', () => {
-      it('should render in nav bar (center-aligned)', () => {
-        getProperties.mockImplementation(() => ({ primaryLogo: 'https://test.com/my-nav-logo.svg' }));
-        const wrapper = mount(<Navigation customFields={{ logoAlignment: 'center' }} />);
-        expect(wrapper.props().customFields.logoAlignment).toBeDefined();
-        expect(wrapper.props().customFields.logoAlignment).toEqual('center');
-        const navBarEl = wrapper.find('.news-theme-navigation-bar');
-        expect(navBarEl.hasClass('logo-center')).toBe(true);
-        const navLogoEl = navBarEl.find('NavLogo > div.nav-logo');
-        expect(navLogoEl).toHaveLength(1);
-        expect(navLogoEl.hasClass('nav-logo-center')).toBe(true);
-      });
-    });
-
-    describe('when the nav logo is left-aligned', () => {
-      it('should render in nav bar (left-aligned)', () => {
-        getProperties.mockImplementation(() => ({ primaryLogo: 'https://test.com/my-nav-logo.svg' }));
-        const wrapper = mount(<Navigation customFields={{ logoAlignment: 'left' }} />);
-        expect(wrapper.props().customFields.logoAlignment).toBeDefined();
-        expect(wrapper.props().customFields.logoAlignment).toEqual('left');
-        const navBarEl = wrapper.find('.news-theme-navigation-bar');
-        expect(navBarEl.hasClass('logo-left')).toBe(true);
-        const navLogoEl = navBarEl.find('NavLogo > div.nav-logo');
-        expect(navLogoEl).toHaveLength(1);
-        expect(navLogoEl.hasClass('nav-logo-left')).toBe(true);
-      });
-    });
-
+  describe('the navigation bar logo auto hide/show behavior', () => {
     describe('when the page has a masthead-block', () => {
       it('should hide the logo on the initial render', () => {
         getProperties.mockImplementation(() => ({}));
         const wrapper = mount(
           <>
-            <Navigation />
+            <Navigation customFields={DEFAULT_SELECTIONS} />
             <div className="masthead-block-container" />
           </>,
         );
@@ -162,7 +128,7 @@ describe('the header navigation feature for the default output type', () => {
       it('should show the logo after 1 second if there is not a masthead', () => {
         jest.useFakeTimers();
         getProperties.mockImplementation(() => ({}));
-        const wrapper = mount(<Navigation />);
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
         act(() => {
           jest.runAllTimers();
           wrapper.setProps({});
@@ -177,7 +143,7 @@ describe('the header navigation feature for the default output type', () => {
         getProperties.mockImplementation(() => ({
           breakpoints: { small: 0, medium: 1500, large: 2000 },
         }));
-        const wrapper = mount(<Navigation />);
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
         act(() => {
           jest.runAllTimers();
           wrapper.setProps({});
@@ -192,7 +158,7 @@ describe('the header navigation feature for the default output type', () => {
         const spy = jest.spyOn(document, 'querySelector').mockImplementation((selector) => (
           (selector === '.masthead-block-container .masthead-block-logo') ? undefined : {}
         ));
-        const wrapper = mount(<Navigation />);
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
         act(() => {
           jest.runAllTimers();
           wrapper.setProps({});
@@ -209,7 +175,7 @@ describe('the header navigation feature for the default output type', () => {
           (selector === '.masthead-block-container .masthead-block-logo') ? {} : undefined
         ));
 
-        const wrapper = mount(<Navigation />);
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
         act(() => {
           jest.runAllTimers();
           wrapper.setProps({});
@@ -233,7 +199,7 @@ describe('the header navigation feature for the default output type', () => {
         ));
 
         jest.useFakeTimers();
-        const wrapper = mount(<Navigation />);
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
         act(() => {
           jest.runAllTimers();
           wrapper.setProps({});
@@ -259,7 +225,7 @@ describe('the header navigation feature for the default output type', () => {
         ));
         getProperties.mockImplementation(() => ({}));
         jest.useFakeTimers();
-        const wrapper = mount(<Navigation />);
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
         act(() => {
           jest.runAllTimers();
           wrapper.setProps({});
@@ -277,22 +243,19 @@ describe('the header navigation feature for the default output type', () => {
   describe('when the nav color is set to "dark"', () => {
     it('should set the "dark" class on the component', () => {
       getProperties.mockImplementation(() => ({ navColor: 'dark' }));
-      const wrapper = mount(<Navigation />);
-
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
       expect(wrapper.find('#main-nav')).toHaveClassName('dark');
     });
 
     it('should set all buttons to use the light color scheme', () => {
       getProperties.mockImplementation(() => ({ navColor: 'dark' }));
-      const wrapper = mount(<Navigation />);
-
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
       expect(wrapper.find('.nav-btn.nav-sections-btn').every('.nav-btn-dark')).toEqual(true);
     });
 
     it('should pass the navColor to the SearchBox', () => {
       getProperties.mockImplementation(() => ({ navColor: 'dark' }));
-      const wrapper = mount(<Navigation />);
-
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
       expect(wrapper.find(SearchBox).first()).toHaveProp('navBarColor', 'dark');
     });
   });
@@ -300,60 +263,56 @@ describe('the header navigation feature for the default output type', () => {
   describe('when the nav color is set to "light"', () => {
     it('should set the "light" class on the component', () => {
       getProperties.mockImplementation(() => ({ navColor: 'light' }));
-      const wrapper = mount(<Navigation />);
-
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
       expect(wrapper.find('#main-nav')).toHaveClassName('light');
     });
     it('should set all buttons to use the light color scheme', () => {
       getProperties.mockImplementation(() => ({ navColor: 'light' }));
-      const wrapper = mount(<Navigation />);
-
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
       expect(wrapper.find('.nav-btn.nav-sections-btn').every('.nav-btn-light')).toEqual(true);
     });
 
     it('should pass the navColor to the SearchBox', () => {
       getProperties.mockImplementation(() => ({ navColor: 'light' }));
-      const wrapper = mount(<Navigation />);
-
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
       expect(wrapper.find(SearchBox).first()).toHaveProp('navBarColor', 'light');
     });
   });
 
   describe('hamburger menu', () => {
     it('opens and closes with the sections button', () => {
-      const wrapper = shallow(<Navigation />);
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+      expect(wrapper.find('div#nav-sections').hasClass('closed')).toBe(true);
 
-      expect(wrapper.find('#nav-sections').hasClass('closed')).toBe(true);
+      expect(wrapper.find('.nav-left > .nav-components--desktop .nav-sections-btn')).toHaveLength(1);
 
-      wrapper.find('.nav-left > .nav-btn').simulate('click');
-      expect(wrapper.find('#nav-sections').hasClass('open')).toBe(true);
+      wrapper.find('.nav-left > .nav-components--desktop .nav-sections-btn').simulate('click');
+      expect(wrapper.find('div#nav-sections').hasClass('open')).toBe(true);
 
-      wrapper.find('.nav-left > .nav-btn').simulate('click');
-      expect(wrapper.find('#nav-sections').hasClass('closed')).toBe(true);
+      wrapper.find('.nav-left > .nav-components--desktop .nav-sections-btn').simulate('click');
+      expect(wrapper.find('div#nav-sections').hasClass('closed')).toBe(true);
     });
 
     it('open with section button, closes when click the container', () => {
-      const wrapper = shallow(<Navigation />);
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+      expect(wrapper.find('div#nav-sections').hasClass('closed')).toBe(true);
 
-      expect(wrapper.find('#nav-sections').hasClass('closed')).toBe(true);
+      wrapper.find('.nav-left > .nav-components--desktop .nav-sections-btn').simulate('click');
+      expect(wrapper.find('div#nav-sections').hasClass('open')).toBe(true);
 
-      wrapper.find('.nav-left > .nav-btn').simulate('click');
-      expect(wrapper.find('#nav-sections').hasClass('open')).toBe(true);
-
-      wrapper.find('#nav-sections').simulate('click', { target: { closest: () => false } });
-      expect(wrapper.find('#nav-sections').hasClass('closed')).toBe(true);
+      wrapper.find('div#nav-sections').simulate('click', { target: { closest: () => false } });
+      expect(wrapper.find('div#nav-sections').hasClass('closed')).toBe(true);
     });
 
     it('open with section button, must not close when inside the drawer', () => {
-      const wrapper = shallow(<Navigation />);
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+      expect(wrapper.find('div#nav-sections').hasClass('closed')).toBe(true);
 
-      expect(wrapper.find('#nav-sections').hasClass('closed')).toBe(true);
+      wrapper.find('.nav-left > .nav-components--desktop .nav-sections-btn').simulate('click');
+      expect(wrapper.find('div#nav-sections').hasClass('open')).toBe(true);
 
-      wrapper.find('.nav-left > .nav-btn').simulate('click');
-      expect(wrapper.find('#nav-sections').hasClass('open')).toBe(true);
-
-      wrapper.find('#nav-sections').simulate('click', { target: { closest: () => true } });
-      expect(wrapper.find('#nav-sections').hasClass('closed')).toBe(false);
+      wrapper.find('div#nav-sections').simulate('click', { target: { closest: () => true } });
+      expect(wrapper.find('div#nav-sections').hasClass('closed')).toBe(false);
     });
   });
   describe('primary color background color option', () => {
@@ -361,7 +320,7 @@ describe('the header navigation feature for the default output type', () => {
       getProperties.mockImplementation(() => ({ navColor: 'light', navBarBackground: 'primary-color' }));
       getThemeStyle.mockImplementation(() => ({ 'primary-color': '#1B6FA6' }));
 
-      const wrapper = mount(<Navigation />);
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
       expect(wrapper.find('StyledComponent').at(0).prop('navBarBackground')).toEqual('#1B6FA6');
     });
   });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
@@ -1,39 +1,39 @@
 import PropTypes from 'prop-types';
 
-const NAV_COMPONENT_OPTIONS = ['search', 'menu', 'none', 'custom'];
-const NAV_SECTIONS = ['left', 'right'];
-const NAV_BREAKPOINTS = ['mobile', 'desktop'];
-const NAV_SLOT_COUNTS = { mobile: 1, desktop: 2 };
-const DEFAULT_SELECTIONS = {
+export const NAV_COMPONENT_OPTIONS = ['search', 'menu', 'none', 'custom'];
+export const NAV_SECTIONS = ['left', 'right'];
+export const NAV_BREAKPOINTS = ['mobile', 'desktop'];
+export const NAV_SLOT_COUNTS = { mobile: 1, desktop: 2 };
+export const DEFAULT_SELECTIONS = {
   leftComponentDesktop1: 'search',
   leftComponentDesktop2: 'menu',
   leftComponentMobile1: 'menu',
 };
 
-const capitalize = (string) => (
+export const capitalize = (string) => (
   !string ? string : [
     String(string).charAt(0).toUpperCase(),
     String(string).substring(1),
   ].join('')
 );
 
-const getNavComponentLabel = (section, breakpoint, position) => (
+export const getNavComponentLabel = (section, breakpoint, position) => (
   `${capitalize(section)} Component ${position} - ${capitalize(breakpoint)}`
 );
 
-const getNavComponentPropTypeKey = (section, breakpoint, position) => (
+export const getNavComponentPropTypeKey = (section, breakpoint, position) => (
   `${section}Component${capitalize(breakpoint)}${position}`
 );
 
-const getNavComponentIndexPropTypeKey = (section, breakpoint, position) => (
+export const getNavComponentIndexPropTypeKey = (section, breakpoint, position) => (
   `${section}ComponentCustomIndex${capitalize(breakpoint)}${position}`
 );
 
-const getNavComponentDefaultSelection = (propTypeKey) => (
+export const getNavComponentDefaultSelection = (propTypeKey) => (
   (propTypeKey && DEFAULT_SELECTIONS[propTypeKey]) || 'none'
 );
 
-const generateNavComponentPropType = (section, breakpoint, position) => ({
+export const generateNavComponentPropType = (section, breakpoint, position) => ({
   name: getNavComponentLabel(section, breakpoint, position),
   group: `${capitalize(breakpoint)} Components`,
   labels: {
@@ -49,13 +49,14 @@ const generateNavComponentPropType = (section, breakpoint, position) => ({
   hidden: false,
 });
 
-const generateNavComponentIndexPropType = (section, breakpoint, position) => ({
+export const generateNavComponentIndexPropType = (section, breakpoint, position) => ({
   name: `If custom, position of ${getNavComponentLabel(section, breakpoint, position)}`,
   group: `${capitalize(breakpoint)} Components`,
   required: false,
   hidden: false,
 });
 
+// istanbul ignore next
 // eslint-disable-next-line import/prefer-default-export
 export const generateNavComponentPropTypes = () => {
   const navComponentPropTypes = {};
@@ -77,41 +78,4 @@ export const generateNavComponentPropTypes = () => {
     });
   });
   return navComponentPropTypes;
-};
-
-export const generateNavComponentMap = (navComponentProps) => {
-  const navComponentMap = {};
-  NAV_SECTIONS.forEach((navSection) => {
-    navComponentMap[navSection] = {};
-    NAV_BREAKPOINTS.forEach((navBreakpoint) => {
-      navComponentMap[navSection][navBreakpoint] = [];
-      let userHasMadeSelection = false;
-      const navComponentKeys = [];
-      // eslint-disable-next-line no-plusplus
-      for (let i = 1; i <= NAV_SLOT_COUNTS[navBreakpoint]; i++) {
-        const customFieldKey = getNavComponentPropTypeKey(navSection, navBreakpoint, i);
-        const customFieldIndexKey = getNavComponentIndexPropTypeKey(navSection, navBreakpoint, i);
-        const customFieldValue = navComponentProps[customFieldKey];
-        const customFieldIndexValue = navComponentProps[customFieldIndexKey];
-        if (customFieldValue !== getNavComponentDefaultSelection(customFieldKey)) {
-          userHasMadeSelection = true;
-        }
-        let navComponentKey = customFieldValue;
-        if (navComponentKey === 'custom' && customFieldIndexValue) {
-          navComponentKey = `${navComponentKey}_${customFieldIndexValue}`;
-        }
-        navComponentKeys.push(navComponentKey);
-      }
-
-      const { useSignInButton = false } = navComponentProps;
-      if (navSection === 'right' && !userHasMadeSelection && !!useSignInButton) {
-        navComponentMap[navSection][navBreakpoint].push('signin');
-      } else {
-        navComponentKeys.forEach((currKey) => {
-          navComponentMap[navSection][navBreakpoint].push(currKey);
-        });
-      }
-    });
-  });
-  return navComponentMap;
 };

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
@@ -1,0 +1,117 @@
+import PropTypes from 'prop-types';
+
+const NAV_COMPONENT_OPTIONS = ['search', 'menu', 'none', 'custom'];
+const NAV_SECTIONS = ['left', 'right'];
+const NAV_BREAKPOINTS = ['mobile', 'desktop'];
+const NAV_SLOT_COUNTS = { mobile: 1, desktop: 2 };
+const DEFAULT_SELECTIONS = {
+  leftComponentDesktop1: 'search',
+  leftComponentDesktop2: 'menu',
+  leftComponentMobile1: 'menu',
+};
+
+const capitalize = (string) => (
+  !string ? string : [
+    String(string).charAt(0).toUpperCase(),
+    String(string).substring(1),
+  ].join('')
+);
+
+const getNavComponentLabel = (section, breakpoint, position) => (
+  `${capitalize(section)} Component ${position} - ${capitalize(breakpoint)}`
+);
+
+const getNavComponentPropTypeKey = (section, breakpoint, position) => (
+  `${section}Component${capitalize(breakpoint)}${position}`
+);
+
+const getNavComponentIndexPropTypeKey = (section, breakpoint, position) => (
+  `${section}ComponentCustomIndex${capitalize(breakpoint)}${position}`
+);
+
+const getNavComponentDefaultSelection = (propTypeKey) => (
+  (propTypeKey && DEFAULT_SELECTIONS[propTypeKey]) || 'none'
+);
+
+const generateNavComponentPropType = (section, breakpoint, position) => ({
+  name: getNavComponentLabel(section, breakpoint, position),
+  group: `${capitalize(breakpoint)} Components`,
+  labels: {
+    search: 'Search',
+    menu: 'Site Menu',
+    none: 'None',
+    custom: 'Custom',
+  },
+  defaultValue: getNavComponentDefaultSelection(
+    getNavComponentPropTypeKey(section, breakpoint, position),
+  ),
+  required: false,
+  hidden: false,
+});
+
+const generateNavComponentIndexPropType = (section, breakpoint, position) => ({
+  name: `If custom, position of ${getNavComponentLabel(section, breakpoint, position)}`,
+  group: `${capitalize(breakpoint)} Components`,
+  required: false,
+  hidden: false,
+});
+
+// eslint-disable-next-line import/prefer-default-export
+export const generateNavComponentPropTypes = () => {
+  const navComponentPropTypes = {};
+  NAV_SECTIONS.forEach((navSection) => {
+    NAV_BREAKPOINTS.forEach((navBreakpoint) => {
+      // eslint-disable-next-line no-plusplus
+      for (let i = 1; i <= NAV_SLOT_COUNTS[navBreakpoint]; i++) {
+        navComponentPropTypes[
+          getNavComponentPropTypeKey(navSection, navBreakpoint, i)
+        ] = PropTypes.oneOf(NAV_COMPONENT_OPTIONS).tag(
+          generateNavComponentPropType(navSection, navBreakpoint, i),
+        );
+        navComponentPropTypes[
+          getNavComponentIndexPropTypeKey(navSection, navBreakpoint, i)
+        ] = PropTypes.number.tag(
+          generateNavComponentIndexPropType(navSection, navBreakpoint, i),
+        );
+      }
+    });
+  });
+  return navComponentPropTypes;
+};
+
+export const generateNavComponentMap = (navComponentProps) => {
+  const navComponentMap = {};
+  NAV_SECTIONS.forEach((navSection) => {
+    navComponentMap[navSection] = {};
+    NAV_BREAKPOINTS.forEach((navBreakpoint) => {
+      navComponentMap[navSection][navBreakpoint] = [];
+      let userHasMadeSelection = false;
+      const navComponentKeys = [];
+      // eslint-disable-next-line no-plusplus
+      for (let i = 1; i <= NAV_SLOT_COUNTS[navBreakpoint]; i++) {
+        const customFieldKey = getNavComponentPropTypeKey(navSection, navBreakpoint, i);
+        const customFieldIndexKey = getNavComponentIndexPropTypeKey(navSection, navBreakpoint, i);
+        const customFieldValue = navComponentProps[customFieldKey];
+        const customFieldIndexValue = navComponentProps[customFieldIndexKey];
+        if (customFieldValue !== getNavComponentDefaultSelection(customFieldKey)) {
+          userHasMadeSelection = true;
+        }
+        let navComponentKey = customFieldValue;
+        if (navComponentKey === 'custom' && customFieldIndexValue) {
+          navComponentKey = `${navComponentKey}_${customFieldIndexValue}`;
+        }
+        navComponentKeys.push(navComponentKey);
+      }
+
+      const { useSignInButton = false } = navComponentProps;
+      if (navSection === 'right' && !userHasMadeSelection && !!useSignInButton) {
+        navComponentMap[navSection][navBreakpoint].push('signin');
+      } else {
+        navComponentKeys.forEach((currKey) => {
+          navComponentMap[navSection][navBreakpoint].push(currKey);
+        });
+      }
+    });
+  });
+  return navComponentMap;
+};

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.test.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.test.js
@@ -1,0 +1,84 @@
+import {
+  capitalize,
+  getNavComponentLabel,
+  getNavComponentPropTypeKey,
+  getNavComponentIndexPropTypeKey,
+  getNavComponentDefaultSelection,
+  generateNavComponentPropType,
+  generateNavComponentIndexPropType,
+} from './nav-helper';
+
+describe('nav-helper', () => {
+  describe('capitalize()', () => {
+    it('returns input when falsy', () => {
+      const result = capitalize(null);
+      expect(result).toEqual(null);
+    });
+
+    it('returns capitalized string', () => {
+      const result = capitalize('something');
+      expect(result).toEqual('Something');
+    });
+  });
+
+  describe('getNavComponentLabel()', () => {
+    it('returns nav item custom field label', () => {
+      const result = getNavComponentLabel('left', 'desktop', 1);
+      expect(result).toEqual('Left Component 1 - Desktop');
+    });
+  });
+
+  describe('getNavComponentPropTypeKey()', () => {
+    it('returns nav item custom field key', () => {
+      const result = getNavComponentPropTypeKey('left', 'desktop', 1);
+      expect(result).toEqual('leftComponentDesktop1');
+    });
+  });
+
+  describe('getNavComponentIndexPropTypeKey()', () => {
+    it('returns nav item index custom field key', () => {
+      const result = getNavComponentIndexPropTypeKey('left', 'desktop', 1);
+      expect(result).toEqual('leftComponentCustomIndexDesktop1');
+    });
+  });
+
+  describe('getNavComponentDefaultSelection()', () => {
+    it('returns nav item custom field default value', () => {
+      const result = getNavComponentDefaultSelection('leftComponentDesktop1');
+      expect(result).toEqual('search');
+    });
+
+    it('returns "none" when nav item custom field default value not found', () => {
+      const result = getNavComponentDefaultSelection('leftComponentDesktop3');
+      expect(result).toEqual('none');
+    });
+  });
+
+  describe('generateNavComponentPropType()', () => {
+    it('returns nav item proptype', () => {
+      const result = generateNavComponentPropType('left', 'desktop', 1);
+      expect(result).toEqual({
+        defaultValue: 'search',
+        group: 'Desktop Components',
+        hidden: false,
+        labels: {
+          custom: 'Custom', menu: 'Site Menu', none: 'None', search: 'Search',
+        },
+        name: 'Left Component 1 - Desktop',
+        required: false,
+      });
+    });
+  });
+
+  describe('generateNavComponentIndexPropType()', () => {
+    it('returns nav item index proptype', () => {
+      const result = generateNavComponentIndexPropType('left', 'desktop', 1);
+      expect(result).toEqual({
+        group: 'Desktop Components',
+        hidden: false,
+        name: 'If custom, position of Left Component 1 - Desktop',
+        required: false,
+      });
+    });
+  });
+});

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -186,11 +186,28 @@ body.nav-open {
 
     &.nav-left,
     &.nav-right {
-      & > * {
-        margin-right: calculateRem(16px);
+      & > .nav-components {
+        &--mobile,
+        &--desktop {
+          & > * {
+            margin-right: calculateRem(16px);
+    
+            &:last-child {
+              margin-right: 0;
+            }
+          }
+        }
 
-        &:last-child {
-          margin-right: 0;
+        &--mobile {
+          @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
+            display: none;
+          }
+        }
+
+        &--desktop {
+          @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+            display: none;
+          }
         }
       }
     }
@@ -211,6 +228,10 @@ body.nav-open {
         max-height: 40px;
         max-width: 240px;
         width: auto;
+      }
+
+      &.svg-logo {
+        flex: 1;
       }
     }
 

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -189,6 +189,8 @@ body.nav-open {
       & > .nav-components {
         &--mobile,
         &--desktop {
+          align-items: center;
+          
           & > * {
             margin-right: calculateRem(16px);
     


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Added configuration custom fields (with both "desktop" and "mobile" options) to the Header Nav Chain Block.

## Jira Ticket
- [PEN-1496](https://arcpublishing.atlassian.net/browse/PEN-1496)

## Acceptance Criteria
![image](https://user-images.githubusercontent.com/26662906/102844609-66643080-43d1-11eb-9ee1-a5b5e80eff89.png)

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `add-fake-weather-feature-for-nav-testing` & `git pull` (https://github.com/WPMedia/Fusion-News-Theme/pull/152/files)
2. After checking out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/shared-styles` in `Fusion-News-Theme`
4. Open homepage in PB editor and test three different combinations of settings. After each change, stage & publish page and open http://localhost/pf/homepage/?_website=the-dagen in separate tab:
a. Logo left-aligned **without** horizontal links defined
b. Logo left-aligned **with** horizontal links defined
c. Logo center-aligned (with or without horizontal links defined - shouldn't matter but feel free to test both)
d. Now within the mobile and desktop groups (under custom fields), try various different combinations of buttons placed in the left and right nav bar containers. When testing the "custom" type, you will need to add a feature as a child of the nav bar chain. Then, you will need to specify the position of the child component to use (which is a "1-based" index - not zero-based). 
![image](https://user-images.githubusercontent.com/26662906/102845145-81837000-43d2-11eb-8198-4df20ce4a878.png)
5. Test clicking on search button and search input box should expand (pushing other elements to the right). The search box should have the same height as the other nav bar buttons.
6. Test making the viewport smaller which cuts off space for the horizontal links to display. When a horizontal links bar has too many links to fit on the current viewport width, the horizontal link elements should be truncated as needed (disappear when no space available for them). Horizontal links bar should be left-aligned against the logo.
7. Ensure that everything displays as expected across breakpoints. When the logo is centered, it should display pretty much the same on tablet/mobile (no horizontal links) except mobile only allows one button/widget on each side of the nav. When the logo is left-aligned, the horizontal links should be hidden on the mobile breakpoint.

## Effect Of Changes
### Before
There were no configuration options for how buttons/widgets could be placed (right vs left side, item order).

### After
There are now configuration options for how buttons/widgets can be placed (right vs left side, item order). The new options allow you to configure what items should display (and in what order) based on the breakpoint (desktop vs mobile).

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.
