### PR TITLE
[PEN-1643] Fallback image sizing

### DIFF
--- a/blocks/shared-styles/scss/_results-list-desktop.scss
+++ b/blocks/shared-styles/scss/_results-list-desktop.scss
@@ -5,7 +5,7 @@
     grid-template-areas:
       'image headline'
       'image description';
-    grid-template-columns: minmax(0, max-content) 1fr;
+    grid-template-columns: 1fr 1fr;
     grid-template-rows: auto minmax(0, 1fr);
 
     .headline-text {

--- a/blocks/shared-styles/scss/_results-list.scss
+++ b/blocks/shared-styles/scss/_results-list.scss
@@ -43,6 +43,7 @@
 
   a > picture > img {
     vertical-align: middle;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
This is just child PR for results list block. Main PR is in engine-theme-sdk

## Description
Fallback Image sizing issue in Top Table List

## Jira Ticket
- [PEN-1643](https://arcpublishing.atlassian.net/browse/PEN-1643)

## Acceptance Criteria
The fallback image displays as the same size as other images in the medium top table list section across all breakpoints

## Test Steps
You can test with this page in corecomponents:

https://corecomponents.arcpublishing.com/pagebuilder/editor/curate/?p=p09JD0qqD50JRr&v=v059xCnqD50JRr

## Effect Of Changes
### Before
![image](https://user-images.githubusercontent.com/47773457/104988363-757ae480-5a4a-11eb-8ab4-dcd2eb76d6c5.png)

### After
![image](https://user-images.githubusercontent.com/47773457/104988394-89264b00-5a4a-11eb-8fc3-ec8d4bbd5fe2.png)


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working. 
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.