### PR TITLE
TMEDIA-173 - Add a client side image resizer content source

### DIFF
--- a/blocks/resizer-image-content-source-block/jest.config.js
+++ b/blocks/resizer-image-content-source-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require('../../jest/jest.config.base');
+
+module.exports = {
+  ...base,
+};

--- a/blocks/resizer-image-content-source-block/sources/resize-image-api-client.js
+++ b/blocks/resizer-image-content-source-block/sources/resize-image-api-client.js
@@ -1,0 +1,63 @@
+import { allowedImageDomains as ALLOWED_IMAGE_DOMAINS } from 'fusion:environment';
+import getResizedImageData from '@wpmedia/resizer-image-block';
+
+const ARCDomain = ['images.arcpublishing.com'];
+
+const params = {
+  // has to be an external image
+  raw_image_url: 'text',
+};
+
+const getAllowedDomains = () => {
+  if (ALLOWED_IMAGE_DOMAINS) {
+    return ARCDomain.concat(ALLOWED_IMAGE_DOMAINS.split(','));
+  }
+  return ARCDomain;
+};
+
+const getDomainHostname = (domain) => {
+  try {
+    return new URL(domain).hostname;
+  } catch (e) {
+    return '';
+  }
+};
+
+const isAnAllowedDomain = (imageUrl) => {
+  const inputHost = getDomainHostname(imageUrl);
+
+  if (inputHost === '') {
+    return false;
+  }
+
+  const matcher = (domain) => inputHost.endsWith(domain) || inputHost === getDomainHostname(domain);
+
+  return getAllowedDomains().some(matcher);
+};
+
+// input: raw image url
+// output: object with dimensions and image keys
+const fetch = (query) => {
+  const {
+    raw_image_url: rawImageUrl,
+    respect_aspect_ratio: respectAspectRatio = false,
+  } = query;
+
+  if (!isAnAllowedDomain(rawImageUrl)) {
+    return {};
+  }
+
+  // last param designates only url -- not data ans object
+  return getResizedImageData(
+    rawImageUrl,
+    null,
+    true,
+    respectAspectRatio,
+    query['arc-site'],
+  );
+};
+
+export default {
+  params,
+  fetch,
+};

--- a/blocks/resizer-image-content-source-block/sources/resize-image-api-client.test.js
+++ b/blocks/resizer-image-content-source-block/sources/resize-image-api-client.test.js
@@ -1,0 +1,81 @@
+const mockFn = jest.fn(() => ({}));
+jest.mock('@wpmedia/resizer-image-block', () => mockFn);
+
+describe('the resizer image api client source block', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should use the proper param types', () => {
+    const { default: contentSource } = require('./resize-image-api-client');
+    expect(contentSource.params).toEqual({
+      raw_image_url: 'text',
+    });
+  });
+
+  it('should not allow an unrestricted domain through return empty object', () => {
+    const { default: contentSource } = require('./resize-image-api-client');
+    expect(contentSource.fetch({ raw_image_url: 'http://sd.jpg' })).toEqual({});
+  });
+
+  it('should return empty object if raw image url is not a URL', () => {
+    const { default: contentSource } = require('./resize-image-api-client');
+    expect(contentSource.fetch({ raw_image_url: 'httspg' })).toEqual({});
+  });
+
+  it('should call getResizedImageData if image and domain match no environment domains', () => {
+    const { default: contentSource } = require('./resize-image-api-client');
+
+    contentSource.fetch({ raw_image_url: 'http://themes.images.arcpublishing.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(1);
+
+    contentSource.fetch({ raw_image_url: 'http://images.arcpublishing.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(2);
+
+    contentSource.fetch({ raw_image_url: 'https://example.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(2);
+  });
+
+  it('should call getResizedImageData if image and domain match with environment domains', () => {
+    jest.mock('fusion:environment', () => ({
+      allowedImageDomains: 'http://example.com',
+    }));
+
+    const { default: contentSource } = require('./resize-image-api-client');
+
+    contentSource.fetch({ raw_image_url: 'http://themes.images.arcpublishing.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(1);
+
+    contentSource.fetch({ raw_image_url: 'http://images.arcpublishing.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(2);
+
+    contentSource.fetch({ raw_image_url: 'https://example.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(3);
+
+    contentSource.fetch({ raw_image_url: 'https://examples.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(3);
+  });
+
+  it('should call getResizedImageData if image and domain match with environment domains', () => {
+    jest.mock('fusion:environment', () => ({
+      allowedImageDomains: 'http://example.com,my-custom-domain.com',
+    }));
+
+    const { default: contentSource } = require('./resize-image-api-client');
+
+    contentSource.fetch({ raw_image_url: 'http://themes.images.arcpublishing.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(1);
+
+    contentSource.fetch({ raw_image_url: 'http://images.arcpublishing.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(2);
+
+    contentSource.fetch({ raw_image_url: 'https://example.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(3);
+
+    contentSource.fetch({ raw_image_url: 'https://examples.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(3);
+
+    contentSource.fetch({ raw_image_url: 'https://my-custom-domain.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(4);
+  });
+});


### PR DESCRIPTION
## Description

Added a client side image resizer content source that will only allow you to run resizer function against a whitelisted set of domains, coming from your environment file and the given arc domain that is part of the content source

## Jira Ticket
- [TMEDIA-173](https://arcpublishing.atlassian.net/browse/TMEDIA-173)

## Acceptance Criteria
* A new content source for client side resizer image URLs
* Content source will only run for whitelisted domains
    * ARC domains are hardcoded into the content source
    * Client domains are an environment setting
* Content source has caching enabled
* Content source DOES NOT expose resizer secrets

## Test Steps

1. Checkout this branch `git checkout TMEDIA-173-client-size-image-resizer`
2. Run fusion repo with `useLocal: true` 
    * In `blocks.json` update `useLocal` to be - `"useLocal": true,`
    * Start fusion `npx fusion start -f`
3. Goto debugger - http://localhost/pagebuilder/tools/debugger
4. Verify there is a new content source `resizer-image-api-client`
5. Verify you can get response object container resized params for the following URL - https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG
6. Verify you do not get a response object of resized params for the following URL - https://arc-anglerfish-staging-staging.s3.amazonaws.com/public/NA6FMAXWP5DR3FDZQ7SGJ3C3FE.png
7. Stop fusion
8. Add the following to your `.env` file `allowedImageDomains=arc-anglerfish-staging-staging.s3.amazonaws.com`
9. Start fusion `npx fusion start -f`
10. Verify both of the following URLs return resized objects from the content source
    * https://arc-anglerfish-staging-staging.s3.amazonaws.com/public/NA6FMAXWP5DR3FDZQ7SGJ3C3FE.png
    * https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG
 

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.