### PR TITLE
PEN-1239 Remove separator from link text

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/_children/link.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/_children/link.jsx
@@ -39,7 +39,7 @@ const StyledLink = styled.a`
 `;
 
 const Link = ({
-  href, name, showSeparator, navBarColor,
+  href, name, navBarColor,
 }) => {
   const externalUrl = /(http(s?)):\/\//i.test(href);
 
@@ -51,12 +51,12 @@ const Link = ({
         rel="noopener noreferrer"
         navBarColor={navBarColor}
       >
-        {`${showSeparator ? '  \u00a0 • \u00a0' : '  \u00a0  \u00a0'}${name}`}
+        {`${name}`}
         <span className="sr-only">(Opens in new window)</span>
       </StyledLink>
     ) : (
       <StyledLink href={fixTrailingSlash(href)} navBarColor={navBarColor}>
-        {`${showSeparator ? '  \u00a0 • \u00a0' : '  \u00a0  \u00a0'}${name}`}
+        {`${name}`}
       </StyledLink>
     )
   );
@@ -66,7 +66,6 @@ Link.propTypes = {
   href: PropTypes.string,
   name: PropTypes.string,
   navBarColor: PropTypes.string,
-  showSeparator: PropTypes.bool,
 };
 
 export default Link;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/_children/link_node.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/_children/link_node.test.jsx
@@ -10,28 +10,28 @@ import Link from './link';
 
 describe('When the link is generated SSR', () => {
   it('must add a final slash to internal urls', () => {
-    const link = renderToString(Link({ href: '/entertaiment', name: 'Entertaiment', showSepartor: false }));
+    const link = renderToString(Link({ href: '/entertaiment', name: 'Entertaiment' }));
     expect(link).toMatch(/\/entertaiment\//);
     expect(link).toMatch(/>*Entertaiment</);
   });
 
   it('must not add a final slash to links with query params', () => {
-    const link = renderToString(Link({ href: '/entertaiment?search=abc', name: 'Entertaiment', showSepartor: false }));
+    const link = renderToString(Link({ href: '/entertaiment?search=abc', name: 'Entertaiment' }));
     expect(link).toMatch(/\/entertaiment\?search=abc/);
   });
 
   it('must not add a final slash to links with hash params', () => {
-    const link = renderToString(Link({ href: '/entertaiment/page#some-anchor', name: 'Entertaiment', showSepartor: false }));
+    const link = renderToString(Link({ href: '/entertaiment/page#some-anchor', name: 'Entertaiment' }));
     expect(link).toMatch(/\/entertaiment\/page#some-anchor/);
   });
 
   it('must not add a final slash to links with a htmlpage', () => {
-    const link = renderToString(Link({ href: '/entertaiment/page.html', name: 'Entertaiment', showSepartor: false }));
+    const link = renderToString(Link({ href: '/entertaiment/page.html', name: 'Entertaiment' }));
     expect(link).toMatch(/\/entertaiment\/page\.html/);
   });
 
   it('must add rel attriutes to external links', () => {
-    const link = renderToString(Link({ href: 'https://example.com/some/page.html', name: 'Entertaiment', showSepartor: false }));
+    const link = renderToString(Link({ href: 'https://example.com/some/page.html', name: 'Entertaiment' }));
     expect(link).toMatch(/href="https:\/\/example.com\/some\/page.html"/);
     expect(link).toMatch(/target="_blank"/);
     expect(link).toMatch(/rel="noopener noreferrer"/);

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
@@ -8,6 +8,8 @@ import Link from './_children/link';
 import './links-bar.scss';
 
 const LinkBarSpan = styled.span`
+  color: ${(props) => (props.navBarColor === 'light' ? '#000' : '#fff')};
+
   a {
     font-family: ${(props) => props.primaryFont};
     white-space: nowrap;
@@ -44,14 +46,15 @@ const HorizontalLinksBar = ({ hierarchy, navBarColor, showHorizontalSeperatorDot
             className="horizontal-links-menu"
             key={item._id}
             primaryFont={font}
+            navBarColor={navBarColor}
           >
+
             {
               item.node_type === 'link'
                 ? (
                   <Link
                     href={item.url}
                     name={item.display_name}
-                    showSeparator={index !== 0 && showSeparator}
                     navBarColor={navBarColor}
                   />
                 )
@@ -59,11 +62,11 @@ const HorizontalLinksBar = ({ hierarchy, navBarColor, showHorizontalSeperatorDot
                   <Link
                     href={item._id}
                     name={item.name}
-                    showSeparator={index !== 0 && showSeparator}
                     navBarColor={navBarColor}
                   />
                 )
             }
+            {(content.children.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : '\u00A0'}
           </LinkBarSpan>
         ))}
       </nav>

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
@@ -65,7 +65,6 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a></span></nav>"',
       '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a> </span></nav>"',
     );
   });
@@ -98,7 +97,6 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a></span></nav>"',
       '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a> </span></nav>"',
     );
   });
@@ -127,7 +125,6 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a></span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a></span></nav>"',
       '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a> </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a> </span></nav>"',
     );
   });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
-jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+jest.mock('fusion:themes', () => jest.fn(() => ({})));
 
 describe('the links bar feature for the default output type', () => {
   afterEach(() => {
@@ -33,9 +33,103 @@ describe('the links bar feature for the default output type', () => {
         ],
       })),
     }));
-    const wrapper = shallow(<LinksBar customFields={{ navigationConfig: 'links' }} />);
+    const wrapper = shallow(
+      <LinksBar customFields={{ navigationConfig: 'links' }} />,
+    );
 
-    expect(wrapper.children().at(0).type()).toBe('nav');
+    expect(
+      wrapper
+        .children()
+        .at(0)
+        .type(),
+    ).toBe('nav');
+  });
+
+  it('should not have separator only one link', () => {
+    const { default: LinksBar } = require('./default');
+    jest.mock('fusion:content', () => ({
+      useContent: jest.fn(() => ({
+        children: [
+          {
+            _id: 'id_1',
+            name: 'test link 1',
+          },
+        ],
+      })),
+    }));
+    const wrapper = shallow(
+      <LinksBar
+        customFields={{ navigationConfig: 'links' }}
+        showHorizontalSeperatorDots
+      />,
+    );
+
+    expect(wrapper.html()).toMatchInlineSnapshot(
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a></span></nav>"',
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a> </span></nav>"',
+    );
+  });
+
+  it('should have separator when more than one link', () => {
+    const { default: LinksBar } = require('./default');
+    jest.mock('fusion:content', () => ({
+      useContent: jest.fn(() => ({
+        children: [
+          {
+            _id: 'id_1',
+            name: 'test link 1',
+          },
+          {
+            _id: 'id_2',
+            name: 'test link 2',
+          },
+          {
+            _id: 'id_3',
+            name: 'test link 3',
+          },
+        ],
+      })),
+    }));
+    const wrapper = shallow(
+      <LinksBar
+        customFields={{ navigationConfig: 'links' }}
+        showHorizontalSeperatorDots
+      />,
+    );
+
+    expect(wrapper.html()).toMatchInlineSnapshot(
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a></span></nav>"',
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a> </span></nav>"',
+    );
+  });
+
+  it('should not have separator when more than one link and showHorizontalSeperatorDots is false', () => {
+    const { default: LinksBar } = require('./default');
+    jest.mock('fusion:content', () => ({
+      useContent: jest.fn(() => ({
+        children: [
+          {
+            _id: 'id_1',
+            name: 'test link 1',
+          },
+          {
+            _id: 'id_2',
+            name: 'test link 2',
+          },
+        ],
+      })),
+    }));
+    const wrapper = shallow(
+      <LinksBar
+        customFields={{ navigationConfig: 'links' }}
+        showHorizontalSeperatorDots={false}
+      />,
+    );
+
+    expect(wrapper.html()).toMatchInlineSnapshot(
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a></span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a></span></nav>"',
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a> </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a> </span></nav>"',
+    );
   });
 
   it('should contain the equal number of links between input and output', () => {
@@ -66,11 +160,17 @@ describe('the links bar feature for the default output type', () => {
         ],
       })),
     }));
-    const wrapper = mount(<LinksBar customFields={{ navigationConfig: 'links' }} />);
+    const wrapper = mount(
+      <LinksBar customFields={{ navigationConfig: 'links' }} />,
+    );
 
     expect(wrapper.find('span.horizontal-links-menu')).toHaveLength(4);
-    expect(wrapper.find('span.horizontal-links-menu a:not([target])')).toHaveLength(3);
-    expect(wrapper.find('span.horizontal-links-menu a[target="_blank"]')).toHaveLength(1);
+    expect(
+      wrapper.find('span.horizontal-links-menu a:not([target])'),
+    ).toHaveLength(3);
+    expect(
+      wrapper.find('span.horizontal-links-menu a[target="_blank"]'),
+    ).toHaveLength(1);
   });
 
   it('should have no menu item if no content is returned', () => {
@@ -80,7 +180,9 @@ describe('the links bar feature for the default output type', () => {
       })),
     }));
     const { default: LinksBar } = require('./default');
-    const wrapper = shallow(<LinksBar customFields={{ navigationConfig: 'links' }} />);
+    const wrapper = shallow(
+      <LinksBar customFields={{ navigationConfig: 'links' }} />,
+    );
 
     expect(wrapper.find('nav > span')).toHaveLength(0);
   });
@@ -91,7 +193,7 @@ describe('the links bar feature for the default output type', () => {
       const wrapper = mount(<Link href="/testurl" name="test" />);
 
       expect(wrapper.props().name).toBe('test');
-      expect(wrapper.find('a').text()).toBe('      test');
+      expect(wrapper.find('a').text()).toBe('test');
     });
   });
 
@@ -127,20 +229,32 @@ describe('the links bar feature for the default output type', () => {
   describe('when a link has query parameters', () => {
     it('should not add a slash at the end of a external link', () => {
       const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="http://example.com/testurl/?query=home" name="test" />);
+      const wrapper = mount(
+        <Link href="http://example.com/testurl/?query=home" name="test" />,
+      );
 
-      expect(wrapper.props().href).toBe('http://example.com/testurl/?query=home');
-      expect(wrapper.find('[href="http://example.com/testurl/?query=home"]').length).toBe(4);
+      expect(wrapper.props().href).toBe(
+        'http://example.com/testurl/?query=home',
+      );
+      expect(
+        wrapper.find('[href="http://example.com/testurl/?query=home"]').length,
+      ).toBe(4);
     });
   });
 
   describe('when a link is to a page', () => {
     it('should not add a slash at the end of the link', () => {
       const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="https://example.com/category/page.html" name="test" />);
+      const wrapper = mount(
+        <Link href="https://example.com/category/page.html" name="test" />,
+      );
 
-      expect(wrapper.props().href).toBe('https://example.com/category/page.html');
-      expect(wrapper.find('[href="https://example.com/category/page.html"]').length).toBe(4);
+      expect(wrapper.props().href).toBe(
+        'https://example.com/category/page.html',
+      );
+      expect(
+        wrapper.find('[href="https://example.com/category/page.html"]').length,
+      ).toBe(4);
     });
   });
 
@@ -157,23 +271,14 @@ describe('the links bar feature for the default output type', () => {
   describe('when a link has a mail', () => {
     it('should not add a slash at the end of the link', () => {
       const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="mailto:readers@washpost.com" name="test" />);
+      const wrapper = mount(
+        <Link href="mailto:readers@washpost.com" name="test" />,
+      );
 
       expect(wrapper.props().href).toBe('mailto:readers@washpost.com');
-      expect(wrapper.find('[href="mailto:readers@washpost.com"]').length).toBe(4);
-    });
-  });
-
-  describe('when a link has show separator based on showSeparator attribute', () => {
-    it('should show dot separator', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="mailto:readers@washpost.com" name="test" navBarColor="light" showSeparator />);
-      expect(wrapper.text()).toContain('    •  test');
-    });
-    it('should not show dot separator', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="mailto:readers@washpost.com" name="test123" navBarColor="light" showSeparator={false} />);
-      expect(wrapper.text()).toContain('      test');
+      expect(wrapper.find('[href="mailto:readers@washpost.com"]').length).toBe(
+        4,
+      );
     });
   });
 });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
@@ -15,15 +15,13 @@
 }
 
 .horizontal-links-menu {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
+  align-items: center;
+  font-size: calculateRem(14px);
   justify-content: center;
 
   a {
     @include link-color-active-hover($ui-primary-font-color);
     font-family: $theme-primary-font-family;
-    font-size: 14px;
     line-height: 14px;
     margin: 8px 0;
     text-align: center;

--- a/blocks/links-bar-block/features/links-bar/_children/link.jsx
+++ b/blocks/links-bar-block/features/links-bar/_children/link.jsx
@@ -31,16 +31,16 @@ function fixTrailingSlash(item) {
   return item;
 }
 
-const Link = ({ href, name, showSeparator }) => {
+const Link = ({ href, name }) => {
   const externalUrl = /(http(s?)):\/\//i.test(href);
 
   return (
     externalUrl ? (
       <a href={fixTrailingSlash(href)} target="_blank" rel="noopener noreferrer">
-        {`${name}${(showSeparator) ? '  \u00a0 • \u00a0  ' : ''}`}
+        {`${name}`}
         <span className="sr-only">(Opens in new window)</span>
       </a>
-    ) : <a href={fixTrailingSlash(href)}>{`${name}${(showSeparator) ? '  \u00a0 • \u00a0  ' : ''}`}</a>
+    ) : <a href={fixTrailingSlash(href)}>{`${name}`}</a>
   );
 };
 

--- a/blocks/links-bar-block/features/links-bar/_children/link_node.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/_children/link_node.test.jsx
@@ -10,28 +10,28 @@ import Link from './link';
 
 describe('When the link is generated SSR', () => {
   it('must add a final slash to internal urls', () => {
-    const link = renderToString(Link({ href: '/entertaiment', name: 'Entertaiment', showSepartor: false }));
+    const link = renderToString(Link({ href: '/entertaiment', name: 'Entertaiment' }));
     expect(link).toMatch(/\/entertaiment\//);
     expect(link).toMatch(/>Entertaiment</);
   });
 
   it('must not add a final slash to links with query params', () => {
-    const link = renderToString(Link({ href: '/entertaiment?search=abc', name: 'Entertaiment', showSepartor: false }));
+    const link = renderToString(Link({ href: '/entertaiment?search=abc', name: 'Entertaiment' }));
     expect(link).toMatch(/\/entertaiment\?search=abc/);
   });
 
   it('must not add a final slash to links with hash params', () => {
-    const link = renderToString(Link({ href: '/entertaiment/page#some-anchor', name: 'Entertaiment', showSepartor: false }));
+    const link = renderToString(Link({ href: '/entertaiment/page#some-anchor', name: 'Entertaiment' }));
     expect(link).toMatch(/\/entertaiment\/page#some-anchor/);
   });
 
   it('must not add a final slash to links with a htmlpage', () => {
-    const link = renderToString(Link({ href: '/entertaiment/page.html', name: 'Entertaiment', showSepartor: false }));
+    const link = renderToString(Link({ href: '/entertaiment/page.html', name: 'Entertaiment' }));
     expect(link).toMatch(/\/entertaiment\/page\.html/);
   });
 
   it('must add rel attriutes to external links', () => {
-    const link = renderToString(Link({ href: 'https://example.com/some/page.html', name: 'Entertaiment', showSepartor: false }));
+    const link = renderToString(Link({ href: 'https://example.com/some/page.html', name: 'Entertaiment' }));
     expect(link).toMatch(/href="https:\/\/example.com\/some\/page.html"/);
     expect(link).toMatch(/target="_blank"/);
     expect(link).toMatch(/rel="noopener noreferrer"/);

--- a/blocks/links-bar-block/features/links-bar/default.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.jsx
@@ -41,20 +41,13 @@ const LinksBar = ({ customFields: { navigationConfig = {} } }) => {
             {
               item.node_type === 'link'
                 ? (
-                  <Link
-                    href={item.url}
-                    name={item.display_name}
-                    showSeparator={content.children.length !== index + 1 && showSeparator}
-                  />
+                  <Link href={item.url} name={item.display_name} />
                 )
                 : (
-                  <Link
-                    href={item._id}
-                    name={item.name}
-                    showSeparator={content.children.length !== index + 1 && showSeparator}
-                  />
+                  <Link href={item._id} name={item.name} />
                 )
             }
+            {(content.children.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : ''}
           </LinkBarSpan>
         ))}
       </nav>

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
-jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+jest.mock('fusion:themes', () => jest.fn(() => ({})));
 
 describe('the links bar feature for the default output type', () => {
   afterEach(() => {
@@ -33,9 +33,63 @@ describe('the links bar feature for the default output type', () => {
         ],
       })),
     }));
-    const wrapper = shallow(<LinksBar customFields={{ navigationConfig: 'links' }} />);
+    const wrapper = shallow(
+      <LinksBar customFields={{ navigationConfig: 'links' }} />,
+    );
 
     expect(wrapper.children().at(0).type()).toBe('nav');
+  });
+
+  it('should not have separator when only one link', () => {
+    const { default: LinksBar } = require('./default');
+    jest.mock('fusion:content', () => ({
+      useContent: jest.fn(() => ({
+        children: [
+          {
+            _id: 'id_1',
+            name: 'test link 1',
+          },
+        ],
+      })),
+    }));
+    const wrapper = shallow(
+      <LinksBar customFields={{ navigationConfig: 'links' }} />,
+    );
+
+    expect(wrapper.html()).toMatchInlineSnapshot(
+      '"<nav class=\\"links-bar\\"><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_1/\\">test link 1</a></span></nav><hr/>"',
+    );
+  });
+
+  it('should have separator when more than one link', () => {
+    const { default: LinksBar } = require('./default');
+    jest.mock('fusion:content', () => ({
+      useContent: jest.fn(() => ({
+        children: [
+          {
+            _id: 'id_1',
+            name: 'test link 1',
+          },
+          {
+            _id: 'id_2',
+            name: 'test link 2',
+          },
+          {
+            _id: 'id_3',
+            node_type: 'link',
+            url: '/',
+            display_name: 'Link Text',
+          },
+        ],
+      })),
+    }));
+    const wrapper = shallow(
+      <LinksBar customFields={{ navigationConfig: 'links' }} />,
+    );
+
+    expect(wrapper.html()).toMatchInlineSnapshot(
+      '"<nav class=\\"links-bar\\"><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_1/\\">test link 1</a>  •  </span><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_2/\\">test link 2</a>  •  </span><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"/\\">Link Text</a></span></nav><hr/>"',
+    );
   });
 
   it('should contain the equal number of links between input and output', () => {
@@ -66,7 +120,9 @@ describe('the links bar feature for the default output type', () => {
         ],
       })),
     }));
-    const wrapper = mount(<LinksBar customFields={{ navigationConfig: 'links' }} />);
+    const wrapper = mount(
+      <LinksBar customFields={{ navigationConfig: 'links' }} />,
+    );
 
     expect(wrapper.find('span.links-menu')).toHaveLength(4);
     expect(wrapper.find('span.links-menu a:not([target])')).toHaveLength(3);
@@ -80,7 +136,9 @@ describe('the links bar feature for the default output type', () => {
       })),
     }));
     const { default: LinksBar } = require('./default');
-    const wrapper = shallow(<LinksBar customFields={{ navigationConfig: 'links' }} />);
+    const wrapper = shallow(
+      <LinksBar customFields={{ navigationConfig: 'links' }} />,
+    );
 
     expect(wrapper.find('nav > span')).toHaveLength(0);
   });
@@ -128,20 +186,32 @@ describe('the links bar feature for the default output type', () => {
   describe('when a link has query parameters', () => {
     it('should not add a slash at the end of a external link', () => {
       const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="http://example.com/testurl/?query=home" name="test" />);
+      const wrapper = mount(
+        <Link href="http://example.com/testurl/?query=home" name="test" />,
+      );
 
-      expect(wrapper.props().href).toBe('http://example.com/testurl/?query=home');
-      expect(wrapper.find('[href="http://example.com/testurl/?query=home"]').length).toBe(2);
+      expect(wrapper.props().href).toBe(
+        'http://example.com/testurl/?query=home',
+      );
+      expect(
+        wrapper.find('[href="http://example.com/testurl/?query=home"]').length,
+      ).toBe(2);
     });
   });
 
   describe('when a link is to a page', () => {
     it('should not add a slash at the end of the link', () => {
       const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="https://example.com/category/page.html" name="test" />);
+      const wrapper = mount(
+        <Link href="https://example.com/category/page.html" name="test" />,
+      );
 
-      expect(wrapper.props().href).toBe('https://example.com/category/page.html');
-      expect(wrapper.find('[href="https://example.com/category/page.html"]').length).toBe(2);
+      expect(wrapper.props().href).toBe(
+        'https://example.com/category/page.html',
+      );
+      expect(
+        wrapper.find('[href="https://example.com/category/page.html"]').length,
+      ).toBe(2);
     });
   });
 
@@ -158,10 +228,14 @@ describe('the links bar feature for the default output type', () => {
   describe('when a link has a mail', () => {
     it('should not add a slash at the end of the link', () => {
       const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="mailto:readers@washpost.com" name="test" />);
+      const wrapper = mount(
+        <Link href="mailto:readers@washpost.com" name="test" />,
+      );
 
       expect(wrapper.props().href).toBe('mailto:readers@washpost.com');
-      expect(wrapper.find('[href="mailto:readers@washpost.com"]').length).toBe(2);
+      expect(wrapper.find('[href="mailto:readers@washpost.com"]').length).toBe(
+        2,
+      );
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3500,6 +3500,12 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "@scarf/scarf": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.1.0.tgz",
+      "integrity": "sha512-b2iE8kjjzzUo2WZ0xuE2N77kfnTds7ClrDxcz3Atz7h2XrNVoAPUoT75i7CY0st5x++70V91Y+c6RpBX9MX7Jg==",
+      "dev": true
+    },
     "@storybook/addon-a11y": {
       "version": "5.3.21",
       "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-5.3.21.tgz",
@@ -6208,7 +6214,7 @@
           "integrity": "sha512-2EXjviyCasK9L/DcJanS5PppZUuadklCaEJlNmYOW9GOhsd8Ck1Z298d22FJJDQnSsCImtVcX2gAVDtg+ZYCPQ==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0",
+            "@wpmedia/news-theme-css": "^4.1.0",
             "styled-components": "^4.4.0"
           },
           "dependencies": {
@@ -9537,23 +9543,45 @@
       }
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.8.1-canary.10",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.8.1-canary.10/ee545fdcb54e2c5417f14812c0fc8a70aa7579c6c65da8b5e0b81ad8cf6c4b78",
-      "integrity": "sha512-YqxGNCFVrWI9oy1we7eXBXuxCaDxr7JtRqmyaRHHhnt8J207ifovmLEk5+ZGJZx7PFzDVST4UclV0uL4Ih4cYQ==",
+      "version": "2.8.1-canary.26",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.8.1-canary.26/0d5d412dd44e1ff2e3235d6b63e8c60d48c6ed8e4111ee81e2543aefcaa17cdd",
+      "integrity": "sha512-Xil1eP87ycMGrXaZxh+kmxYcYjPpqW3YJVyedcev4KpBANtPpmpiTOOE3dZd/OYPkCW9ClwM98T1GpJrMZutIA==",
       "dev": true,
       "requires": {
         "dom-parser": "^0.1.6",
         "is-react": "^1.3.3",
         "lazy-child": "^0.2.0",
-        "polished": "^3.4.4",
+        "polished": "^4.1.0",
         "prop-types": "^15.7.2",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
         "react-modal": "^3.11.1",
+        "react-oembed-container": "^1.0.0",
         "react-swipeable": "^5.5.0",
         "styled-components": "^4.4.1",
         "thumbor-lite": "^0.1.6",
         "timezone": "^1.0.23"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "polished": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/polished/-/polished-4.1.0.tgz",
+          "integrity": "sha512-y8IInTGHuwku7+O+wsJ7OOvNpJF7EPP/IDzF1uj9UJfEEKpMAfeq5gZ5UrtOksM7Jk4+hBAk6Ce8rFOOF4msZg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@scarf/scarf": "^1.1.0"
+          }
+        }
       }
     },
     "@wpmedia/event-tester-block": {
@@ -9568,7 +9596,7 @@
           "integrity": "sha512-OYobEl3kS5kR+16OQ1dkQO0wMgR3cYfLEV4HXLjGW9h61WtYlTnyRbYK+p31EvBTcpY3c68bP+mFXIJoVRY90Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -9603,7 +9631,7 @@
           "integrity": "sha512-jPn6CN8taFWN8cntUbpsignjI4lwTe/YcIzdl8uBBkb0hyWnHIBdPK1kLy/Z3HHxi3bJrtNaTv7Gpc6j/f0O6Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0",
+            "@wpmedia/news-theme-css": "^4.1.0",
             "styled-components": "^4.4.0"
           },
           "dependencies": {
@@ -9634,7 +9662,7 @@
           "integrity": "sha512-kkCx/nROLCJLmUxSnlClYK7IRi10abPQGyshUlf/hBqZSLfkw+Khn+kHeldlKAzbSzutfzb79h+eu6SlgbfjUw==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0",
+            "@wpmedia/news-theme-css": "^4.1.0",
             "styled-components": "^4.4.0"
           },
           "dependencies": {
@@ -9694,7 +9722,7 @@
           "integrity": "sha512-qy7z/k+8l9Wpt+SETXk97dMhMY+d0l18nJicTnBipGpEC9mRn0w/YdLmwzIQguXASUjVuiijwZieM1TyK2cSGw==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -9724,7 +9752,7 @@
           "integrity": "sha512-OYobEl3kS5kR+16OQ1dkQO0wMgR3cYfLEV4HXLjGW9h61WtYlTnyRbYK+p31EvBTcpY3c68bP+mFXIJoVRY90Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -12442,7 +12470,7 @@
           "integrity": "sha512-OYobEl3kS5kR+16OQ1dkQO0wMgR3cYfLEV4HXLjGW9h61WtYlTnyRbYK+p31EvBTcpY3c68bP+mFXIJoVRY90Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -13572,7 +13600,7 @@
           "integrity": "sha512-OYobEl3kS5kR+16OQ1dkQO0wMgR3cYfLEV4HXLjGW9h61WtYlTnyRbYK+p31EvBTcpY3c68bP+mFXIJoVRY90Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -13607,7 +13635,7 @@
           "integrity": "sha512-jPn6CN8taFWN8cntUbpsignjI4lwTe/YcIzdl8uBBkb0hyWnHIBdPK1kLy/Z3HHxi3bJrtNaTv7Gpc6j/f0O6Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0",
+            "@wpmedia/news-theme-css": "^4.1.0",
             "styled-components": "^4.4.0"
           },
           "dependencies": {
@@ -13638,7 +13666,7 @@
           "integrity": "sha512-kkCx/nROLCJLmUxSnlClYK7IRi10abPQGyshUlf/hBqZSLfkw+Khn+kHeldlKAzbSzutfzb79h+eu6SlgbfjUw==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0",
+            "@wpmedia/news-theme-css": "^4.1.0",
             "styled-components": "^4.4.0"
           },
           "dependencies": {
@@ -13669,7 +13697,7 @@
           "integrity": "sha512-qy7z/k+8l9Wpt+SETXk97dMhMY+d0l18nJicTnBipGpEC9mRn0w/YdLmwzIQguXASUjVuiijwZieM1TyK2cSGw==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -13699,7 +13727,7 @@
           "integrity": "sha512-OYobEl3kS5kR+16OQ1dkQO0wMgR3cYfLEV4HXLjGW9h61WtYlTnyRbYK+p31EvBTcpY3c68bP+mFXIJoVRY90Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -13734,7 +13762,7 @@
           "integrity": "sha512-2EXjviyCasK9L/DcJanS5PppZUuadklCaEJlNmYOW9GOhsd8Ck1Z298d22FJJDQnSsCImtVcX2gAVDtg+ZYCPQ==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0",
+            "@wpmedia/news-theme-css": "^4.1.0",
             "styled-components": "^4.4.0"
           },
           "dependencies": {
@@ -14355,7 +14383,7 @@
           "integrity": "sha512-OYobEl3kS5kR+16OQ1dkQO0wMgR3cYfLEV4HXLjGW9h61WtYlTnyRbYK+p31EvBTcpY3c68bP+mFXIJoVRY90Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -14390,7 +14418,7 @@
           "integrity": "sha512-jPn6CN8taFWN8cntUbpsignjI4lwTe/YcIzdl8uBBkb0hyWnHIBdPK1kLy/Z3HHxi3bJrtNaTv7Gpc6j/f0O6Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0",
+            "@wpmedia/news-theme-css": "^4.1.0",
             "styled-components": "^4.4.0"
           },
           "dependencies": {
@@ -14421,7 +14449,7 @@
           "integrity": "sha512-kkCx/nROLCJLmUxSnlClYK7IRi10abPQGyshUlf/hBqZSLfkw+Khn+kHeldlKAzbSzutfzb79h+eu6SlgbfjUw==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0",
+            "@wpmedia/news-theme-css": "^4.1.0",
             "styled-components": "^4.4.0"
           },
           "dependencies": {
@@ -14452,7 +14480,7 @@
           "integrity": "sha512-OYobEl3kS5kR+16OQ1dkQO0wMgR3cYfLEV4HXLjGW9h61WtYlTnyRbYK+p31EvBTcpY3c68bP+mFXIJoVRY90Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -14479,9 +14507,9 @@
       }
     },
     "@wpmedia/news-theme-css": {
-      "version": "4.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/4.0.0/f805365d85dd87792e639f92dbc9d9522f341671263af4efa52b3ee524b85317",
-      "integrity": "sha512-42icwu0ecM5ulq4MjaBgJVp3HTB42zpr+aFKNg7bHjTlPLppG4Nx1Iai6Oirb+yX3d1gL5CeSQje5WSThL17Cw=="
+      "version": "4.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/4.1.0/15e62ff8201be8d64ec1a4e8faf6ddc52e48d1c091075f564898b12ea7333ecb",
+      "integrity": "sha512-D/9sqjPTqVKNHfye9l2I2E2P2HZT4l+7d7sIpEaIOSM9+zUGsmnPDnCDIqDTIKQM5BwH8XjABw2YW29NUoM4xw=="
     },
     "@wpmedia/numbered-list-block": {
       "version": "file:blocks/numbered-list-block"
@@ -15557,7 +15585,7 @@
           "integrity": "sha512-jPn6CN8taFWN8cntUbpsignjI4lwTe/YcIzdl8uBBkb0hyWnHIBdPK1kLy/Z3HHxi3bJrtNaTv7Gpc6j/f0O6Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0",
+            "@wpmedia/news-theme-css": "^4.1.0",
             "styled-components": "^4.4.0"
           },
           "dependencies": {
@@ -15588,7 +15616,7 @@
           "integrity": "sha512-kkCx/nROLCJLmUxSnlClYK7IRi10abPQGyshUlf/hBqZSLfkw+Khn+kHeldlKAzbSzutfzb79h+eu6SlgbfjUw==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0",
+            "@wpmedia/news-theme-css": "^4.1.0",
             "styled-components": "^4.4.0"
           },
           "dependencies": {
@@ -15648,7 +15676,7 @@
           "integrity": "sha512-OYobEl3kS5kR+16OQ1dkQO0wMgR3cYfLEV4HXLjGW9h61WtYlTnyRbYK+p31EvBTcpY3c68bP+mFXIJoVRY90Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -19490,7 +19518,7 @@
           "integrity": "sha512-OYobEl3kS5kR+16OQ1dkQO0wMgR3cYfLEV4HXLjGW9h61WtYlTnyRbYK+p31EvBTcpY3c68bP+mFXIJoVRY90Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {
@@ -19525,7 +19553,7 @@
           "integrity": "sha512-OYobEl3kS5kR+16OQ1dkQO0wMgR3cYfLEV4HXLjGW9h61WtYlTnyRbYK+p31EvBTcpY3c68bP+mFXIJoVRY90Q==",
           "requires": {
             "@wpmedia/engine-theme-sdk": "^2.2.0",
-            "@wpmedia/news-theme-css": "^4.0.0"
+            "@wpmedia/news-theme-css": "^4.1.0"
           },
           "dependencies": {
             "@wpmedia/engine-theme-sdk": {


### PR DESCRIPTION
## Description

Update links bar logic to not include the separator within the anchor link. Move the placement to be outside to not be part of the accessible name of the link

## Jira Ticket
- [PEN-1239](https://arcpublishing.atlassian.net/browse/PEN-1239)

## Acceptance Criteria

When using a screen reader to navigate the site, links in the links bar all read only the link text that is relevant and meaningful

## Test Steps

Using home page - http://localhost/homepage/?_website=the-gazette

1. Checkout this branch `git checkout PEN-1239-link-bar-link-text-includes-separator`
2. In Fusion repo run with share block linked `npx fusion start -f -l @wpmedia/links-bar-block,@wpmedia/header-nav-chain-block,@wpmedia/shared-styles`
3. Navigate to the article page - http://localhost/homepage/?_website=the-gazette
4. Use developer tools to validate the label is correctly on the link
5. Use your keyboard to tab to links bar items and validate on the link text is highlighted


## Effect Of Changes

Header Links Bar before
<img width="1054" alt="PEN-1239-nav-before" src="https://user-images.githubusercontent.com/868127/106453147-c5ad6a00-6480-11eb-919b-b184745ff2cb.png">

Header Links Bar after
<img width="1089" alt="PEN-1239-nav-after" src="https://user-images.githubusercontent.com/868127/106453202-d8c03a00-6480-11eb-9c3d-9c44f3a160be.png">
 

Links Bar before
<img width="819" alt="PEN-1239-links-bar-before" src="https://user-images.githubusercontent.com/868127/106453235-e2e23880-6480-11eb-82b8-d047b43fb207.png">

Links Bar after
<img width="795" alt="PEN-1239-links-bar-after" src="https://user-images.githubusercontent.com/868127/106453252-e970b000-6480-11eb-9410-a9cfde098540.png">

VoiceOver Before
![image](https://user-images.githubusercontent.com/868127/106453290-f7263580-6480-11eb-96c9-7a45e3a7d9ef.png)

VoiceOver After
<img width="625" alt="PEN-1239-voiceover-label-after" src="https://user-images.githubusercontent.com/868127/106453315-01483400-6481-11eb-9346-dc0d4a1e958e.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.