### PR TITLE
removed ad-block from gallery -> global-content

### DIFF
--- a/blocks/gallery-block/features/gallery/_children/global-content.jsx
+++ b/blocks/gallery-block/features/gallery/_children/global-content.jsx
@@ -1,9 +1,11 @@
+/* eslint max-len: 0 */
 import React from 'react';
 import { useFusionContext, useAppContext } from 'fusion:context';
 import { Gallery } from '@wpmedia/engine-theme-sdk';
-import ArcAd from '@wpmedia/ads-block';
+// import ArcAd from '@wpmedia/ads-block';
 import getProperties from 'fusion:properties';
 
+/**
 const GalleryInterstitialAd = () => (
   <ArcAd
     customFields={{
@@ -12,14 +14,17 @@ const GalleryInterstitialAd = () => (
     }}
   />
 );
+ * */
 
 const GlobalContentGallery = ({ phrases }) => {
   const { arcSite } = useFusionContext();
   const { globalContent = {} } = useAppContext();
   const { content_elements: contentElements = [] } = globalContent;
-  const { resizerURL, galleryCubeClicks } = getProperties(arcSite) || {};
-  let adProps = {};
+  // const { resizerURL, galleryCubeClicks } = getProperties(arcSite) || {};
+  const { resizerURL } = getProperties(arcSite) || {};
 
+  /**
+  let adProps = {};
   if (galleryCubeClicks) {
     const value = parseInt(galleryCubeClicks, 10);
     if (!Number.isNaN(value)) {
@@ -41,6 +46,19 @@ const GlobalContentGallery = ({ phrases }) => {
       pausePhrase={phrases.t('global.gallery-pause-autoplay-button')}
       pageCountPhrase={(current, total) => phrases.t('global.gallery-page-count-text', { current, total })}
       {...adProps}
+    />
+  );
+* */
+  return (
+    <Gallery
+      galleryElements={contentElements}
+      resizerURL={resizerURL}
+      ansId={globalContent._id}
+      ansHeadline={globalContent?.headlines?.basic ? globalContent.headlines.basic : ''}
+      expandPhrase={phrases.t('global.gallery-expand-button')}
+      autoplayPhrase={phrases.t('global.gallery-autoplay-button')}
+      pausePhrase={phrases.t('global.gallery-pause-autoplay-button')}
+      pageCountPhrase={(current, total) => phrases.t('global.gallery-page-count-text', { current, total })}
     />
   );
 };

--- a/blocks/gallery-block/features/gallery/_children/global-content.test.jsx
+++ b/blocks/gallery-block/features/gallery/_children/global-content.test.jsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/jsx-props-no-spreading */
+/* eslint-disable react/jsx-props-no-spreading, max-len */
 import React from 'react';
 import { shallow } from 'enzyme';
 
@@ -140,6 +140,7 @@ describe('the global content gallery', () => {
     });
   });
 
+  /**
   describe('when galleryCubeClicks is present', () => {
     it('should send interstitialClicks', () => {
       jest.mock('fusion:context', () => ({
@@ -189,4 +190,5 @@ describe('the global content gallery', () => {
       expect(wrapper.find('Gallery').prop('adElement')).toBeFalsy();
     });
   });
+   * */
 });


### PR DESCRIPTION
## Description
[Missed one file that needed to remove the ad-block deps]

In the last beta release, it was discovered that the gallery and lightbox blocks required the ad-block even if ads were not being leveraged.  It was decided to back out this dependency until a more suitable solution is found.  Instead of removing the logic out of the gallery and lightbox blocks (including the logic in the respective tests), I have instead commented the code out as I feel this will help in providing for the future new solution.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/PEN-1640

## Acceptance Criteria
Customers should not be required to add a new block as part of this release, in order to deploy their website. Per our discussion on 1/6, we will revert the work from PEN-435: Google Ads: Gallery Interstitial CubeREADY FOR DEPLOYMENT from beta for now, so that this is no longer an issue. 
We will reintroduce that functionality in a subsequent release, once we have a better solution for the dependency. 


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x ] Confirmed all the test steps a reviewer will follow above are working. 
- [ x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ x] Confirmed this PR has unit test files
  - [x ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.