### PR TITLE
[PEN-1603] Using a bigger number for instance id generation to prevent collisions

### DIFF
--- a/blocks/ads-block/features/ads/ad-helper.js
+++ b/blocks/ads-block/features/ads/ad-helper.js
@@ -143,7 +143,7 @@ export const getSlotTargeting = (props) => ({
   ad_type: props?.adType,
 });
 
-/* Expects a 'props' object containing feature props, FusionContext, AppContext */
+/* Expects a 'props' object containing feature props, FusionContext */
 export const getAdObject = (props) => {
   const { instanceId = '' } = props;
   const adName = getAdName(props);

--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -1,30 +1,24 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-/* eslint-disable comma-dangle */
 import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from '@arc-fusion/prop-types';
 import getProperties from 'fusion:properties';
-import { useFusionContext, useAppContext } from 'fusion:context';
+import { useFusionContext } from 'fusion:context';
 import adMap from './ad-mapping';
 import ArcAdminAd from './_children/ArcAdminAd';
 import ArcAdsInstance from './_children/ArcAdsInstance';
 import { getAdObject, setPageTargeting } from './ad-helper';
 import './ads.scss';
 
-function generateInstanceId() {
-  function getRandomNumber() {
-    // Number.MAX_SAFE_INTEGER doesn't exist in IE11.
-    return Math.floor(Math.random() * 9007199254740991).toString(16);
-  }
-
-  return [0, 0].map(getRandomNumber).join('-');
+function generateInstanceId(componentId) {
+  return `${componentId}-${Math.floor(Math.random() * 9007199254740991).toString(16)}`;
 }
 
 const ArcAd = (props) => {
   if (typeof window === 'undefined') return null;
-  const [instanceId] = useState(() => generateInstanceId());
+  const fusionContext = useFusionContext();
+  const [instanceId] = useState(() => generateInstanceId(fusionContext.id || '0000'));
   const propsWithContext = {
-    ...useAppContext(),
-    ...useFusionContext(),
+    ...fusionContext,
     ...props,
     instanceId,
   };

--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -10,10 +10,18 @@ import ArcAdsInstance from './_children/ArcAdsInstance';
 import { getAdObject, setPageTargeting } from './ad-helper';
 import './ads.scss';
 
-/** === ArcAd Component === */
+function generateInstanceId() {
+  function getRandomNumber() {
+    // Number.MAX_SAFE_INTEGER doesn't exist in IE11.
+    return Math.floor(Math.random() * 9007199254740991).toString(16);
+  }
+
+  return [0, 0].map(getRandomNumber).join('-');
+}
+
 const ArcAd = (props) => {
   if (typeof window === 'undefined') return null;
-  const [instanceId] = useState(Math.floor(Math.random() * 10000));
+  const [instanceId] = useState(() => generateInstanceId());
   const propsWithContext = {
     ...useAppContext(),
     ...useFusionContext(),

--- a/blocks/ads-block/features/ads/default.test.jsx
+++ b/blocks/ads-block/features/ads/default.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import { useFusionContext, useAppContext } from 'fusion:context';
+import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import ArcAd from './default';
 
@@ -32,7 +32,6 @@ describe('<ArcAd>', () => {
     jest.clearAllMocks();
     getProperties.mockReturnValue(SITE_PROPS_MOCK);
     useFusionContext.mockReturnValue({ isAdmin: false });
-    useAppContext.mockReturnValue({});
   });
 
   it('renders no ad unit in admin dashboard', () => {
@@ -103,7 +102,6 @@ describe('ArcAd with custom advertisement label', () => {
     jest.clearAllMocks();
     getProperties.mockReturnValue({ ...SITE_PROPS_MOCK, ...customLabel });
     useFusionContext.mockReturnValue({ isAdmin: false });
-    useAppContext.mockReturnValue({});
   });
 
   it('renders the label using advertisementLabel property when present', () => {


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
~We actually generate 2 bigger numbers to make extra sure it won't be an issue.~

This uses the provided component fingerprint from Fusion alongside one random number from a very large range.

## Jira Ticket
- [PEN-1603](https://arcpublishing.atlassian.net/browse/PEN-1603)

## Acceptance Criteria
_copy from ticket_

## Test Steps
- Add test steps a reviewer must complete to test this PR

## Effect Of Changes
### Before
Ad `div` `id`s were frequently colliding.

### After
Ad `div` `id` collision is essentially impossible.

## Dependencies or Side Effects
An infinitesimally small chance is not the same zero chance. That said, we should never see a collision.

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working. 
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.