### PR TITLE
PEN-1763 - Regression - Update header links bar

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
@@ -48,7 +48,7 @@ const HorizontalLinksBar = ({ hierarchy, navBarColor, showHorizontalSeperatorDot
             primaryFont={font}
             navBarColor={navBarColor}
           >
-
+            {(index > 0 && showSeparator) ? '\u00a0 • \u00a0' : '\u00A0  \u00A0'}
             {
               item.node_type === 'link'
                 ? (
@@ -66,7 +66,6 @@ const HorizontalLinksBar = ({ hierarchy, navBarColor, showHorizontalSeperatorDot
                   />
                 )
             }
-            {(content.children.length !== index + 1 && showSeparator) ? '\u00a0 • \u00a0' : '\u00A0  \u00A0'}
           </LinkBarSpan>
         ))}
       </nav>

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
@@ -65,7 +65,7 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>    </span></nav>"',
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">    <a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a></span></nav>"',
     );
   });
 
@@ -97,7 +97,7 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>  •  </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a>    </span></nav>"',
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">    <a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a></span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">  •  <a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a></span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">  •  <a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a></span></nav>"',
     );
   });
 
@@ -125,7 +125,7 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a>    </span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\"><a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a>    </span></nav>"',
+      '"<nav class=\\"horizontal-links-bar\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">    <a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a></span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">    <a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a></span></nav>"',
     );
   });
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
@@ -16,7 +16,9 @@
 
 .horizontal-links-menu {
   align-items: center;
+  display: flex;
   font-size: calculateRem(14px);
+  height: 100%;
   justify-content: center;
 
   a {


### PR DESCRIPTION
## Description

Fix issue where when links wrap line-height changes
Move separator to be before all but the first item to fix the wrapping issue making it show the separator after the link item

## Jira Ticket
- [PEN-1763](https://arcpublishing.atlassian.net/browse/PEN-1763)

## Test Steps

1. Checkout this branch `git checkout PEN-1764-styling-regression` (wrong ticket number on branch name)
2. In Fusion repo run with header nav chain block linked `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Navigate to the article page - http://localhost/homepage/?_website=the-gazette
4. Verify there is spacing between the link items in the navigation chain
5. Verify when the screen size is smaller than the needed size to fit all on the navigation chain the links disappear including the separator


## Effect Of Changes
### Before

Links that wrapped move the line placement and leave the separator showing after link item

<img width="1111" alt="PEN-1764-before" src="https://user-images.githubusercontent.com/868127/107974008-dea03a00-6fad-11eb-837e-ff4f1bb9701a.png">


### After

When a link wraps the line placement stays and no separator after the last link item

<img width="1066" alt="PEN-1764-after" src="https://user-images.githubusercontent.com/868127/107974071-f4156400-6fad-11eb-914c-3e5ca70749e7.png">



## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working. 
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.