### PR TITLE
PEN-1651  Manual Promos and Promos have incorrect headline font

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -82,7 +82,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
               {(customFields.showHeadline && customFields.headline)
               && renderWithLink(
                 <HeadlineText
-                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+                  primaryFont={getThemeStyle(arcSite)['primary-font-family']}
                   className="xl-promo-headline"
                 >
                   {customFields.headline}

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -88,7 +88,7 @@ const ExtraLargePromo = ({ customFields }) => {
           title={headlineText}
         >
           <HeadlineText
-            primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+            primaryFont={getThemeStyle(arcSite)['primary-font-family']}
             className="xl-promo-headline"
             {...editableContent(content, 'headlines.basic')}
             suppressContentEditableWarning

--- a/blocks/headline-block/features/headline/default.jsx
+++ b/blocks/headline-block/features/headline/default.jsx
@@ -33,9 +33,13 @@ const HeadlineContainer = () => {
 
   // get primary font
   const { arcSite } = useFusionContext();
-  const { primaryFont } = getThemeStyle(arcSite);
 
-  return (<Headline headlineString={headlineString} primaryFont={primaryFont} />);
+  return (
+    <Headline
+      headlineString={headlineString}
+      primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+    />
+  );
 };
 
 HeadlineContainer.label = 'Headline – Arc Block';

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -104,7 +104,7 @@ const LargeManualPromo = ({ customFields }) => {
               {(customFields.showHeadline && customFields.headline)
               && renderWithLink(
                 <HeadlineText
-                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+                  primaryFont={getThemeStyle(arcSite)['primary-font-family']}
                   className="lg-promo-headline"
                 >
                   {customFields.headline}

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -90,7 +90,7 @@ const LargePromo = ({ customFields }) => {
           title={headlineText}
         >
           <HeadlineText
-            primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+            primaryFont={getThemeStyle(arcSite)['primary-font-family']}
             className="lg-promo-headline"
             {...editableContent(content, 'headlines.basic')}
             suppressContentEditableWarning

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -72,7 +72,7 @@ const MediumManualPromo = ({ customFields }) => {
               {(customFields.showHeadline && customFields.headline)
               && renderWithLink(
                 <HeadlineText
-                  primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+                  primaryFont={getThemeStyle(arcSite)['primary-font-family']}
                   className="md-promo-headline-text"
                 >
                   {customFields.headline}

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -69,7 +69,7 @@ const MediumPromo = ({ customFields }) => {
           title={headlineText}
         >
           <HeadlineText
-            primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+            primaryFont={getThemeStyle(arcSite)['primary-font-family']}
             className="md-promo-headline-text"
             {...editableContent(content, 'headlines.basic')}
             suppressContentEditableWarning

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -55,7 +55,7 @@ const SmallManualPromo = ({ customFields }) => {
       <div className={`promo-headline ${headlineMarginClass}`}>
         { renderWithLink((
           <HeadlineText
-            primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+            primaryFont={getThemeStyle(arcSite)['primary-font-family']}
             className="sm-promo-headline"
           >
             {customFields.headline}

--- a/blocks/small-promo-block/features/small-promo/_children/promo_headline.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_headline.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useEditableContent } from 'fusion:content';
 import { useFusionContext } from 'fusion:context';
-import getProperties from 'fusion:properties';
 import getThemeStyle from 'fusion:themes';
 import styled from 'styled-components';
 import getPromoStyle from './promo_style';
@@ -29,7 +28,7 @@ const PromoHeadline = (props) => {
       >
         <HeadlineText
           primaryFont={
-            getThemeStyle(getProperties(arcSite))[
+            getThemeStyle(arcSite)[
               'primary-font-family'
             ]
           }

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -6,7 +6,6 @@ import EmbedContainer from 'react-oembed-container';
 import './default.scss';
 import styled from 'styled-components';
 import getThemeStyle from 'fusion:themes';
-import getProperties from 'fusion:properties';
 
 const TitleText = styled.h2`
   font-family: ${(props) => props.primaryFont};
@@ -113,7 +112,7 @@ const VideoPlayer = (props) => {
       {title
       && (
       <TitleText
-        primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+        primaryFont={getThemeStyle(arcSite)['primary-font-family']}
         className="xl-promo-headline"
       >
         {title}
@@ -129,7 +128,7 @@ const VideoPlayer = (props) => {
       {description
         && (
         <DescriptionText
-          secondaryFont={getThemeStyle(getProperties(arcSite))['secondary-font-family']}
+          secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
           className="description-text"
         >
           {description}

--- a/blocks/video-promo-block/features/video-promo/default.jsx
+++ b/blocks/video-promo-block/features/video-promo/default.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { useContent } from 'fusion:content';
 import styled from 'styled-components';
 import getThemeStyle from 'fusion:themes';
-import getProperties from 'fusion:properties';
 import { videoOrg, videoEnv } from 'fusion:environment';
 import { useFusionContext } from 'fusion:context';
 import { Video } from '@wpmedia/engine-theme-sdk';
@@ -73,7 +72,7 @@ const VideoPromo = ({ customFields }) => {
           {title
             && (
             <TitleText
-              primaryFont={getThemeStyle(getProperties(arcSite))['primary-font-family']}
+              primaryFont={getThemeStyle(arcSite)['primary-font-family']}
               className="xl-promo-headline"
             >
               {title}
@@ -91,7 +90,7 @@ const VideoPromo = ({ customFields }) => {
           {description
             && (
             <DescriptionText
-              secondaryFont={getThemeStyle(getProperties(arcSite))['secondary-font-family']}
+              secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
               className="description-text"
             >
               {description}


### PR DESCRIPTION
## Description
CMG has noted there seems to be font issues with headlines of some Arc Blocks not honoring site primary fonts. 


## Jira Ticket
- [PEN-1651](https://arcpublishing.atlassian.net/browse/PEN-1651)

## Acceptance Criteria

Those fonts should be honoring the primary font specified in blocks.json which is Source Sans Pro as seen here: https://github.com/wapopartners/CMG-Themes-PageBuilder-Fusion-Features/blob/dev/blocks.json#L2448 



## Test Steps

- In Fusion-News-Theme repo, checkout master & git pull
- After checking out this feature branch in fusion-news-theme-blocks, run` rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
- Run `npx fusion start -f -l  @wpmedia/extra-large-manual-promo-block,@wpmedia/extra-large-promo-block,@wpmedia/headline-block,@wpmedia/large-manual-promo-block,@wpmedia/large-promo-block,@wpmedia/medium-manual-promo-block,@wpmedia/medium-promo-block,@wpmedia/small-manual-promo-block,@wpmedia/small-promo-block,@wpmedia/video-player-block,@wpmedia/video-promo-block`
- Create a page then add these feature listing in a link above
- Inspect the html elements then verify the font are using


## Effect Of Changes
I just capture one example to demonstrate the effect of changes

### Before
Headline not using customization font
![image](https://user-images.githubusercontent.com/61674931/105124572-fc909100-5b0c-11eb-8e05-87828d4d1be8.png)

### After
Headline should using the font configured in blocks.json

![image](https://user-images.githubusercontent.com/61674931/105124580-ff8b8180-5b0c-11eb-9910-36be44c909cb.png)


## Dependencies or Side Effects

# Here's the list of feature impacting by this PR:

- extra-large-manual-promo-block/features/extra-large-manual-promo
- extra-large-promo-block/features/extra-large-promo
- headline-block/features/headline
- large-manual-promo-block/features/large-manual-promo
- large-promo-block/features/large-promo
- medium-manual-promo-block/features/medium-manual-promo
- medium-promo-block/features/medium-promo
- small-manual-promo-block/features/small-manual-promo
- small-promo-block/features/small-promo/_children
- video-player-block/features/video-player
- video-promo-block/features/video-promo



## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.