### PR TITLE
PEN-1125 - Share Bar Label and Key Events

### DIFF
--- a/blocks/share-bar-block/features/share-bar/default.jsx
+++ b/blocks/share-bar-block/features/share-bar/default.jsx
@@ -108,11 +108,11 @@ export const ShareBar = ({
       shareButtons.push((
         <button
           key={social}
-          title={social}
+          id={`article-share-${social}`}
+          aria-label={`Share current article via ${social}`}
           type="button"
           className="shareButton"
           onClick={() => share[social](encodedUrl, encodedTitle, websiteName)}
-          onKeyPress={() => share[social](encodedUrl, encodedTitle, websiteName)}
         >
           { getLogoComponent(social) }
         </button>

--- a/blocks/share-bar-block/features/share-bar/default.test.jsx
+++ b/blocks/share-bar-block/features/share-bar/default.test.jsx
@@ -66,11 +66,11 @@ describe('When the share bar is shown', () => {
     />);
 
     expect(wrapper.find('button.shareButton')).toHaveLength(3);
-    expect(wrapper.find({ title: 'email' })).toHaveLength(1);
-    expect(wrapper.find({ title: 'twitter' })).toHaveLength(1);
-    expect(wrapper.find({ title: 'linkedIn' })).toHaveLength(1);
-    expect(wrapper.find({ title: 'facebook' })).toHaveLength(0);
-    expect(wrapper.find({ title: 'pinterest' })).toHaveLength(0);
+    expect(wrapper.find('#article-share-email')).toHaveLength(1);
+    expect(wrapper.find('#article-share-twitter')).toHaveLength(1);
+    expect(wrapper.find('#article-share-linkedIn')).toHaveLength(1);
+    expect(wrapper.find('#article-share-facebook')).toHaveLength(0);
+    expect(wrapper.find('#article-share-pinterest')).toHaveLength(0);
   });
 
   it('should not show any social buttons when all are marked false', () => {
@@ -111,7 +111,7 @@ describe('When the share bar is shown', () => {
         websiteUrl={websiteUrl}
         headlineString={headlineString}
       />);
-      wrapper.find({ title: 'facebook' }).simulate('click');
+      wrapper.find('#article-share-facebook').simulate('click');
       expect(window.location.origin).toEqual('http://localhost');
       expect(window.open).toBeCalled();
     });
@@ -124,7 +124,7 @@ describe('When the share bar is shown', () => {
         websiteUrl={websiteUrl}
         headlineString={headlineString}
       />);
-      wrapper.find({ title: 'linkedIn' }).simulate('click');
+      wrapper.find('#article-share-linkedIn').simulate('click');
       expect(window.location.origin).toEqual('http://localhost');
       expect(window.open).toBeCalled();
     });
@@ -137,7 +137,7 @@ describe('When the share bar is shown', () => {
         websiteUrl={websiteUrl}
         headlineString={headlineString}
       />);
-      wrapper.find({ title: 'email' }).simulate('click');
+      wrapper.find('#article-share-email').simulate('click');
       expect(window.location.origin).toEqual('http://localhost');
       expect(window.open).toBeCalled();
     });
@@ -150,7 +150,7 @@ describe('When the share bar is shown', () => {
         websiteUrl={websiteUrl}
         headlineString={headlineString}
       />);
-      wrapper.find({ title: 'pinterest' }).simulate('click');
+      wrapper.find('#article-share-pinterest').simulate('click');
       expect(window.location.origin).toEqual('http://localhost');
       expect(window.open).toBeCalled();
     });
@@ -163,19 +163,7 @@ describe('When the share bar is shown', () => {
         websiteUrl={websiteUrl}
         headlineString={headlineString}
       />);
-      wrapper.find({ title: 'twitter' }).simulate('click');
-      expect(window.location.origin).toEqual('http://localhost');
-      expect(window.open).toBeCalled();
-    });
-    it('should work with a keypress', () => {
-      const wrapper = mount(<ShareBar
-        customFields={customFields}
-        websiteName={websiteName}
-        websiteDomain={websiteDomain}
-        websiteUrl={websiteUrl}
-        headlineString={headlineString}
-      />);
-      wrapper.find({ title: 'facebook' }).simulate('keyPress');
+      wrapper.find('#article-share-twitter').simulate('click');
       expect(window.location.origin).toEqual('http://localhost');
       expect(window.open).toBeCalled();
     });


### PR DESCRIPTION
## Description

Update share buttons in share block to have meaningful label, and remove the onKeyPress event.

KeyPress event is safe to remove as each item is a button and the default behaviour of a click event on a button will run when the keyboard Enter and Space keys are used 

## Jira Ticket
- [PEN-1125](https://arcpublishing.atlassian.net/browse/PEN-1125)

## Acceptance Criteria

Each option is a button and should only have space and enter key events bound

Currently if you focus on a button in the share block you can use alphanumeric keys to activate the button

1. Tab to the share bar
2. Tab to focus on any one of the share options
3. Click the letter "a" on your keyboard
4. Button action is activated 
5. Pressing the letter "a" when on the focused share option should do nothing

## Test Steps

Using article page - http://localhost/arts/2020/01/30/thousands-held-on-cruise-ship-in-italy-as-authorities-test-passengers-for-coronavirus/?_website=the-gazette

1. Checkout this branch `git checkout PEN-1125-share-bar-label-and-event`
2. In Fusion repo run with share block linked `npx fusion start -f -l @wpmedia/share-bar-block`
3. Navigate to the article page - http://localhost/arts/2020/01/30/thousands-held-on-cruise-ship-in-italy-as-authorities-test-passengers-for-coronavirus/?_website=the-gazette
4. Use developer tools to validate the label is correctly on the button
5. Use your keyboard to tab to a Share Button and validate it will only activate the share windows with Space or Enter keys of the keyboard

## Effect Of Changes
### Before

Label is not meaningful

<img width="295" alt="PEN-1125-before" src="https://user-images.githubusercontent.com/868127/106283348-bbe5f580-6239-11eb-8f4c-df65811c7713.png">


### After

Label provides a meaningful value

<img width="298" alt="PEN-1125-after" src="https://user-images.githubusercontent.com/868127/106283389-c7d1b780-6239-11eb-96cb-4ee312436dd2.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.