### PR TITLE
PEN-1702 - Use PrimaryFont component within simple list block

### DIFF
--- a/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
+++ b/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
+import { PrimaryFont } from '@wpmedia/shared-styles';
 import { Image } from '@wpmedia/engine-theme-sdk';
 import getProperties from 'fusion:properties';
-
-import Title from './title';
 
 const StoryItem = (props) => {
   const {
     itemTitle = '',
     imageURL = '',
     id = '',
-    primaryFont = '',
     websiteURL,
     showHeadline,
     showImage,
@@ -67,9 +65,9 @@ const StoryItem = (props) => {
           href={websiteURL}
           title={itemTitle}
         >
-          <Title primaryFont={primaryFont} className="simple-list-headline-text">
+          <PrimaryFont as="h2" className="simple-list-headline-text">
             {itemTitle}
-          </Title>
+          </PrimaryFont>
         </a>
       ) : null}
     </article>

--- a/blocks/simple-list-block/features/simple-list/_children/story-item.test.jsx
+++ b/blocks/simple-list-block/features/simple-list/_children/story-item.test.jsx
@@ -6,6 +6,14 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <img url="" alt="placeholder placeholder" />,
 }));
 
+jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+
+jest.mock('fusion:context', () => ({
+  useFusionContext: jest.fn(() => ({
+    arcSite: 'the-gazette',
+  })),
+}));
+
 jest.mock('fusion:properties', () => (jest.fn(() => ({
   fallbackImage: 'placeholder.jpg',
 }))));

--- a/blocks/simple-list-block/features/simple-list/_children/title.jsx
+++ b/blocks/simple-list-block/features/simple-list/_children/title.jsx
@@ -1,7 +1,0 @@
-import styled from 'styled-components';
-
-const Title = styled.h2`
-  font-family: ${(props) => props.primaryFont};
-`;
-
-export default Title;

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useContent } from 'fusion:content';
 import { useFusionContext } from 'fusion:context';
 import { extractResizedParams } from '@wpmedia/resizer-image-block';
-import getThemeStyle from 'fusion:themes';
+import { PrimaryFont } from '@wpmedia/shared-styles';
 import getProperties from 'fusion:properties';
 import Consumer from 'fusion:consumer';
 import StoryItem from './_children/story-item';
@@ -103,8 +103,6 @@ const SimpleList = (props) => {
     websiteDomain,
   } = getProperties(arcSite);
 
-  const primaryFont = getThemeStyle(arcSite)['primary-font-family'];
-
   // need to inject the arc site here into use content
   const { content_elements: contentElements = [] } = useContent({
     source: contentService,
@@ -115,9 +113,9 @@ const SimpleList = (props) => {
     <div key={id} className="list-container layout-section">
       { title
         && (
-        <div className="list-title" primaryFont={primaryFont}>
+        <PrimaryFont as="div" className="list-title">
           {title}
-        </div>
+        </PrimaryFont>
         )}
       {
         contentElements.reduce(unserializeStory(arcSite), []).map(({
@@ -129,7 +127,6 @@ const SimpleList = (props) => {
               id={listItemId}
               itemTitle={itemTitle}
               imageURL={imageURL}
-              primaryFont={primaryFont}
               websiteURL={websiteURL}
               websiteDomain={websiteDomain}
               showHeadline={showHeadline}

--- a/blocks/simple-list-block/package.json
+++ b/blocks/simple-list-block/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "canary",
     "@wpmedia/news-theme-css": "stable",
-    "styled-components": "^4.4.0"
+    "@wpmedia/shared-styles": "canary"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9543,9 +9543,9 @@
       }
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.8.1-canary.26",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.8.1-canary.26/0d5d412dd44e1ff2e3235d6b63e8c60d48c6ed8e4111ee81e2543aefcaa17cdd",
-      "integrity": "sha512-Xil1eP87ycMGrXaZxh+kmxYcYjPpqW3YJVyedcev4KpBANtPpmpiTOOE3dZd/OYPkCW9ClwM98T1GpJrMZutIA==",
+      "version": "2.8.1-canary.29",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.8.1-canary.29/b3590dee5ecf919a3a3af7a918751f777ff64f142be23f7878ea72f4f2eaab87",
+      "integrity": "sha512-mgaJnQ/fgOi4yW5s9SSnigeC0rSKmcc9SCyzUTAAVDm9ktuQ2klLcbGuhBjh8PQAybcEyBPdtzFr193xLgXOBQ==",
       "dev": true,
       "requires": {
         "dom-parser": "^0.1.6",
@@ -9564,9 +9564,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"


### PR DESCRIPTION
## Description

Update simple list block to use the PrimaryFont shared styles block

## Jira Ticket
- [PEN-1702](https://arcpublishing.atlassian.net/browse/PEN-1702)

## Acceptance Criteria

GitHub issue https://github.com/WPMedia/fusion-news-theme-blocks/issues/702

## Test Steps

1. Checkout this branch `PEN-1702-simple-list-primary-font`
2. In Fusion repo run with all promo blocks linked `npx fusion start -f -l @wpmedia/simple-list-block`
3. Open the homepage - http://localhost/pf/homepage/?_website=the-gazette
4. In the sidebar you'll see the simple list bock
5. Verify the heading "Latest News" has the primary font class and styles applied and not output with the attribute primaryFont

## Effect Of Changes
### Before

<img width="1328" alt="PEN-1702-before" src="https://user-images.githubusercontent.com/868127/107057561-85752100-67cb-11eb-9a5f-824e90d2bf3d.png">


### After

<img width="1601" alt="PEN-1702-after" src="https://user-images.githubusercontent.com/868127/107057583-8c9c2f00-67cb-11eb-8eec-35327acf6c73.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.