### PR TITLE
PEN-670 - Reduce duplication of article titles being read twice by assistive technology

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -37,20 +37,20 @@ const ExtraLargeManualPromo = ({ customFields }) => {
     query: { raw_image_url: customFields.imageURL, 'arc-site': arcSite },
   });
 
-  const renderWithLink = useCallback((element, props) => (
+  const renderWithLink = useCallback((element, props, attributes) => (
     <a
       href={customFields.linkURL || '#'}
       className={(props && props.className) || ''}
-      title={customFields.headline}
       target={customFields.newTab ? '_blank' : '_self'}
       rel={customFields.newTab ? 'noreferrer' : ''}
       onClick={!customFields.linkURL ? (evt) => {
         evt.preventDefault();
       } : undefined}
+      {...attributes}
     >
       {element}
     </a>
-  ), [customFields.linkURL, customFields.headline, customFields.newTab]);
+  ), [customFields.linkURL, customFields.newTab]);
 
   return (
     <>
@@ -103,7 +103,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                   resizedImageOptions={resizedImageOptions}
-                />,
+                />, {}, { 'aria-hidden': 'true', tabIndex: '-1' },
               )}
               {(customFields.showDescription && customFields.description)
               && (

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -86,11 +86,7 @@ const ExtraLargePromo = ({ customFields }) => {
   const headlineTmpl = () => {
     if (customFields.showHeadline && headlineText) {
       return (
-        <a
-          href={content.website_url}
-          className="xl-promo-headline"
-          title={headlineText}
-        >
+        <a href={content.website_url} className="xl-promo-headline">
           <HeadlineText
             primaryFont={getThemeStyle(arcSite)['primary-font-family']}
             className="xl-promo-headline"
@@ -174,10 +170,7 @@ const ExtraLargePromo = ({ customFields }) => {
                 ) || (
                   customFields.showImage
                     && (
-                      <a
-                        href={content.website_url}
-                        title={content && content.headlines ? content.headlines.basic : ''}
-                      >
+                      <a href={content.website_url} aria-hidden="true" tabIndex="-1">
                         {imageURL
                           ? (
                             <Image

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -38,20 +38,20 @@ const LargeManualPromo = ({ customFields }) => {
     query: { raw_image_url: customFields.imageURL, 'arc-site': arcSite },
   });
 
-  const renderWithLink = useCallback((element, props) => (
+  const renderWithLink = useCallback((element, props, attributes) => (
     <a
       href={customFields.linkURL || '#'}
       className={(props && props.className) || ''}
-      title={customFields.headline}
       target={customFields.newTab ? '_blank' : '_self'}
       rel={customFields.newTab ? 'noreferrer noopener' : ''}
       onClick={!customFields.linkURL ? (evt) => {
         evt.preventDefault();
       } : undefined}
+      {...attributes}
     >
       {element}
     </a>
-  ), [customFields.linkURL, customFields.headline, customFields.newTab]);
+  ), [customFields.linkURL, customFields.newTab]);
 
   return (
     <>
@@ -74,7 +74,7 @@ const LargeManualPromo = ({ customFields }) => {
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                   resizedImageOptions={resizedImageOptions}
-                />,
+                />, {}, { 'aria-hidden': 'true', tabIndex: '-1' },
               )}
             </div>
           )}

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -88,11 +88,7 @@ const LargePromo = ({ customFields }) => {
   const headlineTmpl = () => {
     if (customFields.showHeadline && headlineText) {
       return (
-        <a
-          href={content.website_url}
-          className="lg-promo-headline"
-          title={headlineText}
-        >
+        <a href={content.website_url} className="lg-promo-headline">
           <HeadlineText
             primaryFont={getThemeStyle(arcSite)['primary-font-family']}
             className="lg-promo-headline"
@@ -168,10 +164,7 @@ const LargePromo = ({ customFields }) => {
                     enableAutoplay={false}
                   />
                 ) : (
-                  <a
-                    href={content.website_url}
-                    title={content && content.headlines ? content.headlines.basic : ''}
-                  >
+                  <a href={content.website_url} aria-hidden="true" tabIndex="-1">
                     {
                       imageURL
                         ? (

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -31,20 +31,20 @@ const MediumManualPromo = ({ customFields }) => {
 
   const hasImage = customFields.showImage && customFields.imageURL;
 
-  const renderWithLink = useCallback((element, props) => (
+  const renderWithLink = useCallback((element, props, attributes) => (
     <a
       href={customFields.linkURL || '#'}
       className={(props && props.className) || ''}
-      title={customFields.headline}
       target={customFields.newTab ? '_blank' : '_self'}
       rel={customFields.newTab ? 'noreferrer noopener' : ''}
       onClick={!customFields.linkURL ? (evt) => {
         evt.preventDefault();
       } : undefined}
+      {...attributes}
     >
       {element}
     </a>
-  ), [customFields.linkURL, customFields.headline, customFields.newTab]);
+  ), [customFields.linkURL, customFields.newTab]);
 
   return (
     <>
@@ -64,7 +64,7 @@ const MediumManualPromo = ({ customFields }) => {
               breakpoints={breakpoints}
               resizerURL={getProperties(arcSite)?.resizerURL}
               resizedImageOptions={resizedImageOptions}
-            />, { className: 'image-link' },
+            />, { className: 'image-link' }, { 'aria-hidden': 'true', tabIndex: '-1' },
           )}
           {(customFields.showHeadline || customFields.showDescription)
           && (

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -62,12 +62,7 @@ const MediumPromo = ({ customFields }) => {
   const headlineTmpl = () => {
     if (customFields.showHeadline && headlineText) {
       return (
-        <a
-          href={content.website_url}
-          className="md-promo-headline"
-          // className={`md-promo-headline headline-${customFields.headlinePosition}`}
-          title={headlineText}
-        >
+        <a href={content.website_url} className="md-promo-headline">
           <HeadlineText
             primaryFont={getThemeStyle(arcSite)['primary-font-family']}
             className="md-promo-headline-text"
@@ -134,11 +129,7 @@ const MediumPromo = ({ customFields }) => {
         <div className={`medium-promo-wrapper ${customFields.showImage ? 'md-promo-image' : ''}`}>
           {customFields.showImage
           && (
-            <a
-              className="image-link"
-              href={content.website_url}
-              title={content && content.headlines ? content.headlines.basic : ''}
-            >
+            <a className="image-link" href={content.website_url} aria-hidden="true" tabIndex="-1">
               {
                 imageURL
                   ? (

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -100,11 +100,7 @@ class NumberedList extends Component {
               <div className="numbered-list-item numbered-item-margins" key={`result-card-${url}`} type="1">
                 {showHeadline
                 && (
-                <a
-                  href={url}
-                  title={headlineText}
-                  className="headline-list-anchor"
-                >
+                <a href={url} className="headline-list-anchor">
                   <SecondaryFont as="p" className="list-item-number">{i + 1}</SecondaryFont>
                   <PrimaryFont as="h2" className="headline-text">{headlineText}</PrimaryFont>
                 </a>
@@ -113,8 +109,9 @@ class NumberedList extends Component {
                 && (
                 <a
                   href={url}
-                  title={headlineText}
                   className="list-anchor-image vertical-align-image"
+                  aria-hidden="true"
+                  tabIndex="-1"
                 >
                   {extractImage(promoItems) ? (
                     <Image

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
@@ -44,11 +44,7 @@ const SearchResult = ({
     <div className="list-item" key={`result-card-${url}`}>
       { showImage && (
         <div className="results-list--image-container mobile-order-2 mobile-image">
-          <a
-            href={url}
-            title={headlineText}
-            className="list-anchor"
-          >
+          <a href={url} className="list-anchor" aria-hidden="true" tabIndex="-1">
             {extractImage(promoItems) ? (
               <Image
                 url={extractImage(promoItems)}
@@ -83,11 +79,7 @@ const SearchResult = ({
       )}
       { showHeadline && (
         <div className="results-list--headline-container mobile-order-1">
-          <a
-            href={url}
-            title={headlineText}
-            className="list-anchor"
-          >
+          <a href={url} className="list-anchor">
             <HeadlineText
               primaryFont={getThemeStyle(arcSite)['primary-font-family']}
               className="headline-text"

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.test.jsx
@@ -172,7 +172,6 @@ describe('The search results', () => {
       const headline = wrapper.find('.list-item').find('.results-list--headline-container');
       expect(headline.length).toEqual(1);
       expect(headline.find('.list-anchor').length).toEqual(1);
-      expect(headline.find('.list-anchor').prop('title')).toEqual('Article with a YouTube embed in it');
       expect(headline.find('h2.headline-text').length).toEqual(1);
       expect(headline.text()).toEqual('Article with a YouTube embed in it');
     });
@@ -199,7 +198,6 @@ describe('The search results', () => {
       const image = wrapper.find('.list-item').find('.results-list--image-container');
       expect(image.length).toEqual(1);
       expect(image.find('.list-anchor').length).toEqual(1);
-      expect(image.find('.list-anchor').prop('title')).toEqual('Article with a YouTube embed in it');
       expect(image.find('Image').length).toEqual(1);
       expect(image.find('Image').prop('alt')).toEqual('Article with a YouTube embed in it');
     });

--- a/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
+++ b/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
@@ -24,8 +24,9 @@ const StoryItem = (props) => {
       {showImage ? (
         <a
           href={websiteURL}
-          title={itemTitle}
           className="simple-list-anchor"
+          aria-hidden="true"
+          tabIndex="-1"
         >
           {imageURL !== '' ? (
             <Image
@@ -65,7 +66,6 @@ const StoryItem = (props) => {
         <a
           className="simple-list-headline-anchor"
           href={websiteURL}
-          title={itemTitle}
         >
           <Title primaryFont={primaryFont} className="simple-list-headline-text">
             {itemTitle}

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -35,20 +35,20 @@ const SmallManualPromo = ({ customFields }) => {
     imageClass: 'col-sm-xl-4',
   };
 
-  const renderWithLink = useCallback((element, props) => (
+  const renderWithLink = useCallback((element, props, attributes) => (
     <a
       href={customFields.linkURL || '#'}
       className={(props && props.className) || ''}
-      title={customFields.headline}
       target={customFields.newTab ? '_blank' : '_self'}
       rel={customFields.newTab ? 'noreferrer noopener' : ''}
       onClick={!customFields.linkURL ? (evt) => {
         evt.preventDefault();
       } : undefined}
+      {...attributes}
     >
       {element}
     </a>
-  ), [customFields.linkURL, customFields.headline, customFields.newTab]);
+  ), [customFields.linkURL, customFields.newTab]);
 
   const headline = customFields.showHeadline && customFields.headline
     && (
@@ -81,7 +81,7 @@ const SmallManualPromo = ({ customFields }) => {
             breakpoints={getProperties(arcSite)?.breakpoints}
             resizerURL={getProperties(arcSite)?.resizerURL}
             resizedImageOptions={resizedImageOptions}
-          />,
+          />, {}, { 'aria-hidden': 'true', tabIndex: '-1' },
         )}
       </div>
     );

--- a/blocks/small-promo-block/features/small-promo/_children/__snapshots__/promo_headline.test.jsx.snap
+++ b/blocks/small-promo-block/features/small-promo/_children/__snapshots__/promo_headline.test.jsx.snap
@@ -14,7 +14,6 @@ exports[`promo headline return null while no content available in props 1`] = `
   >
     <a
       className="sm-promo-headline"
-      title=""
     >
       <styled.h2
         className="sm-promo-headline"

--- a/blocks/small-promo-block/features/small-promo/_children/promo_headline.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_headline.jsx
@@ -21,11 +21,7 @@ const PromoHeadline = (props) => {
   return content ? (
 
     <div className={`promo-headline ${headlineMarginClass}`}>
-      <a
-        href={content.website_url}
-        className="sm-promo-headline"
-        title={content?.headlines?.basic || ''}
-      >
+      <a href={content.website_url} className="sm-promo-headline">
         <HeadlineText
           primaryFont={
             getThemeStyle(arcSite)[

--- a/blocks/small-promo-block/features/small-promo/_children/promo_image.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_image.jsx
@@ -33,10 +33,7 @@ const PromoImage = (props) => {
       <div className={`promo-image ${getPromoStyle(imagePosition, 'margin')}`}>
         <div className="flex no-image-padding">
           {/* <div className="col-sm-xl-4 flex-col"> // from default */}
-          <a
-            href={content?.website_url || ''}
-            title={content?.headlines?.basic || ''}
-          >
+          <a href={content?.website_url || ''} aria-hidden="true" tabIndex="-1">
             {imageURL
               ? (
                 <Image

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -73,7 +73,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineLG && itemTitle) {
       return (
-        <a href={websiteURL} title={itemTitle} className="lg-promo-headline">
+        <a href={websiteURL} className="lg-promo-headline">
           <Title primaryFont={primaryFont} className="lg-promo-headline">
             {itemTitle}
           </Title>
@@ -146,7 +146,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
               ) || (
                 <>
                   { imageURL ? (
-                    <a href={websiteURL} title={itemTitle}>
+                    <a href={websiteURL} aria-hidden="true" tabIndex="-1">
                       <Image
                         resizedImageOptions={resizedImageOptions}
                         url={imageURL}

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -47,7 +47,7 @@ const MediumListItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineMD && itemTitle !== '') {
       return (
-        <a href={websiteURL} title={itemTitle} className="md-promo-headline">
+        <a href={websiteURL} className="md-promo-headline">
           <Title className="md-promo-headline-text" primaryFont={primaryFont}>
             {itemTitle}
           </Title>
@@ -104,23 +104,14 @@ const MediumListItem = (props) => {
     <>
       <article className="container-fluid medium-promo" key={id}>
         <div className={`promo-item-margins medium-promo-wrapper ${customFields.showImageMD ? 'md-promo-image' : ''}`}>
-          {/* {customFields.headlinePositionMD === 'above'
-            && (customFields.showHeadlineMD
-              || customFields.showDescriptionMD
-              || customFields.showBylineMD
-              || customFields.showDateMD) && (
-              <div className={textClass}>
-                {headlineTmpl()}
-                {descriptionTmpl()}
-                <div className="article-meta">
-                  {byLineTmpl()}
-                  {dateTmpl()}
-                </div>
-              </div>
-          )} */}
           {customFields.showImageMD
             && (
-            <a className="image-link" href={websiteURL} title={itemTitle}>
+            <a
+              className="image-link"
+              href={websiteURL}
+              aria-hidden="true"
+              tabIndex="-1"
+            >
               {imageURL !== '' ? (
                 <Image
                   resizedImageOptions={resizedImageOptions}

--- a/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
@@ -52,11 +52,7 @@ const SmallListItem = (props) => {
 
   const PromoHeadline = () => (
     <div className="promo-headline headline-wrap">
-      <a
-        href={websiteURL}
-        title={itemTitle}
-        className="sm-promo-headline"
-      >
+      <a href={websiteURL} className="sm-promo-headline">
         <Title primaryFont={primaryFont} className="sm-promo-headline">
           {itemTitle}
         </Title>
@@ -67,7 +63,7 @@ const SmallListItem = (props) => {
   const PromoImage = () => (
     <div className="promo-image flex-col">
       { imageURL !== '' ? (
-        <a href={websiteURL} title={itemTitle}>
+        <a href={websiteURL} aria-hidden="true" tabIndex="-1">
           <Image
             resizedImageOptions={resizedImageOptions}
             url={imageURL}

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -70,7 +70,7 @@ const VerticalOverlineImageStoryItem = (props) => {
   const headlineTmpl = () => {
     if (customFields.showHeadlineXL && itemTitle) {
       return (
-        <a href={websiteURL} title={itemTitle} className="xl-promo-headline">
+        <a href={websiteURL} className="xl-promo-headline">
           <Title primaryFont={primaryFont} className="xl-promo-headline">
             {itemTitle}
           </Title>
@@ -149,7 +149,7 @@ const VerticalOverlineImageStoryItem = (props) => {
                   ) || (
                     <>
                       { imageURL ? (
-                        <a href={websiteURL} title={itemTitle}>
+                        <a href={websiteURL} aria-hidden="true" tabIndex="-1">
                           <div className="image-wrapper">
                             <Image
                               resizedImageOptions={resizedImageOptions}


### PR DESCRIPTION
## Description

By applying `aria-hidden` and `tabindex` of `-1` to images that are wrapped in `a`nchors we reduce the duplication of links that
1. a user of assistive technology has to tab through
2. reduce the amount of links a screen reader will see in their application (reduce the duplication)

## Jira Ticket
- [PEN-670](https://arcpublishing.atlassian.net/browse/PEN-670)

## Acceptance Criteria

Screen reader should read the available articles as heading links only. For instance, "Apex Legends’ Season 4 trailer provides few answers......" heading level 2 link

## Test Steps

Grab a page builder data backup to get the page Test - All Promos - https://corecomponents.arcpublishing.com/pf/test-all-promos/?_website=the-gazette
If the backup does not have the page, you will need to recreate that page locally

1. Checkout this branch `git checkout PEN-670-article-heading-read-twice`
2. In Fusion repo run with all promo blocks linked `npx fusion start -f -l @wpmedia/extra-large-manual-promo-block,@wpmedia/extra-large-promo-block,@wpmedia/large-manual-promo-block,@wpmedia/large-promo-block,@wpmedia/medium-manual-promo-block,@wpmedia/medium-promo-block,@wpmedia/numbered-list-block,@wpmedia/search-results-list-block,@wpmedia/small-manual-promo-block,@wpmedia/small-promo-block,@wpmedia/top-table-list-block`
3. Navigate to either the Test - All Promos page, or the one you created
4. Using your keyboard tab though the page
5. Verify only the headlines are focused and not the image links


## Effect Of Changes
### Before

Video showing current tabbing behaviour of tabbing to image then headline

https://user-images.githubusercontent.com/868127/107032830-57ccaf80-67ac-11eb-8814-12e6c6d13968.mp4


### After

Video showing tab focus is only set on headlines and not the image links

https://user-images.githubusercontent.com/868127/107032871-67e48f00-67ac-11eb-9eec-1d297955ac10.mp4


## Dependencies or Side Effects
**N/A**

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.