### PR TITLE
TMEDIA-168 - Lazy Load Promo Blocks

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
@@ -4,6 +4,8 @@ import ExtraLargeManualPromo from './default';
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
@@ -40,6 +42,15 @@ describe('the extra large promo feature', () => {
         id: 'testId',
       })),
     }));
+  });
+
+  it('should return null if lazyLoad on the server and not in the admin', () => {
+    const updatedConfig = {
+      ...config,
+      lazyLoad: true,
+    };
+    const wrapper = mount(<ExtraLargeManualPromo customFields={updatedConfig} />);
+    expect(wrapper.html()).toBe(null);
   });
 
   it('should have 1 container fluid class', () => {
@@ -84,6 +95,6 @@ describe('the extra large promo feature', () => {
 
   it('should have one line separator', () => {
     const wrapper = mount(<ExtraLargeManualPromo customFields={config} />);
-    expect(wrapper.find('ExtraLargeManualPromo > hr')).toHaveLength(1);
+    expect(wrapper.find('hr')).toHaveLength(1);
   });
 });

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -14,6 +14,7 @@ import {
   extractVideoEmbedFromStory,
   // presentational component does not do data fetching
   VideoPlayer as VideoPlayerPresentational,
+  LazyLoad, isServerSide,
 } from '@wpmedia/engine-theme-sdk';
 import '@wpmedia/shared-styles/scss/_extra-large-promo.scss';
 import PlaceholderImage from '@wpmedia/placeholder-image-block';
@@ -34,7 +35,7 @@ const DescriptionText = styled.p`
   font-family: ${(props) => props.secondaryFont};
 `;
 
-const ExtraLargePromo = ({ customFields }) => {
+const ExtraLargePromoItem = ({ customFields }) => {
   const { arcSite, id } = useFusionContext();
   const { editableContent } = useEditableContent();
 
@@ -45,7 +46,12 @@ const ExtraLargePromo = ({ customFields }) => {
       : null,
   }) || null;
 
-  const imageConfig = customFields.imageOverrideURL ? 'resize-image-api' : null;
+  let imageConfig = null;
+  if (customFields.imageOverrideURL && customFields.lazyLoad) {
+    imageConfig = 'resize-image-api-client';
+  } else if (customFields.imageOverrideURL) {
+    imageConfig = 'resize-image-api';
+  }
 
   const customFieldImageResizedImageOptions = useContent({
     source: imageConfig,
@@ -170,7 +176,7 @@ const ExtraLargePromo = ({ customFields }) => {
                   customFields.showImage
                     && (
                       <a href={content.website_url} aria-hidden="true" tabIndex="-1">
-                        {imageURL
+                        {imageURL && resizedImageOptions
                           ? (
                             <Image
                               url={imageURL}
@@ -214,6 +220,18 @@ const ExtraLargePromo = ({ customFields }) => {
       </article>
       <hr />
     </>
+  );
+};
+
+const ExtraLargePromo = ({ customFields }) => {
+  const { isAdmin } = useFusionContext();
+  if (customFields.lazyLoad && isServerSide() && !isAdmin) { // On Server
+    return null;
+  }
+  return (
+    <LazyLoad enabled={customFields.lazyLoad && !isAdmin}>
+      <ExtraLargePromoItem customFields={{ ...customFields }} />
+    </LazyLoad>
   );
 };
 
@@ -276,6 +294,11 @@ ExtraLargePromo.propTypes = {
       label: 'Play video in place',
       group: 'Art',
       defaultValue: false,
+    }),
+    lazyLoad: PropTypes.bool.tag({
+      name: 'Lazy Load block?',
+      defaultValue: false,
+      description: 'Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.',
     }),
   }),
 };

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -201,6 +201,7 @@ const ExtraLargePromoItem = ({ customFields }) => {
                               mediumHeight={ratios.mediumHeight}
                               largeWidth={ratios.largeWidth}
                               largeHeight={ratios.largeHeight}
+                              client={imageConfig === 'resize-image-api-client'}
                             />
                           )}
 

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { useContent } from 'fusion:content';
 import { extractVideoEmbedFromStory } from '@wpmedia/engine-theme-sdk';
 import ExtraLargePromo from './default';
@@ -12,6 +12,8 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   localizeDateTime: jest.fn(() => new Date().toDateString()),
   extractVideoEmbedFromStory: jest.fn(() => '<div class="video-embed"></div>'),
   VideoPlayer: ({ embedHTML, id }) => <div dangerouslySetInnerHTML={{ __html: embedHTML }} id={`video-${id}`} />,
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({
@@ -49,6 +51,15 @@ describe('the extra large promo feature', () => {
     jest.mock('fusion:context', () => ({
       useFusionContext: jest.fn(() => mockFusionContext),
     }));
+  });
+
+  it('should return null if lazyLoad on the server and not in the admin', () => {
+    const updatedConfig = {
+      ...config,
+      lazyLoad: true,
+    };
+    const wrapper = mount(<ExtraLargePromo customFields={updatedConfig} />);
+    expect(wrapper.html()).toBe(null);
   });
 
   it('should have 1 container fluid class', () => {
@@ -184,8 +195,7 @@ describe('the extra large promo feature', () => {
     const wrapper = mount(<ExtraLargePromo customFields={myConfig} arcSite="dagen" />);
 
     const image = wrapper.find('Image');
-    expect(image.length).toBe(1);
-    expect(image.props().resizedImageOptions).toEqual(undefined);
+    expect(image.length).toBe(0);
     wrapper.unmount();
   });
 
@@ -302,7 +312,7 @@ describe('the extra large promo feature', () => {
       it('should render Image when no video found in ANS lead art', () => {
         useContent.mockReturnValueOnce(mockData);
         extractVideoEmbedFromStory.mockReturnValueOnce(undefined);
-        const wrapper = shallow(
+        const wrapper = mount(
           <ExtraLargePromo
             customFields={{
               ...config,
@@ -325,7 +335,7 @@ describe('the extra large promo feature', () => {
             },
           },
         });
-        const wrapper = shallow(
+        const wrapper = mount(
           <ExtraLargePromo
             customFields={{
               ...config,
@@ -345,7 +355,7 @@ describe('the extra large promo feature', () => {
         delete mockDataVideoNoEmbed.embed_html;
         useContent.mockReturnValueOnce(mockDataVideoNoEmbed);
         extractVideoEmbedFromStory.mockReturnValueOnce(undefined);
-        const wrapper = shallow(
+        const wrapper = mount(
           <ExtraLargePromo
             customFields={{
               ...config,
@@ -359,7 +369,7 @@ describe('the extra large promo feature', () => {
 
       it('should render VideoPlayer when video embed exists in ANS', () => {
         useContent.mockReturnValueOnce(mockDataVideo);
-        const wrapper = shallow(
+        const wrapper = mount(
           <ExtraLargePromo
             customFields={{
               ...config,

--- a/blocks/extra-large-promo-block/features/extra-large-promo/mock-data.js
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/mock-data.js
@@ -221,6 +221,7 @@ export default {
           type: 'image',
           url:
             'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/DBUX66M3LRFMHKXZOM46RO4EXM.png',
+          resized_params: {},
           version: '0.10.3',
           width: 1179,
           syndication: [Object],

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
@@ -4,6 +4,8 @@ import LargeManualPromo from './default';
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
@@ -41,6 +43,15 @@ describe('the large promo feature', () => {
         id: 'testId',
       })),
     }));
+  });
+
+  it('should return null if lazyLoad on the server and not in the admin', () => {
+    const updatedConfig = {
+      ...config,
+      lazyLoad: true,
+    };
+    const wrapper = mount(<LargeManualPromo customFields={updatedConfig} />);
+    expect(wrapper.html()).toBe(null);
   });
 
   it('should have 1 container fluid class', () => {
@@ -131,6 +142,6 @@ describe('the large promo feature', () => {
 
   it('should have one line separator', () => {
     const wrapper = mount(<LargeManualPromo customFields={config} />);
-    expect(wrapper.find('LargeManualPromo > hr')).toHaveLength(1);
+    expect(wrapper.find('hr')).toHaveLength(1);
   });
 });

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -14,7 +14,7 @@ import {
   extractVideoEmbedFromStory,
   // presentational component does not do data fetching
   VideoPlayer as VideoPlayerPresentational,
-  LazyLoad, isServerSide
+  LazyLoad, isServerSide,
 } from '@wpmedia/engine-theme-sdk';
 import '@wpmedia/shared-styles/scss/_large-promo.scss';
 import PlaceholderImage from '@wpmedia/placeholder-image-block';

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { useContent } from 'fusion:content';
 import { extractVideoEmbedFromStory } from '@wpmedia/engine-theme-sdk';
 import LargePromo from './default';
@@ -12,6 +12,8 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   localizeDateTime: jest.fn(() => new Date().toDateString()),
   extractVideoEmbedFromStory: jest.fn(() => '<div class="video-embed"></div>'),
   VideoPlayer: ({ embedHTML, id }) => <div dangerouslySetInnerHTML={{ __html: embedHTML }} id={`video-${id}`} />,
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
@@ -44,6 +46,15 @@ describe('the large promo feature', () => {
   afterEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+  });
+
+  it('should return null if lazyLoad on the server and not in the admin', () => {
+    const updatedConfig = {
+      ...config,
+      lazyLoad: true,
+    };
+    const wrapper = mount(<LargePromo customFields={updatedConfig} />);
+    expect(wrapper.html()).toBe(null);
   });
 
   it('should have 1 container fluid class', () => {
@@ -262,8 +273,7 @@ describe('the large promo feature', () => {
     const wrapper = mount(<LargePromo customFields={myConfig} arcSite="dagen" />);
 
     const image = wrapper.find('Image');
-    expect(image.length).toBe(1);
-    expect(image.props().resizedImageOptions).toEqual(undefined);
+    expect(image.length).toBe(0);
     wrapper.unmount();
   });
 
@@ -326,7 +336,7 @@ describe('the large promo feature', () => {
       it('should render Image when no video found in ANS lead art', () => {
         useContent.mockReturnValueOnce(mockData);
         extractVideoEmbedFromStory.mockReturnValueOnce(undefined);
-        const wrapper = shallow(
+        const wrapper = mount(
           <LargePromo
             customFields={{
               ...config,
@@ -349,7 +359,7 @@ describe('the large promo feature', () => {
             },
           },
         });
-        const wrapper = shallow(
+        const wrapper = mount(
           <LargePromo
             customFields={{
               ...config,
@@ -369,7 +379,7 @@ describe('the large promo feature', () => {
         delete mockDataVideoNoEmbed.embed_html;
         useContent.mockReturnValueOnce(mockDataVideoNoEmbed);
         extractVideoEmbedFromStory.mockReturnValueOnce(undefined);
-        const wrapper = shallow(
+        const wrapper = mount(
           <LargePromo
             customFields={{
               ...config,
@@ -383,7 +393,7 @@ describe('the large promo feature', () => {
 
       it('should render VideoPlayer when video embed exists in ANS', () => {
         useContent.mockReturnValueOnce(mockDataVideo);
-        const wrapper = shallow(
+        const wrapper = mount(
           <LargePromo
             customFields={{
               ...config,

--- a/blocks/large-promo-block/features/large-promo/mock-data-video.js
+++ b/blocks/large-promo-block/features/large-promo/mock-data-video.js
@@ -748,6 +748,7 @@ export default {
     credits: {},
     caption: 'A snowy waterfall',
     url: 'https://d22ff27hdsy159.cloudfront.net/12-17-2019/t_b47df64ea45e4b178442347c0dc3724b_name_file_1280x720_2000_v3_1_.jpg',
+    resized_params: {},
     width: 1280,
     height: 720,
   },

--- a/blocks/large-promo-block/features/large-promo/mock-data.js
+++ b/blocks/large-promo-block/features/large-promo/mock-data.js
@@ -221,6 +221,7 @@ export default {
           type: 'image',
           url:
             'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/DBUX66M3LRFMHKXZOM46RO4EXM.png',
+          resized_params: {},
           version: '0.10.3',
           width: 1179,
           syndication: [Object],

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
@@ -4,6 +4,8 @@ import MediumManualPromo from './default';
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
@@ -37,6 +39,15 @@ describe('the medium promo feature', () => {
         id: 'testId',
       })),
     }));
+  });
+
+  it('should return null if lazyLoad on the server and not in the admin', () => {
+    const updatedConfig = {
+      ...config,
+      lazyLoad: true,
+    };
+    const wrapper = mount(<MediumManualPromo customFields={updatedConfig} />);
+    expect(wrapper.html()).toBe(null);
   });
 
   it('should have 1 container fluid class', () => {
@@ -103,6 +114,6 @@ describe('the medium promo feature', () => {
 
   it('should have one line separator', () => {
     const wrapper = mount(<MediumManualPromo customFields={config} />);
-    expect(wrapper.find('MediumManualPromo > hr')).toHaveLength(1);
+    expect(wrapper.find('hr')).toHaveLength(1);
   });
 });

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -7,6 +7,8 @@ const { default: mockData } = require('./mock-data');
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
   localizeDateTime: jest.fn(() => new Date().toDateString()),
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
@@ -41,6 +43,15 @@ describe('the medium promo feature', () => {
         id: 'testId',
       })),
     }));
+  });
+
+  it('should return null if lazyLoad on the server and not in the admin', () => {
+    const updatedConfig = {
+      ...config,
+      lazyLoad: true,
+    };
+    const wrapper = mount(<MediumPromo customFields={updatedConfig} />);
+    expect(wrapper.html()).toBe(null);
   });
 
   it('should have 1 container fluid class', () => {
@@ -183,7 +194,7 @@ describe('the medium promo feature', () => {
     wrapper.unmount();
   });
 
-  it('show image useContent for resizer parameter returns undefined if falsy', () => {
+  it('no image is shown if resizer returns no resized image options', () => {
     const myConfig = {
       showHeadline: true,
       showImage: true,
@@ -196,8 +207,7 @@ describe('the medium promo feature', () => {
     const wrapper = mount(<MediumPromo customFields={myConfig} arcSite="dagen" />);
 
     const image = wrapper.find('Image');
-    expect(image.length).toBe(1);
-    expect(image.props().resizedImageOptions).toEqual(undefined);
+    expect(image.length).toBe(0);
     wrapper.unmount();
   });
 

--- a/blocks/medium-promo-block/features/medium-promo/mock-data.js
+++ b/blocks/medium-promo-block/features/medium-promo/mock-data.js
@@ -221,6 +221,7 @@ export default {
           type: 'image',
           url:
             'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/DBUX66M3LRFMHKXZOM46RO4EXM.png',
+          resized_params: {},
           version: '0.10.3',
           width: 1179,
           syndication: [Object],

--- a/blocks/placeholder-image-block/features/placeholder-image/default.jsx
+++ b/blocks/placeholder-image-block/features/placeholder-image/default.jsx
@@ -9,6 +9,8 @@ import withFusionContext from 'fusion:context';
 class PlaceholderImage extends React.Component {
   constructor(props) {
     super(props);
+    this.clientSide = props.client || false;
+
     this.state = { resizedImageOptions: {} };
     this.fetch = this.fetch.bind(this);
     this.getTargetFallbackImageUrl = this.getTargetFallbackImageUrl.bind(this);
@@ -32,7 +34,7 @@ class PlaceholderImage extends React.Component {
     const targetFallbackImage = this.getTargetFallbackImageUrl();
     this.fetchContent({
       resizedImageOptions: {
-        source: 'resize-image-api',
+        source: this.clientSide ? 'resize-image-api-client' : 'resize-image-api',
         query: { raw_image_url: targetFallbackImage, respect_aspect_ratio: true },
       },
     });
@@ -49,6 +51,10 @@ class PlaceholderImage extends React.Component {
       largeHeight = 105,
     } = this.props;
     const { resizedImageOptions } = this.state;
+
+    if (!resizedImageOptions) {
+      return null;
+    }
 
     return (
       <>

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
@@ -4,6 +4,8 @@ import SmallManualPromo from './default';
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: ({ url }) => <img src={url} alt="fake test image" />,
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
@@ -110,7 +112,7 @@ describe('the small promo feature', () => {
 
   it('should have one line separator', () => {
     const wrapper = mount(<SmallManualPromo customFields={config} />);
-    expect(wrapper.find('SmallManualPromo > hr')).toHaveLength(1);
+    expect(wrapper.find('hr')).toHaveLength(1);
   });
 
   it('should render even without a link url', () => {

--- a/blocks/small-promo-block/features/small-promo/_children/promo_image.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_image.jsx
@@ -14,7 +14,12 @@ const PromoImage = (props) => {
   const { arcSite } = useFusionContext();
   const promoType = discoverPromoType(content);
 
-  const imageConfig = customFields.imageOverrideURL ? 'resize-image-api' : null;
+  let imageConfig = null;
+  if (customFields.imageOverrideURL && customFields.lazyLoad) {
+    imageConfig = 'resize-image-api-client';
+  } else if (customFields.imageOverrideURL) {
+    imageConfig = 'resize-image-api';
+  }
 
   const customFieldImageResizedImageOptions = useContent({
     source: imageConfig,
@@ -32,9 +37,8 @@ const PromoImage = (props) => {
     ? (
       <div className={`promo-image ${getPromoStyle(imagePosition, 'margin')}`}>
         <div className="flex no-image-padding">
-          {/* <div className="col-sm-xl-4 flex-col"> // from default */}
           <a href={content?.website_url || ''} aria-hidden="true" tabIndex="-1">
-            {imageURL
+            {imageURL && resizedImageOptions
               ? (
                 <Image
                   url={imageURL}
@@ -59,6 +63,7 @@ const PromoImage = (props) => {
                   mediumHeight={ratios.mediumHeight}
                   largeWidth={ratios.largeWidth}
                   largeHeight={ratios.largeHeight}
+                  client={imageConfig === 'resize-image-api-client'}
                 />
               )}
             <PromoLabel type={promoType} size="small" />

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -191,7 +191,7 @@ describe('the small promo feature', () => {
     wrapper.unmount();
   });
 
-  it('show image useContent for resizer parameter returns undefined if falsy', () => {
+  it('no image is shown if resizer returns no resized image options', () => {
     const myConfig = {
       showHeadline: true,
       showImage: true,
@@ -203,9 +203,7 @@ describe('the small promo feature', () => {
 
     const wrapper = mount(<SmallPromo customFields={myConfig} arcSite="dagen" />);
 
-    const image = wrapper.find('Image');
-    expect(image.length).toBe(1);
-    expect(image.props().resizedImageOptions).toEqual(undefined);
+    expect(wrapper.find('Image').length).toBe(0);
     wrapper.unmount();
   });
 

--- a/blocks/small-promo-block/features/small-promo/mock-data.js
+++ b/blocks/small-promo-block/features/small-promo/mock-data.js
@@ -221,6 +221,7 @@ export default {
           type: 'image',
           url:
             'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/DBUX66M3LRFMHKXZOM46RO4EXM.png',
+          resized_params: {},
           version: '0.10.3',
           width: 1179,
           syndication: [Object],


### PR DESCRIPTION
## Description

Add Lazy Load functionality to the follow list blocks

* XL Promo
* XL Manual Promo
* Large Promo 
* Large Manul Promo
* Medium Promo 
* Medium Manual Promo
* Small Manual Promo
* Small Promo (minor update)

Also update placeholder image block to account for the client side resizer content source when block is being used within a lazy load block.
Also made a small adjustment to the small promo to account for the new client side content source

## Jira Ticket
- [TMEDA-168](https://arcpublishing.atlassian.net/browse/TMEDIA-168)

## Acceptance Criteria
1. A new boolean custom field called Lazy load block? should be added to all blocks listed in the section above
    * If Lazy load block? is true, the block should lazy load on the page once it comes within 300px of the viewport
    * If Lazy load block? is false, the block should load immediately (it should not lazy load) – this is the existing behavior
2. The default value for this custom setting should be false
3. Server sider render of the feature will not return and HTML
4. Client side should fetch content if needed (Verify using network panel to see API call)
5. LazyLoad should not be active within the PageBuilder Editor UI

## Test Steps

1. Checkout this branch `git checkout TMEDIA-168-lazy-load-promos`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/placeholder-image-block,@wpmedia/small-promo-block,@wpmedia/small-manual-promo-block,@wpmedia/medium-promo-block,@wpmedia/medium-manual-promo-block,@wpmedia/large-promo-block,@wpmedia/large-manual-promo-block,@wpmedia/extra-large-promo-block,@wpmedia/extra-large-manual-promo-block`
3. Either on a new page or existing page toggle on the new custom field option "lazyLoad" each of the blocks.
4. View the published page
5. Verify the HTML for each feature is not present on page load - You can disable JavaScript in dev tools and verify the features you enabled lazyLoad for do not render on server render
6. Verify when you scroll the page that as you begin to get nearer the features there are network calls to fetch the content needed for each feature you have enabled lazyLoad for.
7. For promo blocks where you can specify a custom image, you should see a call the the `resizer-image-api-client` content source when lazy load is turned on

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.