### PR TITLE
Added Queryly Search option to Header Nav Chain Block

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -4,6 +4,7 @@ import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 import HamburgerMenuIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/HamburgerMenuIcon';
 import SearchBox from './search-box';
+import QuerylySearch from './queryly-search';
 import { WIDGET_CONFIG } from '../nav-helper';
 
 const NavWidget = ({
@@ -27,6 +28,11 @@ const NavWidget = ({
         placeholderText={phrases.t('header-nav-chain-block.search-text')}
         customSearchAction={customSearchAction}
         alwaysOpen={WIDGET_CONFIG[placement]?.expandSearch}
+      />
+    )) || (type === 'queryly' && (
+      <QuerylySearch
+        iconSize={WIDGET_CONFIG[placement]?.iconSize}
+        theme={navColor}
       />
     )) || (type === 'menu' && (
       <button

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
@@ -1,0 +1,15 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import React from 'react';
+import SearchIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/SearchIcon';
+
+const QuerylySearch = ({ theme = 'dark', iconSize = 16 }) => (
+  <div className={`nav-search ${theme}`}>
+    <button className={`nav-btn nav-btn-${theme} transparent border queryly`} type="button">
+      <label htmlFor="queryly_toggle">
+        <SearchIcon height={iconSize} width={iconSize} />
+      </label>
+    </button>
+  </div>
+);
+
+export default QuerylySearch;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import QuerylySearch from './queryly-search';
+
+const testQuerylySearch = ({ root, theme, iconSize = 16 }) => {
+  const container = root.find('.nav-search');
+  expect(container).toHaveLength(1);
+  expect(container).toHaveClassName(theme);
+  const navBtn = container.find('button.nav-btn');
+  expect(navBtn).toHaveLength(1);
+  expect(navBtn).toHaveClassName(`nav-btn-${theme}`);
+  expect(navBtn).toHaveClassName('queryly');
+  expect(navBtn).toHaveClassName('border');
+  expect(navBtn).toHaveClassName('transparent');
+  const querylyLabel = navBtn.find('label');
+  expect(querylyLabel).toHaveLength(1);
+  expect(querylyLabel.prop('htmlFor')).toEqual('queryly_toggle');
+  const searchIcon = querylyLabel.find('SearchIcon');
+  expect(searchIcon).toHaveLength(1);
+  expect(searchIcon.prop('height')).toEqual(iconSize);
+  expect(searchIcon.prop('width')).toEqual(iconSize);
+};
+
+describe('<QuerylySearch/>', () => {
+  it('renders with default props', () => {
+    const wrapper = shallow(<QuerylySearch />);
+    testQuerylySearch({ root: wrapper, theme: 'dark' });
+  });
+
+  it('renders with dark theme and default icon size', () => {
+    const wrapper = shallow(<QuerylySearch theme="dark" />);
+    testQuerylySearch({ root: wrapper, theme: 'dark' });
+  });
+
+  it('renders with light theme and default icon size', () => {
+    const wrapper = shallow(<QuerylySearch theme="light" />);
+    testQuerylySearch({ root: wrapper, theme: 'light' });
+  });
+
+  it('renders with custom icon size', () => {
+    const wrapper = shallow(<QuerylySearch theme="dark" iconSize={24} />);
+    testQuerylySearch({ root: wrapper, theme: 'dark', iconSize: 24 });
+  });
+});

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
@@ -7,6 +7,14 @@ export const NAV_LABELS = {
   menu: 'Sections Menu',
 };
 
+export const WIDGET_OPTIONS = {
+  none: 'None',
+  search: 'Arc Search',
+  queryly: 'Queryly Search',
+  menu: 'Sections Menu',
+  custom: 'Custom',
+};
+
 export const DEFAULT_SELECTIONS = {
   leftComponentDesktop1: 'search',
   leftComponentDesktop2: 'menu',
@@ -19,7 +27,7 @@ export const WIDGET_CONFIG = {
     iconSize: 16,
     expandSearch: false,
     slotCounts: { mobile: 1, desktop: 2 },
-    options: ['search', 'menu', 'none', 'custom'],
+    options: ['search', 'queryly', 'menu', 'none', 'custom'],
     sections: ['left', 'right'],
   },
   'section-menu': {
@@ -57,12 +65,7 @@ export const getNavComponentDefaultSelection = (propTypeKey) => (
 export const generateNavComponentPropType = (section, breakpoint, position) => ({
   name: getNavComponentLabel(section, breakpoint, position),
   group: `${capitalize(breakpoint)} Components`,
-  labels: {
-    search: 'Search',
-    menu: 'Sections Menu',
-    none: 'None',
-    custom: 'Custom',
-  },
+  labels: WIDGET_OPTIONS,
   defaultValue: getNavComponentDefaultSelection(
     getNavComponentPropTypeKey(section, breakpoint, position),
   ),

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.test.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.test.js
@@ -62,7 +62,11 @@ describe('nav-helper', () => {
         group: 'Desktop Components',
         hidden: false,
         labels: {
-          custom: 'Custom', menu: 'Sections Menu', none: 'None', search: 'Search',
+          none: 'None',
+          search: 'Arc Search',
+          queryly: 'Queryly Search',
+          menu: 'Sections Menu',
+          custom: 'Custom',
         },
         name: 'Left Component 1 - Desktop',
         required: false,

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -38,37 +38,59 @@ body.nav-open {
   &:hover {
     outline: none;
   }
-}
 
-.nav-btn-dark > span {
-  color: $ui-btn-white-color;
-}
+  &-dark {
+    span {
+      color: $ui-btn-white-color;
+    }
 
-.nav-btn-light > span {
-  color: $ui-medium-gray;
-}
+    svg > path {
+      fill: $ui-btn-white-color;
+    }
 
-.nav-btn-dark > svg > path {
-  fill: $ui-btn-white-color;
-}
-
-.nav-btn-light > svg > path {
-  fill: $ui-medium-gray;
-}
-
-.nav-btn-dark.border {
-  border: $border-width solid $border-color-dull;
-
-  &:hover {
-    border: $border-width solid $border-color-bright;
+    &.border {
+      border: $border-width solid $border-color-dull;
+    
+      &:hover {
+        border: $border-width solid $border-color-bright;
+      }
+    }
+    
   }
-}
 
-.nav-btn-light.border {
-  border: $border-width solid $ui-light-gray;
+  &-light {
+    span {
+      color: $ui-medium-gray;
+    }
 
-  &:hover {
-    border: $border-width solid $ui-medium-gray;
+    svg > path {
+      fill: $ui-medium-gray;
+    }
+
+    &.border {
+      border: $border-width solid $ui-light-gray;
+
+      &:hover {
+        border: $border-width solid $ui-medium-gray;
+      }
+    }
+  }
+
+  &.queryly {
+    padding: 0;
+
+    label {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      justify-items: center;
+      align-content: center;
+      padding-left: $btn-padding;
+      padding-right: $btn-padding;
+      cursor: pointer;
+    }
   }
 }
 
@@ -156,12 +178,6 @@ body.nav-open {
 
   &.light {
     border-bottom: $border-width solid $border-rule-color;
-  }
-
-  @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
-    .nav-search {
-      display: none;
-    }
   }
 
   * {


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Added Queryly Search option to Header Nav Chain Block.

## Jira Ticket
- [PEN-1504](https://arcpublishing.atlassian.net/browse/PEN-1504)

## Acceptance Criteria
_copy from ticket_

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. After checking out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/shared-styles` in `Fusion-News-Theme`
4. Open homepage in PB editor, edit nav block, and set one of the nav buttons to the new `Queryly Search` option. Do this for both Desktop and Mobile configuration options (doesn't matter if you set it to the right or left side of the nav bar)
5. Test clicking on search button (on both desktop and mobile views) and it should open the Queryly search overlay
6. Ensure that the Queryly search button looks the same as the Arc Search button

![image](https://user-images.githubusercontent.com/26662906/104615606-0454bf00-564f-11eb-8729-5e620f7454a1.png)
![image](https://user-images.githubusercontent.com/26662906/104615675-15053500-564f-11eb-819e-d5f350d06508.png)

## Effect Of Changes
### Before
There was no Queryly search option in the Header Nav Chain Block

### After
There is now a Queryly search option in the Header Nav Chain Block

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.
