### PR TITLE
PEN-1616: Ability to set Queryly search button in Sections Menu Components

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -5,13 +5,13 @@ import getTranslatedPhrases from 'fusion:intl';
 import HamburgerMenuIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/HamburgerMenuIcon';
 import SearchBox from './search-box';
 import QuerylySearch from './queryly-search';
-import { WIDGET_CONFIG } from '../nav-helper';
+import { WIDGET_CONFIG, PLACEMENT_AREAS } from '../nav-helper';
 
 const NavWidget = ({
   type,
   position = 0,
   children = [],
-  placement = 'nav-bar',
+  placement = PLACEMENT_AREAS.NAV_BAR,
   customSearchAction,
   menuButtonClickAction,
 }) => {
@@ -30,9 +30,10 @@ const NavWidget = ({
         alwaysOpen={WIDGET_CONFIG[placement]?.expandSearch}
       />
     )) || (type === 'queryly' && (
-      <QuerylySearch
-        iconSize={WIDGET_CONFIG[placement]?.iconSize}
-        theme={navColor}
+      <QuerylySearch theme={
+        placement === PLACEMENT_AREAS.SECTION_MENU
+          ? 'dark' : navColor
+        }
       />
     )) || (type === 'menu' && (
       <button

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.test.jsx
@@ -1,16 +1,23 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import NavWidget from './nav-widget';
 import SearchBox from './search-box';
+import QuerylySearch from './queryly-search';
+import { WIDGET_CONFIG, PLACEMENT_AREAS } from '../nav-helper';
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({
-  navColor: 'dark', locale: 'somelocale',
+  navColor: 'light', locale: 'somelocale',
 }))));
 jest.mock('fusion:context', () => ({
   useFusionContext: jest.fn(() => ({
     arcSite: 'dagen',
   })),
 }));
