### PR TITLE
PEN-1527: Fix Advertisement Label displaying when no Ad Unit is populated on the active breakpoint

### DIFF
--- a/blocks/ads-block/features/ads/ads.scss
+++ b/blocks/ads-block/features/ads/ads.scss
@@ -1,28 +1,29 @@
-.advertisement-label {
-  color: $ui-medium-gray;
-  font-size: calculateRem(12px);
-  line-height: calculateRem(16px);
-  white-space: nowrap;
-
-  &--desktop {
-    @media only screen and (max-width: map-get($grid-breakpoints-max, sm)) {
-      display: none;
-    }
-  }
-}
-
 .arcad_feature {
   .arcad_container {
     margin-left: auto;
     margin-right: auto;
     width: min-content;
+    color: $ui-medium-gray;
+    font-size: calculateRem(12px);
+    line-height: calculateRem(16px);
 
     .arcad {
-      text-align: center;
-
       div[id^='google_ads_iframe'] {
-        text-align: center;
+        & > iframe[id^='google_ads_iframe'] {
+          margin-bottom: calculateRem(32px);
+        }
+      }
+
+      &.pb-ad-admin {
+        margin-bottom: calculateRem(32px);
+        font-size: calculateRem(14px);
+        line-height: calculateRem(18px);
+        color: white;
       }
     }
   }
+}
+
+.layout-section .arcad_feature {
+  margin-bottom: 0;
 }

--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable comma-dangle */
 import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from '@arc-fusion/prop-types';
+import styled from 'styled-components';
 import getProperties from 'fusion:properties';
 import { useFusionContext, useAppContext } from 'fusion:context';
 import adMap from './ad-mapping';
@@ -9,6 +10,19 @@ import ArcAdminAd from './_children/ArcAdminAd';
 import ArcAdsInstance from './_children/ArcAdsInstance';
 import { getAdObject, setPageTargeting } from './ad-helper';
 import './ads.scss';
+
+/* Styled Components */
+const StyledAdUnit = styled.div`
+  .arcad > div[id^='google_ads_iframe']:not(:empty):before {
+    content: "${(props) => props.adLabel}";
+    ${(props) => (props.displayAdLabel ? '' : 'display: none')}
+  }
+
+  .arcad > div[id^='google_ads_iframe']:empty[style] {
+    width: 0px !important;
+    height: 0px !important;
+  }
+`;
 
 /** === ArcAd Component === */
 const ArcAd = (props) => {
@@ -29,7 +43,10 @@ const ArcAd = (props) => {
     }),
   );
   // istanbul ignore next
-  const isAMP = () => (!!(propsWithContext.outputType && propsWithContext.outputType === 'amp'));
+  const isAMP = () => (
+    !!(propsWithContext.outputType
+      && propsWithContext.outputType === 'amp')
+  );
 
   const {
     arcSite,
@@ -39,8 +56,6 @@ const ArcAd = (props) => {
     },
   } = propsWithContext;
   const siteVars = getProperties(arcSite);
-
-  const [labelDisplayClass, setLabelDisplayClass] = useState('no-display');
 
   const registerAd = useCallback(() => {
     const publisherIds = { dfp_publisher_id: siteVars.dfpId };
@@ -52,11 +67,6 @@ const ArcAd = (props) => {
         params: config,
         publisherIds,
         debug,
-      }, (cb) => {
-        // render advertisement label after ad returns
-        if (cb && cb.adId) {
-          setLabelDisplayClass('');
-        }
       });
   }, [config, debug, propsWithContext, siteVars]);
 
@@ -68,20 +78,14 @@ const ArcAd = (props) => {
     id, adClass, adType, dimensions, slotName,
   } = config;
 
