### PR TITLE
TMEDIA-21 - Import within component

### DIFF
--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -7,9 +7,6 @@ import getTranslatedPhrases from 'fusion:intl';
 
 import { Gallery, ErrorBoundary } from '@wpmedia/engine-theme-sdk';
 
-const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block')
-  .catch(() => ({ default: () => <p>Ad block not found</p> })));
-
 const GalleryFeature = (
   {
     customFields: {
@@ -18,6 +15,9 @@ const GalleryFeature = (
     } = {},
   },
 ) => {
+  const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block')
+    .catch(() => ({ default: () => <p>Ad block not found</p> })));
+
   const { arcSite } = useFusionContext();
   const { resizerURL, galleryCubeClicks, locale = 'en' } = getProperties(arcSite);
   const { globalContent = {} } = useAppContext();

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -16,9 +16,6 @@ import {
 import './leadart.scss';
 import FullscreenIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/FullscreenIcon';
 
-const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block')
-  .catch(() => ({ default: () => <p>Ad block not found</p> })));
-
 const LeadArtWrapperDiv = styled.div`
   figcaption {
     font-family: ${(props) => props.primaryFont};
@@ -78,6 +75,9 @@ class LeadArt extends Component {
     } = this.state;
 
     const { arcSite, customFields, id } = this.props;
+
+    const AdFeature = lazy(/* istanbul ignore next */ () => import('@wpmedia/ads-block')
+      .catch(() => ({ default: () => <p>Ad block not found</p> })));
 
     if (content.promo_items && (content.promo_items.lead_art || content.promo_items.basic)) {
       const lead_art = (content.promo_items.lead_art || content.promo_items.basic);


### PR DESCRIPTION
Moving import into the component to try and prevent webpack trying to bundle the component at run time


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working. 
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.