### PR TITLE
PEN-1628: Fix the missing margin-left footer

### DIFF
--- a/blocks/footer-block/features/footer/footer.scss
+++ b/blocks/footer-block/features/footer/footer.scss
@@ -1,6 +1,6 @@
 footer {
-  margin-left: auto;
-  margin-right: auto;
+  margin-left: 5%;
+  margin-right: 5%;
   width: 100%;
 
   //Fix for IE 11 and non grid browsers


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
[LIB] Footer links breakpoint padding is missing

## Jira Ticket
- [PEN-1628](https://arcpublishing.atlassian.net/browse/PEN-1628)

## Acceptance Criteria
When adding footer navigation with multiple rows of columns, the rows having spacing between them.

## Test Steps
- Create a new page Test PEN-1628.
- Choose layout @wpmedia/right-rail-block/right-rail.
- In Curate page, at footer part, add Footer - Arc Block feature. Then in Custom Fields/Configure Content, select navigation-hierarchy for Schemas and site-service-hierarchy for Custom Fields/Content Source. Then press Update button.
Share and Publish this page.
- Open the page [Test PEN-1628](http://localhost/pf/test-pen-1628/?_website=the-sun), then narrow down the size of browser window around 1440x535.

## Effect Of Changes
### Before
The footer looks like no left margin when the width of window size is around 1440 px.
![image](https://user-images.githubusercontent.com/12291608/104270320-d181be00-54ca-11eb-94ed-f53eb434c9f4.png)

### After
The footer has left margin for all window size.
![image](https://user-images.githubusercontent.com/12291608/104280122-03505000-54de-11eb-8850-f1fe67cc9da5.png)

## Dependencies or Side Effects
NO

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