+jest.mock('fusion:intl', () => jest.fn(
+  () => ({
+    t: jest.fn(() => 'test-translation'),
+  }),
+));
 
 describe('<NavWidget/>', () => {
   it('renders null when type "none"', () => {
@@ -19,24 +26,75 @@ describe('<NavWidget/>', () => {
     expect(wrapper.isEmptyRender()).toBe(true);
   });
 
-  it('renders nav widget - search', () => {
+  it('renders nav widget - arc search w/ "nav-bar" placement', () => {
     const customSearchAction = jest.fn(() => {});
-    const wrapper = mount(
+    const placement = PLACEMENT_AREAS.NAV_BAR;
+    const cfg = WIDGET_CONFIG[placement];
+    const wrapper = shallow(
       <NavWidget
         type="search"
+        placement={placement}
         customSearchAction={customSearchAction}
       />,
     );
     expect(wrapper).toHaveLength(1);
     const searchWidget = wrapper.find(SearchBox);
     expect(searchWidget).toHaveLength(1);
+    expect(searchWidget.prop('iconSize')).toEqual(cfg?.iconSize);
+    expect(searchWidget.prop('navBarColor')).toEqual('light');
+    expect(searchWidget.prop('placeholderText')).toEqual('test-translation');
     expect(searchWidget.prop('customSearchAction')).toEqual(customSearchAction);
-    const searchEl = searchWidget.find('.nav-search');
-    expect(searchEl).toHaveLength(1);
-    expect(searchEl.hasClass('dark')).toBe(true);
+    expect(searchWidget.prop('alwaysOpen')).toEqual(cfg.expandSearch);
   });
 
-  it('renders nav widget - menu', () => {
+  it('renders nav widget - arc search w/ "section-menu" placement', () => {
+    const customSearchAction = jest.fn(() => {});
+    const placement = PLACEMENT_AREAS.SECTION_MENU;
+    const cfg = WIDGET_CONFIG[placement];
+    const wrapper = shallow(
+      <NavWidget
+        type="search"
+        placement={placement}
+        customSearchAction={customSearchAction}
+      />,
+    );
+    expect(wrapper).toHaveLength(1);
+    const searchWidget = wrapper.find(SearchBox);
+    expect(searchWidget).toHaveLength(1);
+    expect(searchWidget.prop('iconSize')).toEqual(cfg?.iconSize);
+    expect(searchWidget.prop('navBarColor')).toEqual('light');
+    expect(searchWidget.prop('placeholderText')).toEqual('test-translation');
+    expect(searchWidget.prop('customSearchAction')).toEqual(customSearchAction);
+    expect(searchWidget.prop('alwaysOpen')).toEqual(cfg.expandSearch);
+  });
+
+  it('renders nav widget - queryly search w/ "nav-bar" placement', () => {
+    const wrapper = shallow(
+      <NavWidget
+        type="queryly"
+        placement={PLACEMENT_AREAS.NAV_BAR}
+      />,
+    );
+    expect(wrapper).toHaveLength(1);
+    const querylyWidget = wrapper.find(QuerylySearch);
+    expect(querylyWidget).toHaveLength(1);
+    expect(querylyWidget.prop('theme')).toEqual('light');
+  });
+
+  it('renders nav widget - queryly search w/ "section-menu" placement', () => {
+    const wrapper = shallow(
+      <NavWidget
+        type="queryly"
+        placement={PLACEMENT_AREAS.SECTION_MENU}
+      />,
+    );
+    expect(wrapper).toHaveLength(1);
+    const querylyWidget = wrapper.find(QuerylySearch);
+    expect(querylyWidget).toHaveLength(1);
+    expect(querylyWidget.prop('theme')).toEqual('dark');
+  });
+
+  it('renders nav widget - section menu', () => {
     const menuButtonClick = jest.fn(() => {});
     const wrapper = mount(
       <NavWidget
@@ -46,7 +104,7 @@ describe('<NavWidget/>', () => {
     );
     expect(wrapper).toHaveLength(1);
     const menuWidget = wrapper.find('button.nav-sections-btn');
-    expect(menuWidget.hasClass('nav-btn-dark')).toBe(true);
+    expect(menuWidget.hasClass('nav-btn-light')).toBe(true);
     expect(menuWidget).toHaveLength(1);
     expect(menuWidget.prop('onClick')).toEqual(menuButtonClick);
   });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import SearchIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/SearchIcon';
 
 const QuerylySearch = ({ theme = 'dark', iconSize = 16 }) => (
-  <div className={`nav-search ${theme}`}>
-    <button className={`nav-btn nav-btn-${theme} transparent border queryly`} type="button">
+  <div className={`nav-search ${theme} queryly`}>
+    <button className={`nav-btn nav-btn-${theme} transparent border`} type="button">
       <label htmlFor="queryly_toggle">
         <SearchIcon height={iconSize} width={iconSize} />
       </label>

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.test.jsx
@@ -6,10 +6,10 @@ const testQuerylySearch = ({ root, theme, iconSize = 16 }) => {
   const container = root.find('.nav-search');
   expect(container).toHaveLength(1);
   expect(container).toHaveClassName(theme);
+  expect(container).toHaveClassName('queryly');
   const navBtn = container.find('button.nav-btn');
   expect(navBtn).toHaveLength(1);
   expect(navBtn).toHaveClassName(`nav-btn-${theme}`);
-  expect(navBtn).toHaveClassName('queryly');
   expect(navBtn).toHaveClassName('border');
   expect(navBtn).toHaveClassName('transparent');
   const querylyLabel = navBtn.find('label');

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -9,6 +9,7 @@ import getThemeStyle from 'fusion:themes';
 import { useDebouncedCallback } from 'use-debounce';
 import {
   WIDGET_CONFIG,
+  PLACEMENT_AREAS,
   NAV_BREAKPOINTS,
   getNavComponentPropTypeKey,
   getNavComponentIndexPropTypeKey,
@@ -274,7 +275,10 @@ const Nav = (props) => {
 
   const hasUserConfiguredNavItems = () => {
     let userHasConfigured = false;
-    const { slotCounts, sections: navBarSections } = WIDGET_CONFIG['nav-bar'];
+    const {
+      slotCounts,
+      sections: navBarSections,
+    } = WIDGET_CONFIG[PLACEMENT_AREAS.NAV_BAR];
     navBarSections.forEach((side) => {
       NAV_BREAKPOINTS.forEach((bpoint) => {
         for (let i = 1; i <= slotCounts[bpoint]; i++) {
@@ -334,7 +338,7 @@ const Nav = (props) => {
                 <WidgetList
                   id={side}
                   breakpoint={breakpoint}
-                  placement="nav-bar"
+                  placement={PLACEMENT_AREAS.NAV_BAR}
                 />
               </div>
             ))
@@ -352,7 +356,7 @@ const Nav = (props) => {
             <WidgetList
               id={navSection}
               breakpoint={breakpoint}
-              placement="section-menu"
+              placement={PLACEMENT_AREAS.SECTION_MENU}
             />
           </div>
         ))}

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -5,7 +5,7 @@ import getProperties from 'fusion:properties';
 import getThemeStyle from 'fusion:themes';
 import Navigation from './default';
 import SearchBox from './_children/search-box';
-import { DEFAULT_SELECTIONS } from './nav-helper';
+import { DEFAULT_SELECTIONS, PLACEMENT_AREAS } from './nav-helper';
 
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
@@ -159,7 +159,7 @@ describe('the header navigation feature for the default output type', () => {
         expect(navWidget).toHaveLength(1);
         expect(navWidget.prop('type')).toEqual('custom');
         expect(navWidget.prop('position')).toEqual(1);
-        expect(navWidget.prop('placement')).toEqual('section-menu');
+        expect(navWidget.prop('placement')).toEqual(PLACEMENT_AREAS.SECTION_MENU);
       });
       it('should render custom widget on desktop', () => {
         const CUSTOM_SELECTIONS = {
@@ -171,7 +171,7 @@ describe('the header navigation feature for the default output type', () => {
         expect(navWidget).toHaveLength(1);
         expect(navWidget.prop('type')).toEqual('custom');
         expect(navWidget.prop('position')).toEqual(1);
-        expect(navWidget.prop('placement')).toEqual('section-menu');
+        expect(navWidget.prop('placement')).toEqual(PLACEMENT_AREAS.SECTION_MENU);
       });
       it('should render two widgets on mobile', () => {
         const CUSTOM_SELECTIONS = {
@@ -183,10 +183,10 @@ describe('the header navigation feature for the default output type', () => {
         const navWidgets = testSectionMenuWidget(CUSTOM_SELECTIONS, 'mobile');
         expect(navWidgets).toHaveLength(2);
         expect(navWidgets.at(0).prop('type')).toEqual('search');
-        expect(navWidgets.at(0).prop('placement')).toEqual('section-menu');
+        expect(navWidgets.at(0).prop('placement')).toEqual(PLACEMENT_AREAS.SECTION_MENU);
         expect(navWidgets.at(1).prop('type')).toEqual('custom');
         expect(navWidgets.at(1).prop('position')).toEqual(1);
-        expect(navWidgets.at(1).prop('placement')).toEqual('section-menu');
+        expect(navWidgets.at(1).prop('placement')).toEqual(PLACEMENT_AREAS.SECTION_MENU);
       });
       it('should render two widgets on desktop', () => {
         const CUSTOM_SELECTIONS = {
@@ -199,9 +199,9 @@ describe('the header navigation feature for the default output type', () => {
         expect(navWidgets).toHaveLength(2);
         expect(navWidgets.at(0).prop('type')).toEqual('custom');
         expect(navWidgets.at(0).prop('position')).toEqual(1);
-        expect(navWidgets.at(0).prop('placement')).toEqual('section-menu');
+        expect(navWidgets.at(0).prop('placement')).toEqual(PLACEMENT_AREAS.SECTION_MENU);
         expect(navWidgets.at(1).prop('type')).toEqual('search');
-        expect(navWidgets.at(1).prop('placement')).toEqual('section-menu');
+        expect(navWidgets.at(1).prop('placement')).toEqual(PLACEMENT_AREAS.SECTION_MENU);
       });
     });
   });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.js
@@ -1,5 +1,10 @@
 import PropTypes from 'prop-types';
 
+export const PLACEMENT_AREAS = {
+  NAV_BAR: 'nav-bar',
+  SECTION_MENU: 'section-menu',
+};
+
 export const NAV_BREAKPOINTS = ['mobile', 'desktop'];
 export const NAV_LABELS = {
   left: 'Left',
@@ -23,18 +28,18 @@ export const DEFAULT_SELECTIONS = {
 };
 
 export const WIDGET_CONFIG = {
-  'nav-bar': {
+  [PLACEMENT_AREAS.NAV_BAR]: {
     iconSize: 16,
     expandSearch: false,
     slotCounts: { mobile: 1, desktop: 2 },
     options: ['search', 'queryly', 'menu', 'none', 'custom'],
     sections: ['left', 'right'],
   },
-  'section-menu': {
+  [PLACEMENT_AREAS.SECTION_MENU]: {
     iconSize: 21,
     expandSearch: true,
     slotCounts: { mobile: 2, desktop: 2 },
-    options: ['search', 'none', 'custom'],
+    options: ['search', 'queryly', 'none', 'custom'],
     sections: ['menu'],
   },
 };

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -75,23 +75,6 @@ body.nav-open {
       }
     }
   }
-
-  &.queryly {
-    padding: 0;
-
-    label {
-      width: 100%;
-      height: 100%;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      justify-items: center;
-      align-content: center;
-      padding-left: $btn-padding;
-      padding-right: $btn-padding;
-      cursor: pointer;
-    }
-  }
 }
 
 .nav-sections-btn {
@@ -165,6 +148,23 @@ body.nav-open {
     padding: 0;
     transition: all 0.25s cubic-bezier(0.49, 0.37, 0.45, 0.71);
     width: 0;
+  }
+
+  &.queryly > .nav-btn {
+    padding: 0;
+
+    label {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      justify-items: center;
+      align-content: center;
+      padding-left: $btn-padding;
+      padding-right: $btn-padding;
+      cursor: pointer;
+    }
   }
 }
 
@@ -348,23 +348,27 @@ body.nav-open {
     flex-direction: column;
     width: $section-width;
 
-    .nav-search {
-      input {
-        flex: 1;
-      }
-
-      &.open {
-        input {
-          height: calculateRem(48px);
-        }
-
-        &.dark {
-          border: 0;
-        }
-      }
-    }
-
     .nav-menu {
+      .nav-widget {
+        .nav-search {
+          justify-content: flex-start;
+
+          input {
+            flex: 1;
+          }
+
+          &.open {
+            input {
+              height: calculateRem(48px);
+            }
+
+            &.dark {
+              border: 0;
+            }
+          }
+        }
+      }
+
       & > .nav-components {
         &--mobile,
         &--desktop {          


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Added 'Queryly Search' option to Header Nav Chain Block as customization option, refactored, added/modified unit testing

## Jira Ticket
- [PEN-1616](https://arcpublishing.atlassian.net/browse/PEN-1616)

## Acceptance Criteria
![image](https://user-images.githubusercontent.com/26662906/104776551-e024db00-573f-11eb-9a27-1d80949dbf04.png)

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. After checking out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/shared-styles` in `Fusion-News-Theme`
4. Open homepage in PB editor, edit nav block, and set one of the **section menu** widgets to the new `Queryly Search` option. Do this for both Desktop and Mobile configuration options (doesn't matter if you set it as `Sections Menu Component 1` or `Sections Menu Component 2`)
5. Test clicking on search button (on both desktop and mobile views) and it should open the Queryly search overlay
6. Ensure that the Queryly search button looks the same as the Arc Search button

![image](https://user-images.githubusercontent.com/26662906/104779099-16fcf000-5744-11eb-90ef-1fd0ec391036.png)
![image](https://user-images.githubusercontent.com/26662906/104779177-3d229000-5744-11eb-9294-95fe97105284.png)


## Effect Of Changes
### Before
There was no Queryly search option in "section menu" in the Header Nav Chain Block

### After
There is now a Queryly search option in "section menu" in the Header Nav Chain Block that displays a Queryly search button. Clicking this button opens the Queryly search overlay.

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.