### PR TITLE
Proof of concept to remove fusion dependency within blocks

### DIFF
--- a/blocks/links-bar-block/features/links-bar/compose-hooks.jsx
+++ b/blocks/links-bar-block/features/links-bar/compose-hooks.jsx
@@ -1,0 +1,32 @@
+/*
+  This should be moved to a more global location to allow easier
+  resuse across blocks
+*/
+import React from 'react';
+
+const composeHooks = (hooks) => (Component) => {
+  if (!Component) {
+    throw new Error('Component must be provided to compose');
+  }
+
+  if (!hooks) {
+    return Component;
+  }
+
+  return (props) => {
+    const hooksObject = typeof hooks === 'function' ? hooks(props) : hooks;
+
+    const hooksProps = {};
+
+    Object.entries(hooksObject).forEach((hook) => {
+      const hookName = hook[0];
+      const hookValue = hook[1]();
+
+      hooksProps[hookName] = hookValue;
+    });
+
+    return <Component {...hooksProps} {...props} />;
+  };
+};
+
+export default composeHooks;

--- a/blocks/links-bar-block/features/links-bar/default.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.jsx
@@ -1,60 +1,18 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 import { useContent } from 'fusion:content';
 import { useFusionContext } from 'fusion:context';
-import getThemeStyle from 'fusion:themes';
-import Link from './_children/link';
+import composeHooks from './compose-hooks';
+import LinkBar from './link-bar';
 
