### PR TITLE
TMEDIA-21 - Add ad mapping for inline gallery ad

### DIFF
--- a/blocks/ads-block/features/ads/ad-mapping.js
+++ b/blocks/ads-block/features/ads/ad-mapping.js
@@ -30,6 +30,13 @@ const adMapping = {
     dimensionsArray: [sz300x250, sz300x250, sz300x250],
     ampDimensionsArray: sz300x250,
   },
+  '300x250_gallery': {
+    adName: 'gallery_cube',
+    adLabel: 'Gallery Cube',
+    adClass: '300x250',
+    dimensionsArray: [sz300x250, sz300x250, sz300x250],
+    ampDimensionsArray: sz300x250,
+  },
   '300x250|300x600': {
     adName: 'flex_cube',
     adLabel: 'Flex Cube',

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -21,7 +21,7 @@ const GalleryFeature = (
     const { default: AdFeature } = require('@wpmedia/ads-block');
     AdBlock = () => (
       <AdFeature customFields={{
-        adType: '300x250',
+        adType: '300x250_gallery',
         displayAdLabel: true,
       }}
       />

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -81,7 +81,7 @@ class LeadArt extends Component {
       const { default: AdFeature } = require('@wpmedia/ads-block');
       AdBlock = () => (
         <AdFeature customFields={{
-          adType: '300x250',
+          adType: '300x250_gallery',
           displayAdLabel: true,
         }}
         />


### PR DESCRIPTION
## Description

Ad block within gallery should have ad type as `gallery_cube` - Adding a new gallery mapping to allow for this

## Jira Ticket
- [TMEDIA-21](https://arcpublishing.atlassian.net/browse/TMEDIA-21)

## Acceptance Criteria

* Ad within Gallery should have ad type set to `gallery_cube`

## Test Steps

1. Checkout this branch `git checkout TMEDIA-21-gallery-ad-type`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/ads-block,@wpmedia/gallery-block,@wpmedia/lead-art-block`
3. Verify that a site with the property `galleryCubeClicks` can see ads in their galleries, and lead art galleries and the ad type is set to `gallery_cube` on ad calls in the network tab
    * Lead Art Gallery - http://localhost/news/2020/11/04/story-that-has-a-gallery-without-a-basic-promo-image-as-lead-art/?_website=the-sun
    * Gallery - http://localhost/pf/gallery-example/?_website=the-sun

## Effect Of Changes
### After

Ad call has header ad type set to `gallery_cube` on the `prev_scp` query string parameter to the google ad call when the ad is loaded

<img width="664" alt="TMEDIA-21-ad-type" src="https://user-images.githubusercontent.com/868127/110689529-b1286400-81da-11eb-8a9a-206b19e959ac.png">

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.