### PR TITLE
PEN-1506 Simple List & Card List has div instead of article tags

### DIFF
--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -132,7 +132,7 @@ class CardList extends React.Component {
                   )
                   : ''
               }
-              <div
+              <article
                 className="list-item-simple"
                 key={`result-card-${contentElements[0].websites[arcSite].website_url}`}
               >
@@ -207,7 +207,7 @@ class CardList extends React.Component {
                     />
                   </div>
                 </div>
-              </div>
+              </article>
               {
                 contentElements.slice(1).map((element) => {
                   const {

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -66,7 +66,7 @@ describe('Card list', () => {
       wrapper.update();
       expect(wrapper.find('.card-list-container').length).toEqual(1);
       expect(wrapper.find('article.card-list-item').length).toEqual(0);
-      expect(wrapper.find('.list-item-simple').length).toEqual(1);
+      expect(wrapper.find('article.list-item-simple').length).toEqual(1);
       expect(wrapper.find('.simple-results-list-container').childAt(0).hasClass('list-item-simple')).toEqual(true);
     });
   });
@@ -101,27 +101,27 @@ describe('Card list', () => {
       });
 
       it('should render two anchor tags - one around image one for the title', () => {
-        expect(wrapper.find('.list-item-simple').find('.list-anchor').length).toEqual(2);
+        expect(wrapper.find('article.list-item-simple').find('.list-anchor').length).toEqual(2);
         expect(wrapper.find('#card-list--link-container').find('Image').length).toEqual(1);
         expect(wrapper.find('HeadlineText.card-list-headline #card-list--headline-link').length).toEqual(1);
       });
 
       it('should render one image wrapped in an anchor tag', () => {
-        expect(wrapper.find('.list-item-simple').find('.list-anchor').find('Image').length).toEqual(1);
+        expect(wrapper.find('article.list-item-simple').find('.list-anchor').find('Image').length).toEqual(1);
       });
 
       it('should render an anchor ', () => {
-        expect(wrapper.find('.list-item-simple').find('.list-anchor').at(0).find('a').length).toEqual(1);
+        expect(wrapper.find('article.list-item-simple').find('.list-anchor').at(0).find('a').length).toEqual(1);
       });
 
       it('should render an anchor and an image with the correct url', () => {
-        const anchors = wrapper.find('.list-item-simple').find('.list-anchor');
+        const anchors = wrapper.find('article.list-item-simple').find('.list-anchor');
         expect(anchors.at(0).prop('href')).toEqual('/this/is/the/correct/url');
         expect(anchors.at(1).prop('href')).toEqual('/this/is/the/correct/url');
       });
 
       it('should render an anchor and an image with alt text', () => {
-        expect(wrapper.find('.list-item-simple').find('.list-anchor').find('Image').prop('alt')).toEqual('Article with a YouTube embed in it');
+        expect(wrapper.find('article.list-item-simple').find('.list-anchor').find('Image').prop('alt')).toEqual('Article with a YouTube embed in it');
       });
 
       it('should render an overline', () => {
@@ -133,7 +133,7 @@ describe('Card list', () => {
       });
 
       it('should render an author and a publish date section', () => {
-        expect(wrapper.find('.list-item-simple').find('.author-date').length).toEqual(1);
+        expect(wrapper.find('article.list-item-simple').find('.author-date').length).toEqual(1);
       });
 
       it('should render a byline', () => {
@@ -157,7 +157,7 @@ describe('Card list', () => {
       });
 
       it('should not add the line divider', () => {
-        expect(wrapper.find('.list-item-simple--divider').length).toEqual(0);
+        expect(wrapper.find('article.list-item-simple--divider').length).toEqual(0);
       });
     });
   });
@@ -258,7 +258,7 @@ describe('Card list', () => {
         expect(wrapper.find('.author-date').length).toBe(1);
       });
       it('should render image', () => {
-        expect(wrapper.find('.list-item-simple Image').length).toBe(1);
+        expect(wrapper.find('article.list-item-simple Image').length).toBe(1);
       });
     });
   });


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
_Information about what you changed for this PR_
Relace div by using article tag for Simple list and card list
## Jira Ticket
- [PEN-1506](https://arcpublishing.atlassian.net/browse/PEN-1506)

## Acceptance Criteria
_copy from ticket_
Expected Behavior
article-tag wrapping an article for Simple list and card list

## Test Steps
- Add test steps a reviewer must complete to test this PR
1. In Fusion-News-Theme repo, checkout master & git pull
2. After checking out this feature branch in fusion-news-theme-blocks, run rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..
3. Run npx fusion start -f -l @wpmedia/card-list-block,@wpmedia/simple-list-block in Fusion-News-Theme
4. Create a page then add Card List and Simple List for testing purpose
Inspect the html element on all of article to verify

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]
<img width="1248" alt="Screen Shot 2020-12-23 at 10 44 09" src="https://user-images.githubusercontent.com/61674931/102958059-a5e46700-450e-11eb-8524-334e65877bf2.png">


### After
_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]
<img width="1284" alt="Screen Shot 2020-12-23 at 11 02 33" src="https://user-images.githubusercontent.com/61674931/102958067-aa108480-450e-11eb-9cf6-3e15b4d2615a.png">

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
