### PR TITLE
PEN-1115 - Add ratio custom field and logic to all manual promo blocks

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import getThemeStyle from 'fusion:themes';
 import getProperties from 'fusion:properties';
 import { useFusionContext } from 'fusion:context';
+import { imageRatioCustomField, ratiosFor } from '@wpmedia/resizer-image-block';
 
 import '@wpmedia/shared-styles/scss/_extra-large-promo.scss';
 import { Image } from '@wpmedia/engine-theme-sdk';
@@ -36,6 +37,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
     source: 'resize-image-api',
     query: { raw_image_url: customFields.imageURL, 'arc-site': arcSite },
   });
+  const ratios = ratiosFor('XL', customFields.imageRatio);
 
   const renderWithLink = useCallback((element, props, attributes) => (
     <a
@@ -94,12 +96,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
                 <Image
                   url={customFields.imageURL}
                   alt={customFields.headline}
-                  smallWidth={400}
-                  smallHeight={300}
-                  mediumWidth={600}
-                  mediumHeight={450}
-                  largeWidth={800}
-                  largeHeight={600}
+                  {...ratios}
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                   resizedImageOptions={resizedImageOptions}
@@ -182,6 +179,7 @@ ExtraLargeManualPromo.propTypes = {
         group: 'Show promo elements',
       },
     ),
+    ...imageRatioCustomField('imageRatio', 'Art', '4:3'),
   }),
 };
 

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
@@ -52,9 +52,24 @@ describe('the extra large promo feature', () => {
     expect(wrapper.find('a')).toHaveLength(3);
   });
 
