### PR TITLE
Add github action file for stylelint checks on only diffs for PRs

### DIFF
--- a/.github/workflows/stylelint-pr.yml
+++ b/.github/workflows/stylelint-pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     # synchronize	commit(s) pushed to the pull request
     types: [synchronize, opened]
+    branches-ignore:
+      - rc
+      - stable
+      - beta
 
 jobs:
   stylelint_pr_diffs:

--- a/.github/workflows/stylelint-pr.yml
+++ b/.github/workflows/stylelint-pr.yml
@@ -1,0 +1,33 @@
+name: Stylelint PR Diffs
+
+on:
+  pull_request:
+    # synchronize	commit(s) pushed to the pull request
+    types: [synchronize, opened]
+
+jobs:
+  stylelint_pr_diffs:
+    name: Stylelint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Rep
+        uses: actions/checkout@v1
+
+      - name: Setup Node with 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: stylelint
+        uses: reviewdog/action-stylelint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          fail_on_error: true
+          reporter: github-pr-review
+          filter_mode: 'diff_context'
+          stylelint_config: '.stylelintrc.json'
+          stylelint_input: '**/*.(scss|jsx)'

--- a/.github/workflows/stylelint-pr.yml
+++ b/.github/workflows/stylelint-pr.yml
@@ -19,8 +19,18 @@ jobs:
           node-version: "12"
           registry-url: "https://npm.pkg.github.com"
 
-      - name: Install dependencies
+      - name: Cache Node Modules
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Clean install (CI) dependencies if lockfile (above) changed
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: stylelint
         uses: reviewdog/action-stylelint@v1


### PR DESCRIPTION
## Description
Adds a GitHub action for running stylelint against the code changed in the PR. 

* Its set to only run on the diff on each commit tolerance of the diff check is -+ 3 lines


## Jira Ticket
- [PEN-1694](https://arcpublishing.atlassian.net/browse/PEN-1694)

## Test Steps

Commit a change to some Sass/CSS that would trigger a failure

## Effect Of Changes

See PR #708 for example of GitHub action in "action" 😄 

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working. 
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.