### PR TITLE
PEN-1679: Ability to configure offset override for Top Table List

### DIFF
--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -121,6 +121,7 @@ const TopTableList = (props) => {
   const {
     customFields: {
       listContentConfig: { contentService = '', contentConfigValues = {} } = {},
+      offsetOverride = 0,
       extraLarge = 0,
       large = 0,
       medium = 0,
@@ -155,8 +156,8 @@ const TopTableList = (props) => {
     query: { 'arc-site': arcSite, ...contentConfigValues },
   }) || {};
 
-  const siteContent = contentElements.reduce((acc, element) => {
-    if (element.websites?.[arcSite]) {
+  const siteContent = contentElements.reduce((acc, element, index) => {
+    if (element.websites?.[arcSite] && index >= offsetOverride) {
       return acc.concat(element);
     }
     return acc;
@@ -248,6 +249,11 @@ TopTableListWrapper.propTypes = {
     listContentConfig: PropTypes.contentConfig('ans-feed').tag({
       group: 'Configure Content',
       label: 'Display Content Info',
+    }),
+    offsetOverride: PropTypes.number.tag({
+      group: 'Configure Content',
+      label: 'Offset Override',
+      defaultValue: 0,
     }),
     extraLarge: PropTypes.number.tag({
       label: generateLabelString('Extra Large'),

--- a/blocks/top-table-list-block/features/top-table-list/default.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.test.jsx
@@ -134,6 +134,82 @@ describe('top table list', () => {
     expect(wrapper.find('.top-table-list-container').children().length).toBe(1);
   });
 
+  it('renders content with offset override custom field set', () => {
+    const { default: TopTableList } = require('./default');
+    TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});
+
+    jest.mock('fusion:content', () => ({
+      useContent: jest.fn(() => ({
+        content_elements: [
+          {
+            _id: 'kjdfh',
+            promo_items: {
+              basic: {
+                type: 'image',
+                url: 'url',
+              },
+            },
+            headlines: {
+              basic: 'Basic Headline',
+            },
+            description: {
+              basic: 'Basic description',
+            },
+            credits: {
+              by: ['Bob Woodward'],
+            },
+            websites: {
+              'the-sun': {
+                website_url: 'url',
+              },
+            },
+          },
+          {
+            _id: 'abcde',
+            promo_items: {
+              basic: {
+                type: 'image',
+                url: 'url',
+              },
+            },
+            headlines: {
+              basic: 'Alt Headline',
+            },
+            description: {
+              basic: 'Alt description',
+            },
+            credits: {
+              by: ['John Doe'],
+            },
+            websites: {
+              'the-sun': {
+                website_url: 'url',
+              },
+            },
+          },
+        ],
+      })),
+    }));
+
+    const smConfig = {
+      ...config,
+      small: 1,
+      showImageSM: true,
+      imageRatioSM: '4:3',
+      offsetOverride: 1,
+    };
+    const wrapper = mount(
+      <TopTableList customFields={smConfig} arcSite="" deployment={jest.fn((path) => path)} />,
+    );
+    const container = wrapper.find('.top-table-list-container');
+    expect(container.children().length).toBe(1);
+    const storyItem = container.find('StoryItemContainer');
+    expect(storyItem).toHaveLength(1);
+    expect(storyItem.prop('id')).toEqual('abcde');
+    expect(storyItem.prop('itemTitle')).toEqual('Alt Headline');
+    expect(storyItem.prop('description')).toEqual('Alt description');
+  });
+
   it('renders content only for the arcSite', () => {
     const { default: TopTableList } = require('./default');
     TopTableList.prototype.fetchContent = jest.fn().mockReturnValue({});


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Added 'Offset Override' custom field to Top Table List block. This custom field is different than the normal `offset` query parameter defined in the content source configuration. It allows the user to define an `Offset Override` value used to start the rendering at the specified item index _while_ still being able to pull the full list of items from the content source. This is used to synchronize multiple instances of the Top Table List block to the same content cache entry instead of each instance using its own cache (which is what happens when you would define different content query values on each block). More details on why this was needed are available on the ticket.

## Jira Ticket
- [PEN-1679](https://arcpublishing.atlassian.net/browse/PEN-1679)

## Acceptance Criteria
![image](https://user-images.githubusercontent.com/26662906/105254820-01266b00-5b48-11eb-93b6-2b7fce4aa6aa.png)

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`
2. After checking out this feature branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
3. Run `npx fusion start -f -l @wpmedia/top-table-list-block` in `Fusion-News-Theme`
4. Open a test page in PB editor and add three `Top Table List` blocks to the main section
5. Click on each one and add the following configurations:
![image](https://user-images.githubusercontent.com/26662906/105255457-32ec0180-5b49-11eb-8bfe-123f2d1a16ab.png)
![image](https://user-images.githubusercontent.com/26662906/105255501-51ea9380-5b49-11eb-9d35-d89b5e2f22f4.png)
![image](https://user-images.githubusercontent.com/26662906/105255542-64fd6380-5b49-11eb-9288-9fb563351524.png)
6. Stage, publish & open your test page in a separate tab with `_website=the-gazette` param
7. You should see that each Top Table List block on the page has a different list of stories displayed with no duplication
8. Now go back to PB editor and remove the `Offset Override` value from each Top Table List block instance (or set to `0`)
9. Stage, publish, & open page in new tab. You should see that all of the Top Table List block instances are displaying the same stories since there's no longer an `Offset Override` custom field defined on any of them.

## Effect Of Changes
There was no way to set an offset on a Top Table List block without using the `offset` query param in the content source.

### After
There is now an `Offset Override` custom field that allows the user to offset the story list while retrieving the entire list of items from the content source and without defining an `offset` param in the query.

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.