### PR TITLE
PEN-1594 Ability to use See More button when using Collections conten…

### DIFF
--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -49,7 +49,6 @@ class ResultsList extends Component {
       storedList: {},
       resultList: {},
       seeMore: true,
-      nextCollection: {},
       placeholderResizedImageOptions: {},
     };
     this.phrases = getTranslatedPhrases(getProperties(props.arcSite).locale || 'en');
@@ -136,12 +135,7 @@ class ResultsList extends Component {
           seeMore: {
             source: contentService,
             query,
-            transform: (data) => {
-              if (!data || !data.content_elements || data.content_elements.length === 0) {
-                return false;
-              }
-              return true;
-            },
+            transform: (data) => !!(data?.content_elements?.length),
           },
         });
       }
@@ -155,29 +149,22 @@ class ResultsList extends Component {
       const { resultList } = this.state;
       this.state.storedList = resultList;
 
+      // Check if there are available next item from collection
       if (listContentConfig.contentService === 'content-api-collections') {
         const query = { ...contentConfigValues };
         const from = parseInt(contentConfigValues.from, 10) || 0;
         const size = parseInt(contentConfigValues.size, 10) || 10;
         query.from = from + size + 1;
         this.fetchContent({
-          nextCollection: {
+          seeMore: {
             source: contentService,
             query,
+            transform: (data) => !!(data?.content_elements?.length),
           },
         });
-      }
-      const { nextCollection } = this.state;
-
-      // Check if there are available stories
-      if (resultList?.content_elements) {
-        // Hide button if no additional stories from initial content
-        if ((resultList.content_elements.length >= resultList.count)
-          || !nextCollection
-          || !nextCollection.content_elements
-          || (nextCollection.content_elements.length === 0)) {
-          this.state.seeMore = false;
-        }
+      } else if (resultList?.content_elements
+        && resultList.content_elements.length >= resultList.count) {
+        this.state.seeMore = false;
       }
     }
   }

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -49,8 +49,8 @@ class ResultsList extends Component {
       storedList: {},
       resultList: {},
       seeMore: true,
+      nextCollection: {},
       placeholderResizedImageOptions: {},
-      count: 0,
     };
     this.phrases = getTranslatedPhrases(getProperties(props.arcSite).locale || 'en');
     this.fetchStories(false);
