### PR TITLE
Reduce stylelint errors, named color, border: none ignore

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -23,12 +23,8 @@
     ],
     "font-family-no-missing-generic-family-keyword": null,
     "order/properties-alphabetical-order": null,
-    "declaration-property-value-disallowed-list": [
-      {
-        "border": [
-          "none"
-        ]
-      }
-    ]
+    "declaration-property-value-disallowed-list": {
+      "/^border/": []
+    }
   }
 }

--- a/blocks/ads-block/features/ads/ads.scss
+++ b/blocks/ads-block/features/ads/ads.scss
@@ -18,7 +18,7 @@
         margin-bottom: calculateRem(32px);
         font-size: calculateRem(14px);
         line-height: calculateRem(18px);
-        color: white;
+        color: #fff;
       }
     }
   }

--- a/blocks/card-list-block/features/card-list/card-list.scss
+++ b/blocks/card-list-block/features/card-list/card-list.scss
@@ -77,6 +77,7 @@
 
 .list-item-simple {
   @include block-internal-spacing;
+
   &--divider {
     box-shadow: inset 0 -1px 0 0 $ui-light-gray;
   }

--- a/blocks/footer-block/features/footer/footer.scss
+++ b/blocks/footer-block/features/footer/footer.scss
@@ -13,7 +13,7 @@ footer {
   }
 
   .container {
-    @media screen and (max-width: 95rem) and (min-width: 90rem)  {
+    @media screen and (max-width: 95rem) and (min-width: 90rem) {
       margin-left: 5%;
       margin-right: 5%;
     }

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -37,8 +37,8 @@ const StyledNav = styled.nav`
   align-items: center;
   width: 100%;
   position: sticky;
-  top: 0px;
-  margin-bottom: 0px;
+  top: 0;
+  margin-bottom: 0;
 
   .news-theme-navigation-bar {
     @media screen and (max-width: ${(props) => props.breakpoint}px) {
@@ -51,7 +51,8 @@ const StyledNav = styled.nav`
     transition: 0.5s;
     z-index: ${navZIdx};
 
-    &.nav-logo, & > .nav-logo {
+    &.nav-logo,
+    & > .nav-logo {
       img {
         height: auto;
         max-width: 240px;

--- a/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
+++ b/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
@@ -1,6 +1,7 @@
 .numbered-list-container {
   @include block-margin-bottom;
   @include block-internal-spacing;
+
   .list-title {
     color: $ui-primary-font-color;
     font-size: calculateRem(20px);

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -78,6 +78,7 @@ body.nav-open {
 
   @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
     margin: 0;
+
     span {
       display: none;
     }
@@ -240,7 +241,8 @@ body.nav-open {
       justify-content: flex-end;
     }
 
-    &.nav-logo, & > .nav-logo {
+    &.nav-logo,
+    & > .nav-logo {
       justify-content: center;
 
       &.svg-logo {


### PR DESCRIPTION
- All semantic changes, no visual difference
- Ignored the border: none issue `declaration-property-value-disallowed-list`. There is a difference between the proposed solution output and the our code. I based the ignore setup on this https://github.com/bjankord/stylelint-config-sass-guidelines/issues/16 based off of this convo 
- Ran stylelint fix 
- Fixed named color

## before 

222 problems found
 severity level "error": 205
  no-descending-specificity: 45
  selector-max-compound-selectors: 56
  scss/selector-no-redundant-nesting-selector: 14
  max-nesting-depth: 4
  rule-empty-line-before: 3
  selector-list-comma-newline-after: 2
  selector-no-qualifying-type: 36
  selector-class-pattern: 12
  color-named: 1
  declaration-property-value-disallowed-list: 13
  block-opening-brace-space-before: 1
  selector-max-id: 14
  length-zero-no-unit: 2
  property-no-vendor-prefix: 1
  value-no-vendor-prefix: 1
 severity level "warning": 17
  plugin/no-unsupported-browser-features: 17

## after

200 problems found
 severity level "error": 183
  no-descending-specificity: 45
  selector-max-compound-selectors: 56
  scss/selector-no-redundant-nesting-selector: 14
  max-nesting-depth: 4
  selector-no-qualifying-type: 36
  selector-class-pattern: 12
  selector-max-id: 14
  property-no-vendor-prefix: 1
  value-no-vendor-prefix: 1
 severity level "warning": 17
  plugin/no-unsupported-browser-features: 17