### PR TITLE
PEN-1438 [CMG] Ability to animate logo height in navigation chain

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -142,6 +142,8 @@ const Nav = (props) => {
 
   const displayLinks = horizontalLinksHierarchy && logoAlignment === 'left';
 
+  const navHeight = desktopNavivationStartHeight || 56;
+
   const mainContent = useContent({
     source: 'site-service-hierarchy',
     query: {
@@ -363,7 +365,7 @@ const Nav = (props) => {
         className={`${navColor === 'light' ? 'light' : 'dark'}`}
         font={primaryFont}
         navBarBackground={backgroundColor}
-        navHeight={desktopNavivationStartHeight}
+        navHeight={navHeight}
         scrolled={scrolled}
         breakpoint={breakpoints.medium}
       >
@@ -381,7 +383,7 @@ const Nav = (props) => {
           className={`nav-sections ${isSectionDrawerOpen ? 'open' : 'closed'}`}
           onClick={closeDrawer}
           font={primaryFont}
-          navHeight={desktopNavivationStartHeight}
+          navHeight={navHeight}
           scrolled={scrolled}
           breakpoint={breakpoints.medium}
         >


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
_Information about what you changed for this PR_

The default value for 'Starting desktop navigation bar height' custom property does not work as expected, that's causing the layout issue with current header navigation bar. This PR going to fix it!

## Jira Ticket
- [PEN-1438](https://arcpublishing.atlassian.net/browse/PEN-1438)

## Acceptance Criteria
_copy from ticket_

1. The two new custom fields described above are added to the Navigation Chain, per specs above

2. If a PageBuilder user enters a value for Starting desktop navigation bar height, then when the page first loads on Desktop breakpoint, the navigation bar height should be the number they entered. The max value possible is 200px.

a. e.g. if they entered 100, then the height of the navigation bar should be 100px. 

b. The height of the logo should grow to fill the available space. There should continue to be the specified spacing (in yellow) above and below the logo

c. All other elements within the navigation should be centered vertically, and their height should not change 

3. If a PageBuilder user enters a value for Shrink navigation bar after scrolling, then after the reader scrolls that amount of pixels, the navigation bar should animate back to its standard height (56px). 

a. Once a reader scrolls down the page this many pixels, the navigation bar should animate and return to its standard size. 

b. This prototype can be used for UX animation guidance: https://kind-elion-573ea9.netlify.app/

c. All buttons should stay in the same place – the only things that change position are the logo (its width shrinks) and if horizontal links are present, they have more space to display (since the logo width has shrunk)

4. Tests and documentation are updated to cover this functionality.

## Test Steps
- Add test steps a reviewer must complete to test this PR
1. In Fusion-News-Theme repo, checkout master & git pull
2. After checking out this feature branch in fusion-news-theme-blocks, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
Run: `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/shared-styles`
Create a page then add navigation bar for testing 

## Effect Of Changes
### Before

![image](https://user-images.githubusercontent.com/61674931/104088558-71a4d080-529a-11eb-9320-9586d3afc927.png)


### After
_Example: When I clicked the search button, the button turned green._

![image](https://user-images.githubusercontent.com/61674931/104088567-87b29100-529a-11eb-9530-e69c63ee5790.png)


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working. 
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.