-  const display = adType === 'right_rail_cube' ? 'desktop' : 'all';
-
   return (
-    <div
+    <StyledAdUnit
       id={`arcad_feature-${instanceId}`}
-      className="arcad_feature margin-md-bottom"
+      className="arcad_feature"
+      adLabel={siteVars?.advertisementLabel || 'ADVERTISEMENT'}
+      displayAdLabel={!isAdmin && displayAdLabel && !isAMP()}
     >
       <div className="arcad_container">
-        {!isAdmin && displayAdLabel && !isAMP() && (
-          <div
-            className={`advertisement-label advertisement-label--${display} ${labelDisplayClass}`}
-            dangerouslySetInnerHTML={{ __html: siteVars.advertisementLabel || 'ADVERTISEMENT' }}
-          />
-        )}
         {!isAdmin && !isAMP() && (
           <div id={id} className={`arcad ad-${adClass}`} />
         )}
@@ -92,7 +96,7 @@ const ArcAd = (props) => {
           dimensions={dimensions}
         />
       </div>
-    </div>
+    </StyledAdUnit>
   );
 };
 

--- a/blocks/ads-block/features/ads/default.test.jsx
+++ b/blocks/ads-block/features/ads/default.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { useFusionContext, useAppContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import ArcAd from './default';
@@ -40,7 +40,7 @@ describe('<ArcAd>', () => {
     useFusionContext.mockReturnValueOnce({ isAdmin: true });
     const wrapper = mount(<ArcAd {...AD_PROPS_MOCK} />);
     expect(wrapper).toBeDefined();
-    const container = wrapper.find('.arcad_feature');
+    const container = wrapper.find('div.arcad_feature');
     expect(container).toHaveLength(1);
     expect(container.find('.arcad')).toBeDefined();
     expect(container.find('.arcad')).toHaveLength(0);
@@ -49,7 +49,7 @@ describe('<ArcAd>', () => {
   it('renders ad unit when not in admin dashboard', () => {
     const wrapper = mount(<ArcAd {...AD_PROPS_MOCK} />);
     expect(wrapper).toBeDefined();
-    const container = wrapper.find('.arcad_feature');
+    const container = wrapper.find('div.arcad_feature');
     expect(container).toHaveLength(1);
     expect(container.find('.arcad')).toBeDefined();
     expect(container.find('.arcad')).toHaveLength(1);
@@ -62,55 +62,54 @@ describe('<ArcAd>', () => {
         displayAdLabel: false,
       },
     };
-    const wrapper = shallow(<ArcAd {...adProps} />);
-    expect(wrapper.find('div.advertisement-label')).toHaveLength(0);
+    const wrapper = mount(<ArcAd {...adProps} />);
+    const container = wrapper.find('StyledComponent.arcad_feature');
+    expect(container).toHaveLength(1);
+    expect(container.prop('displayAdLabel')).toBe(false);
+    expect(container.prop('adLabel')).toEqual('ADVERTISEMENT');
   });
 
-  it('advertisement label class exist when enabled', () => {
-    const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
-    expect(wrapper.find('div.advertisement-label')).toHaveLength(1);
+  it('renders advertisement label when enabled', () => {
+    const wrapper = mount(<ArcAd {...AD_PROPS_MOCK} />);
+    const container = wrapper.find('StyledComponent.arcad_feature');
+    expect(container).toHaveLength(1);
+    expect(container.prop('displayAdLabel')).toBe(true);
+    expect(container.prop('adLabel')).toEqual('ADVERTISEMENT');
   });
 
-  it('does not render advertisement label before ad callback', () => {
-    const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
-    expect(wrapper.find('div.advertisement-label').is('.no-display')).toEqual(true);
-  });
+  describe('ArcAd - Advertisement Label', () => {
+    it('renders no advertisement label when disabled', () => {
+      const adProps = {
+        ...AD_PROPS_MOCK,
+        customFields: {
+          displayAdLabel: false,
+        },
+      };
+      const wrapper = mount(<ArcAd {...adProps} />);
+      const container = wrapper.find('StyledComponent.arcad_feature');
+      expect(container).toHaveLength(1);
+      expect(container.prop('displayAdLabel')).toBe(false);
+      expect(container.prop('adLabel')).toEqual('ADVERTISEMENT');
+    });
 
-  it('renders the label with text ADVERTISEMENT when advertisementLabel property is missing', () => {
-    const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
-    /* eslint-disable-next-line no-underscore-dangle */
-    expect(wrapper.find('div.advertisement-label').prop('dangerouslySetInnerHTML').__html).toEqual('ADVERTISEMENT');
-  });
+    it('renders advertisement label when enabled', () => {
+      const wrapper = mount(<ArcAd {...AD_PROPS_MOCK} />);
+      const container = wrapper.find('StyledComponent.arcad_feature');
+      expect(container).toHaveLength(1);
+      expect(container.prop('displayAdLabel')).toBe(true);
+      expect(container.prop('adLabel')).toEqual('ADVERTISEMENT');
+    });
 
-  it('should use "all" on wrapper for advertisement label', () => {
-    const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
-    expect(wrapper.find('div.advertisement-label--all')).toHaveLength(1);
-  });
-
-  it('should use "desktop" on wrapper for advertisement right_rail_cube', () => {
-    const mockData = { ...AD_PROPS_MOCK };
-    mockData.customFields.adType = '300x250|300x600_rightrail';
-    const wrapper = shallow(<ArcAd {...mockData} />);
-    expect(wrapper.find('div.advertisement-label--desktop')).toHaveLength(1);
-  });
-});
-
-describe('ArcAd with custom advertisement label', () => {
-  const customLabel = {
-    advertisementLabel: "Advertisement / <a href='http://example.com' target='_blank'>Advertisement</a>",
-  };
-  beforeEach(() => {
-    jest.clearAllMocks();
-    getProperties.mockReturnValue({ ...SITE_PROPS_MOCK, ...customLabel });
-    useFusionContext.mockReturnValue({ isAdmin: false });
-    useAppContext.mockReturnValue({});
-  });
-
-  it('renders the label using advertisementLabel property when present', () => {
-    const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
-    expect(
-      /* eslint-disable-next-line no-underscore-dangle */
-      wrapper.find('div.advertisement-label').prop('dangerouslySetInnerHTML').__html,
-    ).toEqual(customLabel.advertisementLabel);
+    it('renders custom advertisement label', () => {
+      const customSiteProps = {
+        advertisementLabel: "Advertisement / <a href='http://example.com' target='_blank'>Advertisement</a>",
+      };
+      getProperties.mockReturnValue({ ...SITE_PROPS_MOCK, ...customSiteProps });
+      const wrapper = mount(<ArcAd {...AD_PROPS_MOCK} />);
+      const container = wrapper.find('StyledComponent.arcad_feature');
+      expect(container).toHaveLength(1);
+      expect(container.prop('displayAdLabel')).toBe(true);
+      expect(container.prop('adLabel')).toEqual(customSiteProps.advertisementLabel);
+    });
   });
 });


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Came up with new solution for advertisement label that allows it to display _only_ when ad unit is populated with a creative by DFP.

## Jira Ticket
- [PEN-1527](https://arcpublishing.atlassian.net/browse/PEN-1527)

## Acceptance Criteria

1. When an ad unit is not populated, no advertisement label should be displayed on the page
2. Update any necessary tests and documentation

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. After checking out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/ads-block` in `Fusion-News-Theme`
4. Put one instance of each `adType` (configured through custom fields) on a page. Then stage & publish.
5. Open page in separate tab and check how the page looks across breakpoints. On mobile, it appears that the test DFP account doesn't return any creatives for most of the ad types. For these ad units that fail to populate creatives, there should no longer be an ad label displaying. The ad unit(s) that do populate _should_ have an ad label though.
6. Go back to PB admin, open custom fields for one of the ad units and set the "display ad label" custom field to "unchecked"
7. Stage, publish & view page in separate tab. You should see that the ad label is successfully hidden on the corresponding ad unit.

## Effect Of Changes
### Before
Advertisement label was still displaying on ad units that failed to load a creative

### After
Advertisement label should only display above ad units that receive a valid creative and should be hidden if the ad unit is empty

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.