### PR TITLE
PEN-1611 Ability to turn off separating dots in Navigation Chain hori…

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -137,6 +137,8 @@ const Nav = (props) => {
 
   const navHeight = desktopNavivationStartHeight || 56;
 
+  const showDotSeparators = showHorizontalSeperatorDots || true;
+
   const mainContent = useContent({
     source: 'site-service-hierarchy',
     query: {
@@ -369,7 +371,7 @@ const Nav = (props) => {
             <HorizontalLinksBar
               hierarchy={horizontalLinksHierarchy}
               navBarColor={navColor}
-              showHorizontalSeperatorDots={showHorizontalSeperatorDots}
+              showHorizontalSeperatorDots={showDotSeparators}
             />
           )}
           <NavSection side="right" />


### PR DESCRIPTION
## Description
Fix for https://arcpublishing.atlassian.net/browse/PEN-1611?focusedCommentId=508294
The root cause by defaultValue for the custom property does not work as expected.

## Jira Ticket
- [PEN-1611](https://arcpublishing.atlassian.net/browse/PEN-1611)

## Acceptance Criteria
1. A new boolean Custom Field is added to the Navigation Chain called Display dots between horizontal links in a new Custom Field group named Display

2. If this value is true, then when horizontal links are present, they should continue to have these dot separators as they do currently

3. If this value is false, then when horizontal links are present, they should not have these dot separators. The rest of the spacing between links should still be present. 

3. The default value for this custom field should be true

4. Tests and documentation are updated as necessary

## Test Steps

1. In Fusion-News-Theme repo, checkout master & git pull
2. After checking out this feature branch in fusion-news-theme-blocks, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run: `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/shared-styles`
4. Create a page then add navigation bar for testing
5. 


## Effect Of Changes
### Before
<img width="1476" alt="Screen Shot 2021-01-13 at 18 29 15" src="https://user-images.githubusercontent.com/61674931/104446760-7f759100-55cd-11eb-8e39-bb4b7c4dea2e.png">

### After

<img width="1476" alt="Screen Shot 2021-01-13 at 18 21 53" src="https://user-images.githubusercontent.com/61674931/104446162-9f588500-55cc-11eb-9fd0-56eced758aa6.png">
<img width="1476" alt="Screen Shot 2021-01-13 at 18 24 04" src="https://user-images.githubusercontent.com/61674931/104446170-a384a280-55cc-11eb-9fc9-7e7ac338a7f7.png">


## Dependencies or Side Effects



## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
- [ ] 
## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.