### PR TITLE
PEN-1496: UAT fixes

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -280,7 +280,7 @@ const Nav = (props) => {
         </StyledSectionDrawer>
 
       </StyledNav>
-      {(!displayLinks && isAdmin) && (
+      {(horizontalLinksHierarchy && logoAlignment !== 'left' && isAdmin) && (
         <StyledWarning>
           In order to render horizontal links, the logo must be aligned to the left.
         </StyledWarning>

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -208,11 +208,12 @@ const Nav = (props) => {
     const renderWidgets = (bpoint) => {
       let widgetList = [];
       let userHasConfigured = false;
+      console.log('customFields', customFields);
       // eslint-disable-next-line no-plusplus
       for (let i = 1; i <= NAV_SLOT_COUNTS[bpoint]; i++) {
         const cFieldKey = getNavComponentPropTypeKey(side, bpoint, i);
         const cFieldIndexKey = getNavComponentIndexPropTypeKey(side, bpoint, i);
-        const navWidgetType = customFields[cFieldKey] || 'none';
+        const navWidgetType = getNavComponentDefaultSelection(cFieldKey);
         if (!!navWidgetType && navWidgetType !== 'none') {
           widgetList.push(
             <NavWidget

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -208,7 +208,6 @@ const Nav = (props) => {
     const renderWidgets = (bpoint) => {
       let widgetList = [];
       let userHasConfigured = false;
-      console.log('customFields', customFields);
       // eslint-disable-next-line no-plusplus
       for (let i = 1; i <= NAV_SLOT_COUNTS[bpoint]; i++) {
         const cFieldKey = getNavComponentPropTypeKey(side, bpoint, i);

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
@@ -38,7 +38,7 @@ export const generateNavComponentPropType = (section, breakpoint, position) => (
   group: `${capitalize(breakpoint)} Components`,
   labels: {
     search: 'Search',
-    menu: 'Site Menu',
+    menu: 'Sections Menu',
     none: 'None',
     custom: 'Custom',
   },

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.test.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.test.js
@@ -62,7 +62,7 @@ describe('nav-helper', () => {
         group: 'Desktop Components',
         hidden: false,
         labels: {
-          custom: 'Custom', menu: 'Site Menu', none: 'None', search: 'Search',
+          custom: 'Custom', menu: 'Sections Menu', none: 'None', search: 'Search',
         },
         name: 'Left Component 1 - Desktop',
         required: false,

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -201,14 +201,20 @@ body.nav-open {
         }
 
         &--mobile {
-          @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-            display: none;
-          }
+          display: none;
         }
 
         &--desktop {
-          @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+          display: inherit;
+        }
+
+        @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+          &--desktop {
             display: none;
+          }
+
+          &--mobile {
+            display: inherit;
           }
         }
       }


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
_UAT feedback from PEN-1496_

## Jira Ticket
- [PEN-1496](https://arcpublishing.atlassian.net/browse/PEN-1496)

## UAT Feedback
1) [Default custom fields should also work for existing chains](https://arcpublishing.atlassian.net/browse/PEN-1496?focusedCommentId=499295)
2) No components are displaying on Tablet
3) Existing signInOrder component displays as expected on Desktop, but not Tablet/Mobile
4) Error message displaying in situations where it shouldn’t
5) In all the custom fields that currently have the display name Site Menu, change that display name to Sections Menu

## Test Steps
1) So, I'm not sure how to test this one, because I can't replicate an "existing" chain without a db dump. I'll point it out in thee code what I changed that I think should fix it on a deployed environment. Tips on how to fix it welcome 😂 

2) Turns out, this was *only* happening at `768px` exactly! You can check that it is working by doing the following
  - Add a navigation chain to a page.
  - Use the browser tools to make the size of the screen 768 OR use the admin and switch the device to iPad.
  - Ensure that the mobile components are displaying.
  - Check smaller and larger sizes to confirm nothing else is looking wrong.

3) Again, I was not sure how to replicate this scenario without a DB dump. However, I did go on to the deployed environment link and tested this issue with a different widget and it seems to be working without the current HTML box.
  - Go to the navigation test page in the admin: https://corecomponents.arcpublishing.com/pagebuilder/editor/curate?p=pJJg8YsIdoUnNsWjs&v=vf0zCdFwUsUnNsWjs
  - Go to the "existing" navigation chain and swap out the first feature for another one (for example, the example weather widget)
  - Confirm it displays in tablet
  - Yeah, I don't know what's going on with the html box because it doesn't seem to be breakpoint dependent? I dunno.

4) Error Message fix:
 - Add the navigation chain in the admin. The warning should not appear immediately.
 - Mimic adding in a hierarchy by putting text into the `Horizontal Links hierarchy` custom field under the configure content group. The warning should appear!
 - Update the logo to be left aligned. Bye, warning! It should be gone.

5) Custom fields change
  - In the admin, the custom fields for the components should say `sections menu`, not `site menu`

## Dependencies or Side Effects
- I've updated the tests that related to this chain, but there are 4 existing tests not working on canary before this. Not sure what to do about those.

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
