### PR TITLE
PEN 1601 Section title block has undefined menu

### DIFF
--- a/blocks/section-title-block/features/section-title/_children/mock-data.js
+++ b/blocks/section-title-block/features/section-title/_children/mock-data.js
@@ -60,6 +60,46 @@ const mockTwoSection = {
   },
 };
 
+const mockTwoSectionWithUrl = {
+  arcSite: 'site',
+  globalContent: {
+    _id: '/',
+    name: 'Section Title',
+    children: [
+      {
+        _id: '/news',
+        _website: 'The Washington Post',
+        privilege: 'News',
+        name: 'News',
+        order: {
+          default: 1002,
+        },
+        ancestors: {
+          default: ['/'],
+        },
+        inactive: false,
+        children: [],
+      },
+      {
+        _id: '/sports',
+        _website: 'The Washington Post',
+        privilege: 'Sports',
+        display_name: 'Sports',
+        url: 'www.google.com',
+        node_type: 'link',
+        order: {
+          default: 1002,
+        },
+        ancestors: {
+          default: ['/'],
+        },
+        inactive: false,
+        children: [],
+      },
+    ],
+  },
+};
+
 const mockNestedChildren = {
   arcSite: 'site',
   globalContent: {
@@ -134,5 +174,5 @@ const mockNoChildren = {
 };
 
 export {
-  mockOneSection, mockTwoSection, mockNestedChildren, mockNoChildren,
+  mockOneSection, mockTwoSection, mockNestedChildren, mockNoChildren, mockTwoSectionWithUrl,
 };

--- a/blocks/section-title-block/features/section-title/_children/section-title.jsx
+++ b/blocks/section-title-block/features/section-title/_children/section-title.jsx
@@ -14,6 +14,18 @@ const StyledLink = styled.a`
   text-decoration: none;
 `;
 
+const Separator = '  \u00a0 • \u00a0  ';
+
+const styledLinkTmpl = (name, id, separator, arcSite) => (
+  <StyledLink
+    primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+    href={id}
+    key={id}
+  >
+    {`${name}${separator}`}
+  </StyledLink>
+);
+
 const SectionTitle = (props) => {
   const { content } = props;
   const { arcSite } = useFusionContext();
@@ -24,25 +36,23 @@ const SectionTitle = (props) => {
   );
 
   return (
-    !!(content && content.name) && (
+    !!(content && (content.name || content.display_name)) && (
       <>
         <StyledTitle
           primaryFont={getThemeStyle(arcSite)['primary-font-family']}
           className="section-title"
         >
-          {content.name}
+          {content.name || content.display_name}
         </StyledTitle>
         <div className="section-container">
           {
             !!(content.children && content.children.length > 0)
             && (content.children.map((child, index) => (
-              <StyledLink
-                primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-                href={child._id}
-                key={child._id}
-              >
-                {`${child.name}${(content.children.length !== index + 1 && showSeparator) ? '  \u00a0 • \u00a0  ' : ''}`}
-              </StyledLink>
+              (child.node_type && child.node_type === 'link' && (
+                styledLinkTmpl(child.display_name, child.url, ((content.children.length !== index + 1 && showSeparator) ? Separator : ''), arcSite)
+              )) || (
+                styledLinkTmpl(child.name, child._id, ((content.children.length !== index + 1 && showSeparator) ? Separator : ''), arcSite)
+              )
             )))
           }
         </div>

--- a/blocks/section-title-block/features/section-title/_children/section-title.test.jsx
+++ b/blocks/section-title-block/features/section-title/_children/section-title.test.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import SectionTitle from './section-title';
-import { mockOneSection, mockTwoSection, mockNoChildren } from './mock-data';
+import { mockOneSection, mockTwoSection, mockNoChildren, mockTwoSectionWithUrl } from './mock-data';
 
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:context', () => ({
@@ -70,6 +70,18 @@ describe('the section title block', () => {
 
           expect(wrapper.find('a').length).toEqual(0);
         });
+      });
+
+      it('should render sub-section links with url', () => {
+        const wrapper = mount(<SectionTitle content={mockTwoSectionWithUrl.globalContent} />);
+
+        expect(wrapper.find('.section-container').length).toEqual(1);
+        expect(wrapper.find('a').length).toEqual(2);
+        expect(wrapper.find('a').at(0).props().href).toBe('/news');
+        expect(wrapper.find('a').at(1).props().href).toBe('www.google.com');
+
+        expect(wrapper.find('a').at(0)).toIncludeText('News');
+        expect(wrapper.find('a').at(1)).toIncludeText('Sports');
       });
     });
   });

--- a/blocks/section-title-block/features/section-title/_children/section-title.test.jsx
+++ b/blocks/section-title-block/features/section-title/_children/section-title.test.jsx
@@ -2,7 +2,9 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import SectionTitle from './section-title';
-import { mockOneSection, mockTwoSection, mockNoChildren, mockTwoSectionWithUrl } from './mock-data';
+import {
+  mockOneSection, mockTwoSection, mockNoChildren, mockTwoSectionWithUrl 
+} from './mock-data';
 
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:context', () => ({

--- a/blocks/section-title-block/features/section-title/_children/section-title.test.jsx
+++ b/blocks/section-title-block/features/section-title/_children/section-title.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import SectionTitle from './section-title';
 import {
-  mockOneSection, mockTwoSection, mockNoChildren, mockTwoSectionWithUrl 
+  mockOneSection, mockTwoSection, mockNoChildren, mockTwoSectionWithUrl,
 } from './mock-data';
 
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Added functionality to parse raw URL's in hierarchy

## Jira Ticket
- [PEN-1601](https://arcpublishing.atlassian.net/browse/PEN-1601)

## Acceptance Criteria
Reproduce steps
Enter an absolute url into a hierarchy
Set that hierarchy on the section title block
See the title in the block, it will say 'undefined' (see screenshot) 

## Test Steps
- Add test steps a reviewer must complete to test this PR
- In Fusion-News-Theme repo, checkout master & git pull
- After checking out this feature branch in fusion-news-theme-blocks, run rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/section-title-block && npm i && cd ../..
- Run: npx fusion start -f -l @wpmedia/section-title-block
- Create a page then add section-title-block for testing
- Configure Content Source for Title Block, Content-Source: site-service-hierarchy, hierarchy: links-bar
- Verify the results (you should not see undefined menu)

## Effect Of Changes
### Before
![image](https://user-images.githubusercontent.com/47773457/104415553-c733f280-55a4-11eb-94da-e20366e01d11.png)


### After
![image](https://user-images.githubusercontent.com/47773457/104415510-b5eae600-55a4-11eb-907e-a5d9c5972fb9.png)


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
