### PR TITLE
PEN-1767 Scss modules headline

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,9 @@ const path = require('path');
 // Export a function. Accept the base config as the only param.
 module.exports = {
 	stories: ['../stories/*.stories.@(js|jsx|mdx|tsx)', '../blocks/**/*.story.@(js|jsx|mdx|tsx)' ],
-	addons: ['@storybook/addon-a11y/register', '@storybook/addon-docs', '@storybook/addon-knobs'],
+  addons: ['@storybook/addon-a11y/register', '@storybook/addon-docs', '@storybook/addon-knobs',     
+  
+  ],
 	webpackFinal: async (config, { configType }) => {
 		// `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
 		// You can change the configuration based on that.
@@ -23,8 +25,9 @@ module.exports = {
 			}
 		},
 		config.module.rules.push({
-			test: /\.scss$/,
-			use: ['style-loader', 'css-loader',
+      test: /\.scss$/,
+      exclude: /\.module\.scss$/,
+      use: ['style-loader', 'css-loader',
 			{
 				loader: 'sass-loader',
 				options: {
@@ -41,9 +44,37 @@ module.exports = {
 			},
 			],
 			include: path.resolve(__dirname, '../'),
-		});
+    });
+
+    config.module.rules.push({
+      test: /\.module\.scss$/,
+      sideEffects: false,
+      use: [
+        "style-loader",
+        {
+          loader: "css-loader",
+          options: {
+            modules: true,
+          },
+        },
+        {
+          loader: 'sass-loader',
+          options: {
+            prependData: () => {
+              return `
+                @import '~@wpmedia/news-theme-css/scss';
+  
+                // Should look for a better way to do this ->
+                // This should be defaulted in the news-theme-css repo too!
+                $theme-primary-font-family: $primary-font-family !default;
+              `;
+            }
+          }
+        }
+      ],
+    });
 
 		// Return the altered config
 		return config;
-	},
+  },
 };

--- a/blocks/headline-block/features/headline/default.jsx
+++ b/blocks/headline-block/features/headline/default.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
-import './headline.scss';
+import styles from './headline.module.scss';
 
 const HeadlineHeader = styled.h1`
   font-family: ${(props) => props.primaryFont};
@@ -17,7 +17,8 @@ export const Headline = ({ headlineString, primaryFont }) => (
   */
   (headlineString !== '') && (
     <HeadlineHeader
-      className="headline"
+      // use css modules to scope styles
+      className={styles.headline}
       primaryFont={primaryFont}
       // dangerouslySetInnerHTML seems to be a pattern for blocks
       dangerouslySetInnerHTML={{ __html: headlineString }}

--- a/blocks/headline-block/features/headline/headline.module.scss
+++ b/blocks/headline-block/features/headline/headline.module.scss
@@ -1,3 +1,3 @@
-h1.headline {
+.headline {
   line-height: calculateRem(48px);
 }

--- a/blocks/headline-block/index.story.jsx
+++ b/blocks/headline-block/index.story.jsx
@@ -16,3 +16,7 @@ export const customHeadline = () => {
     <Headline headlineString={headlineString} primaryFont={primaryFont} />
   );
 };
+
+export const comicSansFontFamily = () => (
+  <Headline headlineString="Emperor Has No Pants" primaryFont="Comic Sans MS" />
+);


### PR DESCRIPTION
- use FUSION version 2.6.4-bandito.0-scss-modules-test deployed from https://github.com/WPMedia/fusion/pull/1290
- run `npx fusion start -l -f @wpmedia/headline-block
- see that the headline block has the designated style in its headline.module.scss when ran locally 
- this prevents scoping issues where one block's styles affects another
- can use headline block with global content api url `/sports/2020/01/03/desktop-article-headline-georgia-bold-h1-40px48px-with-two-lines-of-text-just-like-this-right-here/`
- can also see the effect with `npm run storybook` and see the headline block


todo: name hash as expected with css modules to some extent
 https://stackoverflow.com/a/49212981/7491536 https://webpack.js.org/loaders/css-loader/#object

<img width="877" alt="Screen Shot 2021-01-20 at 17 44 48" src="https://user-images.githubusercontent.com/5950956/105254714-cf150900-5b47-11eb-8d3c-3e94a3044a12.png">
<img width="1308" alt="Screen Shot 2021-01-20 at 17 45 02" src="https://user-images.githubusercontent.com/5950956/105254716-cf150900-5b47-11eb-96ab-f341d8254b85.png">
