### PR TITLE
PEN-1700 - Top Table List - Small items spacing -> RC

### DIFF
--- a/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
@@ -110,7 +110,7 @@ const SmallListItem = (props) => {
   return (
     <article
       key={id}
-      className={`top-table-list-small-promo small-promo ${colClasses} layout-section wrap-bottom`}
+      className={`top-table-list-small-promo small-promo ${colClasses}`}
     >
       <div className={`promo-container ${layout} ${isReverseLayout ? 'reverse' : ''} sm-promo-padding-btm`}>
         { showHeadline && <PromoHeadline /> }

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -1,5 +1,6 @@
 .top-table-list-section-small {
   hr {
+    margin: calculateRem(16px) 0;
     width: 100%;
   }
 }


### PR DESCRIPTION
## Description

Fixes the spacing issue on top table list - small items to match the intended design secs of 16px

**Note:** This PR is pointed to `rc` as it's needed for the next release

## Jira Ticket
- [PEN-1700](https://arcpublishing.atlassian.net/browse/PEN-1700)

## Acceptance Criteria

Per our design specs, there should be only 16px spacing above and 16px below the horizontal rule

## Test Steps

_Ensure you have PB data from production_

Using page - http://localhost/pf/top-table-list-configs/?_website=the-gazette

1. Checkout this branch `git checkout PEN-1700-top-list-small-items-spacing`
2. In Fusion repo run with share block linked `npx fusion start -f -l @wpmedia/top-table-list`
3. Navigate to the follow page - http://localhost/pf/top-table-list-configs/?_website=the-gazette
4. Verify the spacing between the horizontal rule is 16px above and below
5. From page builder you can edit the feature and update the custom field Show border bottom on Small story setting
6. Verify the spacing is now 32px (the border is hidden) and the spacing remains the same

## Effect Of Changes

### After

<img width="1000" alt="PEN-1700-after" src="https://user-images.githubusercontent.com/868127/106766192-87a37800-6631-11eb-8b42-40b68008d900.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.