-import './links-bar.scss';
-
-const LinkBarSpan = styled.span`
-  a {
-    font-family: ${(props) => props.primaryFont};
-  }
-`;
-
-const LinksBar = ({ customFields: { navigationConfig = {} } }) => {
-  const content = useContent({
-    source: navigationConfig.contentService,
+const LinksBar = composeHooks((props) => ({
+  useFusionContext,
+  useContent: () => useContent({
+    source: props.customFields.navigationConfig.contentService,
     query: {
-      ...navigationConfig.contentConfigValues,
+      ...props.customFields.navigationConfig.contentConfigValues,
     },
-  });
-  const { id, arcSite } = useFusionContext();
-  const menuItems = (content && content.children) ? content.children : [];
-  const showSeparator = !!(
-    content
-    && content.children
-    && content.children.length > 1
-  );
-
-  return (
-    <>
-      <nav key={id} className="links-bar">
-        {menuItems && menuItems.map((item, index) => (
-          <LinkBarSpan
-            className="links-menu"
-            key={item._id}
-            primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-          >
-            {
-              item.node_type === 'link'
-                ? (
-                  <Link href={item.url} name={item.display_name} />
-                )
-                : (
-                  <Link href={item._id} name={item.name} />
-                )
-            }
-            {(content.children.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : ''}
-          </LinkBarSpan>
-        ))}
-      </nav>
-      <hr />
-    </>
-  );
-};
+  }),
+}))(LinkBar);
 
 LinksBar.label = 'Links Bar – Arc Block';
 

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-jest.mock('fusion:themes', () => jest.fn(() => ({})));
+jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 
 describe('the links bar feature for the default output type', () => {
   afterEach(() => {
@@ -39,58 +39,6 @@ describe('the links bar feature for the default output type', () => {
     const wrapper = mount(<LinkBar useContent={content} useFusionContext={fusionContext} />);
 
     expect(wrapper.children().at(0).type()).toBe('nav');
-  });
-
-  it('should not have separator when only one link', () => {
-    const { default: LinksBar } = require('./default');
-    jest.mock('fusion:content', () => ({
-      useContent: jest.fn(() => ({
-        children: [
-          {
-            _id: 'id_1',
-            name: 'test link 1',
-          },
-        ],
-      })),
-    }));
-    const wrapper = shallow(
-      <LinksBar customFields={{ navigationConfig: 'links' }} />,
-    );
-
-    expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"links-bar\\"><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_1/\\">test link 1</a></span></nav><hr/>"',
-    );
-  });
-
-  it('should have separator when more than one link', () => {
-    const { default: LinksBar } = require('./default');
-    jest.mock('fusion:content', () => ({
-      useContent: jest.fn(() => ({
-        children: [
-          {
-            _id: 'id_1',
-            name: 'test link 1',
-          },
-          {
-            _id: 'id_2',
-            name: 'test link 2',
-          },
-          {
-            _id: 'id_3',
-            node_type: 'link',
-            url: '/',
-            display_name: 'Link Text',
-          },
-        ],
-      })),
-    }));
-    const wrapper = shallow(
-      <LinksBar customFields={{ navigationConfig: 'links' }} />,
-    );
-
-    expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"links-bar\\"><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_1/\\">test link 1</a>  •  </span><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_2/\\">test link 2</a>  •  </span><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"/\\">Link Text</a></span></nav><hr/>"',
-    );
   });
 
   it('should contain the equal number of links between input and output', () => {
@@ -179,32 +127,20 @@ describe('the links bar feature for the default output type', () => {
   describe('when a link has query parameters', () => {
     it('should not add a slash at the end of a external link', () => {
       const { default: Link } = require('./_children/link');
-      const wrapper = mount(
-        <Link href="http://example.com/testurl/?query=home" name="test" />,
-      );
+      const wrapper = mount(<Link href="http://example.com/testurl/?query=home" name="test" />);
 
-      expect(wrapper.props().href).toBe(
-        'http://example.com/testurl/?query=home',
-      );
-      expect(
-        wrapper.find('[href="http://example.com/testurl/?query=home"]').length,
-      ).toBe(2);
+      expect(wrapper.props().href).toBe('http://example.com/testurl/?query=home');
+      expect(wrapper.find('[href="http://example.com/testurl/?query=home"]').length).toBe(2);
     });
   });
 
   describe('when a link is to a page', () => {
     it('should not add a slash at the end of the link', () => {
       const { default: Link } = require('./_children/link');
-      const wrapper = mount(
-        <Link href="https://example.com/category/page.html" name="test" />,
-      );
+      const wrapper = mount(<Link href="https://example.com/category/page.html" name="test" />);
 
-      expect(wrapper.props().href).toBe(
-        'https://example.com/category/page.html',
-      );
-      expect(
-        wrapper.find('[href="https://example.com/category/page.html"]').length,
-      ).toBe(2);
+      expect(wrapper.props().href).toBe('https://example.com/category/page.html');
+      expect(wrapper.find('[href="https://example.com/category/page.html"]').length).toBe(2);
     });
   });
 
@@ -221,14 +157,10 @@ describe('the links bar feature for the default output type', () => {
   describe('when a link has a mail', () => {
     it('should not add a slash at the end of the link', () => {
       const { default: Link } = require('./_children/link');
-      const wrapper = mount(
-        <Link href="mailto:readers@washpost.com" name="test" />,
-      );
+      const wrapper = mount(<Link href="mailto:readers@washpost.com" name="test" />);
 
       expect(wrapper.props().href).toBe('mailto:readers@washpost.com');
-      expect(wrapper.find('[href="mailto:readers@washpost.com"]').length).toBe(
-        2,
-      );
+      expect(wrapper.find('[href="mailto:readers@washpost.com"]').length).toBe(2);
     });
   });
 });

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 jest.mock('fusion:themes', () => jest.fn(() => ({})));
 
@@ -18,24 +18,25 @@ describe('the links bar feature for the default output type', () => {
   });
 
   it('should be a nav element', () => {
-    const { default: LinksBar } = require('./default');
-    jest.mock('fusion:content', () => ({
-      useContent: jest.fn(() => ({
-        children: [
-          {
-            _id: 'id_1',
-            name: 'test link 1',
-          },
-          {
-            _id: 'id_2',
-            name: 'test link 2',
-          },
-        ],
-      })),
-    }));
-    const wrapper = shallow(
-      <LinksBar customFields={{ navigationConfig: 'links' }} />,
-    );
+    const { default: LinkBar } = require('./link-bar');
+    const fusionContext = { arcSite: 'abc' };
+    const content = {
+      children: [
+        {
+          _id: 123,
+          node_type: 'link',
+          url: 'http://google.com',
+          display_name: 'Text',
+        },
+        {
+          _id: 123,
+          node_type: 'link',
+          url: 'http://google.com',
+          display_name: 'Text 2',
+        },
+      ],
+    };
+    const wrapper = mount(<LinkBar useContent={content} useFusionContext={fusionContext} />);
 
     expect(wrapper.children().at(0).type()).toBe('nav');
   });
@@ -93,36 +94,33 @@ describe('the links bar feature for the default output type', () => {
   });
 
   it('should contain the equal number of links between input and output', () => {
-    const { default: LinksBar } = require('./default');
-    jest.mock('fusion:content', () => ({
-      useContent: jest.fn(() => ({
-        children: [
-          {
-            _id: 'id_1',
-            name: 'test link 1',
-          },
-          {
-            _id: 'id_2',
-            name: 'test link 2',
-          },
-          {
-            _id: 'id_3',
-            node_type: 'link',
-            url: '/',
-            display_name: 'Link Text',
-          },
-          {
-            _id: 'id_4',
-            node_type: 'link',
-            url: 'http://arcpublishing.com',
-            display_name: 'Link Text',
-          },
-        ],
-      })),
-    }));
-    const wrapper = mount(
-      <LinksBar customFields={{ navigationConfig: 'links' }} />,
-    );
+    const { default: LinkBar } = require('./link-bar');
+    const fusionContext = { arcSite: 'abc' };
+    const content = {
+      children: [
+        {
+          _id: 'id_1',
+          name: 'test link 1',
+        },
+        {
+          _id: 'id_2',
+          name: 'test link 2',
+        },
+        {
+          _id: 'id_3',
+          node_type: 'link',
+          url: '/',
+          display_name: 'Link Text',
+        },
+        {
+          _id: 'id_4',
+          node_type: 'link',
+          url: 'http://arcpublishing.com',
+          display_name: 'Link Text',
+        },
+      ],
+    };
+    const wrapper = mount(<LinkBar useContent={content} useFusionContext={fusionContext} />);
 
     expect(wrapper.find('span.links-menu')).toHaveLength(4);
     expect(wrapper.find('span.links-menu a:not([target])')).toHaveLength(3);
@@ -130,15 +128,10 @@ describe('the links bar feature for the default output type', () => {
   });
 
   it('should have no menu item if no content is returned', () => {
-    jest.mock('fusion:content', () => ({
-      useContent: jest.fn(() => ({
-        children: [],
-      })),
-    }));
-    const { default: LinksBar } = require('./default');
-    const wrapper = shallow(
-      <LinksBar customFields={{ navigationConfig: 'links' }} />,
-    );
+    const { default: LinkBar } = require('./link-bar');
+    const fusionContext = { arcSite: 'abc' };
+    const content = {};
+    const wrapper = mount(<LinkBar useContent={content} useFusionContext={fusionContext} />);
 
     expect(wrapper.find('nav > span')).toHaveLength(0);
   });

--- a/blocks/links-bar-block/features/links-bar/link-bar.jsx
+++ b/blocks/links-bar-block/features/links-bar/link-bar.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+import getThemeStyle from 'fusion:themes';
+import Link from './_children/link';
+
+import './links-bar.scss';
+
+const LinkBarSpan = styled.span`
+  a {
+    font-family: ${(props) => props.primaryFont};
+  }
+`;
+
+const LinkBar = ({
+  useFusionContext: { arcSite, id },
+  useContent: { children: menuItems = [] },
+}) => {
+  const showSeparator = !!(menuItems.length > 1);
+
+  return (
+    <>
+      <nav key={id} className="links-bar">
+        {menuItems && menuItems.map((item, index) => (
+          <LinkBarSpan
+            className="links-menu"
+            key={item._id}
+            primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+          >
+            {
+              item.node_type === 'link'
+                ? (
+                  <Link href={item.url} name={item.display_name} />
+                )
+                : (
+                  <Link href={item._id} name={item.name} />
+                )
+            }
+            {(content.children.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : ''}
+          </LinkBarSpan>
+        ))}
+      </nav>
+      <hr />
+    </>
+  );
+};
+
+export default LinkBar;

--- a/blocks/links-bar-block/features/links-bar/link-bar.jsx
+++ b/blocks/links-bar-block/features/links-bar/link-bar.jsx
@@ -35,7 +35,7 @@ const LinkBar = ({
                   <Link href={item._id} name={item.name} />
                 )
             }
-            {(children.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : ''}
+            {(menuItems.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : ''}
           </LinkBarSpan>
         ))}
       </nav>

--- a/blocks/links-bar-block/features/links-bar/link-bar.jsx
+++ b/blocks/links-bar-block/features/links-bar/link-bar.jsx
@@ -35,7 +35,7 @@ const LinkBar = ({
                   <Link href={item._id} name={item.name} />
                 )
             }
-            {(content.children.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : ''}
+            {(children.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : ''}
           </LinkBarSpan>
         ))}
       </nav>

--- a/blocks/links-bar-block/index.story.jsx
+++ b/blocks/links-bar-block/index.story.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import LinkBar from './features/links-bar/link-bar';
+
+export default {
+  title: 'Link Bar Block',
+  decorators: [withKnobs],
+};
+
+const fusionContext = { arcSite: 'abc' };
+
+export const twoLinks = () => {
+  const content = {
+    children: [
+      {
+        _id: 123,
+        node_type: 'link',
+        url: 'http://google.com',
+        display_name: text('Link 1', 'Link Text'),
+      },
+      {
+        _id: 123,
+        node_type: 'link',
+        url: 'http://google.com',
+        display_name: text('Link 2', 'Link Text'),
+      },
+    ],
+  };
+
+  return (
+    <LinkBar useContent={content} useFusionContext={fusionContext} />
+  );
+};


### PR DESCRIPTION
## Description

Small proof of concept to remove Fusion hooks from being used directly within the block components, moving to a compose model where hook data is passed down to the presentation component. You then use destructing in the component to only get the items you need.

<img width="1038" alt="Google Chrome-2021-02-01-19-20 23" src="https://user-images.githubusercontent.com/868127/106507149-8acc2600-64c2-11eb-97d5-b905ebe540c8.png">
