### PR TITLE
PEN-1503: [CMG] Ability to control Section Menu components

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -4,13 +4,13 @@ import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 import HamburgerMenuIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/HamburgerMenuIcon';
 import SearchBox from './search-box';
-
-const ICON_SIZE = 16;
+import { WIDGET_CONFIG } from '../nav-helper';
 
 const NavWidget = ({
   type,
   position = 0,
   children = [],
+  placement = 'nav-bar',
   customSearchAction,
   menuButtonClickAction,
 }) => {
@@ -22,10 +22,11 @@ const NavWidget = ({
   const predefinedWidget = (
     (type === 'search' && (
       <SearchBox
-        iconSize={ICON_SIZE}
+        iconSize={WIDGET_CONFIG[placement].iconSize}
         navBarColor={navColor}
         placeholderText={phrases.t('header-nav-chain-block.search-text')}
         customSearchAction={customSearchAction}
+        alwaysOpen={WIDGET_CONFIG[placement].expandSearch}
       />
     )) || (type === 'menu' && (
       <button
@@ -34,7 +35,11 @@ const NavWidget = ({
         className={`nav-btn nav-sections-btn border transparent ${navColor === 'light' ? 'nav-btn-light' : 'nav-btn-dark'}`}
       >
         <span>{phrases.t('header-nav-chain-block.sections-button')}</span>
-        <HamburgerMenuIcon fill={null} height={ICON_SIZE} width={ICON_SIZE} />
+        <HamburgerMenuIcon
+          fill={null}
+          height={WIDGET_CONFIG[placement].iconSize}
+          width={WIDGET_CONFIG[placement].iconSize}
+        />
       </button>
     ))
   );

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -22,11 +22,11 @@ const NavWidget = ({
   const predefinedWidget = (
     (type === 'search' && (
       <SearchBox
-        iconSize={WIDGET_CONFIG[placement].iconSize}
+        iconSize={WIDGET_CONFIG[placement]?.iconSize}
         navBarColor={navColor}
         placeholderText={phrases.t('header-nav-chain-block.search-text')}
         customSearchAction={customSearchAction}
-        alwaysOpen={WIDGET_CONFIG[placement].expandSearch}
+        alwaysOpen={WIDGET_CONFIG[placement]?.expandSearch}
       />
     )) || (type === 'menu' && (
       <button
@@ -37,8 +37,8 @@ const NavWidget = ({
         <span>{phrases.t('header-nav-chain-block.sections-button')}</span>
         <HamburgerMenuIcon
           fill={null}
-          height={WIDGET_CONFIG[placement].iconSize}
-          width={WIDGET_CONFIG[placement].iconSize}
+          height={WIDGET_CONFIG[placement]?.iconSize}
+          width={WIDGET_CONFIG[placement]?.iconSize}
         />
       </button>
     ))

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -220,9 +220,7 @@ const Nav = (props) => {
     return userHasConfigured;
   };
 
-  const WidgetList = ({
-    id, breakpoint, placement,
-  }) => {
+  const WidgetList = ({ id, breakpoint, placement }) => {
     if (!id || !breakpoint) return null;
     const { slotCounts } = WIDGET_CONFIG[placement];
     const widgetList = [];

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -230,10 +230,12 @@ const Nav = (props) => {
       const navWidgetType = getNavWidgetType(cFieldKey);
       if (!!navWidgetType && navWidgetType !== 'none') {
         widgetList.push(
-          <div className="nav-widget">
+          <div
+            className="nav-widget"
+            key={`${id}_${breakpoint}_${i}`}
+          >
             <NavWidget
               {...props}
-              key={`${id}_${breakpoint}_${i}`}
               type={navWidgetType}
               position={customFields[cFieldIndexKey]}
               placement={placement}

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -6,19 +6,16 @@ import { useContent } from 'fusion:content';
 import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getThemeStyle from 'fusion:themes';
-import getTranslatedPhrases from 'fusion:intl';
 import { useDebouncedCallback } from 'use-debounce';
 import {
+  WIDGET_CONFIG,
   NAV_BREAKPOINTS,
-  NAV_SLOT_COUNTS,
-  NAV_SECTIONS,
   getNavComponentPropTypeKey,
   getNavComponentIndexPropTypeKey,
   generateNavComponentPropTypes,
   getNavComponentDefaultSelection,
 } from './nav-helper';
 import SectionNav from './_children/section-nav';
-import SearchBox from './_children/search-box';
 import NavLogo from './_children/nav-logo';
 import NavWidget from './_children/nav-widget';
 // shares styles with header nav block
@@ -71,7 +68,6 @@ const Nav = (props) => {
 
   const {
     navColor,
-    locale = 'en',
     breakpoints = { small: 0, medium: 768, large: 992 },
     navBarBackground,
   } = getProperties(arcSite);
@@ -89,11 +85,9 @@ const Nav = (props) => {
     backgroundColor = '#fff';
   }
 
-  const phrases = getTranslatedPhrases(locale);
-
   const {
     children = [],
-    customFields = {},
+    customFields,
   } = props;
   const {
     hierarchy,
@@ -212,9 +206,10 @@ const Nav = (props) => {
 
   const hasUserConfiguredNavItems = () => {
     let userHasConfigured = false;
-    NAV_SECTIONS.forEach((side) => {
+    const { slotCounts, sections: navBarSections } = WIDGET_CONFIG['nav-bar'];
+    navBarSections.forEach((side) => {
       NAV_BREAKPOINTS.forEach((bpoint) => {
-        for (let i = 1; i <= NAV_SLOT_COUNTS[bpoint]; i++) {
+        for (let i = 1; i <= slotCounts[bpoint]; i++) {
           const cFieldKey = getNavComponentPropTypeKey(side, bpoint, i);
           const navWidgetType = getNavWidgetType(cFieldKey);
           const matchesDefault = navWidgetType !== getNavComponentDefaultSelection(cFieldKey);
@@ -225,30 +220,36 @@ const Nav = (props) => {
     return userHasConfigured;
   };
 
-  const NavSection = ({ side }) => {
-    const renderWidgets = (bpoint) => {
-      const widgetList = [];
-      for (let i = 1; i <= NAV_SLOT_COUNTS[bpoint]; i++) {
-        const cFieldKey = getNavComponentPropTypeKey(side, bpoint, i);
-        const cFieldIndexKey = getNavComponentIndexPropTypeKey(side, bpoint, i);
-        const navWidgetType = getNavWidgetType(cFieldKey);
-        if (!!navWidgetType && navWidgetType !== 'none') {
-          widgetList.push(
-            <div className="nav-widget">
-              <NavWidget
-                {...props}
-                key={`${side}_${bpoint}_${i}`}
-                type={navWidgetType}
-                position={customFields[cFieldIndexKey]}
-                menuButtonClickAction={hamburgerClick}
-              />
-            </div>,
-          );
-        }
+  const WidgetList = ({
+    id, breakpoint, placement,
+  }) => {
+    if (!id || !breakpoint) return null;
+    const { slotCounts } = WIDGET_CONFIG[placement];
+    const widgetList = [];
+    for (let i = 1; i <= slotCounts[breakpoint]; i++) {
+      const cFieldKey = getNavComponentPropTypeKey(id, breakpoint, i);
+      const cFieldIndexKey = getNavComponentIndexPropTypeKey(id, breakpoint, i);
+      const navWidgetType = getNavWidgetType(cFieldKey);
+      if (!!navWidgetType && navWidgetType !== 'none') {
+        widgetList.push(
+          <div className="nav-widget">
+            <NavWidget
+              {...props}
+              key={`${id}_${breakpoint}_${i}`}
+              type={navWidgetType}
+              position={customFields[cFieldIndexKey]}
+              placement={placement}
+              menuButtonClickAction={hamburgerClick}
+            />
+          </div>,
+        );
       }
-      return widgetList;
-    };
-    return !side ? null : (
+    }
+    return widgetList;
+  };
+
+  const NavSection = ({ side }) => (
+    !side ? null : (
       <div key={side} className={`nav-${side}`}>
         {
           // Support for deprecated 'signInOrder' custom field
@@ -262,10 +263,31 @@ const Nav = (props) => {
             ? children[signInOrder - 1]
             : NAV_BREAKPOINTS.map((breakpoint) => (
               <div key={breakpoint} className={`nav-components--${breakpoint}`}>
-                { renderWidgets(breakpoint) }
+                <WidgetList
+                  id={side}
+                  breakpoint={breakpoint}
+                  placement="nav-bar"
+                />
               </div>
             ))
         }
+      </div>
+    )
+  );
+
+  const MenuWidgets = () => {
+    const navSection = 'menu';
+    return (
+      <div key={navSection} className={`nav-${navSection}`}>
+        {NAV_BREAKPOINTS.map((breakpoint) => (
+          <div key={breakpoint} className={`nav-components--${breakpoint}`}>
+            <WidgetList
+              id={navSection}
+              breakpoint={breakpoint}
+              placement="section-menu"
+            />
+          </div>
+        ))}
       </div>
     );
   };
@@ -287,15 +309,20 @@ const Nav = (props) => {
           <NavSection side="right" />
         </div>
 
-        <StyledSectionDrawer id="nav-sections" className={`nav-sections ${isSectionDrawerOpen ? 'open' : 'closed'}`} onClick={closeDrawer} font={primaryFont}>
+        <StyledSectionDrawer
+          id="nav-sections"
+          className={`nav-sections ${isSectionDrawerOpen ? 'open' : 'closed'}`}
+          onClick={closeDrawer}
+          font={primaryFont}
+        >
           <div className="inner-drawer-nav" style={{ zIndex: 10 }}>
             <SectionNav sections={sections}>
-              <SearchBox iconSize={21} alwaysOpen placeholderText={phrases.t('header-nav-chain-block.search-text')} />
+              <MenuWidgets />
             </SectionNav>
           </div>
         </StyledSectionDrawer>
-
       </StyledNav>
+
       {(horizontalLinksHierarchy && logoAlignment !== 'left' && isAdmin) && (
         <StyledWarning>
           In order to render horizontal links, the logo must be aligned to the left.

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -45,12 +45,16 @@ describe('the header navigation feature for the default output type', () => {
 
   it('should render nothing inside the .nav-right on desktop', () => {
     const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-    expect(wrapper.find('.nav-right > .nav-components--desktop').children()).toHaveLength(0);
+    const widgetList = wrapper.find('.nav-right > .nav-components--desktop > WidgetList');
+    expect(widgetList).toHaveLength(1);
+    expect(widgetList.children()).toHaveLength(0);
   });
 
   it('should render nothing inside the .nav-right on mobile', () => {
     const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-    expect(wrapper.find('.nav-right > .nav-components--mobile').children()).toHaveLength(0);
+    const widgetList = wrapper.find('.nav-right > .nav-components--mobile > WidgetList');
+    expect(widgetList).toHaveLength(1);
+    expect(widgetList.children()).toHaveLength(0);
   });
 
   it('should render horizontal links when "logoAlignment" is "left"', () => {
@@ -89,8 +93,12 @@ describe('the header navigation feature for the default output type', () => {
             {[<button key={1} type="button">Sign In</button>]}
           </Navigation>,
         );
-        expect(wrapper.find('.nav-right > .nav-components--desktop').children()).toHaveLength(0);
-        expect(wrapper.find('.nav-right > .nav-components--mobile').children()).toHaveLength(0);
+        const widgetListMobile = wrapper.find('.nav-right > .nav-components--mobile > WidgetList');
+        const widgetListDesktop = wrapper.find('.nav-right > .nav-components--desktop > WidgetList');
+        expect(widgetListMobile).toHaveLength(1);
+        expect(widgetListDesktop).toHaveLength(1);
+        expect(widgetListMobile.children()).toHaveLength(0);
+        expect(widgetListDesktop.children()).toHaveLength(0);
       });
     });
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -20,98 +20,188 @@ jest.mock('fusion:content', () => ({
 }));
 
 describe('the header navigation feature for the default output type', () => {
-  it('should render search and sections menu in the top-left navbar on desktop', () => {
-    const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-    const navLeftDesktop = wrapper.find('.nav-left > .nav-components--desktop');
-    expect(navLeftDesktop).toHaveLength(1);
-    const searchWidget = navLeftDesktop.find('.nav-search');
-    expect(searchWidget).toHaveLength(1);
-    const menuWidget = navLeftDesktop.find('.nav-sections-btn');
-    expect(menuWidget).toHaveLength(1);
+  describe('horizontal links bar', () => {
+    it('should render horizontal links when "logoAlignment" is "left"', () => {
+      const cFields = {
+        ...DEFAULT_SELECTIONS,
+        logoAlignment: 'left',
+        horizontalLinksHierarchy: 'default',
+      };
+      const wrapper = mount(<Navigation customFields={cFields} />);
+      const navBar = wrapper.find('.news-theme-navigation-bar');
+      expect(navBar.hasClass('horizontal-links')).toBe(true);
+      expect(navBar.hasClass('logo-left')).toBe(true);
+      const linksBar = navBar.find('HorizontalLinksBar');
+      expect(linksBar).toHaveLength(1);
+      expect(linksBar.prop('hierarchy')).toEqual(cFields.horizontalLinksHierarchy);
+    });
+
+    it('should not render horizontal links when "logoAlignment" is "center"', () => {
+      const cFields = {
+        ...DEFAULT_SELECTIONS,
+        logoAlignment: 'center',
+        horizontalLinksHierarchy: 'default',
+      };
+      const wrapper = mount(<Navigation customFields={cFields} />);
+      const navBar = wrapper.find('.news-theme-navigation-bar');
+      expect(navBar.hasClass('horizontal-links')).toBe(false);
+      expect(navBar.hasClass('logo-center')).toBe(true);
+      expect(navBar.find('HorizontalLinksBar')).toHaveLength(0);
+    });
   });
 
-  it('should render sections menu in the top-left navbar on mobile', () => {
-    const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-    const navLeftDesktop = wrapper.find('.nav-left > .nav-components--mobile');
-    expect(navLeftDesktop).toHaveLength(1);
-    const menuWidget = navLeftDesktop.find('.nav-sections-btn');
-    expect(menuWidget).toHaveLength(1);
-  });
+  describe('navigation bar widgets/buttons', () => {
+    describe('nav-bar default configuration', () => {
+      it('should render search and sections menu in the top-left navbar on desktop', () => {
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        const navLeftDesktop = wrapper.find('.nav-left > .nav-components--desktop');
+        expect(navLeftDesktop).toHaveLength(1);
+        const searchWidget = navLeftDesktop.find('.nav-search');
+        expect(searchWidget).toHaveLength(1);
+        const menuWidget = navLeftDesktop.find('.nav-sections-btn');
+        expect(menuWidget).toHaveLength(1);
+      });
 
-  it('should render a SearchBox component in the side navbar', () => {
-    const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-    expect(wrapper.find('#nav-sections').find(SearchBox)).toHaveLength(1);
-  });
+      it('should render sections menu in the top-left navbar on mobile', () => {
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        const navLeftDesktop = wrapper.find('.nav-left > .nav-components--mobile');
+        expect(navLeftDesktop).toHaveLength(1);
+        const menuWidget = navLeftDesktop.find('.nav-sections-btn');
+        expect(menuWidget).toHaveLength(1);
+      });
 
-  it('should render nothing inside the .nav-right on desktop', () => {
-    const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-    const widgetList = wrapper.find('.nav-right > .nav-components--desktop > WidgetList');
-    expect(widgetList).toHaveLength(1);
-    expect(widgetList.children()).toHaveLength(0);
-  });
+      it('should render nothing inside the .nav-right on desktop', () => {
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        const widgetList = wrapper.find('.nav-right > .nav-components--desktop > WidgetList');
+        expect(widgetList).toHaveLength(1);
+        expect(widgetList.children()).toHaveLength(0);
+      });
 
-  it('should render nothing inside the .nav-right on mobile', () => {
-    const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-    const widgetList = wrapper.find('.nav-right > .nav-components--mobile > WidgetList');
-    expect(widgetList).toHaveLength(1);
-    expect(widgetList.children()).toHaveLength(0);
-  });
-
-  it('should render horizontal links when "logoAlignment" is "left"', () => {
-    const cFields = {
-      ...DEFAULT_SELECTIONS,
-      logoAlignment: 'left',
-      horizontalLinksHierarchy: 'default',
-    };
-    const wrapper = mount(<Navigation customFields={cFields} />);
-    const navBar = wrapper.find('.news-theme-navigation-bar');
-    expect(navBar.hasClass('horizontal-links')).toBe(true);
-    expect(navBar.hasClass('logo-left')).toBe(true);
-    const linksBar = navBar.find('HorizontalLinksBar');
-    expect(linksBar).toHaveLength(1);
-    expect(linksBar.prop('hierarchy')).toEqual(cFields.horizontalLinksHierarchy);
-  });
-
-  it('should not render horizontal links when "logoAlignment" is "center"', () => {
-    const cFields = {
-      ...DEFAULT_SELECTIONS,
-      logoAlignment: 'center',
-      horizontalLinksHierarchy: 'default',
-    };
-    const wrapper = mount(<Navigation customFields={cFields} />);
-    const navBar = wrapper.find('.news-theme-navigation-bar');
-    expect(navBar.hasClass('horizontal-links')).toBe(false);
-    expect(navBar.hasClass('logo-center')).toBe(true);
-    expect(navBar.find('HorizontalLinksBar')).toHaveLength(0);
-  });
-
-  describe('when the signInOrder customField is set', () => {
-    describe('when no child component exists at the signInOrder index', () => {
-      it('should render nothing inside the .nav-right', () => {
-        const wrapper = mount(
-          <Navigation customFields={{ ...DEFAULT_SELECTIONS, signInOrder: 2 }}>
-            {[<button key={1} type="button">Sign In</button>]}
-          </Navigation>,
-        );
-        const widgetListMobile = wrapper.find('.nav-right > .nav-components--mobile > WidgetList');
-        const widgetListDesktop = wrapper.find('.nav-right > .nav-components--desktop > WidgetList');
-        expect(widgetListMobile).toHaveLength(1);
-        expect(widgetListDesktop).toHaveLength(1);
-        expect(widgetListMobile.children()).toHaveLength(0);
-        expect(widgetListDesktop.children()).toHaveLength(0);
+      it('should render nothing inside the .nav-right on mobile', () => {
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        const widgetList = wrapper.find('.nav-right > .nav-components--mobile > WidgetList');
+        expect(widgetList).toHaveLength(1);
+        expect(widgetList.children()).toHaveLength(0);
       });
     });
 
-    describe('when a child component exists at the signInOrder index', () => {
-      it('should render the child component inside the .nav-right', () => {
+    // The 'signInOrder' custom field is deprecated but still necessary for compatibility
+    describe('when the signInOrder customField is set', () => {
+      describe('when no child component exists at the signInOrder index', () => {
+        it('should render nothing inside the .nav-right', () => {
+          const wrapper = mount(
+            <Navigation customFields={{ ...DEFAULT_SELECTIONS, signInOrder: 2 }}>
+              {[<button key={1} type="button">Sign In</button>]}
+            </Navigation>,
+          );
+          const widgetListMobile = wrapper.find('.nav-right > .nav-components--mobile > WidgetList');
+          const widgetListDesktop = wrapper.find('.nav-right > .nav-components--desktop > WidgetList');
+          expect(widgetListMobile).toHaveLength(1);
+          expect(widgetListDesktop).toHaveLength(1);
+          expect(widgetListMobile.children()).toHaveLength(0);
+          expect(widgetListDesktop.children()).toHaveLength(0);
+        });
+      });
+
+      describe('when a child component exists at the signInOrder index', () => {
+        it('should render the child component inside the .nav-right', () => {
+          const wrapper = mount(
+            <Navigation customFields={{ signInOrder: 1 }}>
+              {[<button key={1} type="button">Sign In</button>]}
+            </Navigation>,
+          );
+          const navRight = wrapper.find('.nav-right');
+          expect(navRight.children()).toHaveLength(1);
+          expect(navRight.find('button')).toHaveText('Sign In');
+        });
+      });
+    });
+  });
+
+  describe('sections menu widgets/buttons', () => {
+    describe('sections menu default configuration', () => {
+      it('should render a search widget in the sections menu on mobile', () => {
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        const container = wrapper.find('#nav-sections .nav-menu');
+        expect(container.find('.nav-components--mobile').find(SearchBox)).toHaveLength(1);
+      });
+
+      it('should render nothing in the sections menu on desktop', () => {
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        const container = wrapper.find('#nav-sections .nav-menu');
+        const widgetList = container.find('.nav-components--desktop > WidgetList');
+        expect(widgetList).toHaveLength(1);
+        expect(widgetList.children()).toHaveLength(0);
+      });
+    });
+
+    describe('sections menu custom configuration', () => {
+      const testSectionMenuWidget = (customFields, breakpoint) => {
+        const TestComponent = jest.fn(() => <div id="test-component" />);
         const wrapper = mount(
-          <Navigation customFields={{ signInOrder: 1 }}>
-            {[<button key={1} type="button">Sign In</button>]}
+          <Navigation customFields={customFields}>
+            <TestComponent />
           </Navigation>,
         );
-        const navRight = wrapper.find('.nav-right');
-        expect(navRight.children()).toHaveLength(1);
-        expect(navRight.find('button')).toHaveText('Sign In');
+        const container = wrapper.find('#nav-sections .nav-menu');
+        const widgetList = container.find(`.nav-components--${breakpoint} > WidgetList`);
+        expect(widgetList).toHaveLength(1);
+        return widgetList.find('NavWidget');
+      };
+
+      it('should render custom widget on mobile', () => {
+        const CUSTOM_SELECTIONS = {
+          ...DEFAULT_SELECTIONS,
+          menuComponentMobile1: 'custom',
+          menuComponentCustomIndexMobile1: 1,
+        };
+        const navWidget = testSectionMenuWidget(CUSTOM_SELECTIONS, 'mobile');
+        expect(navWidget).toHaveLength(1);
+        expect(navWidget.prop('type')).toEqual('custom');
+        expect(navWidget.prop('position')).toEqual(1);
+        expect(navWidget.prop('placement')).toEqual('section-menu');
+      });
+      it('should render custom widget on desktop', () => {
+        const CUSTOM_SELECTIONS = {
+          ...DEFAULT_SELECTIONS,
+          menuComponentDesktop1: 'custom',
+          menuComponentCustomIndexDesktop1: 1,
+        };
+        const navWidget = testSectionMenuWidget(CUSTOM_SELECTIONS, 'desktop');
+        expect(navWidget).toHaveLength(1);
+        expect(navWidget.prop('type')).toEqual('custom');
+        expect(navWidget.prop('position')).toEqual(1);
+        expect(navWidget.prop('placement')).toEqual('section-menu');
+      });
+      it('should render two widgets on mobile', () => {
+        const CUSTOM_SELECTIONS = {
+          ...DEFAULT_SELECTIONS,
+          menuComponentMobile1: 'search',
+          menuComponentMobile2: 'custom',
+          menuComponentCustomIndexMobile2: 1,
+        };
+        const navWidgets = testSectionMenuWidget(CUSTOM_SELECTIONS, 'mobile');
+        expect(navWidgets).toHaveLength(2);
+        expect(navWidgets.at(0).prop('type')).toEqual('search');
+        expect(navWidgets.at(0).prop('placement')).toEqual('section-menu');
+        expect(navWidgets.at(1).prop('type')).toEqual('custom');
+        expect(navWidgets.at(1).prop('position')).toEqual(1);
+        expect(navWidgets.at(1).prop('placement')).toEqual('section-menu');
+      });
+      it('should render two widgets on desktop', () => {
+        const CUSTOM_SELECTIONS = {
+          ...DEFAULT_SELECTIONS,
+          menuComponentDesktop1: 'custom',
+          menuComponentCustomIndexDesktop1: 1,
+          menuComponentDesktop2: 'search',
+        };
+        const navWidgets = testSectionMenuWidget(CUSTOM_SELECTIONS, 'desktop');
+        expect(navWidgets).toHaveLength(2);
+        expect(navWidgets.at(0).prop('type')).toEqual('custom');
+        expect(navWidgets.at(0).prop('position')).toEqual(1);
+        expect(navWidgets.at(0).prop('placement')).toEqual('section-menu');
+        expect(navWidgets.at(1).prop('type')).toEqual('search');
+        expect(navWidgets.at(1).prop('placement')).toEqual('section-menu');
       });
     });
   });
@@ -244,43 +334,44 @@ describe('the header navigation feature for the default output type', () => {
       });
     });
   });
+  describe('nav color scheme', () => {
+    describe('when the nav color is set to "dark"', () => {
+      it('should set the "dark" class on the component', () => {
+        getProperties.mockImplementation(() => ({ navColor: 'dark' }));
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        expect(wrapper.find('#main-nav')).toHaveClassName('dark');
+      });
 
-  describe('when the nav color is set to "dark"', () => {
-    it('should set the "dark" class on the component', () => {
-      getProperties.mockImplementation(() => ({ navColor: 'dark' }));
-      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-      expect(wrapper.find('#main-nav')).toHaveClassName('dark');
+      it('should set all buttons to use the light color scheme', () => {
+        getProperties.mockImplementation(() => ({ navColor: 'dark' }));
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        expect(wrapper.find('.nav-btn.nav-sections-btn').every('.nav-btn-dark')).toEqual(true);
+      });
+
+      it('should pass the navColor to the SearchBox', () => {
+        getProperties.mockImplementation(() => ({ navColor: 'dark' }));
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        expect(wrapper.find(SearchBox).first()).toHaveProp('navBarColor', 'dark');
+      });
     });
 
-    it('should set all buttons to use the light color scheme', () => {
-      getProperties.mockImplementation(() => ({ navColor: 'dark' }));
-      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-      expect(wrapper.find('.nav-btn.nav-sections-btn').every('.nav-btn-dark')).toEqual(true);
-    });
+    describe('when the nav color is set to "light"', () => {
+      it('should set the "light" class on the component', () => {
+        getProperties.mockImplementation(() => ({ navColor: 'light' }));
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        expect(wrapper.find('#main-nav')).toHaveClassName('light');
+      });
+      it('should set all buttons to use the light color scheme', () => {
+        getProperties.mockImplementation(() => ({ navColor: 'light' }));
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        expect(wrapper.find('.nav-btn.nav-sections-btn').every('.nav-btn-light')).toEqual(true);
+      });
 
-    it('should pass the navColor to the SearchBox', () => {
-      getProperties.mockImplementation(() => ({ navColor: 'dark' }));
-      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-      expect(wrapper.find(SearchBox).first()).toHaveProp('navBarColor', 'dark');
-    });
-  });
-
-  describe('when the nav color is set to "light"', () => {
-    it('should set the "light" class on the component', () => {
-      getProperties.mockImplementation(() => ({ navColor: 'light' }));
-      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-      expect(wrapper.find('#main-nav')).toHaveClassName('light');
-    });
-    it('should set all buttons to use the light color scheme', () => {
-      getProperties.mockImplementation(() => ({ navColor: 'light' }));
-      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-      expect(wrapper.find('.nav-btn.nav-sections-btn').every('.nav-btn-light')).toEqual(true);
-    });
-
-    it('should pass the navColor to the SearchBox', () => {
-      getProperties.mockImplementation(() => ({ navColor: 'light' }));
-      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
-      expect(wrapper.find(SearchBox).first()).toHaveProp('navBarColor', 'light');
+      it('should pass the navColor to the SearchBox', () => {
+        getProperties.mockImplementation(() => ({ navColor: 'light' }));
+        const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+        expect(wrapper.find(SearchBox).first()).toHaveProp('navBarColor', 'light');
+      });
     });
   });
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
@@ -82,8 +82,9 @@ export const generateNavComponentIndexPropType = (section, breakpoint, position)
 export const generateNavComponentPropTypes = () => {
   const navComponentPropTypes = {};
   Object.keys(WIDGET_CONFIG).forEach((cfgKey) => {
-    const cfg = WIDGET_CONFIG[cfgKey];
-    const { sections, options, slotCounts } = cfg;
+    const {
+      sections, options, slotCounts,
+    } = WIDGET_CONFIG[cfgKey];
     sections.forEach((navSection) => {
       NAV_BREAKPOINTS.forEach((navBreakpoint) => {
         // eslint-disable-next-line no-plusplus

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
@@ -1,13 +1,34 @@
 import PropTypes from 'prop-types';
 
-export const NAV_COMPONENT_OPTIONS = ['search', 'menu', 'none', 'custom'];
-export const NAV_SECTIONS = ['left', 'right'];
 export const NAV_BREAKPOINTS = ['mobile', 'desktop'];
-export const NAV_SLOT_COUNTS = { mobile: 1, desktop: 2 };
+export const NAV_LABELS = {
+  left: 'Left',
+  right: 'Right',
+  menu: 'Sections Menu',
+};
+
 export const DEFAULT_SELECTIONS = {
   leftComponentDesktop1: 'search',
   leftComponentDesktop2: 'menu',
   leftComponentMobile1: 'menu',
+  menuComponentMobile1: 'search',
+};
+
+export const WIDGET_CONFIG = {
+  'nav-bar': {
+    iconSize: 16,
+    expandSearch: false,
+    slotCounts: { mobile: 1, desktop: 2 },
+    options: ['search', 'menu', 'none', 'custom'],
+    sections: ['left', 'right'],
+  },
+  'section-menu': {
+    iconSize: 21,
+    expandSearch: true,
+    slotCounts: { mobile: 2, desktop: 2 },
+    options: ['search', 'none', 'custom'],
+    sections: ['menu'],
+  },
 };
 
 export const capitalize = (string) => (
@@ -18,7 +39,7 @@ export const capitalize = (string) => (
 );
 
 export const getNavComponentLabel = (section, breakpoint, position) => (
-  `${capitalize(section)} Component ${position} - ${capitalize(breakpoint)}`
+  `${NAV_LABELS[section]} Component ${position} - ${capitalize(breakpoint)}`
 );
 
 export const getNavComponentPropTypeKey = (section, breakpoint, position) => (
@@ -60,21 +81,23 @@ export const generateNavComponentIndexPropType = (section, breakpoint, position)
 // eslint-disable-next-line import/prefer-default-export
 export const generateNavComponentPropTypes = () => {
   const navComponentPropTypes = {};
-  NAV_SECTIONS.forEach((navSection) => {
-    NAV_BREAKPOINTS.forEach((navBreakpoint) => {
-      // eslint-disable-next-line no-plusplus
-      for (let i = 1; i <= NAV_SLOT_COUNTS[navBreakpoint]; i++) {
-        navComponentPropTypes[
-          getNavComponentPropTypeKey(navSection, navBreakpoint, i)
-        ] = PropTypes.oneOf(NAV_COMPONENT_OPTIONS).tag(
-          generateNavComponentPropType(navSection, navBreakpoint, i),
-        );
-        navComponentPropTypes[
-          getNavComponentIndexPropTypeKey(navSection, navBreakpoint, i)
-        ] = PropTypes.number.tag(
-          generateNavComponentIndexPropType(navSection, navBreakpoint, i),
-        );
-      }
+  Object.keys(WIDGET_CONFIG).forEach((cfgKey) => {
+    const cfg = WIDGET_CONFIG[cfgKey];
+    const { sections, options, slotCounts } = cfg;
+    sections.forEach((navSection) => {
+      NAV_BREAKPOINTS.forEach((navBreakpoint) => {
+        // eslint-disable-next-line no-plusplus
+        for (let i = 1; i <= slotCounts[navBreakpoint]; i++) {
+          const itemSelectionKey = getNavComponentPropTypeKey(navSection, navBreakpoint, i);
+          const itemIndexKey = getNavComponentIndexPropTypeKey(navSection, navBreakpoint, i);
+          navComponentPropTypes[itemSelectionKey] = PropTypes.oneOf(options).tag(
+            generateNavComponentPropType(navSection, navBreakpoint, i),
+          );
+          navComponentPropTypes[itemIndexKey] = PropTypes.number.tag(
+            generateNavComponentIndexPropType(navSection, navBreakpoint, i),
+          );
+        }
+      });
     });
   });
   return navComponentPropTypes;

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -78,6 +78,9 @@ body.nav-open {
 
   @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
     margin: 0;
+    span {
+      display: none;
+    }
   }
 
   > span,
@@ -156,8 +159,7 @@ body.nav-open {
   }
 
   @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
-    .nav-search,
-    .nav-sections-btn span {
+    .nav-search {
       display: none;
     }
   }
@@ -317,12 +319,6 @@ body.nav-open {
     width: 0;
   }
 
-  @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-    .nav-search {
-      display: none;
-    }
-  }
-
   @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
     .subsection-container {
       display: none;
@@ -336,6 +332,10 @@ body.nav-open {
     width: $section-width;
 
     .nav-search {
+      input {
+        flex: 1;
+      }
+
       &.open {
         input {
           height: calculateRem(48px);
@@ -346,15 +346,35 @@ body.nav-open {
         }
       }
     }
-  }
 
-  .nav-search {
-    border-bottom: $border-width solid $nav-search-border-color;
-    margin: 16px 20px 0;
-    padding-bottom: 16px;
+    .nav-menu {
+      & > .nav-components {
+        &--mobile,
+        &--desktop {          
+          & > .nav-widget {
+            margin-top: calculateRem(16px);
+            padding: 0 20px;
+          }
+        }
 
-    input {
-      flex: 1;
+        &--mobile {
+          display: none;
+        }
+
+        &--desktop {
+          display: inherit;
+        }
+
+        @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+          &--desktop {
+            display: none;
+          }
+
+          &--mobile {
+            display: inherit;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Added customizable section menu widgets via custom fields

## Jira Ticket
- [PEN-1503](https://arcpublishing.atlassian.net/browse/PEN-1503)

## Acceptance Criteria
![image](https://user-images.githubusercontent.com/26662906/103912209-9d725b80-50cc-11eb-8c3f-2f9bcb5cdfb5.png)

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. Check out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/shared-styles` in `Fusion-News-Theme`
4. Add a Header Nav Chain Block to a page
5. Now within the mobile and desktop groups (under custom fields), try various different combinations of widgets placed in the section menu. When testing the "custom" type, you will need to add a feature as a child of the nav bar chain. Then, you will need to specify the position of the child component to use (which is a "1-based" index - not zero-based).
![image](https://user-images.githubusercontent.com/26662906/103911861-2dfc6c00-50cc-11eb-9038-6db149553c44.png)
![image](https://user-images.githubusercontent.com/26662906/103911966-51bfb200-50cc-11eb-89ab-c0050b334db5.png)
6. Test clicking on search button and search input box should expand (pushing other elements to the right). The search box should have the same height as the other nav bar buttons.
7. Ensure that everything displays as expected across breakpoints with no obvious visual regressions.

## Effect Of Changes
### Before
Section menu widgets were not customizable and only a search bar would display on mobile (with no ability to change this).

### After
Section menu widgets are now customizable and you can choose up to two widgets to include per breakpoint.

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.