### PR TITLE
TMEDIA-21 catch failed import

### DIFF
--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -7,7 +7,8 @@ import getTranslatedPhrases from 'fusion:intl';
 
 import { Gallery, ErrorBoundary } from '@wpmedia/engine-theme-sdk';
 
-const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block'));
+const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block'))
+  .catch(() => ({ default: () => <p>Ad block not found</p> }));
 
 const GalleryFeature = (
   {

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -7,8 +7,8 @@ import getTranslatedPhrases from 'fusion:intl';
 
 import { Gallery, ErrorBoundary } from '@wpmedia/engine-theme-sdk';
 
-const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block'))
-  .catch(() => ({ default: () => <p>Ad block not found</p> }));
+const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block')
+  .catch(() => ({ default: () => <p>Ad block not found</p> })));
 
 const GalleryFeature = (
   {

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -12,11 +12,12 @@ import {
   VideoPlayer as VideoPlayerPresentational,
   ErrorBoundary,
 } from '@wpmedia/engine-theme-sdk';
-// import ArcAd from '@wpmedia/ads-block';
+
 import './leadart.scss';
 import FullscreenIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/FullscreenIcon';
 
-const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block'));
+const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block'))
+  .catch(() => ({ default: () => <p>Ad block not found</p> }));
 
 const LeadArtWrapperDiv = styled.div`
   figcaption {

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -16,8 +16,8 @@ import {
 import './leadart.scss';
 import FullscreenIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/FullscreenIcon';
 
-const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block'))
-  .catch(() => ({ default: () => <p>Ad block not found</p> }));
+const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block')
+  .catch(() => ({ default: () => <p>Ad block not found</p> })));
 
 const LeadArtWrapperDiv = styled.div`
   figcaption {


### PR DESCRIPTION
## Description

Update import to have a catch so when webpack is run in production mode it catches the error and doesn't fail the build

## Jira Ticket
- [TMEDIA-21](https://arcpublishing.atlassian.net/browse/TMEDIA-21)


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working. 
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.