### PR TITLE
reverting ad block integration in gallery and lead art

### DIFF
--- a/blocks/gallery-block/features/gallery/_children/custom-content.jsx
+++ b/blocks/gallery-block/features/gallery/_children/custom-content.jsx
@@ -1,10 +1,12 @@
+/* eslint max-len: 0 */
 import React from 'react';
 import { useContent } from 'fusion:content';
 import { useFusionContext } from 'fusion:context';
 import { Gallery } from '@wpmedia/engine-theme-sdk';
-import ArcAd from '@wpmedia/ads-block';
+// import ArcAd from '@wpmedia/ads-block';
 import getProperties from 'fusion:properties';
 
+/**
 const GalleryInterstitialAd = () => (
   <ArcAd
     customFields={{
@@ -13,6 +15,7 @@ const GalleryInterstitialAd = () => (
     }}
   />
 );
+ * */
 
 const CustomContentGallery = ({ contentConfig, phrases }) => {
   const { arcSite } = useFusionContext();
@@ -21,9 +24,10 @@ const CustomContentGallery = ({ contentConfig, phrases }) => {
     query: contentConfig.contentConfigValues,
   }) || {};
   const { content_elements: contentElements = [] } = content;
+  const { resizerURL } = getProperties(arcSite) || {};
+  /**
   const { resizerURL, galleryCubeClicks } = getProperties(arcSite) || {};
   let adProps = {};
-
   if (galleryCubeClicks) {
     const value = parseInt(galleryCubeClicks, 10);
     if (!Number.isNaN(value)) {
@@ -33,7 +37,9 @@ const CustomContentGallery = ({ contentConfig, phrases }) => {
       };
     }
   }
+  * */
 
+  /**
   return (
     <Gallery
       galleryElements={contentElements}
@@ -45,6 +51,19 @@ const CustomContentGallery = ({ contentConfig, phrases }) => {
       pausePhrase={phrases.t('global.gallery-pause-autoplay-button')}
       pageCountPhrase={(current, total) => phrases.t('global.gallery-page-count-text', { current, total })}
       {...adProps}
+    />
+  );
+   * */
+  return (
+    <Gallery
+      galleryElements={contentElements}
+      resizerURL={resizerURL}
+      ansId={content?._id ? content._id : ''}
+      ansHeadline={content?.headlines?.basic ? content.headlines.basic : ''}
+      expandPhrase={phrases.t('global.gallery-expand-button')}
+      autoplayPhrase={phrases.t('global.gallery-autoplay-button')}
+      pausePhrase={phrases.t('global.gallery-pause-autoplay-button')}
+      pageCountPhrase={(current, total) => phrases.t('global.gallery-page-count-text', { current, total })}
     />
   );
 };

--- a/blocks/gallery-block/features/gallery/_children/custom-content.test.jsx
+++ b/blocks/gallery-block/features/gallery/_children/custom-content.test.jsx
@@ -97,7 +97,7 @@ describe('the custom content gallery', () => {
       expect(wrapper.find('Gallery').props().expandPhrase).toEqual('Expand');
       expect(wrapper.find('Gallery').props().autoplayPhrase).toEqual('Autoplay');
       expect(wrapper.find('Gallery').props().pausePhrase).toEqual('Pause autoplay');
-      expect(wrapper.find('Gallery').props().interstitialClicks).toEqual(5);
+      // expect(wrapper.find('Gallery').props().interstitialClicks).toEqual(5);
       expect(typeof wrapper.find('Gallery').props().pageCountPhrase).toEqual('function');
       expect(wrapper.find('Gallery').props().pageCountPhrase(1, 5)).toEqual('%{current} of %{total}');
     });
@@ -123,7 +123,7 @@ describe('the custom content gallery', () => {
       expect(typeof wrapper.find('Gallery').props().pageCountPhrase).toEqual('function');
     });
   });
-
+  /**
   describe('when galleryCubeClicks is present', () => {
     it('should send interstitialClicks', () => {
       jest.mock('fusion:context', () => ({
@@ -166,4 +166,5 @@ describe('the custom content gallery', () => {
       expect(wrapper.find('Gallery').prop('adElement')).toBeFalsy();
     });
   });
+   * */
 });

--- a/blocks/gallery-block/features/gallery/_children/global-content.jsx
+++ b/blocks/gallery-block/features/gallery/_children/global-content.jsx
@@ -1,9 +1,11 @@
+/* eslint max-len: 0 */
 import React from 'react';
 import { useFusionContext, useAppContext } from 'fusion:context';
 import { Gallery } from '@wpmedia/engine-theme-sdk';
-import ArcAd from '@wpmedia/ads-block';
+// import ArcAd from '@wpmedia/ads-block';
 import getProperties from 'fusion:properties';
 