@@ -85,7 +85,7 @@ class ResultsList extends Component {
     const { customFields: { listContentConfig } } = this.props;
     const { contentService, contentConfigValues } = listContentConfig;
     if (additionalStoryAmount) {
-      const { storedList, count } = this.state;
+      const { storedList } = this.state;
       // Check for next value
       if (storedList.next) {
         // Determine content service type
@@ -118,8 +118,8 @@ class ResultsList extends Component {
           this.state.seeMore = false;
         }
       } else if (listContentConfig.contentService === 'content-api-collections') {
-        const from = parseInt(contentConfigValues.from, 0);
-        const size = parseInt(contentConfigValues.size, 10);
+        let from = parseInt(contentConfigValues.from, 10) || 0;
+        const size = parseInt(contentConfigValues.size, 10) || 10;
         contentConfigValues.from = String(from + size);
         this.fetchContent({
           resultList: {
@@ -128,39 +128,54 @@ class ResultsList extends Component {
             transform: (data) => fetchStoriesTransform(data, storedList),
           },
         });
-        // Hide button if no more stories to load
-        if ((storedList.content_elements.length + size) >= count) {
-          this.state.seeMore = false;
-        }
-      }
-    } else {
-      if (listContentConfig.contentService === 'content-api-collections') {
-        // Count all items from collection based on contentConfigValues conditions
+
         const query = { ...contentConfigValues };
-        // By default collection limit 20 items
-        query.size = '20';
+        from = parseInt(contentConfigValues.from, 10) || 0;
+        query.from = String(from + size + 1);
         this.fetchContent({
-          collection: {
+          seeMore: {
             source: contentService,
             query,
+            transform: (data) => {
+              if (!data || data.content_elements.length === 0) {
+                return false;
+              }
+              return true;
+            },
           },
         });
-        const { collection } = this.state;
-        this.state.count = collection?.content_elements ? collection.content_elements.length : 0;
       }
+    } else {
       this.fetchContent({
         resultList: {
           source: contentService,
           query: contentConfigValues,
         },
       });
-      const { resultList, count } = this.state;
+      const { resultList } = this.state;
       this.state.storedList = resultList;
+
+      if (listContentConfig.contentService === 'content-api-collections') {
+        const query = { ...contentConfigValues };
+        const from = parseInt(contentConfigValues.from, 10) || 0;
+        const size = parseInt(contentConfigValues.size, 10) || 10;
+        query.from = from + size + 1;
+        console.log(from);
+        this.fetchContent({
+          nextCollection: {
+            source: contentService,
+            query,
+          },
+        });
+      }
+      const { nextCollection } = this.state;
+
       // Check if there are available stories
       if (resultList?.content_elements) {
         // Hide button if no additional stories from initial content
         if ((resultList.content_elements.length >= resultList.count)
-          || (resultList.content_elements.length >= count)) {
+          || !nextCollection
+          || (nextCollection.content_elements.length === 0)) {
           this.state.seeMore = false;
         }
       }

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -137,7 +137,7 @@ class ResultsList extends Component {
             source: contentService,
             query,
             transform: (data) => {
-              if (!data || data.content_elements.length === 0) {
+              if (!data || !data.content_elements || data.content_elements.length === 0) {
                 return false;
               }
               return true;
@@ -160,7 +160,6 @@ class ResultsList extends Component {
         const from = parseInt(contentConfigValues.from, 10) || 0;
         const size = parseInt(contentConfigValues.size, 10) || 10;
         query.from = from + size + 1;
-        console.log(from);
         this.fetchContent({
           nextCollection: {
             source: contentService,
@@ -175,6 +174,7 @@ class ResultsList extends Component {
         // Hide button if no additional stories from initial content
         if ((resultList.content_elements.length >= resultList.count)
           || !nextCollection
+          || !nextCollection.content_elements
           || (nextCollection.content_elements.length === 0)) {
           this.state.seeMore = false;
         }

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -46,6 +46,11 @@ describe('The results list', () => {
 
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn()
+      .mockReturnValue({ fetched: fetched(mockReturnData) });
 
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: mockData }, () => {
@@ -69,6 +74,10 @@ describe('The results list', () => {
 
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue(oneListItem);
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched(oneListItem) });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: oneListItem }, () => {
       it('should have one parent wrapper', () => {
@@ -131,6 +140,11 @@ describe('The results list', () => {
 
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue(LineItemWithOutDescription);
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn()
+      .mockReturnValue({ fetched: fetched(LineItemWithOutDescription) });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: LineItemWithOutDescription }, () => {
       wrapper.update();
@@ -167,6 +181,11 @@ describe('The results list', () => {
 
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue(withoutByline);
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn()
+      .mockReturnValue({ fetched: fetched(withoutByline) });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: withoutByline }, () => {
       wrapper.update();
@@ -193,7 +212,11 @@ describe('The results list', () => {
 
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
-
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn()
+      .mockReturnValue({ fetched: fetched(mockReturnData) });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="dagen" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: mockData }, () => {
       wrapper.update();
@@ -220,6 +243,11 @@ describe('The results list', () => {
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
     ResultsList.prototype.fetchStories = jest.fn().mockReturnValue({});
+
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
 
     const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
 
@@ -250,6 +278,11 @@ describe('The results list', () => {
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
     ResultsList.prototype.fetchStories = jest.fn().mockReturnValue({});
+
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
     const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: oneListItem }, () => {
       wrapper.update();
@@ -280,6 +313,11 @@ describe('The results list', () => {
     };
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
     const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: oneListItem }, () => {
       wrapper.update();
@@ -310,6 +348,11 @@ describe('The results list', () => {
     };
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
     const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: oneListItem }, () => {
       wrapper.update();
@@ -340,6 +383,11 @@ describe('The results list', () => {
     };
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
     const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: oneListItem }, () => {
       wrapper.update();
@@ -373,6 +421,11 @@ describe('The results list', () => {
     };
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
     const wrapper = shallow(<ResultsList customFields={listContentConfig} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: oneListItem }, () => {
       wrapper.update();
@@ -404,6 +457,10 @@ describe('The results list', () => {
     ResultsList.prototype.fetchStories = jest.fn().mockReturnValue(mockReturnData);
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
 
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: mockData, seeMore: true }, () => {
       wrapper.update();
@@ -436,6 +493,11 @@ describe('The results list', () => {
 
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue(mockData);
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn()
+      .mockReturnValue({ fetched: fetched({ mockData }) });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: mockData, seeMore: false }, () => {
       wrapper.update();
@@ -461,6 +523,11 @@ describe('The results list from collection', () => {
     const customFields = { listContentConfig };
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({ collectionFirst10Items });
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn()
+      .mockReturnValue({ fetched: fetched({ collectionFirst10Items }) });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-gazette" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: collectionFirst10Items }, () => {
       wrapper.update();
@@ -482,6 +549,11 @@ describe('The results list from collection', () => {
     const customFields = { listContentConfig };
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({ mockCollections });
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn()
+      .mockReturnValue({ fetched: fetched({ mockCollections }) });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-gazette" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: collectionFirst10Items, seeMore: false }, () => {
       wrapper.update();
@@ -504,6 +576,11 @@ describe('The results list from collection', () => {
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({ mockCollections });
     ResultsList.prototype.fetchStories = jest.fn().mockReturnValue(collectionFirst10Items);
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn()
+      .mockReturnValue({ fetched: fetched({ mockCollections }) });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-gazette" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: collectionFirst10Items, seeMore: true }, () => {
       wrapper.update();
@@ -527,6 +604,10 @@ describe('The results list from collection', () => {
     const { default: ResultsList } = require('./default');
     const fetchMock = jest.fn().mockReturnValue({});
     ResultsList.prototype.fetchContent = fetchMock;
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-gazette" deployment={jest.fn((path) => path)} />);
     fetchMock.mockClear();
     wrapper.setState({ storedList: collectionFirst10Items });

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -462,7 +462,7 @@ describe('The results list from collection', () => {
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({ collectionFirst10Items });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-gazette" deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ resultList: collectionFirst10Items, count: 11 }, () => {
+    wrapper.setState({ resultList: collectionFirst10Items }, () => {
       wrapper.update();
       expect(wrapper.find('.results-list-container').length).toEqual(1);
       expect(wrapper.find('.list-item').length).toEqual(10);
@@ -483,7 +483,7 @@ describe('The results list from collection', () => {
     const { default: ResultsList } = require('./default');
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({ mockCollections });
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-gazette" deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ resultList: collectionFirst10Items, count: 10, seeMore: false }, () => {
+    wrapper.setState({ resultList: collectionFirst10Items, seeMore: false }, () => {
       wrapper.update();
       expect(wrapper.find('.results-list-container').length).toEqual(1);
       expect(wrapper.find('.list-item').length).toEqual(10);
@@ -505,7 +505,7 @@ describe('The results list from collection', () => {
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({ mockCollections });
     ResultsList.prototype.fetchStories = jest.fn().mockReturnValue(collectionFirst10Items);
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-gazette" deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ resultList: collectionFirst10Items, count: 11, seeMore: true }, () => {
+    wrapper.setState({ resultList: collectionFirst10Items, seeMore: true }, () => {
       wrapper.update();
       expect(ResultsList.prototype.fetchStories.mock.calls.length).toEqual(1);
       wrapper.find('.btn').simulate('click');
@@ -529,10 +529,10 @@ describe('The results list from collection', () => {
     ResultsList.prototype.fetchContent = fetchMock;
     const wrapper = shallow(<ResultsList customFields={customFields} arcSite="the-gazette" deployment={jest.fn((path) => path)} />);
     fetchMock.mockClear();
-    wrapper.setState({ storedList: collectionFirst10Items, count: 11 });
+    wrapper.setState({ storedList: collectionFirst10Items });
     wrapper.update();
     wrapper.instance().fetchStories(true);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(wrapper.state('seeMore')).toEqual(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(wrapper.state('seeMore')).toEqual(true);
   });
 });

--- a/blocks/results-list-block/features/results-list/internalTests.test.jsx
+++ b/blocks/results-list-block/features/results-list/internalTests.test.jsx
@@ -26,6 +26,10 @@ describe('getFallbackImageURL', () => {
 
   it('should NOT call deployment with context path if http is contained in fallback image url', () => {
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
 
     const mockDeployment = jest.fn();
     const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath="/pf" customFields={customFields} />);
@@ -49,8 +53,12 @@ describe('fetchPlaceholder', () => {
   const customFields = { listContentConfig };
 
   it('should call fetchContent if fallback image contains resources', () => {
-    const fetchContentMock = jest.fn().mockReturnValue({});
-    ResultsList.prototype.fetchContent = fetchContentMock;
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    const fetchContentMock = jest.fn().mockReturnValue({ fetched: fetched({}) });
+    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    ResultsList.prototype.getContent = fetchContentMock;
     const mockDeployment = jest.fn();
     const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath="/pf" customFields={customFields} />);
     mockDeployment.mockClear();
@@ -58,7 +66,7 @@ describe('fetchPlaceholder', () => {
     wrapper.instance().fetchPlaceholder();
 
     expect(fetchContentMock).toHaveBeenCalledTimes(1);
-    expect(fetchContentMock).toHaveBeenCalledWith({ resultList: { query: { offset: '0', query: 'type: story', size: '1' }, source: 'story-feed-query' } });
+    expect(fetchContentMock).toHaveBeenCalledWith('story-feed-query', { offset: '0', query: 'type: story', size: '1' });
   });
 });
 
@@ -76,6 +84,10 @@ describe('fetchStories', () => {
   it('should make appropriate calculations if has additionalStoryAmount and story-feed-query', () => {
     const fetchContentMock = jest.fn().mockReturnValue({});
     ResultsList.prototype.fetchContent = fetchContentMock;
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
 
     const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFields} />);
     fetchContentMock.mockClear();
@@ -102,6 +114,10 @@ describe('fetchStories', () => {
   it('should make appropriate calculations if has additionalStoryAmount and story-feed-query and no storedList.next', () => {
     const fetchContentMock = jest.fn().mockReturnValue({});
     ResultsList.prototype.fetchContent = fetchContentMock;
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
 
     const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFields} />);
     fetchContentMock.mockClear();
@@ -116,6 +132,10 @@ describe('fetchStories', () => {
   it('should make appropriate calculations if has additionalStoryAmount and story-feed-query and no storedList.next', () => {
     const fetchContentMock = jest.fn().mockReturnValue({});
     ResultsList.prototype.fetchContent = fetchContentMock;
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
 
     const listContentConfigStory = {
       contentConfigValues: {
@@ -153,6 +173,10 @@ describe('fetchStories', () => {
   it('should make appropriate calculations if has additionalStoryAmount and non-specified and no storedList.next', () => {
     const fetchContentMock = jest.fn().mockReturnValue({});
     ResultsList.prototype.fetchContent = fetchContentMock;
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
 
     const listContentConfigOther = {
       contentConfigValues: {
@@ -188,7 +212,10 @@ describe('fetchStories', () => {
 
   it('should update seeMore if value is greater than storied list count', () => {
     const fetchContentMock = jest.fn().mockReturnValue({ content_elements: ['elem1', 'elem2'] });
-    ResultsList.prototype.getContent = fetchContentMock;
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({ content_elements: ['elem1', 'elem2'] }) });
 
     const listContentConfigStoryFeed = {
       contentConfigValues: {
@@ -213,6 +240,10 @@ describe('fetchStories', () => {
 describe('fetchStoriesTransform', () => {
   it('if has no data, return storedList', () => {
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
 
     const result = fetchStoriesTransform(null, 'storedList');
     expect(result).toEqual('storedList');
@@ -239,6 +270,11 @@ describe('styled components', () => {
 
   it('renders styled headline, read more button and description', () => {
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
+    const fetched = (content) => new Promise((resolve) => {
+      resolve(content);
+    });
+    ResultsList.prototype.getContent = jest.fn()
+      .mockReturnValue({ fetched: fetched({ mockReturnData }) });
     ResultsList.prototype.getThemeStyle = jest.fn().mockReturnValue({ 'primary-font-family': 'font1' });
 
     const mockDeployment = jest.fn();


### PR DESCRIPTION
…t source

**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
_Information about what you changed for this PR_
Rework on PEN-1594.

## Jira Ticket
- [PEN-1594](https://arcpublishing.atlassian.net/browse/PEN-1594)

Acceptance Criteria
copy from ticket
What should be happening
Clicking the read more button portion of the results-list block should load more stories when that block is configured with the content-api-collections content source.

Test Steps
1. Add test steps a reviewer must complete to test this PR
2. In Fusion-News-Theme repo, checkout master & git pull
3. After checking out this feature branch in fusion-news-theme-blocks, run rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..
4. Run: npx fusion start -f -l @wpmedia/results-list-block
5. Create a page then add the feature results-list-block and configure content-api-collections for testing

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._
The result list could not present more than 20 items

[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._

Supported pagination on the result list, present more than 20 items

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.