### PR TITLE
PEN-1382 - See More focus management

### DIFF
--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -67,7 +67,7 @@ class ResultsList extends Component {
     if (prevFocusItem === focusItem && prevFocusItem > 0) {
       const nextItem = resultList.content_elements[focusItem];
       if (nextItem?._id) {
-        this.listItemRefs[nextItem._id].querySelector('a').focus();
+        this.listItemRefs[nextItem._id].querySelector('a:not([aria-hidden])').focus();
       }
     }
   }
@@ -228,6 +228,8 @@ class ResultsList extends Component {
                   <a
                     href={url}
                     title={headlineText}
+                    aria-hidden="true"
+                    tabIndex="-1"
                   >
                     {extractImage(promoItems) ? (
                       <Image

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -36,7 +36,7 @@ const ReadMoreButton = styled.button`
 
   &:not(:disabled):not(.disabled):active:hover,
   &:not(:disabled):not(.disabled):hover:hover {
-    background-color: ${(props) => props.primaryColor}; 
+    background-color: ${(props) => props.primaryColor};
   }
 `;
 
@@ -46,17 +46,30 @@ class ResultsList extends Component {
     super(props);
     this.arcSite = props.arcSite;
     this.state = {
-      storedList: {},
       resultList: {},
       seeMore: true,
       placeholderResizedImageOptions: {},
+      focusItem: 0,
     };
     this.phrases = getTranslatedPhrases(getProperties(props.arcSite).locale || 'en');
+    this.listItemRefs = {};
     this.fetchPlaceholder();
   }
 
   componentDidMount() {
     this.fetchStories(false);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const prevFocusItem = prevState.focusItem;
+    const { focusItem, resultList } = this.state;
+
+    if (prevFocusItem === focusItem && prevFocusItem > 0) {
+      const nextItem = resultList.content_elements[focusItem];
+      if (nextItem?._id) {
+        this.listItemRefs[nextItem._id].querySelector('a').focus();
+      }
+    }
   }
 
   getFallbackImageURL() {
@@ -87,23 +100,24 @@ class ResultsList extends Component {
     const { customFields: { listContentConfig } } = this.props;
     const { contentService, contentConfigValues } = listContentConfig;
     if (additionalStoryAmount) {
-      const { storedList } = this.state;
+      const { resultList } = this.state;
+      const currentCount = resultList?.content_elements?.length;
       // Check for next value
-      if (storedList.next) {
+      if (resultList.next) {
         // Determine content service type
         let value;
         switch (listContentConfig.contentService) {
           case 'story-feed-query':
             value = parseInt(contentConfigValues.size, 10);
-            contentConfigValues.offset = (storedList.next).toString();
-            value += storedList.next;
+            contentConfigValues.offset = (resultList.next).toString();
+            value += resultList.next;
             break;
           case 'story-feed-author':
           case 'story-feed-sections':
           case 'story-feed-tag':
             value = parseInt(contentConfigValues.feedSize, 10);
-            contentConfigValues.feedOffset = (storedList.next).toString();
-            value += storedList.next;
+            contentConfigValues.feedOffset = (resultList.next).toString();
+            value += resultList.next;
             break;
           default:
             break;
@@ -112,12 +126,14 @@ class ResultsList extends Component {
           resultList: {
             source: contentService,
             query: contentConfigValues,
-            transform: (data) => fetchStoriesTransform(data, storedList),
+            transform: (data) => fetchStoriesTransform(data, resultList),
           },
         });
         // Hide button if no more stories to load
-        if (value >= storedList.count) {
-          this.state.seeMore = false;
+        if (value >= resultList.count) {
+          this.setState({
+            seeMore: false,
+          });
         }
       } else if (listContentConfig.contentService === 'content-api-collections') {
         let from = parseInt(contentConfigValues.from, 10) || 0;
@@ -127,7 +143,7 @@ class ResultsList extends Component {
           resultList: {
             source: contentService,
             query: contentConfigValues,
-            transform: (data) => fetchStoriesTransform(data, storedList),
+            transform: (data) => fetchStoriesTransform(data, resultList),
           },
         });
 
@@ -142,10 +158,14 @@ class ResultsList extends Component {
           },
         });
       }
+
+      this.setState({
+        focusItem: currentCount,
+      });
     } else {
       const { fetched } = this.getContent(listContentConfig.contentService, contentConfigValues);
       fetched.then((response) => {
-        this.setState({ resultList: response, storedList: response });
+        this.setState({ resultList: response });
         if (response?.content_elements
           && response?.count
           && response.content_elements.length >= response.count) {
@@ -196,7 +216,13 @@ class ResultsList extends Component {
           const showSeparator = by && by.length !== 0;
           const url = websites[arcSite].website_url;
           return (
-            <div className="list-item" key={`result-card-${url}`}>
+            <div
+              className="list-item"
+              key={`result-card-${url}`}
+              ref={(ref) => {
+                this.listItemRefs[element._id] = ref;
+              }}
+            >
               { promoElements.showImage && (
                 <div className="results-list--image-container mobile-order-2 mobile-image">
                   <a

--- a/blocks/results-list-block/features/results-list/internalTests.test.jsx
+++ b/blocks/results-list-block/features/results-list/internalTests.test.jsx
@@ -91,11 +91,10 @@ describe('fetchStories', () => {
 
     const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFields} />);
     fetchContentMock.mockClear();
-    wrapper.setState({ storedList: { next: 2 } });
+    wrapper.setState({ resultList: { next: 2 } });
     wrapper.update();
     wrapper.instance().fetchStories(true);
 
-    expect(wrapper.state('resultList')).toEqual({});
     expect(fetchContentMock).toHaveBeenCalledTimes(1);
     const partialObj = {
       resultList: {
@@ -111,7 +110,7 @@ describe('fetchStories', () => {
     expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
   });
 
-  it('should make appropriate calculations if has additionalStoryAmount and story-feed-query and no storedList.next', () => {
+  it('should make appropriate calculations if has additionalStoryAmount and story-feed-query and no resultList.next', () => {
     const fetchContentMock = jest.fn().mockReturnValue({});
     ResultsList.prototype.fetchContent = fetchContentMock;
     const fetched = (content) => new Promise((resolve) => {
@@ -121,15 +120,14 @@ describe('fetchStories', () => {
 
     const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFields} />);
     fetchContentMock.mockClear();
-    wrapper.setState({ storedList: {} });
+    wrapper.setState({ resultList: {} });
     wrapper.update();
     wrapper.instance().fetchStories(true);
 
-    expect(wrapper.state('resultList')).toEqual({});
     expect(fetchContentMock).toHaveBeenCalledTimes(0);
   });
 
-  it('should make appropriate calculations if has additionalStoryAmount and story-feed-query and no storedList.next', () => {
+  it('should make appropriate calculations if has additionalStoryAmount and story-feed-query and no resultList.next', () => {
     const fetchContentMock = jest.fn().mockReturnValue({});
     ResultsList.prototype.fetchContent = fetchContentMock;
     const fetched = (content) => new Promise((resolve) => {
@@ -149,11 +147,10 @@ describe('fetchStories', () => {
 
     const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFieldsNoSize} />);
     fetchContentMock.mockClear();
-    wrapper.setState({ storedList: { next: 2 } });
+    wrapper.setState({ resultList: { next: 2 } });
     wrapper.update();
     wrapper.instance().fetchStories(true);
 
-    expect(wrapper.state('resultList')).toEqual({});
     expect(fetchContentMock).toHaveBeenCalledTimes(1);
     const partialObj = {
       resultList: {
@@ -170,7 +167,7 @@ describe('fetchStories', () => {
     expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
   });
 
-  it('should make appropriate calculations if has additionalStoryAmount and non-specified and no storedList.next', () => {
+  it('should make appropriate calculations if has additionalStoryAmount and non-specified and no resultList.next', () => {
     const fetchContentMock = jest.fn().mockReturnValue({});
     ResultsList.prototype.fetchContent = fetchContentMock;
     const fetched = (content) => new Promise((resolve) => {
@@ -190,11 +187,10 @@ describe('fetchStories', () => {
 
     const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFieldsOther} />);
     fetchContentMock.mockClear();
-    wrapper.setState({ storedList: { next: 2 } });
+    wrapper.setState({ resultList: { next: 2 } });
     wrapper.update();
     wrapper.instance().fetchStories(true);
 
-    expect(wrapper.state('resultList')).toEqual({});
     expect(fetchContentMock).toHaveBeenCalledTimes(1);
     const partialObj = {
       resultList: {
@@ -229,7 +225,7 @@ describe('fetchStories', () => {
 
     const wrapper = shallow(<ResultsList arcSite="the-sun" contextPath="/pf" customFields={customFieldsStoryFeed} />);
     fetchContentMock.mockClear();
-    wrapper.setState({ storedList: { next: 2, count: 0 } });
+    wrapper.setState({ resultList: { next: 2, count: 0 } });
     wrapper.update();
     wrapper.instance().fetchStories(true);
 
@@ -238,18 +234,18 @@ describe('fetchStories', () => {
 });
 
 describe('fetchStoriesTransform', () => {
-  it('if has no data, return storedList', () => {
+  it('if has no data, return resultList', () => {
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
     const fetched = (content) => new Promise((resolve) => {
       resolve(content);
     });
     ResultsList.prototype.getContent = jest.fn().mockReturnValue({ fetched: fetched({}) });
 
-    const result = fetchStoriesTransform(null, 'storedList');
-    expect(result).toEqual('storedList');
+    const result = fetchStoriesTransform(null, 'resultList');
+    expect(result).toEqual('resultList');
   });
 
-  it('if has  data, return concatenated data with storedList', () => {
+  it('if has  data, return concatenated data with resultList', () => {
     ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
 
     const result = fetchStoriesTransform({ content_elements: ['A', 'B'], next: 10 }, { content_elements: ['C', 'D'] });


### PR DESCRIPTION
## Description

Update the result list component to set focus on the first loaded story after using the "See More" button

## Jira Ticket
- [PEN-1382](https://arcpublishing.atlassian.net/browse/PEN-1382)

## Acceptance Criteria

'See More' results focus should be on the first of the loaded stories.

## Test Steps

Using page - http://localhost/pf/local/?_website=the-gazette

1. Checkout this branch `git checkout PEN-1382-see-more-focus`
2. In Fusion repo run with share block linked `npx fusion start -f -l @wpmedia/results-list-block`
3. Navigate to the follow page - http://localhost/pf/local/?_website=the-gazette
4. Scroll down to see the "See More" button
5. Click on the button
6. After results have loaded click the tab button on your keyboard
7. Next item to be focused is the 11th article - the first one from the next set to be added

## Effect Of Changes
### Before

Focus is sent to the side bar


### After

https://user-images.githubusercontent.com/868127/106643203-46ec2600-6581-11eb-8855-abe26597e676.mp4


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.