### PR TITLE
Sub sections accessible via keyboard

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -17,7 +17,6 @@
     "font-family-no-missing-generic-family-keyword": null,
     "order/properties-alphabetical-order": null,
     "declaration-property-value-disallowed-list": [
-      true,
       {
         "border": [
           "none"

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
@@ -17,14 +17,18 @@ const onClickSubsection = (evt) => {
   }
 
   const container = t.closest('.subsection-anchor');
+  const button = t.querySelector('.submenu-caret') ?? t.closest('.submenu-caret');
   const subsection = container.nextElementSibling;
   const css = container.classList;
+
   if (css.contains('open')) {
     css.remove('open');
     subsection.classList.remove('open');
+    button.setAttribute('aria-expanded', false);
   } else {
     css.add('open');
     subsection.classList.add('open');
+    button.setAttribute('aria-expanded', true);
   }
   evt.stopPropagation();
 };
@@ -37,12 +41,22 @@ const isSamePath = (current, menuLink) => {
 };
 
 /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
+// Disabled a11y eslint is valid here as the div isn't focusable
+// and doesn't need to be as the caret is a button which is focusable
+// and has default button behaviour and the onClick event on the parent
+// div receives the event via propagation.
 const SubSectionAnchor = ({ item, isOpen }) => (
   <div className={`subsection-anchor ${isOpen ? 'open' : ''}`} onClick={onClickSubsection}>
     <SectionAnchor item={item} />
-    <span className="submenu-caret">
+    <button
+      type="button"
+      className="submenu-caret"
+      aria-expanded={isOpen ? 'true' : 'false'}
+      aria-label={`Show ${item.display_name ?? item.name} sub sections`}
+      aria-controls={`header_sub_section_${item._id.replace('/', '')}`}
+    >
       <ChevronRight height={20} width={20} />
-    </span>
+    </button>
   </div>
 );
 /* eslint-enable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
@@ -59,12 +73,12 @@ const SectionItem = ({ item }) => {
       { hasChildren(item)
         ? <SubSectionAnchor item={item} isOpen={isOpen} />
         : <SectionAnchor item={item} /> }
-      {hasChildren(item) && <SubSectionMenu items={item.children} isOpen={isOpen} />}
+      {hasChildren(item) && <SubSectionMenu items={item.children} isOpen={isOpen} id={item._id.replace('/', '')} />}
     </li>
   );
 };
 
-const SubSectionMenu = ({ items, isOpen }) => {
+const SubSectionMenu = ({ items, isOpen, id }) => {
   const itemsList = items.map((item) => (
     <li className="subsection-item" key={item._id}>
       {item.node_type === 'link'
@@ -75,7 +89,7 @@ const SubSectionMenu = ({ items, isOpen }) => {
 
   return (
     <div className={`subsection-container ${isOpen ? 'open' : ''}`}>
-      <ul className="subsection-menu">{itemsList}</ul>
+      <ul className="subsection-menu" id={`header_sub_section_${id}`}>{itemsList}</ul>
     </div>
   );
 };

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
@@ -175,6 +175,44 @@ describe('the SectionNav component', () => {
       expect(section.find('Link > a')).toHaveProp('target', '_blank');
       expect(section.find('Link > a')).toHaveProp('rel', 'noopener noreferrer');
     });
+
+    it('submenu "caret" button sets open class correctly on parent', () => {
+      const wrapper = mount(<SectionNav sections={items} />);
+      const section = wrapper.find('li.section-item').at(0);
+      const caret = section.find('.subsection-anchor .submenu-caret').at(0);
+      const sectionMenu = section.find('.subsection-anchor').at(0);
+
+      expect(sectionMenu.getDOMNode().classList.contains('open')).toBe(false);
+      caret.simulate('click');
+      wrapper.update();
+      expect(sectionMenu.getDOMNode().classList.contains('open')).toBe(true);
+    });
+
+    it('submenu "caret" button sets correct aria-expanded on open and close', () => {
+      const wrapper = mount(<SectionNav sections={items} />);
+      const section = wrapper.find('li.section-item').at(0);
+      const caret = section.find('.subsection-anchor .submenu-caret').at(0);
+
+      expect(caret.getDOMNode().getAttribute('aria-expanded')).toBe('false');
+      caret.simulate('click');
+      wrapper.update();
+      expect(caret.getDOMNode().getAttribute('aria-expanded')).toBe('true');
+      caret.simulate('click');
+      wrapper.update();
+      expect(caret.getDOMNode().getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('clicking menu item link does not open sub sections', () => {
+      const wrapper = mount(<SectionNav sections={items} />);
+      const section = wrapper.find('li.section-item').at(0);
+      const menuItem = section.find('.subsection-anchor a');
+      const sectionMenu = section.find('.subsection-anchor').at(0);
+
+      expect(sectionMenu.getDOMNode().classList.contains('open')).toBe(false);
+      menuItem.simulate('click');
+      wrapper.update();
+      expect(sectionMenu.getDOMNode().classList.contains('open')).toBe(false);
+    });
   });
 
   describe('when a link is not missing a trailing slash', () => {

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -50,12 +50,12 @@ body.nav-open {
 
     &.border {
       border: $border-width solid $border-color-dull;
-    
+
       &:hover {
         border: $border-width solid $border-color-bright;
       }
     }
-    
+
   }
 
   &-light {
@@ -208,10 +208,10 @@ body.nav-open {
         &--mobile,
         &--desktop {
           align-items: center;
-          
+
           & > .nav-widget {
             margin-right: calculateRem(16px);
-            
+
             &:last-child {
               margin-right: 0;
             }
@@ -371,7 +371,7 @@ body.nav-open {
 
       & > .nav-components {
         &--mobile,
-        &--desktop {          
+        &--desktop {
           & > .nav-widget {
             margin-top: calculateRem(16px);
             padding: 0 20px;
@@ -495,6 +495,9 @@ body.nav-open {
 
   .submenu-caret {
     align-self: center;
+    appearance: none;
+    background: transparent;
+    border: 0;
     display: flex;
 
     path {


### PR DESCRIPTION
## Description

* Updated caret to be a button to allow to be accessible via the keyboard.
* Added the use of aria-label to provide meaningful name to the caret button
* Added the use of aria-expanded to provide context of state of sections

## Jira Ticket
- [PEN-1238](https://arcpublishing.atlassian.net/browse/PEN-1238)

## Acceptance Criteria
When a user is using a keyboard to navigate the site, the user should be able to access the sub navigation with their keyboard

1. Using your keyboard to tab through the main navigation
2. Tabbing onto a navigation item that shows a > (right carat) to indicate sub navigation items
3. Next tab item should be the > (right carat) with label denoting open to view sub navigation items
4. Upon opening the sub navigation - the sub navigation items are put into the tab order and will be the next item the user tabs to

## Test Steps

_Expectation of a production core components recent data file locally for testing_ 

1. In Theme-blocks directory checkout this branch `git checkout PEN-1238-sub-sections-not-reachable-via-keyboard`
2. In Fusion News Theme start fusions using `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/shared-styles`
3. View The Gazette homepage - http://localhost/pf/homepage/?_website=the-gazette
4. Open the Section menu
5. Start tabbing using your keyboards tab key - may take a few tabs to get into the sections menu (this is another ticket)
6. Tab through the menu until you reach the caret after news
7. Press the enter or space key on your keyboard to open the sub section menu
8. Press tab again and the next focused menu item should be the first item in the News sub section
9. Using Shift + Tab will allow you to tab backwards
10. If a menu is open pressing enter or space on the caret will close the menu and remove those links from being in the tab order

## Effect Of Changes
### Before

User is unable to reach sub section menu items using only their keyboard

https://user-images.githubusercontent.com/868127/105481098-7b690380-5c9e-11eb-8796-3570a6c73b03.mp4


### After

User **is able** to reach sub section menu items using only their keyboard

https://user-images.githubusercontent.com/868127/105481870-896b5400-5c9f-11eb-920e-93c11ecdedb5.mp4


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [C] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.