### PR TITLE
PEN-1763 nav chain links spacing regression

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
@@ -66,7 +66,7 @@ const HorizontalLinksBar = ({ hierarchy, navBarColor, showHorizontalSeperatorDot
                   />
                 )
             }
-            {(content.children.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : '\u00A0'}
+            {(content.children.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : '\u00A0  \u00A0'}
           </LinkBarSpan>
         ))}
       </nav>

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
@@ -65,7 +65,6 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a> </span></nav>"',
       '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>    </span></nav>"',
     );
   });
@@ -98,7 +97,6 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a> </span></nav>"',
       '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a>    </span></nav>"',
     );
   });
@@ -127,7 +125,6 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a> </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a> </span></nav>"',
       '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>    </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>    </span></nav>"',
     );
   });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
@@ -66,6 +66,7 @@ describe('the links bar feature for the default output type', () => {
 
     expect(wrapper.html()).toMatchInlineSnapshot(
       '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a> </span></nav>"',
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>    </span></nav>"',
     );
   });
 
@@ -98,6 +99,7 @@ describe('the links bar feature for the default output type', () => {
 
     expect(wrapper.html()).toMatchInlineSnapshot(
       '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a> </span></nav>"',
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a>    </span></nav>"',
     );
   });
 
@@ -126,6 +128,7 @@ describe('the links bar feature for the default output type', () => {
 
     expect(wrapper.html()).toMatchInlineSnapshot(
       '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a> </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a> </span></nav>"',
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>    </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>    </span></nav>"',
     );
   });
 


### PR DESCRIPTION
## Description

Fix a regression on the header nav chain links spacing

## Jira Ticket
- [PEN-1763](https://arcpublishing.atlassian.net/browse/PEN-1763)

## Test Steps

Using home page - http://localhost/homepage/?_website=the-gazette

1. Checkout this branch `git checkout PEN-1763-nav-chain-links-spacing-regression`
2. In Fusion repo run with header nav chain block linked `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Navigate to the article page - http://localhost/homepage/?_website=the-gazette
4. Verify there is spacing between the link items in the navigation chain
5. In pagebuilder you can use the custom fields to enable separator and verify the separator is then displayed


## Effect Of Changes
### Before

<img width="1030" alt="PEN-1763-before" src="https://user-images.githubusercontent.com/868127/107375828-122c2180-6ae1-11eb-8862-65075f88ffc9.png">


### After

<img width="1060" alt="PEN-1763-after" src="https://user-images.githubusercontent.com/868127/107375843-17896c00-6ae1-11eb-827a-26ac999fa42a.png">


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.