### PR TITLE
PEN-1522 - Top table list ellipsis

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,6 +8,7 @@
     "stylelint-config-sass-guidelines"
   ],
   "rules": {
+    "max-nesting-depth": 5,
     "plugin/no-unsupported-browser-features": [
       true,
       {

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -132,7 +132,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
   return (
     <>
       <article key={id} className="container-fluid large-promo">
-        <div id="promo-item-margins" className="row lg-promo-padding-bottom">
+        <div className="promo-item-margins row lg-promo-padding-bottom">
           { customFields.showImageLG && (
             <div className="col-sm-12 col-md-xl-6 flex-col">
               {(

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -103,7 +103,7 @@ const MediumListItem = (props) => {
   return (
     <>
       <article className="container-fluid medium-promo" key={id}>
-        <div id="promo-item-margins" className={`medium-promo-wrapper ${customFields.showImageMD ? 'md-promo-image' : ''}`}>
+        <div className={`promo-item-margins medium-promo-wrapper ${customFields.showImageMD ? 'md-promo-image' : ''}`}>
           {/* {customFields.headlinePositionMD === 'above'
             && (customFields.showHeadlineMD
               || customFields.showDescriptionMD

--- a/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
@@ -112,7 +112,7 @@ const SmallListItem = (props) => {
       key={id}
       className={`top-table-list-small-promo small-promo ${colClasses} layout-section wrap-bottom`}
     >
-      <div className={`promo-item-margins promo-container ${layout} ${isReverseLayout ? 'reverse' : ''} sm-promo-padding-btm`}>
+      <div className={`promo-container ${layout} ${isReverseLayout ? 'reverse' : ''} sm-promo-padding-btm`}>
         { showHeadline && <PromoHeadline /> }
         { showImage && <PromoImage /> }
       </div>

--- a/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
@@ -51,7 +51,7 @@ const SmallListItem = (props) => {
   };
 
   const PromoHeadline = () => (
-    <div className={`promo-headline headline-wrap-${layout}`}>
+    <div className="promo-headline headline-wrap">
       <a
         href={websiteURL}
         title={itemTitle}
@@ -110,9 +110,9 @@ const SmallListItem = (props) => {
   return (
     <article
       key={id}
-      className={`small-promo ${colClasses} layout-section wrap-bottom`}
+      className={`top-table-list-small-promo small-promo ${colClasses} layout-section wrap-bottom`}
     >
-      <div id="promo-item-margins" className={`promo-container ${layout} ${isReverseLayout ? 'reverse' : ''} sm-promo-padding-btm`}>
+      <div className={`promo-item-margins promo-container ${layout} ${isReverseLayout ? 'reverse' : ''} sm-promo-padding-btm`}>
         { showHeadline && <PromoHeadline /> }
         { showImage && <PromoImage /> }
       </div>

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -128,7 +128,7 @@ const VerticalOverlineImageStoryItem = (props) => {
   return (
     <>
       <article className="container-fluid xl-large-promo" key={id}>
-        <div id="promo-item-margins" className="row xl-promo-padding-bottom">
+        <div className="promo-item-margins row xl-promo-padding-bottom">
           {(customFields.showHeadlineXL
             || customFields.showDescriptionXL
             || customFields.showBylineXL

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -1,120 +1,117 @@
-.top-table-list-container {
-  .top-table-list-section-small {
-    & > .small-promo {
-      img {
-        width: 100%;
+.top-table-list-section-small {
+  hr {
+    margin-bottom: 0;
+    width: 100%;
+  }
+}
+
+.top-table-list-small-promo {
+  img {
+    width: 100%;
+  }
+
+  .promo-container {
+    display: flex;
+    flex-direction: row;
+
+    > div {
+      &:nth-child(odd) {
+        padding-right: 0.75rem;
       }
 
-      .promo-container {
-        display: flex;
-        flex-direction: row;
-
-        & > div {
-          &:nth-child(odd) {
-            padding-right: 0.75rem;
-          }
-      
-          &:nth-child(even) {
-            padding-left: 0.75rem;
-          }
-        }
-
-        &.horizontal.reverse {
-          flex-direction: row-reverse;
-
-          & > div {
-            &:nth-child(odd) {
-              padding-left: 0.75rem;
-              padding-right: 0;
-            }
-        
-            &:nth-child(even) {
-              padding-left: 0;
-              padding-right: 0.75rem;
-            }
-          }
-        }
-
-        &.vertical {
-          @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
-            flex-direction: column;
-
-            & > div {
-              padding: 0;
-
-              &:first-child {
-                padding-bottom: 0.75rem;
-              }
-            }
-
-            &.reverse {
-              flex-direction: column-reverse;
-
-              & > div {
-                padding: 0;
-  
-                &:last-child {
-                  padding-bottom: 0.75rem;
-                }
-              }
-            }
-          }
-        }
-
-        .promo-headline {
-          flex: 2;
-
-          &.headline-wrap-vertical {
-            height: 4.6em;
-            overflow: hidden;
-            display: -webkit-box;
-            -webkit-box-orient: vertical;
-            -webkit-line-clamp: 3;
-            -moz-box-oriented: vertical;
-            /* opera */
-            text-overflow: -o-ellipsis-lastline;
-          }
-
-          &.headline-wrap-horizontal {
-            height: 50px;
-            overflow: hidden;
-          }
-        }
-
-        .promo-image {
-          flex: 1;
-
-          a {
-            display: flex;
-            flex-direction: column;
-          }
-
-          &.flex-col {
-            justify-content: center;
-          }
-        }
-
-        &.sm-promo-padding-btm {
-          @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
-            padding-top: 0;
-          }
-        }
+      &:nth-child(even) {
+        padding-left: 0.75rem;
       }
+    }
 
-      &.wrap-bottom {
-        margin-bottom: 0 !important;
+    &.horizontal.reverse {
+      flex-direction: row-reverse;
 
-        @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
-          margin-bottom: inherit;
+      > div {
+        padding-left: 0;
+        padding-right: 0;
+
+        &:nth-child(odd) {
+          padding-left: 0.75rem;
+        }
+
+        &:nth-child(even) {
+          padding-right: 0.75rem;
         }
       }
     }
 
-    hr {
-      width: 100%;
+    &.vertical {
+      @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
+        flex-direction: column;
+
+        > div {
+          padding: 0;
+
+          &:first-child {
+            margin-bottom: 0.75rem;
+          }
+        }
+
+        &.reverse {
+          flex-direction: column-reverse;
+
+          > div {
+            margin-bottom: 0;
+            padding: 0;
+
+            &:last-child {
+              margin-bottom: 0.75rem;
+            }
+          }
+        }
+      }
+    }
+
+    &.sm-promo-padding-btm {
+      @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
+        padding-top: 0;
+      }
     }
   }
 
+  .promo-headline {
+    flex: 2;
+
+    &.headline-wrap {
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+      -moz-box-oriented: vertical;
+      /* opera */
+      text-overflow: -o-ellipsis-lastline;
+    }
+  }
+
+  .promo-image {
+    flex: 1;
+
+    a {
+      display: flex;
+      flex-direction: column;
+    }
+
+    &.flex-col {
+      justify-content: center;
+    }
+  }
+
+  &.wrap-bottom {
+    margin-bottom: 0 !important;
+
+    @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
+      margin-bottom: inherit;
+    }
+  }
+}
+
+.top-table-list-container {
   &.wrap-bottom {
     margin-bottom: inherit !important;
   }
@@ -130,15 +127,15 @@
   .hr-borderless {
     visibility: hidden;
   }
+}
 
-  #promo-item-margins {
-    @media screen and (min-width: map-get($grid-breakpoints, 'sm')) {
-      margin-bottom: 1rem;
-      margin-top: 1rem;
-    }
-    @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      margin-bottom: 1.5rem;
-      margin-top: 1.5rem;
-    }
+.promo-item-margins {
+  @media screen and (min-width: map-get($grid-breakpoints, 'sm')) {
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+  }
+  @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
+    margin-bottom: 1.5rem;
+    margin-top: 1.5rem;
   }
 }

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -1,6 +1,5 @@
 .top-table-list-section-small {
   hr {
-    margin-bottom: 0;
     width: 100%;
   }
 }


### PR DESCRIPTION
## Description

1. Updated the small list item to have an ellipsis set to 3 lines consistently, using a single class for all
2. Fixed a regression in spacing on small list items caused by #699 
3. Update code from #699 to use class rather than ID to avoid having non unique IDs output in the HTML 
4. Update stylelint config to allow a little more nesting levels than 1 which is set within `stylelint-config-sass-guidelines`
5. Little refactoring of CSS to reduce stylelint errors

## Jira Ticket
- [PEN-1522](https://arcpublishing.atlassian.net/browse/PEN-1522)

## Acceptance Criteria

For all Image Position options, the following should be true: 

Headline can go up to 3 lines

If headline is longer than that, text is cut off with an ellipsis (…) on the 3rd line

## Test Steps

_Expectation of a production core components recent data file locally for testing_

1. In Theme-blocks directory checkout this branch git checkout `PEN-1522-top-table-list-ellipsis-small`
2. In Fusion News Theme start fusion using `npx fusion start -f -l @wpmedia/top-table-list-block`
3. Visit page - http://localhost/pf/top-table-list-configs/?_website=the-gazette 
4. Verify top table list small items all have ellipsis' as and when required - No line should be greater than 3 lines

## Effect Of Changes
### Before

<img width="976" alt="PEN-1522-before" src="https://user-images.githubusercontent.com/868127/105891078-1bf55580-6008-11eb-9f69-219d0f766aec.png">


### After

<img width="973" alt="PEN-1522-after" src="https://user-images.githubusercontent.com/868127/105891119-27488100-6008-11eb-8a21-8c0c04099f3b.png">

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.