### PR TITLE
TMEDIA-57 - Fix jumping nav bar around shrink height

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -249,9 +249,10 @@ const Nav = (props) => {
       return undefined;
     }
     const handleScroll = () => {
-      if (window.pageYOffset > shrinkDesktopNavivationHeight) {
+      const pageOffset = window.pageYOffset;
+      if (pageOffset > shrinkDesktopNavivationHeight) {
         setScrolled(true);
-      } else {
+      } else if (pageOffset < (shrinkDesktopNavivationHeight - desktopNavivationStartHeight)) {
         setScrolled(false);
       }
     };
@@ -260,7 +261,7 @@ const Nav = (props) => {
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [shrinkDesktopNavivationHeight, breakpoints]);
+  }, [shrinkDesktopNavivationHeight, desktopNavivationStartHeight, breakpoints]);
 
   const getNavWidgetType = (fieldKey) => (
     customFields[fieldKey] || getNavComponentDefaultSelection(fieldKey)


### PR DESCRIPTION
## Description
As the navigation shrinks when page reaches the shrink height number, this causes the offset to change which then causes the height to trigger again and you get into a loop of setting and unsetting height.

Due to height changing the offset I added logic to account for the height difference in shrink height and starting height to stop the jumping happening

## Jira Ticket
- [TMEDIA-57](https://arcpublishing.atlassian.net/browse/TMEDIA-57)

## Acceptance Criteria
_smooth transition around threshold_

## Test Steps

1. Checkout this branch `git checkout TMEDIA-57-jumping-nav-height-with-shrink-logic`
2. Run fusion repo with linked blocks `npx fusion start -f -l @header-nav-chain-block`
3. In PageBuilder for a given page set header nav chain custom fields to have
    * Starting desktop navigation bar height - 100
    * Shrink navigation bar after scrolling - 200
4. Publish page
5. View published page and scroll to around the threshold of the _Shrink navigation bar after scrolling_ and verify the navigation bar shrinks and does not go into a jumping frenzy
6. Scroll the other direction and see the navigation bar increases in height as per custom fields 


## Effect Of Changes
### Before

Example provided 

https://user-images.githubusercontent.com/868127/108772619-264a3700-7555-11eb-96d5-8a8ec8905005.mov


### After

https://user-images.githubusercontent.com/868127/108772824-6a3d3c00-7555-11eb-8332-f7feee53e96d.mp4


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.