-  it('should have one img when show image is true', () => {
+  it('should have one img when show image is true with 4:3 default ratio', () => {
     const wrapper = mount(<ExtraLargeManualPromo customFields={config} />);
     expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(600);
+  });
+
+  it('should accept a 16:9 image ratio', () => {
+    const myConfig = { ...config, imageRatio: '16:9' };
+    const wrapper = mount(<ExtraLargeManualPromo customFields={myConfig} />);
+    expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(450);
+  });
+
+  it('should accept a 3:2 image ratio', () => {
+    const myConfig = { ...config, imageRatio: '3:2' };
+    const wrapper = mount(<ExtraLargeManualPromo customFields={myConfig} />);
+    expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(533);
   });
 
   it('should have no Image when show image is false', () => {

--- a/blocks/extra-large-manual-promo-block/package.json
+++ b/blocks/extra-large-manual-promo-block/package.json
@@ -29,6 +29,7 @@
     "@wpmedia/engine-theme-sdk": "canary",
     "@wpmedia/news-theme-css": "stable",
     "@wpmedia/shared-styles": "canary",
+    "@wpmedia/resizer-image-block": "canary",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -5,6 +5,7 @@ import getThemeStyle from 'fusion:themes';
 import getProperties from 'fusion:properties';
 import { useFusionContext } from 'fusion:context';
 import { Image } from '@wpmedia/engine-theme-sdk';
+import { imageRatioCustomField, ratiosFor } from '@wpmedia/resizer-image-block';
 import { useContent } from 'fusion:content';
 
 import '@wpmedia/shared-styles/scss/_large-promo.scss';
@@ -37,6 +38,7 @@ const LargeManualPromo = ({ customFields }) => {
     source: 'resize-image-api',
     query: { raw_image_url: customFields.imageURL, 'arc-site': arcSite },
   });
+  const ratios = ratiosFor('LG', customFields.imageRatio);
 
   const renderWithLink = useCallback((element, props, attributes) => (
     <a
@@ -65,12 +67,7 @@ const LargeManualPromo = ({ customFields }) => {
                   url={customFields.imageURL}
                   alt={customFields.headline}
                   // large promo has 4:3
-                  smallWidth={274}
-                  smallHeight={206}
-                  mediumWidth={274}
-                  mediumHeight={206}
-                  largeWidth={377}
-                  largeHeight={283}
+                  {...ratios}
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                   resizedImageOptions={resizedImageOptions}
@@ -180,6 +177,7 @@ LargeManualPromo.propTypes = {
       defaultValue: true,
       group: 'Show promo elements',
     }),
+    ...imageRatioCustomField('imageRatio', 'Art', '4:3'),
   }),
 };
 

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
@@ -53,9 +53,24 @@ describe('the large promo feature', () => {
     expect(wrapper.find('a')).toHaveLength(3);
   });
 
-  it('should have one img when show image is true', () => {
+  it('should have one img when show image is true with 4:3 default ratio', () => {
     const wrapper = mount(<LargeManualPromo customFields={config} />);
     expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(283);
+  });
+
+  it('should accept a 16:9 image ratio', () => {
+    const myConfig = { ...config, imageRatio: '16:9' };
+    const wrapper = mount(<LargeManualPromo customFields={myConfig} />);
+    expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(212);
+  });
+
+  it('should accept a 3:2 image ratio', () => {
+    const myConfig = { ...config, imageRatio: '3:2' };
+    const wrapper = mount(<LargeManualPromo customFields={myConfig} />);
+    expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(251);
   });
 
   it('Headline div should have class .col-md-xl-6 when show image is true', () => {

--- a/blocks/large-manual-promo-block/package.json
+++ b/blocks/large-manual-promo-block/package.json
@@ -28,6 +28,7 @@
     "@wpmedia/engine-theme-sdk": "canary",
     "@wpmedia/news-theme-css": "stable",
     "@wpmedia/shared-styles": "canary",
+    "@wpmedia/resizer-image-block": "canary",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -5,6 +5,7 @@ import getThemeStyle from 'fusion:themes';
 import getProperties from 'fusion:properties';
 import { useFusionContext } from 'fusion:context';
 import { Image } from '@wpmedia/engine-theme-sdk';
+import { imageRatioCustomField, ratiosFor } from '@wpmedia/resizer-image-block';
 import { useContent } from 'fusion:content';
 
 import '@wpmedia/shared-styles/scss/_medium-promo.scss';
@@ -30,6 +31,7 @@ const MediumManualPromo = ({ customFields }) => {
   } = getProperties(arcSite);
 
   const hasImage = customFields.showImage && customFields.imageURL;
+  const ratios = ratiosFor('MD', customFields.imageRatio);
 
   const renderWithLink = useCallback((element, props, attributes) => (
     <a
@@ -55,12 +57,7 @@ const MediumManualPromo = ({ customFields }) => {
               // medium is 16:9
               url={customFields.imageURL}
               alt={customFields.headline}
-              smallWidth={274}
-              smallHeight={154}
-              mediumWidth={274}
-              mediumHeight={154}
-              largeWidth={400}
-              largeHeight={225}
+              {...ratios}
               breakpoints={breakpoints}
               resizerURL={getProperties(arcSite)?.resizerURL}
               resizedImageOptions={resizedImageOptions}
@@ -141,6 +138,7 @@ MediumManualPromo.propTypes = {
         group: 'Show promo elements',
       },
     ),
+    ...imageRatioCustomField('imageRatio', 'Art', '3:2'),
   }),
 };
 

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -68,6 +68,21 @@ describe('the medium promo feature', () => {
   it('should have one img when show image is true', () => {
     const wrapper = mount(<MediumPromo customFields={config} />);
     expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(225);
+  });
+
+  it('should accept a 16:9 image ratio', () => {
+    const myConfig = { ...config, imageRatio: '16:9' };
+    const wrapper = mount(<MediumPromo customFields={myConfig} />);
+    expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(225);
+  });
+
+  it('should accept a 3:2 image ratio', () => {
+    const myConfig = { ...config, imageRatio: '3:2' };
+    const wrapper = mount(<MediumPromo customFields={myConfig} />);
+    expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(267);
   });
 
   it('should have class .md-promo-image when show image is true', () => {

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -31,6 +31,7 @@
     "@wpmedia/engine-theme-sdk": "canary",
     "@wpmedia/news-theme-css": "stable",
     "@wpmedia/shared-styles": "canary",
+    "@wpmedia/resizer-image-block": "canary",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -6,6 +6,7 @@ import { Image } from '@wpmedia/engine-theme-sdk';
 import styled from 'styled-components';
 import getThemeStyle from 'fusion:themes';
 import { useContent } from 'fusion:content';
+import { imageRatioCustomField, ratiosFor } from '@wpmedia/resizer-image-block';
 import getPromoContainer from './_children/promo_container';
 import getPromoStyle from './_children/promo_style';
 
@@ -26,6 +27,7 @@ const SmallManualPromo = ({ customFields }) => {
     source: 'resize-image-api',
     query: { raw_image_url: customFields.imageURL, 'arc-site': arcSite },
   });
+  const ratios = ratiosFor('SM', customFields.imageRatio);
 
   const promoContainersStyles = {
     containerClass: getPromoStyle(imagePosition, 'container'),
@@ -72,12 +74,7 @@ const SmallManualPromo = ({ customFields }) => {
             url={customFields.imageURL}
             alt={customFields.headline}
             // small should be 3:2 aspect ratio
-            smallWidth={105}
-            smallHeight={70}
-            mediumWidth={105}
-            mediumHeight={70}
-            largeWidth={105}
-            largeHeight={70}
+            {...ratios}
             breakpoints={getProperties(arcSite)?.breakpoints}
             resizerURL={getProperties(arcSite)?.resizerURL}
             resizedImageOptions={resizedImageOptions}
@@ -138,6 +135,7 @@ SmallManualPromo.propTypes = {
         below: 'Image Below',
       },
     }),
+    ...imageRatioCustomField('imageRatio', 'Art', '3:2'),
   }),
 };
 

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
@@ -42,9 +42,24 @@ describe('the small promo feature', () => {
     expect(wrapper.find('.container-fluid')).toHaveLength(1);
   });
 
-  it('should have two link elements by default', () => {
+  it('should have two link elements by default with 4:3 default ratio', () => {
     const wrapper = mount(<SmallManualPromo customFields={config} />);
     expect(wrapper.find('a')).toHaveLength(2);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(267);
+  });
+
+  it('should accept a 16:9 image ratio', () => {
+    const myConfig = { ...config, imageRatio: '16:9' };
+    const wrapper = mount(<SmallManualPromo customFields={myConfig} />);
+    expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(225);
+  });
+
+  it('should accept a 3:2 image ratio', () => {
+    const myConfig = { ...config, imageRatio: '3:2' };
+    const wrapper = mount(<SmallManualPromo customFields={myConfig} />);
+    expect(wrapper.find('Image')).toHaveLength(1);
+    expect(wrapper.find('Image').prop('largeHeight')).toBe(267);
   });
 
   it('should have one img when show image is true', () => {

--- a/blocks/small-manual-promo-block/package.json
+++ b/blocks/small-manual-promo-block/package.json
@@ -28,6 +28,7 @@
     "@wpmedia/engine-theme-sdk": "canary",
     "@wpmedia/news-theme-css": "stable",
     "@wpmedia/shared-styles": "canary",
+    "@wpmedia/resizer-image-block": "canary",
     "styled-components": "^4.4.0"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"


### PR DESCRIPTION
## Description

Update all manual promo blocks to add the Aspect ratio custom field to allow the editor to control the image size used in the feature

## Jira Ticket
- [PEN-1115](https://arcpublishing.atlassian.net/browse/PEN-1115)

## Acceptance Criteria

1. For each of the four Manual Promo Blocks (Small, Medium, Large and Extra Large) , there’s a new custom field of Select type named Image Ratio under the Image group that controls the image ratio for that display size. A PB user should be able to select from these options:
    * 16:9
    * 3:2
    * 4:3
2. Each block should have a default ratio that is selected by default whenever a user adds that block to the page. Additionally, if none of these options are selected, then the default ratio should be applied. (This is to ensure backwards compatibility for Arc Blocks that have already been placed on pages + templates). Those default ratios are:
    * XL: 4:3
    * Large: 4:3
    * Medium: 16:9
    * Small: 3:2
3. Documentation is written for this functionality
4. Unit tests are updated if necessary

## Test Steps

1. Checkout this branch `git checkout PEN-1115-manual-promo-blocks-image-ratios`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/small-manual-promo-block,@wpmedia/medium-manual-promo-block,@wpmedia/large-manual-promo-block,@wpmedia/extra-large-manual-promo-block`
3. In PagBuilder add each manual promo block and for each promo block you will see a new custom field option under "Art" that allows for picking the aspect ratio to be used

## Effect Of Changes

### After
<img width="316" alt="PEN-115-new-custom-field" src="https://user-images.githubusercontent.com/868127/108529855-d6f1d580-72cc-11eb-87b0-9e583b77249b.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.