### PR TITLE
PEN-1496 UAT Fixes

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-plusplus */
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -10,6 +11,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import {
   NAV_BREAKPOINTS,
   NAV_SLOT_COUNTS,
+  NAV_SECTIONS,
   getNavComponentPropTypeKey,
   getNavComponentIndexPropTypeKey,
   generateNavComponentPropTypes,
@@ -204,53 +206,67 @@ const Nav = (props) => {
     };
   }, [breakpoints]);
 
+  const getNavWidgetType = (fieldKey) => (
+    customFields[fieldKey] || getNavComponentDefaultSelection(fieldKey)
+  );
+
+  const hasUserConfiguredNavItems = () => {
+    let userHasConfigured = false;
+    NAV_SECTIONS.forEach((side) => {
+      NAV_BREAKPOINTS.forEach((bpoint) => {
+        for (let i = 1; i <= NAV_SLOT_COUNTS[bpoint]; i++) {
+          const cFieldKey = getNavComponentPropTypeKey(side, bpoint, i);
+          const navWidgetType = getNavWidgetType(cFieldKey);
+          const matchesDefault = navWidgetType !== getNavComponentDefaultSelection(cFieldKey);
+          if (!userHasConfigured && matchesDefault) userHasConfigured = true;
+        }
+      });
+    });
+    return userHasConfigured;
+  };
+
   const NavSection = ({ side }) => {
     const renderWidgets = (bpoint) => {
-      let widgetList = [];
-      let userHasConfigured = false;
-      // eslint-disable-next-line no-plusplus
+      const widgetList = [];
       for (let i = 1; i <= NAV_SLOT_COUNTS[bpoint]; i++) {
         const cFieldKey = getNavComponentPropTypeKey(side, bpoint, i);
         const cFieldIndexKey = getNavComponentIndexPropTypeKey(side, bpoint, i);
-        const navWidgetType = getNavComponentDefaultSelection(cFieldKey);
+        const navWidgetType = getNavWidgetType(cFieldKey);
         if (!!navWidgetType && navWidgetType !== 'none') {
           widgetList.push(
-            <NavWidget
-              {...props}
-              key={`${side}_${bpoint}_${i}`}
-              type={navWidgetType}
-              position={customFields[cFieldIndexKey]}
-              menuButtonClickAction={hamburgerClick}
-            />,
+            <div className="nav-widget">
+              <NavWidget
+                {...props}
+                key={`${side}_${bpoint}_${i}`}
+                type={navWidgetType}
+                position={customFields[cFieldIndexKey]}
+                menuButtonClickAction={hamburgerClick}
+              />
+            </div>,
           );
         }
-        if (
-          !userHasConfigured
-          && navWidgetType !== getNavComponentDefaultSelection(cFieldKey)
-        ) userHasConfigured = true;
-      }
-      // Support for deprecated 'signInOrder' custom field
-      if (
-        !userHasConfigured
-        && signInOrder
-        && Number.isInteger(signInOrder)
-        && side === 'right'
-        && children[signInOrder - 1]
-      ) {
-        widgetList = [children[signInOrder - 1]];
       }
       return widgetList;
     };
-    return (
-      !side ? null : (
-        <div key={side} className={`nav-${side}`}>
-          { NAV_BREAKPOINTS.map((breakpoint) => (
-            <div key={breakpoint} className={`nav-components--${breakpoint}`}>
-              { renderWidgets(breakpoint) }
-            </div>
-          ))}
-        </div>
-      )
+    return !side ? null : (
+      <div key={side} className={`nav-${side}`}>
+        {
+          // Support for deprecated 'signInOrder' custom field
+          // "If" condition is for rendering "signIn" element
+          // "Else" condition is for standard nav bar customization logic
+          side === 'right'
+          && !hasUserConfiguredNavItems()
+          && signInOrder
+          && Number.isInteger(signInOrder)
+          && children[signInOrder - 1]
+            ? children[signInOrder - 1]
+            : NAV_BREAKPOINTS.map((breakpoint) => (
+              <div key={breakpoint} className={`nav-components--${breakpoint}`}>
+                { renderWidgets(breakpoint) }
+              </div>
+            ))
+        }
+      </div>
     );
   };
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -101,12 +101,9 @@ describe('the header navigation feature for the default output type', () => {
             {[<button key={1} type="button">Sign In</button>]}
           </Navigation>,
         );
-        const navRightDesktop = wrapper.find('.nav-right > .nav-components--desktop');
-        const navRightMobile = wrapper.find('.nav-right > .nav-components--mobile');
-        expect(navRightDesktop.children()).toHaveLength(1);
-        expect(navRightMobile.children()).toHaveLength(1);
-        expect(navRightDesktop.find('button')).toHaveText('Sign In');
-        expect(navRightMobile.find('button')).toHaveText('Sign In');
+        const navRight = wrapper.find('.nav-right');
+        expect(navRight.children()).toHaveLength(1);
+        expect(navRight.find('button')).toHaveText('Sign In');
       });
     });
   });

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -191,9 +191,9 @@ body.nav-open {
         &--desktop {
           align-items: center;
           
-          & > * {
+          & > .nav-widget {
             margin-right: calculateRem(16px);
-    
+            
             &:last-child {
               margin-right: 0;
             }


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Fixed issue with `signInOrder` component not rendering on mobile (when existing from previous setup of NavBar when `signInOrder` custom field was previously available - now deprecated/hidden). Also fixed recently-introduced regression where _none_ of the nav bar item configuration custom fields were working anymore.

## Jira Ticket
- [PEN-1496](https://arcpublishing.atlassian.net/browse/PEN-1496)

## Acceptance Criteria
![image](https://user-images.githubusercontent.com/26662906/103683314-a7bb1b00-4f4f-11eb-95b7-9b88fba8b1a3.png)
![image](https://user-images.githubusercontent.com/26662906/103683357-b73a6400-4f4f-11eb-8c24-b0a55edcb7ba.png)

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. Check out `stable` branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/shared-styles` in `Fusion-News-Theme`
4. Add a Header Nav Chain Block to the page and since we're on `stable`, you should still see the `signInOrder` custom field. Set this to `1` and add an `example WeatherWidget` feature as a child of this chain.
5. Stage & publish these changes
6. Now checkout **this feature branch** in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
7. Run `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/shared-styles` in `Fusion-News-Theme`
8. Hard reload the page that you added the previous Header Nav Chain Block to. You should still see the nav bar item rendered via the `signInOrder` on the right side of the nav bar.
9. Now add _another_ Header Nav Chain Block to the page and test three different combinations of settings. After each change, stage & publish page and open http://localhost/pf/homepage/?_website=the-dagen in separate tab:
a. Logo left-aligned **without** horizontal links defined
b. Logo left-aligned **with** horizontal links defined
c. Logo center-aligned (with or without horizontal links defined - shouldn't matter but feel free to test both)
d. Now within the mobile and desktop groups (under custom fields), try various different combinations of buttons placed in the left and right nav bar containers. When testing the "custom" type, you will need to add a feature as a child of the nav bar chain. Then, you will need to specify the position of the child component to use (which is a "1-based" index - not zero-based). _**These configuration options were previously not working after a regression was introduced in a recent fix PR. They should all be working now. **_
![image](https://user-images.githubusercontent.com/26662906/102845145-81837000-43d2-11eb-8198-4df20ce4a878.png)
10. Test clicking on search button and search input box should expand (pushing other elements to the right). The search box should have the same height as the other nav bar buttons.
11. Test making the viewport smaller which cuts off space for the horizontal links to display. When a horizontal links bar has too many links to fit on the current viewport width, the horizontal link elements should be truncated as needed (disappear when no space available for them). Horizontal links bar should be left-aligned against the logo.
12. Ensure that everything displays as expected across breakpoints. When the logo is centered, it should display pretty much the same on tablet/mobile (no horizontal links) except mobile only allows one button/widget on each side of the nav. When the logo is left-aligned, the horizontal links should be hidden on the mobile breakpoint.

## Effect Of Changes
### Before
Item rendered via `signInOrder` custom field was not rendering on mobile breakpoint.
Custom fields for customizing nav bar items were no longer working.

### After
Item rendered via `signInOrder` custom field now renders on all breakpoints.
Custom fields for customizing nav bar items are now fixed and working as expected.

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working. 
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
