### PR TITLE
TMEDIA-171 lazy load article body, article tag author bio blocks

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -9,6 +9,7 @@ import {
   Gallery, ImageMetadata, Image,
   // presentational component does not do data fetching
   VideoPlayer as VideoPlayerPresentational,
+  LazyLoad, isServerSide,
 } from '@wpmedia/engine-theme-sdk';
 import Blockquote from './_children/blockquote';
 import Header from './_children/heading';
@@ -230,7 +231,7 @@ const ArticleBody = styled.article`
   }
 `;
 
-const ArticleBodyChain = ({ children }) => {
+const ArticleBodyChainItems = ({ children }) => {
   const {
     globalContent: items = {}, customFields = {}, arcSite, id,
   } = useFusionContext();
@@ -284,12 +285,31 @@ const ArticleBodyChain = ({ children }) => {
   );
 };
 
+const ArticleBodyChain = ({ customFields = {}, children }) => {
+  const { isAdmin } = useFusionContext();
+  if (customFields.lazyLoad && isServerSide() && !isAdmin) { // On Server
+    return null;
+  }
+  return (
+    <LazyLoad enabled={customFields.lazyLoad && !isAdmin}>
+      <ArticleBodyChainItems customFields={{ ...customFields }}>
+        {children}
+      </ArticleBodyChainItems>
+    </LazyLoad>
+  );
+};
+
 ArticleBodyChain.propTypes = {
   customFields: PropTypes.shape({
     elementPlacement: PropTypes.kvp.tag({
       label: 'Ad placements',
       group: 'Inline ads',
       description: 'Places your inline article body ads in the article body chain. For each ad feature in the chain, fill in two values below: Field 1) The position of the ad within the chain and Field 2) the paragraph number that this ad should follow in the article body. For example, entering 1 and 3 would mean that the first ad in the article body chain will be placed after the third paragraph in the article.',
+    }),
+    lazyLoad: PropTypes.bool.tag({
+      name: 'Lazy Load block?',
+      defaultValue: false,
+      description: 'Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.',
     }),
   }),
 };

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -1,9 +1,17 @@
 const React = require('react');
 const { mount } = require('enzyme');
 
+jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
+
 jest.mock('fusion:properties', () => (jest.fn(() => ({
   resizerURL: 'https://resizer.me',
 }))));
+
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  Image: () => <div />,
+  ImageMetadata: () => <div />,
+  LazyLoad: ({ children }) => <>{ children }</>,
+}));
 
 describe('article-body chain', () => {
   describe('when it is initialized', () => {
@@ -1359,15 +1367,18 @@ describe('article-body chain', () => {
           <span>3</span>
         </ArticleBodyChain>,
       );
-      expect(wrapper.find('figure').length).toEqual(1);
-      expect(wrapper.find('figure').find('Image').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('span').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('p').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('p').find('.title').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('p').text()).toMatch("Australia surf trip Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break.  (Brett Danielsen/Death to Stock Photo)");
-      expect(wrapper.find('figure').find('figcaption').find('p').find('.title')
-        .text()).toMatch('Australia surf trip ');
+      const figureEl = wrapper.find('figure');
+      expect(figureEl).toHaveLength(1);
+      expect(figureEl.find('Image')).toHaveLength(1);
+      const figCaptionEl = figureEl.find('figcaption');
+      expect(figCaptionEl).toHaveLength(1);
+      const imageMetadataEl = figCaptionEl.find('ImageMetadata');
+      expect(imageMetadataEl).toHaveLength(1);
+      expect(imageMetadataEl.prop('caption')).toContain("Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break.");
+      expect(imageMetadataEl.prop('subtitle')).toMatch('Australia surf trip');
+      const authorCredits = imageMetadataEl.prop('credits');
+      expect(authorCredits?.by[0]?.name).toEqual('Brett Danielsen');
+      expect(authorCredits?.affiliation[0]?.name).toEqual('Death to Stock Photo');
     });
     it('should not render image with figcaption and author', () => {
       jest.mock('fusion:context', () => ({
@@ -1593,15 +1604,18 @@ describe('article-body chain', () => {
           <span>3</span>
         </ArticleBodyChain>,
       );
-      expect(wrapper.find('figure').length).toEqual(1);
-      expect(wrapper.find('figure').find('Image').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('span').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('p').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('p').find('.title').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('p').text()).toMatch("Australia surf trip Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break.");
-      expect(wrapper.find('figure').find('figcaption').find('p').find('.title')
-        .text()).toMatch('Australia surf trip ');
+      const figureEl = wrapper.find('figure');
+      expect(figureEl).toHaveLength(1);
+      expect(figureEl.find('Image')).toHaveLength(1);
+      const figCaptionEl = figureEl.find('figcaption');
+      expect(figCaptionEl).toHaveLength(1);
+      const imageMetadataEl = figCaptionEl.find('ImageMetadata');
+      expect(imageMetadataEl).toHaveLength(1);
+      expect(imageMetadataEl.prop('caption')).toContain("Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break.");
+      expect(imageMetadataEl.prop('subtitle')).toMatch('Australia surf trip');
+      const vanityCredits = imageMetadataEl.prop('vanityCredits');
+      expect(vanityCredits?.by).toHaveLength(0);
+      expect(vanityCredits?.affiliation).toHaveLength(0);
     });
 
     it('should override photographer and credit by using vanity_credits', () => {
@@ -1736,16 +1750,19 @@ describe('article-body chain', () => {
           <span>3</span>
         </ArticleBodyChain>,
       );
-      expect(wrapper.find('figure').length).toEqual(1);
-      expect(wrapper.find('figure').find('Image').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('span').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('p').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('p').find('.title').length).toEqual(1);
-      expect(wrapper.find('figure').find('figcaption').find('p').text())
-        .toMatch("Australia surf trip Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break.  (Here's my vanity photographer/Here's my vanity credit)");
-      expect(wrapper.find('figure').find('figcaption').find('p').find('.title')
-        .text()).toMatch('Australia surf trip ');
+
+      const figureEl = wrapper.find('figure');
+      expect(figureEl).toHaveLength(1);
+      expect(figureEl.find('Image')).toHaveLength(1);
+      const figCaptionEl = figureEl.find('figcaption');
+      expect(figCaptionEl).toHaveLength(1);
+      const imageMetadataEl = figCaptionEl.find('ImageMetadata');
+      expect(imageMetadataEl).toHaveLength(1);
+      expect(imageMetadataEl.prop('caption')).toContain("Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break.");
+      expect(imageMetadataEl.prop('subtitle')).toMatch('Australia surf trip');
+      const authorCredits = imageMetadataEl.prop('credits');
+      expect(authorCredits?.by[0]?.name).toEqual('Brett Danielsen');
+      expect(authorCredits?.affiliation[0]?.name).toEqual('Death to Stock Photo');
     });
   });
 

--- a/blocks/article-tag-block/features/tag/default.jsx
+++ b/blocks/article-tag-block/features/tag/default.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
+import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { LinkBackgroundHover } from '@wpmedia/news-theme-css/js/styled/linkHovers';
 import './tags.scss';
 
@@ -10,7 +12,7 @@ const Tags = styled(LinkBackgroundHover)`
   font-family: ${(props) => props.primaryFont};
 `;
 
-const ArticleTags = () => {
+const ArticleTagItems = () => {
   const { arcSite, globalContent: content } = useFusionContext();
   const { 'primary-color': primaryColor, 'primary-font': primaryFont } = getThemeStyle(arcSite);
   const defaultBackgroundColor = '#14689A';
@@ -29,6 +31,28 @@ const ArticleTags = () => {
   ) : null;
 };
 
+const ArticleTags = ({ customFields = {} }) => {
+  const { isAdmin } = useFusionContext();
+  if (customFields?.lazyLoad && isServerSide() && !isAdmin) { // On Server
+    return null;
+  }
+  return (
+    <LazyLoad enabled={customFields.lazyLoad && !isAdmin}>
+      <ArticleTagItems customFields={{ ...customFields }} />
+    </LazyLoad>
+  );
+};
+
 ArticleTags.label = 'Tags Bar – Arc Block';
+
+ArticleTags.propTypes = {
+  customFields: PropTypes.shape({
+    lazyLoad: PropTypes.bool.tag({
+      name: 'Lazy Load block?',
+      defaultValue: false,
+      description: 'Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.',
+    }),
+  }),
+};
 
 export default ArticleTags;

--- a/blocks/article-tag-block/features/tag/default.test.jsx
+++ b/blocks/article-tag-block/features/tag/default.test.jsx
@@ -5,6 +5,11 @@ describe('the article tag block', () => {
   jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
   jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
 
+  jest.mock('@wpmedia/engine-theme-sdk', () => ({
+    LazyLoad: ({ children }) => <>{ children }</>,
+    isServerSide: () => true,
+  }));
+
   describe('when the global content has an array of tags in its taxonomy', () => {
     const mockReturnData = {
       arcSite: 'the-sun',
@@ -33,6 +38,15 @@ describe('the article tag block', () => {
       jest.mock('fusion:context', () => ({
         useFusionContext: mockFunction,
       }));
+    });
+
+    it('should return null if lazyLoad on the server and not in the admin', () => {
+      const { default: ArticleTags } = require('./default.jsx');
+      const config = {
+        lazyLoad: true,
+      };
+      const wrapper = mount(<ArticleTags customFields={config} />);
+      expect(wrapper.html()).toBe(null);
     });
 
     it('should render a parent container for the tags', () => {

--- a/blocks/author-bio-block/features/author-bio/default.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
 import styled from 'styled-components';
@@ -19,6 +20,8 @@ import {
   WhatsAppIcon,
   SoundCloudIcon,
   RssIcon,
+  LazyLoad,
+  isServerSide,
 } from '@wpmedia/engine-theme-sdk';
 import getProperties from 'fusion:properties';
 
@@ -83,7 +86,7 @@ const renderAuthorInfo = (author, arcSite) => {
   );
 };
 
-const AuthorBio = () => {
+const AuthorBioItems = () => {
   const { globalContent: content, arcSite } = useFusionContext();
   const { credits = {} } = content;
   const { by = [] } = credits;
@@ -340,6 +343,28 @@ const AuthorBio = () => {
   );
 };
 
+const AuthorBio = ({ customFields = {} }) => {
+  const { isAdmin } = useFusionContext();
+  if (customFields.lazyLoad && isServerSide() && !isAdmin) { // On Server
+    return null;
+  }
+  return (
+    <LazyLoad enabled={customFields.lazyLoad && !isAdmin}>
+      <AuthorBioItems customFields={{ ...customFields }} />
+    </LazyLoad>
+  );
+};
+
 AuthorBio.label = 'Short Author Bio – Arc Block';
+
+AuthorBio.propTypes = {
+  customFields: PropTypes.shape({
+    lazyLoad: PropTypes.bool.tag({
+      name: 'Lazy Load block?',
+      defaultValue: false,
+      description: 'Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.',
+    }),
+  }),
+};
 
 export default AuthorBio;

--- a/blocks/author-bio-block/features/author-bio/default.test.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 jest.mock('@wpmedia/news-theme-css', () => ({
   lightenDarkenColor: () => 'blue',
@@ -25,9 +25,24 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   WhatsAppIcon: () => <svg>WhatsAppIcon</svg>,
   SoundCloudIcon: () => <svg>SoundCloudIcon</svg>,
   RssIcon: () => <svg>RssIcon</svg>,
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
+}));
+
+jest.mock('fusion:context', () => ({
+  useFusionContext: () => ({ isAdmin: false }),
 }));
 
 describe('Given the list of author(s) from the article', () => {
+  it('should return null if lazyLoad on the server and not in the admin', () => {
+    const { default: AuthorBio } = require('./default.jsx');
+    const config = {
+      lazyLoad: true,
+    };
+    const wrapper = mount(<AuthorBio customFields={config} />);
+    expect(wrapper.html()).toBe(null);
+  });
+
   it("should show one author's bio", () => {
     const { default: AuthorBio } = require('./default');
 
@@ -243,7 +258,7 @@ describe('Given the list of author(s) from the article', () => {
         },
       })),
     }));
-    const wrapper = shallow(<AuthorBio />);
+    const wrapper = mount(<AuthorBio />);
     expect(wrapper.find('Image')).toHaveLength(1);
     expect(wrapper.find('Image').prop('url')).toEqual('https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg');
   });


### PR DESCRIPTION
## Description

Add Lazy Load functionality to the follow blocks

* Article Body
* Article Tag
* Author Bio


## Jira Ticket
- [TMEDIA-171](https://arcpublishing.atlassian.net/browse/TMEDIA-171)

## Acceptance Criteria
1. A new boolean custom field called Lazy load block? should be added to all blocks listed in the section above
    * If Lazy load block? is true, the block should lazy load on the page once it comes within 300px of the viewport
    * If Lazy load block? is false, the block should load immediately (it should not lazy load) – this is the existing behavior
2. The default value for this custom setting should be false
3. Server sider render of the feature will not return and HTML
4. Client side should fetch content if needed (Verify using network panel to see API call)
5. LazyLoad should not be active within the PageBuilder Editor UI

## Test Steps
1. Checkout this branch `git checkout TMEDIA-171-lazy-load-artice-body-tag-author-bio`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/author-bio-block,@wpmedia/article-tag-block,@wpmedia/article-body-block`
3. Using the following page - http://localhost/local/2020/09/23/story-with-related-content/?_website=the-sun
4. Verify the page loads as intended
5. In PageBuilder edit the template `article right rail` and enabled lazy load custom field for the three blocks
    * Article Body
    * Article Tag
    * Author Bio
6. Publish the page and visit the same page again and verify content is loaded and rendered client side

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.