### PR TITLE
PEN-1631 Support for "Hide photographer" and "Vanity photographer" in…

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -63,6 +63,7 @@ function parseArticleItem(item, index, arcSite, phrases) {
         credits,
         alt_text: altText,
         resized_params: resizedImageOptions = {},
+        vanity_credits: vanityCredits,
       } = item;
 
       return (url && url.length > 0) ? (
@@ -81,7 +82,12 @@ function parseArticleItem(item, index, arcSite, phrases) {
             resizerURL={getProperties(arcSite)?.resizerURL}
           />
           <figcaption>
-            <ImageMetadata subtitle={subtitle} caption={caption} credits={credits} />
+            <ImageMetadata
+              subtitle={subtitle}
+              caption={caption}
+              credits={credits}
+              vanityCredits={vanityCredits}
+            />
           </figcaption>
         </figure>
       ) : null;

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -1468,6 +1468,286 @@ describe('article-body chain', () => {
       expect(wrapper.find('figure').find('figcaption').length).toEqual(0);
       expect(wrapper.find('figure').find('figcaption').find('p').length).toEqual(0);
     });
+
+    it('should hide photographer and credit', () => {
+      jest.mock('fusion:properties', () => (jest.fn(() => ({
+        resizerURL: 'https://fake.cdn.com/resizer',
+      }))));
+
+      jest.mock('fusion:context', () => ({
+        useAppContext: jest.fn(() => ({
+          globalContent: {
+            content_elements: [
+              {
+                caption: 'my cool caption',
+                subtitle: 'my cool subtitle',
+              },
+            ],
+          },
+        })),
+        useFusionContext: jest.fn(() => ({
+          globalContent: {
+            _id: '22ACHIRFI5CD5GRFON6AL3JSJE',
+            type: 'story',
+            version: '0.10.2',
+            content_elements: [
+              {
+                _id: 'CITIAYX2ERDOPP2TPJGEUV7SNQ',
+                additional_properties: {
+                  fullSizeResizeUrl: '/photo/resize/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                  galleries: [
+                    {
+                      headlines: {
+                        basic: 'A day at the beach',
+                      },
+                      _id: 'ZMTIFZGC2NCYTDVU7GIGHJKEUY',
+                    },
+                  ],
+                  ingestionMethod: 'manual',
+                  keywords: [
+
+                  ],
+                  mime_type: 'image/jpeg',
+                  originalName: 'DeathtoStock_EnergyandSerenity4.jpg',
+                  originalUrl: 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                  owner: 'sara.carothers@washpost.com',
+                  proxyUrl: '/photo/resize/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                  published: true,
+                  resizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                  restricted: false,
+                  thumbnailResizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/aMX7W71KcKyhfbNdL5RBDpt4RY8=/300x0/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                  version: 1,
+                  comments: [
+
+                  ],
+                  _id: 'VRN2LG34XNDX5MZD64SPU4UNYY',
+                },
+                address: {
+
+                },
+                alt_text: 'A person walks down a path with their surfboard towards the ocean.',
+                caption: "Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break. ",
+                created_date: '2019-07-09T22:26:02Z',
+                credits: {
+                  affiliation: [
+                    {
+                      name: 'Death to Stock Photo',
+                      type: 'author',
+                    },
+                  ],
+                  by: [
+                    {
+                      byline: 'Brett Danielsen (custom credit)',
+                      name: 'Brett Danielsen',
+                      type: 'author',
+                    },
+                  ],
+                },
+                vanity_credits: {
+                  "by": [],
+                  "affiliation": []
+                },
+                distributor: {
+                  mode: 'reference',
+                  reference_id: '508c6d12-f2bb-47db-a836-b2b5de225c43',
+                },
+                height: 3744,
+                image_type: 'photograph',
+                last_updated_date: '2019-07-09T22:29:42Z',
+                licensable: false,
+                owner: {
+                  id: 'corecomponents',
+                  sponsored: false,
+                },
+                source: {
+                  name: 'Death to Stock Photo',
+                  source_type: 'stock',
+                  edit_url: 'https://corecomponents.arcpublishing.com/photo/CITIAYX2ERDOPP2TPJGEUV7SNQ',
+                  system: 'Anglerfish',
+                },
+                subtitle: 'Australia surf trip',
+                taxonomy: {
+                  associated_tasks: [
+
+                  ],
+                },
+                type: 'image',
+                url: 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                version: '0.9.0',
+                width: 5616,
+                resized_params: { '1440x0': '' },
+              },
+            ],
+          },
+          arcSite: 'the-sun',
+          customFields: { },
+        })),
+      }));
+      const { default: ArticleBodyChain } = require('./default');
+      const wrapper = mount(
+        <ArticleBodyChain>
+          <div>1</div>
+          <div>2</div>
+          <span>3</span>
+        </ArticleBodyChain>,
+      );
+      expect(wrapper.find('figure').length).toEqual(1);
+      expect(wrapper.find('figure').find('Image').length).toEqual(1);
+      expect(wrapper.find('figure').find('figcaption').length).toEqual(1);
+      expect(wrapper.find('figure').find('figcaption').find('span').length).toEqual(1);
+      expect(wrapper.find('figure').find('figcaption').find('p').length).toEqual(1);
+      expect(wrapper.find('figure').find('figcaption').find('p').find('.title').length).toEqual(1);
+      expect(wrapper.find('figure').find('figcaption').find('p').text()).toMatch("Australia surf trip Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break.");
+      expect(wrapper.find('figure').find('figcaption').find('p').find('.title')
+        .text()).toMatch('Australia surf trip ');
+    });
+
+    it('should override photographer and credit by using vanity_credits', () => {
+      jest.mock('fusion:properties', () => (jest.fn(() => ({
+        resizerURL: 'https://fake.cdn.com/resizer',
+      }))));
+
+      jest.mock('fusion:context', () => ({
+        useAppContext: jest.fn(() => ({
+          globalContent: {
+            content_elements: [
+              {
+                caption: 'my cool caption',
+                subtitle: 'my cool subtitle',
+              },
+            ],
+          },
+        })),
+        useFusionContext: jest.fn(() => ({
+          globalContent: {
+            _id: '22ACHIRFI5CD5GRFON6AL3JSJE',
+            type: 'story',
+            version: '0.10.2',
+            content_elements: [
+              {
+                _id: 'CITIAYX2ERDOPP2TPJGEUV7SNQ',
+                additional_properties: {
+                  fullSizeResizeUrl: '/photo/resize/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                  galleries: [
+                    {
+                      headlines: {
+                        basic: 'A day at the beach',
+                      },
+                      _id: 'ZMTIFZGC2NCYTDVU7GIGHJKEUY',
+                    },
+                  ],
+                  ingestionMethod: 'manual',
+                  keywords: [
+
+                  ],
+                  mime_type: 'image/jpeg',
+                  originalName: 'DeathtoStock_EnergyandSerenity4.jpg',
+                  originalUrl: 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                  owner: 'sara.carothers@washpost.com',
+                  proxyUrl: '/photo/resize/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                  published: true,
+                  resizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                  restricted: false,
+                  thumbnailResizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/aMX7W71KcKyhfbNdL5RBDpt4RY8=/300x0/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                  version: 1,
+                  comments: [
+
+                  ],
+                  _id: 'VRN2LG34XNDX5MZD64SPU4UNYY',
+                },
+                address: {
+
+                },
+                alt_text: 'A person walks down a path with their surfboard towards the ocean.',
+                caption: "Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break. ",
+                created_date: '2019-07-09T22:26:02Z',
+                credits: {
+                  affiliation: [
+                    {
+                      name: 'Death to Stock Photo',
+                      type: 'author',
+                    },
+                  ],
+                  by: [
+                    {
+                      byline: 'Brett Danielsen (custom credit)',
+                      name: 'Brett Danielsen',
+                      type: 'author',
+                    },
+                  ],
+                },
+                vanity_credits: {
+                  "by": [
+                    {
+                      "type": "author",
+                      "name": "Here's my vanity photographer"
+                    }
+                  ],
+                  "affiliation": [
+                    {
+                      "type": "author",
+                      "name": "Here's my vanity credit"
+                    }
+                  ]
+                },
+                distributor: {
+                  mode: 'reference',
+                  reference_id: '508c6d12-f2bb-47db-a836-b2b5de225c43',
+                },
+                height: 3744,
+                image_type: 'photograph',
+                last_updated_date: '2019-07-09T22:29:42Z',
+                licensable: false,
+                owner: {
+                  id: 'corecomponents',
+                  sponsored: false,
+                },
+                source: {
+                  name: 'Death to Stock Photo',
+                  source_type: 'stock',
+                  edit_url: 'https://corecomponents.arcpublishing.com/photo/CITIAYX2ERDOPP2TPJGEUV7SNQ',
+                  system: 'Anglerfish',
+                },
+                subtitle: 'Australia surf trip',
+                taxonomy: {
+                  associated_tasks: [
+
+                  ],
+                },
+                type: 'image',
+                url: 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+                version: '0.9.0',
+                width: 5616,
+                resized_params: { '1440x0': '' },
+              },
+            ],
+          },
+          arcSite: 'the-sun',
+          customFields: { },
+        })),
+      }));
+      const { default: ArticleBodyChain } = require('./default');
+      const wrapper = mount(
+        <ArticleBodyChain>
+          <div>1</div>
+          <div>2</div>
+          <span>3</span>
+        </ArticleBodyChain>,
+      );
+      expect(wrapper.find('figure').length).toEqual(1);
+      expect(wrapper.find('figure').find('Image').length).toEqual(1);
+      expect(wrapper.find('figure').find('figcaption').length).toEqual(1);
+      expect(wrapper.find('figure').find('figcaption').find('span').length).toEqual(1);
+      expect(wrapper.find('figure').find('figcaption').find('p').length).toEqual(1);
+      expect(wrapper.find('figure').find('figcaption').find('p').find('.title').length).toEqual(1);
+      expect(wrapper.find('figure').find('figcaption').find('p').text())
+        .toMatch("Australia surf trip Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break.  (Here's my vanity photographer/Here's my vanity credit)");
+      expect(wrapper.find('figure').find('figcaption').find('p').find('.title')
+        .text()).toMatch('Australia surf trip ');
+    });
+  });
+
+  describe('Render divider correctly', () => {
     it('should render divider in content', () => {
       jest.mock('fusion:context', () => ({
         useFusionContext: jest.fn(() => ({

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -1544,8 +1544,8 @@ describe('article-body chain', () => {
                   ],
                 },
                 vanity_credits: {
-                  "by": [],
-                  "affiliation": []
+                  by: [],
+                  affiliation: [],
                 },
                 distributor: {
                   mode: 'reference',
@@ -1677,18 +1677,18 @@ describe('article-body chain', () => {
                   ],
                 },
                 vanity_credits: {
-                  "by": [
+                  by: [
                     {
-                      "type": "author",
-                      "name": "Here's my vanity photographer"
-                    }
+                      type: 'author',
+                      name: "Here's my vanity photographer",
+                    },
                   ],
-                  "affiliation": [
+                  affiliation: [
                     {
-                      "type": "author",
-                      "name": "Here's my vanity credit"
-                    }
-                  ]
+                      type: 'author',
+                      name: "Here's my vanity credit",
+                    },
+                  ],
                 },
                 distributor: {
                   mode: 'reference',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9531,9 +9531,9 @@
       }
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.8.1-canary.4",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.8.1-canary.4/25b29e9cb18d443f24864cdcf104b89140bb41b3bc1d67169b8c77a078a419aa",
-      "integrity": "sha512-vvp/FbiKgja72gQaBfRbXazHvPkmXajdGbBd13e+tsOz3gD7axsDfXn5X5qqHxndWtDOLGgyUwNyv+UkZdPYPw==",
+      "version": "2.8.1-canary.10",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.8.1-canary.10/ee545fdcb54e2c5417f14812c0fc8a70aa7579c6c65da8b5e0b81ad8cf6c4b78",
+      "integrity": "sha512-YqxGNCFVrWI9oy1we7eXBXuxCaDxr7JtRqmyaRHHhnt8J207ifovmLEk5+ZGJZx7PFzDVST4UclV0uL4Ih4cYQ==",
       "dev": true,
       "requires": {
         "dom-parser": "^0.1.6",


### PR DESCRIPTION
## Description
Allow ImageMetadata ability to override credits details by using vanityCredits props.

## Jira Ticket
- [PEN-1631](https://arcpublishing.atlassian.net/browse/PEN-1631)

## Acceptance Criteria
1. If an image within the article body has vanity_credits populated with values present, those values should be used instead of the photographer and credit

2. If an image within the article body has vanity_credits but no values are present, the photographer and/or credit should not display at all on this image

3. If vanity_credits does not exist on the image, then the photographer and credit should display as they normally do (no change needed) 

4. For all of these use cases, the customer should be able to have a combination of functionality (for example, Photographer could be hidden and Credit could be a Vanity Credit; or Photographer could be unchanged and Credit could be hidden)

5. Tests and documentation are updated to cover this functionality

## Test Steps
1. Add test steps a reviewer must complete to test this PR
2. In Fusion-News-Theme repo, checkout master & git pull
3. After checking out this feature branch in fusion-news-theme-blocks, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
4. Run:` npx fusion start -f -l @wpmedia/article-body-block`
5. Create a page then add article-body-block for testing
6. Configure Global Source by content-api
7. Configure _id by : PRZ46M5HPZAIFOOGZYX2QMS3WM (story published by Sara already)
8. Verify the results

## Effect Of Changes
### Before
![image](https://user-images.githubusercontent.com/61674931/104185195-398ec080-5447-11eb-9d1f-4a6d8f622806.png)
![image](https://user-images.githubusercontent.com/61674931/104185294-5925e900-5447-11eb-940d-5e6e35c4c268.png)


### After
![Screen Shot 2021-01-11 at 20 02 41](https://user-images.githubusercontent.com/61674931/104185873-2c260600-5448-11eb-8153-e65f67ecd379.png)
![Screen Shot 2021-01-11 at 20 03 30](https://user-images.githubusercontent.com/61674931/104185892-30eaba00-5448-11eb-888a-d3e3dda62daa.png)


## Dependencies or Side Effects
This PR depends on: https://github.com/WPMedia/engine-theme-sdk/pull/146

**This PR to update engine them sdk first, then required another PR on fusion-new-theme-blocks!**
## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.