### PR TITLE
Pen tmedia-6: remove hardcoded font urls

### DIFF
--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -69,6 +69,7 @@ describe('renders a page', () => {
       websiteDomain: '',
       fallbackImage: '/resources/placeholder.jpg',
       resizerURL: 'resizer',
+      fontUrl: ['https://fonts.googleapis.com/css?family=Roboto+Condensed|Roboto'],
     }))));
   });
   afterAll(() => {
@@ -81,6 +82,14 @@ describe('renders a page', () => {
       <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} {...mockFuntions} />,
     );
     expect(wrapper.find('head').length).toBe(1);
+  });
+
+  it('should have a font loading URL', () => {
+    const { default: DefaultOutputType } = require('../default');
+    const wrapper = shallow(
+      <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} {...mockFuntions} />,
+    );
+    expect(wrapper.find("[data-testid='font-loading-url-0']").length).toBe(1);
   });
 
   it('should have a body', () => {
@@ -105,7 +114,7 @@ describe('renders a page', () => {
     const wrapper = shallow(
       <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} {...mockFuntions} />,
     );
-    expect(wrapper.find('link').length).toBe(1);
+    expect(wrapper.find('link').length).toBe(2);
   });
 
   it('should have a MedataData component', () => {

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -123,8 +123,8 @@ const SampleOutputType = ({
   const buildFontUrl = () => {
     // If fontURL is an array, then iterate over the array and build out the links
     if (fontUrl && Array.isArray(fontUrl) && fontUrl.length > 0) {
-      const fontLinks = fontUrl.map((url) => (
-        <link href={url} rel="stylesheet" />
+      const fontLinks = fontUrl.map((url, index) => (
+        <link data-testid={`font-loading-url-${index}`} href={url} rel="stylesheet" />
       ));
       return (
         <>{fontLinks}</>

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -124,37 +124,18 @@ const SampleOutputType = ({
 
   const pageType = metaValue('page-type');
 
-  const googleFonts = () => {
-    switch (websiteName) {
-      case 'Arc Demo 1':
-        return (
-          <link href="https://fonts.googleapis.com/css?family=Work Sans" rel="stylesheet" />
-        );
-      case 'Arc Demo 2':
-        return (
-          <link href="https://fonts.googleapis.com/css?family=Eczar" rel="stylesheet" />
-        );
-      case 'Arc Demo 3':
-        return (
-          <>
-            <link href="https://fonts.googleapis.com/css?family=Open Sans" rel="stylesheet" />
-            <link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet" />
-          </>
-        );
-      case 'Arc Demo 4':
-        return (
-          <>
-            <link href="https://fonts.googleapis.com/css?family=Open Sans" rel="stylesheet" />
-            <link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet" />
-          </>
-        );
-      case 'Arc Demo 5':
-        return (
-          <link href="https://fonts.googleapis.com/css?family=Space Mono" rel="stylesheet" />
-        );
-      default:
-        return fontUrl ? <link href={fontUrl} rel="stylesheet" /> : '';
+  const buildFontUrl = () => {
+    // If fontURL is an array, then iterate over the array and build out the links
+    if (fontUrl && Array.isArray(fontUrl) && fontUrl.length > 0) {
+      const fontLinks = fontUrl.map((url) => (
+        <link href={url} rel="stylesheet" />
+      ));
+      return (
+        <>{fontLinks}</>
+      );
     }
+    // Legacy support where fontUrl is a string
+    return fontUrl ? <link href={fontUrl} rel="stylesheet" /> : '';
   };
 
   const ieTest = 'window.isIE = !!window.MSInputMethodContext && !!document.documentMode;';
@@ -218,7 +199,7 @@ const SampleOutputType = ({
           data-loaded-via="powa-manifest"
         />
         <link rel="preload" as="script" href={powaDrive} />
-        {googleFonts()}
+        {buildFontUrl()}
         {nativoIntegration
           ? (<script type="text/javascript" data-integration="nativo-ad" src="https://s.ntv.io/serve/load.js" async />)
           : null}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9538,9 +9538,9 @@
       }
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.9.2-canary.1",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.9.2-canary.1/2c1059e71586fa8826c043b283f0e61b4876b1897fa247d4872ac1c8dc9b8367",
-      "integrity": "sha1-jBT943/OIOVOijLhhGEmFEmhIlU=",
+      "version": "2.9.2-canary.4",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.9.2-canary.4/fd51ed8228231489ec5cb81d0142d767f1af04a0c2cf5c4808e21bb2cc6747c3",
+      "integrity": "sha512-e8yRUHiBejFevLtn/AvNAgJIzfm4oStKAstn3hynrGRaTCQcFAvRH1eFU/7RhLDIH/n7O+EbCiD6ZlG9YN8j9A==",
       "dev": true,
       "requires": {
         "dom-parser": "^0.1.6",
@@ -9559,9 +9559,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
-          "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -14504,7 +14504,7 @@
     "@wpmedia/news-theme-css": {
       "version": "4.1.0",
       "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/4.1.0/15e62ff8201be8d64ec1a4e8faf6ddc52e48d1c091075f564898b12ea7333ecb",
-      "integrity": "sha1-yf5NTpIlB4IKTwS5h90zGcTZxKI="
+      "integrity": "sha512-D/9sqjPTqVKNHfye9l2I2E2P2HZT4l+7d7sIpEaIOSM9+zUGsmnPDnCDIqDTIKQM5BwH8XjABw2YW29NUoM4xw=="
     },
     "@wpmedia/numbered-list-block": {
       "version": "file:blocks/numbered-list-block"


### PR DESCRIPTION
## Description
This removes the hardcoded font urls and strictly relies on the fontUrl to be present in blocks.json.  Also this ticket concerns changes made to the theme API where fontUrl will be an array of font urls, instead of a just a string:  https://github.com/WPMedia/themebuilder-api/pull/75.  To keep backwards compatibility, an inspection of the fontUrl value is checked to see if its an array or string and then processed accordingly.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/TMEDIA-6

## Acceptance Criteria
Remove the site specific logic
If a site has a `fontUrl` set in their properties the correct font stylesheet is loaded

## Test Steps
1) Pull the latest master from Fusion-News-Theme.  Note the changes to the blocks.json (fontUrl property).
2) Run this branch locally
3) Create a page and publish.
4) View the published page for a site that is setting the fontUrl and confirm the font url is in the header and the fonts are showing up on the elements.


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x ] Confirmed all the test steps a reviewer will follow above are working. 
- [x ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x ] Confirmed this PR has unit test files
  - [x ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.