### PR TITLE
PEN-1628: Fixing the footer's missing margin-left (continue)

### DIFF
--- a/blocks/footer-block/features/footer/footer.scss
+++ b/blocks/footer-block/features/footer/footer.scss
@@ -1,6 +1,6 @@
 footer {
-  margin-left: 5%;
-  margin-right: 5%;
+  margin-left: auto;
+  margin-right: auto;
   width: 100%;
 
   //Fix for IE 11 and non grid browsers
@@ -9,6 +9,13 @@ footer {
     @supports (display: grid) {
       justify-content: initial;
       row-gap: 1rem;
+    }
+  }
+
+  .container {
+    @media (min-width: 90rem)  {
+      margin-left: 5%;
+      margin-right: 5%;
     }
   }
 


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
[LIB] Footer links breakpoint padding is missing
- Convert back margin-left of footer to `auto`
- Add margin-left for `container` if its min-width is 90 rem (I got this information from right-rail-block component). 

## Jira Ticket
- [PEN-1628](https://arcpublishing.atlassian.net/browse/PEN-1628)

## Acceptance Criteria
When adding footer navigation with multiple rows of columns, the rows having spacing between them.

## Test Steps
- Create a new page Test PEN-1628.
- Choose layout @wpmedia/right-rail-block/right-rail.
- In Curate page, at footer part, add Footer - Arc Block feature. Then in Custom Fields/Configure Content, select navigation-hierarchy for Schemas and site-service-hierarchy for Custom Fields/Content Source. Then press Update button.
- Share and Publish this page.
- Open the page Test PEN-1628, then narrow down the browser window.

## Effect Of Changes
### Before
![Screen Shot 2021-01-12 at 11 35 46](https://user-images.githubusercontent.com/12291608/104891041-fd0d1880-59a2-11eb-80eb-6a5e52c4f77f.png)

### After
![Screen Shot 2021-01-12 at 13 52 11](https://user-images.githubusercontent.com/12291608/104891089-0dbd8e80-59a3-11eb-977c-06e9a2e1a055.png)

## Dependencies or Side Effects
NO

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.