+/**
 const GalleryInterstitialAd = () => (
   <ArcAd
     customFields={{
@@ -12,14 +14,17 @@ const GalleryInterstitialAd = () => (
     }}
   />
 );
+ * */
 
 const GlobalContentGallery = ({ phrases }) => {
   const { arcSite } = useFusionContext();
   const { globalContent = {} } = useAppContext();
   const { content_elements: contentElements = [] } = globalContent;
-  const { resizerURL, galleryCubeClicks } = getProperties(arcSite) || {};
-  let adProps = {};
+  // const { resizerURL, galleryCubeClicks } = getProperties(arcSite) || {};
+  const { resizerURL } = getProperties(arcSite) || {};
 
+  /**
+  let adProps = {};
   if (galleryCubeClicks) {
     const value = parseInt(galleryCubeClicks, 10);
     if (!Number.isNaN(value)) {
@@ -41,6 +46,19 @@ const GlobalContentGallery = ({ phrases }) => {
       pausePhrase={phrases.t('global.gallery-pause-autoplay-button')}
       pageCountPhrase={(current, total) => phrases.t('global.gallery-page-count-text', { current, total })}
       {...adProps}
+    />
+  );
+* */
+  return (
+    <Gallery
+      galleryElements={contentElements}
+      resizerURL={resizerURL}
+      ansId={globalContent._id}
+      ansHeadline={globalContent?.headlines?.basic ? globalContent.headlines.basic : ''}
+      expandPhrase={phrases.t('global.gallery-expand-button')}
+      autoplayPhrase={phrases.t('global.gallery-autoplay-button')}
+      pausePhrase={phrases.t('global.gallery-pause-autoplay-button')}
+      pageCountPhrase={(current, total) => phrases.t('global.gallery-page-count-text', { current, total })}
     />
   );
 };

--- a/blocks/gallery-block/features/gallery/_children/global-content.test.jsx
+++ b/blocks/gallery-block/features/gallery/_children/global-content.test.jsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/jsx-props-no-spreading */
+/* eslint-disable react/jsx-props-no-spreading, max-len */
 import React from 'react';
 import { shallow } from 'enzyme';
 

--- a/blocks/gallery-block/features/gallery/_children/global-content.test.jsx
+++ b/blocks/gallery-block/features/gallery/_children/global-content.test.jsx
@@ -140,6 +140,7 @@ describe('the global content gallery', () => {
     });
   });
 
+  /**
   describe('when galleryCubeClicks is present', () => {
     it('should send interstitialClicks', () => {
       jest.mock('fusion:context', () => ({
@@ -189,4 +190,5 @@ describe('the global content gallery', () => {
       expect(wrapper.find('Gallery').prop('adElement')).toBeFalsy();
     });
   });
+   * */
 });

--- a/blocks/gallery-block/package.json
+++ b/blocks/gallery-block/package.json
@@ -26,8 +26,7 @@
   },
   "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "canary",
-    "@wpmedia/news-theme-css": "canary",
-    "@wpmedia/ads-block": "canary"
+    "@wpmedia/news-theme-css": "canary"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -1,4 +1,4 @@
-/* eslint-disable camelcase */
+/* eslint-disable camelcase, max-len */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Consumer from 'fusion:consumer';
@@ -10,7 +10,7 @@ import VideoPlayer from '@wpmedia/video-player-block';
 import {
   Gallery, ImageMetadata, Image, Lightbox,
 } from '@wpmedia/engine-theme-sdk';
-import ArcAd from '@wpmedia/ads-block';
+// import ArcAd from '@wpmedia/ads-block';
 import './leadart.scss';
 import FullscreenIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/FullscreenIcon';
 
@@ -182,6 +182,7 @@ class LeadArt extends Component {
           </LeadArtWrapperFigure>
         );
       } if (lead_art.type === 'gallery') {
+        /**
         const GalleryInterstitialAd = () => (
           <ArcAd
             customFields={{
@@ -214,7 +215,21 @@ class LeadArt extends Component {
             {...adProps}
           />
         );
+        * */
+        return (
+          <Gallery
+            galleryElements={lead_art.content_elements}
+            resizerURL={getProperties(arcSite)?.resizerURL}
+            ansId={lead_art._id}
+            ansHeadline={lead_art.headlines.basic ? lead_art.headlines.basic : ''}
+            expandPhrase={this.phrases.t('global.gallery-expand-button')}
+            autoplayPhrase={this.phrases.t('global.gallery-autoplay-button')}
+            pausePhrase={this.phrases.t('global.gallery-pause-autoplay-button')}
+            pageCountPhrase={(current, total) => this.phrases.t('global.gallery-page-count-text', { current, total })}
+          />
+        );
       }
+
       return null;
     }
     return null;


### PR DESCRIPTION
## Description
In the last beta release, it was discovered that the gallery and lightbox blocks required the ad-block even if ads were not being leveraged.  It was decided to back out this dependency until a more suitable solution is found.  Instead of removing the logic out of the gallery and lightbox blocks (including the logic in the respective tests), I have instead commented the code out as I feel this will help in providing for the future new solution.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/PEN-1640

## Acceptance Criteria
Customers should not be required to add a new block as part of this release, in order to deploy their website. Per our discussion on 1/6, we will revert the work from PEN-435: Google Ads: Gallery Interstitial CubeREADY FOR DEPLOYMENT from beta for now, so that this is no longer an issue. 
We will reintroduce that functionality in a subsequent release, once we have a better solution for the dependency. 


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x ] Confirmed all the test steps a reviewer will follow above are working. 
- [ x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ x] Confirmed this PR has unit test files
  - [x ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.