### PR TITLE
Update correction output to be H2 element, but maintain existing styling

### DIFF
--- a/blocks/article-body-block/chains/article-body/_articlebody.scss
+++ b/blocks/article-body-block/chains/article-body/_articlebody.scss
@@ -125,7 +125,6 @@
 
     padding: map-get($spacers, 'sm') 0;
 
-    div,
     p {
       color: $ui-medium-gray;
       display: inline;
@@ -136,7 +135,7 @@
       margin: 0;
     }
 
-    h6 {
+    h2 {
       font-style: italic;
       text-transform: uppercase;
     }
@@ -277,7 +276,7 @@
       &:hover {
         border-bottom: 1px solid #7f7f7f;
       }
-      
+
     }
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
       margin-bottom: map-get($spacers, 'lg');

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -143,8 +143,8 @@ function parseArticleItem(item, index, arcSite, phrases, id) {
       return (item.text && item.text.length > 0) ? (
         <Fragment key={key}>
           <section className="correction">
-            <h6>{item.correction_type || 'Correction'}</h6>
-            <div>{item.text}</div>
+            <h2 className="h6-primary">{item.correction_type || 'Correction'}</h2>
+            <p>{item.text}</p>
           </section>
         </Fragment>
       ) : null;

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -952,6 +952,8 @@ describe('article-body chain', () => {
         </ArticleBodyChain>,
       );
       expect(wrapper.find('.correction')).toHaveLength(1);
+      expect(wrapper.find('.correction h2')).toHaveLength(1);
+      expect(wrapper.find('.correction p')).toHaveLength(1);
     });
 
     it('should not render correction when no data is provided', () => {


### PR DESCRIPTION
## Description

Update correction output to be a `h2` in markup to maintain hierarchy order with headings on an article page, whilst maintaining the existing styling.
Also updated the text output to use the `p` tag for semantic meaning

## Jira Ticket
- [PEN-674](https://arcpublishing.atlassian.net/browse/PEN-674)

## Acceptance Criteria

User Impact - If If headings and subheadings are not positioned in a hierarchy, it will be difficult for a screen reader user to understand and distinguish between main topics and subtopics of the page content, while cycling through all of the headings.

Dev Recommendations:  Headings must be in a valid logical order, 

## Test Steps

1. Checkout out this PR's branch `git checkout PEN-674-incorrect-subheading-level`
2. Run New Theme Feature pack with the article-body-block linked `npx fusion start -f -l @wpmedia/article-body-block`
3. Goto an article page that has a correction block output - http://localhost/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/?_website=the-gazette
4. Verify it's using an `h2` in markup and maintains existing styling


## Effect Of Changes
### Before

<img width="926" alt="PEN-674-before" src="https://user-images.githubusercontent.com/868127/107359673-e141f180-6acc-11eb-8f26-6eeca565407a.png">

### After

<img width="925" alt="PEN-674-after" src="https://user-images.githubusercontent.com/868127/107359696-e69f3c00-6acc-11eb-88a4-dc02e10a4b65.png">

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.