### PR TITLE
[RC] PEN-1821 - Add custom field description text

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -456,6 +456,7 @@ Nav.propTypes = {
     }),
     desktopNavivationStartHeight: PropTypes.number.tag({
       label: 'Starting desktop navigation bar height',
+      description: 'Select the height of the navigation bar (in px) when the user first opens a page on desktop. Must be between 56 and 200.',
       group: 'Logo',
       max: 200,
       min: 56,
@@ -463,6 +464,7 @@ Nav.propTypes = {
     }),
     shrinkDesktopNavivationHeight: PropTypes.number.tag({
       label: 'Shrink navigation bar after scrolling',
+      description: 'How far should the user scroll (in px) until the navigation height shrinks back to standard size (56px) on desktop? Must be greater than the value configured for "Starting desktop navigation bar height".',
       group: 'Logo',
       min: 56,
     }),


### PR DESCRIPTION
## Description

Adding description text to custom fields `desktopNavivationStartHeight` and `shrinkDesktopNavivationHeight` for showing in PageBuilder Editor

<img width="279" alt="PEN-1821-doc-update" src="https://user-images.githubusercontent.com/868127/109295122-1e74e600-7826-11eb-8276-89a92e085635.png">


## Jira Ticket
- [PEN-1821](https://arcpublishing.atlassian.net/browse/PEN-1821)

## Test steps

1. Checkout this branch `git checkout PEN-1821-custom-field-info-update`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. In Pagebuilder - http://localhost/pagebuilder/pages
4. Go to a page that has the header nav chain block added - or add it to a new page
5. Verify the ? icon appears next to the two custom fields `desktopNavivationStartHeight` and `shrinkDesktopNavivationHeight`


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.