### PR TITLE
TMEDIA-28-small-promo-link-url

### DIFF
--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -16,7 +16,8 @@ const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
 `;
 
-const SmallManualPromo = ({ customFields }) => {
+const SmallManualPromo = ({ customFields = {} }) => {
+  const { showImage = true } = customFields;
   const { arcSite } = useFusionContext();
   const imagePosition = customFields?.imagePosition || 'right';
 
@@ -31,9 +32,9 @@ const SmallManualPromo = ({ customFields }) => {
 
   const promoContainersStyles = {
     containerClass: getPromoStyle(imagePosition, 'container'),
-    headlineClass: customFields.showImage
+    headlineClass: showImage
       ? 'col-sm-xl-8'
-      : 'col-sm-xl-12 no-image-padding',
+      : 'col-sm-xl-12',
     imageClass: 'col-sm-xl-4',
   };
 
@@ -66,7 +67,7 @@ const SmallManualPromo = ({ customFields }) => {
       </div>
     );
 
-  const image = customFields.showImage && customFields.imageURL
+  const image = showImage && customFields.imageURL
     && (
       <div className={imageMarginClass}>
         { renderWithLink(
@@ -83,14 +84,15 @@ const SmallManualPromo = ({ customFields }) => {
       </div>
     );
 
-  return customFields.linkURL ? (
+  // base case for rendering image without even a link
+  return (
     <>
       <article className="container-fluid small-promo">
         {getPromoContainer(headline, image, promoContainersStyles, imagePosition)}
       </article>
       <hr />
     </>
-  ) : null;
+  );
 };
 
 SmallManualPromo.propTypes = {

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import SmallManualPromo from './default';
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
-  Image: () => <div />,
+  Image: ({ url }) => <img src={url} alt="fake test image" />,
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
@@ -111,5 +111,19 @@ describe('the small promo feature', () => {
   it('should have one line separator', () => {
     const wrapper = mount(<SmallManualPromo customFields={config} />);
     expect(wrapper.find('SmallManualPromo > hr')).toHaveLength(1);
+  });
+
+  it('should render even without a link url', () => {
+    const imageURL = 'www.google.com/fake.png';
+    const noLinkURLConfig = {
+      imageURL,
+    };
+
+    const wrapper = mount(<SmallManualPromo customFields={noLinkURLConfig} />);
+    // testing for whether that import is shallow component
+    expect(wrapper.find('Image')).toHaveLength(1);
+
+    // testing whether the image url was indeed passed down
+    expect(wrapper.find('img').prop('src')).toEqual(imageURL);
   });
 });


### PR DESCRIPTION
## Description
Promo link url required for rendering anything

<img width="1400" alt="Screen Shot 2021-02-22 at 09 41 31" src="https://user-images.githubusercontent.com/5950956/108731514-41378f80-74f2-11eb-8faa-bb656f8a0b71.png">

before: see issue https://github.com/WPMedia/fusion-news-theme-blocks/issues/749

basically, can the small promo image render without a link url 

## Jira Ticket
- https://arcpublishing.atlassian.net/browse/PEN-1813
