### PR TITLE
PEN-1438 [CMG] Ability to animate logo height in navigation chain

### DIFF
--- a/blocks/alert-bar-block/features/alert-bar/alert-bar.scss
+++ b/blocks/alert-bar-block/features/alert-bar/alert-bar.scss
@@ -1,4 +1,3 @@
-$nav-bar-height: 56px;
 $alert-bar-height: 56px;
 
 .alert-bar {
@@ -34,12 +33,5 @@ $alert-bar-height: 56px;
     margin-right: 0;
     padding-left: calculateRem(8px);
     padding-right: calculateRem(8px);
-  }
-}
-
-#fusion-app .has-alert + .main {
-  padding-top: calc(#{$nav-bar-height} + #{$alert-bar-height} + #{map-get($spacers, 'lg')});
-  @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-    padding-top: calc(#{$nav-bar-height} + #{$alert-bar-height} + #{map-get($spacers, 'md')});
   }
 }

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -34,8 +34,9 @@ const sectionZIdx = navZIdx - 1;
 const StyledNav = styled.nav`
   align-items: center;
   width: 100%;
-  position: fixed;
+  position: sticky;
   top: 0px;
+  margin-bottom: 0px;
 
   .news-theme-navigation-bar {
     @media screen and (max-width: ${(props) => props.breakpoint}px) {
@@ -68,17 +69,6 @@ const StyledNav = styled.nav`
 
   * {
     font-family: ${(props) => props.font};
-  }
-
-  & + *, & ~ nav:nth-of-type(2) {
-
-    @media screen and (max-width: ${(props) => props.breakpoint}px) {
-      margin-top: ${standardNavHeight}px;
-    }
-    
-    @media screen and (min-width: ${(props) => props.breakpoint}px) {
-      margin-top: ${(props) => (props.scrolled ? standardNavHeight : props.navHeight)}px;
-    }
   }
 
 `;

--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
@@ -10,20 +10,17 @@ body {
   min-height: 100vh;
 
   .page-header {
-    position: fixed;
+    position: sticky;
+    top: 0;
     width: 100%;
     z-index: 9;
   }
 
   .main {
     flex-grow: 1;
-    padding-top: calc(56px + #{map-get($spacers, 'lg')});
     transition: padding-top 0.3s linear;
     width: 100%;
 
-    @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding-top: calc(56px + #{map-get($spacers, 'md')});
-    }
 
     @media screen and (max-width: 95rem) and (min-width: 90rem) {
       .container {

--- a/blocks/right-rail-block/layouts/right-rail/default.scss
+++ b/blocks/right-rail-block/layouts/right-rail/default.scss
@@ -10,20 +10,17 @@ body {
   min-height: 100vh;
 
   .page-header {
-    position: fixed;
+    position: sticky;
+    top: 0;
     width: 100%;
     z-index: 9;
   }
 
   .main {
     flex-grow: 1;
-    padding-top: calc(56px + #{map-get($spacers, 'lg')});
     transition: padding-top 0.3s linear;
     width: 100%;
 
-    @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      padding-top: calc(56px + #{map-get($spacers, 'md')});
-    }
 
     @media screen and (max-width: 95rem) and (min-width: 90rem) {
       .container {


### PR DESCRIPTION
## Description
This PR fixing the first comment from Poorva: https://arcpublishing.atlassian.net/browse/PEN-1438?focusedCommentId=506909



## Jira Ticket
- [PEN-1438](https://arcpublishing.atlassian.net/browse/PEN-1438)

## Acceptance Criteria

1. The two new custom fields described above are added to the Navigation Chain, per specs above

2. If a PageBuilder user enters a value for Starting desktop navigation bar height, then when the page first loads on Desktop breakpoint, the navigation bar height should be the number they entered. The max value possible is 200px.

a. e.g. if they entered 100, then the height of the navigation bar should be 100px. 

b. The height of the logo should grow to fill the available space. There should continue to be the specified spacing (in yellow) above and below the logo

c. All other elements within the navigation should be centered vertically, and their height should not change 

3. If a PageBuilder user enters a value for Shrink navigation bar after scrolling, then after the reader scrolls that amount of pixels, the navigation bar should animate back to its standard height (56px). 

a. Once a reader scrolls down the page this many pixels, the navigation bar should animate and return to its standard size. 

b. This prototype can be used for UX animation guidance: https://kind-elion-573ea9.netlify.app/

c. All buttons should stay in the same place – the only things that change position are the logo (its width shrinks) and if horizontal links are present, they have more space to display (since the logo width has shrunk)

4. Tests and documentation are updated to cover this functionality.

## Test Steps
- Add test steps a reviewer must complete to test this PR
1. In Fusion-News-Theme repo, checkout master & git pull
2. After checking out this feature branch in fusion-news-theme-blocks, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run: `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/right-rail-advanced-block,@wpmedia/right-rail-block,@wpmedia/alert-bar-block`
4. Create a page then add navigation bar for testing 


## Effect Of Changes
### Before
![image](https://user-images.githubusercontent.com/61674931/104572278-57963400-5686-11eb-9499-cf1fad305d53.png)


### After
![image](https://user-images.githubusercontent.com/61674931/104572971-f1f67780-5686-11eb-89fe-cbc9ac358c7b.png)


## Dependencies or Side Effects
N/A

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
