### PR TITLE
PEN-1604 Google Ad Block | Out of Page: False for oop adtype

### DIFF
--- a/blocks/ads-block/features/ads/ad-mapping.js
+++ b/blocks/ads-block/features/ads/ad-mapping.js
@@ -21,7 +21,6 @@ const adMapping = {
     adName: 'oop',
     adLabel: 'OOP',
     adClass: '1x1',
-    dimensionsArray: [sz1x1, sz1x1, sz1x1],
     ampDimensionsArray: sz1x1,
   },
   '300x250': {


### PR DESCRIPTION



**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
_Information about what you changed for this PR_

The OOP ad is displaying as Out of Page: False in the googleconsole and therefore no ad would render. Will Cook looked into this and determined the following update needs to be made for the oop ad. 

Following this documentation, https://github.com/washingtonpost/arcads#out-of-page-ads
_If an advertisement has an empty or missing dimensions parameter it will be considered as a DFP Out of Page creative and rendered as such._



## Jira Ticket
- [PEN-1604](https://arcpublishing.atlassian.net/browse/PEN-1604)

## Acceptance Criteria
_copy from ticket_
Google ad - OOP should work

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. In Fusion-News-Theme repo, checkout master & git pull
2. After checking out this feature branch in fusion-news-theme-blocks, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run: `npx fusion start -f -l @wpmedia/ads-block`
4. Create a page then add the google ad block, configure ad type as OOP for testing.
5. Open chrome dev tool by using Fn + F12
6. Enter `googletag.openConsole()` into command tab
7. You should see the google ad - out of page flag set is true

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._
<img width="965" alt="Screen Shot 2021-01-06 at 23 02 31" src="https://user-images.githubusercontent.com/61674931/103790211-7d627e00-5073-11eb-8271-52cf0e16d02d.png">
[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._
<img width="965" alt="Screen Shot 2021-01-06 at 22 58 46" src="https://user-images.githubusercontent.com/61674931/103790184-7471ac80-5073-11eb-9d2b-80bb1d2942d2.png">

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.