### PR TITLE
TMEDIA-169 - List block server side missing content bug

### DIFF
--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -62,8 +62,8 @@ class CardList extends React.Component {
 
     this.fetchPlaceholder();
 
-    // On Server and in Admin
-    if (this.lazyLoad && isServerSide() && this.isAdmin) {
+    // Fetch stories if lazyLoad is not enabled, the code is running on the server
+    if (!this.lazyLoad && isServerSide()) {
       this.fetchStories();
     }
   }
@@ -108,7 +108,7 @@ class CardList extends React.Component {
   }
 
   render() {
-    if (this.lazyLoad && isServerSide() && !this.isAdmin) { // On Server
+    if (this.lazyLoad && isServerSide() && !this.isAdmin) {
       return null;
     }
 

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -17,6 +17,7 @@ jest.mock('fusion:properties', () => (jest.fn(() => ({
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
   LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 
 jest.mock('@wpmedia/byline-block', () => ({
@@ -30,6 +31,26 @@ jest.mock('@wpmedia/date-block', () => ({
 }));
 
 describe('Card list', () => {
+  it('should render null if isServerSide and lazyLoad enabled', () => {
+    const listContentConfig = {
+      contentConfigValues: {
+        offset: '0',
+        query: 'type:story',
+        size: '30',
+      },
+      contentService: 'story-feed-query',
+    };
+    const customFields = {
+      listContentConfig,
+      lazyLoad: true,
+    };
+
+    const { default: CardList } = require('./default');
+    CardList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
+    const wrapper = mount(<CardList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+    expect(wrapper.html()).toBe(null);
+  });
+
   it('should render a list of stories', () => {
     const listContentConfig = {
       contentConfigValues: {

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -29,8 +29,8 @@ class NumberedList extends Component {
 
     this.fetchPlaceholder();
 
-    // On Server and in Admin
-    if (this.lazyLoad && isServerSide() && this.isAdmin) {
+    // Fetch stories if lazyLoad is not enabled, the code is running on the server
+    if (!this.lazyLoad && isServerSide()) {
       this.fetchStories();
     }
   }
@@ -75,7 +75,7 @@ class NumberedList extends Component {
   }
 
   render() {
-    if (this.lazyLoad && isServerSide() && !this.isAdmin) { // On Server
+    if (this.lazyLoad && isServerSide() && !this.isAdmin) {
       return null;
     }
 

--- a/blocks/numbered-list-block/features/numbered-list/default.test.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.test.jsx
@@ -8,6 +8,7 @@ jest.mock('fusion:properties', () => (jest.fn(() => ({
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <img alt="test" />,
   LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 const { default: mockData } = require('./mock-data');
 
@@ -25,6 +26,29 @@ jest.mock('@wpmedia/shared-styles', () => ({
 
 describe('The numbered-list-block', () => {
   describe('render a list of numbered-list-items', () => {
+    it('should render null if isServerSide and lazyLoad enabled', () => {
+      const listContentConfig = {
+        contentConfigValues:
+        {
+          offset: '0',
+          query: 'type:story',
+          size: '30',
+        },
+        contentService: 'story-feed-query',
+      };
+      const customFields = {
+        listContentConfig,
+        showHeadline: true,
+        showImage: true,
+        lazyLoad: true,
+      };
+
+      const { default: NumberedList } = require('./default');
+      NumberedList.prototype.fetchContent = jest.fn().mockReturnValue({});
+      const wrapper = mount(<NumberedList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+      expect(wrapper.html()).toBe(null);
+    });
+
     it('should render list item with headline, image and a number', () => {
       const { default: NumberedList } = require('./default');
       const listContentConfig = {

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -60,6 +60,11 @@ class ResultsList extends Component {
     this.isAdmin = props.isAdmin;
 
     this.fetchPlaceholder();
+
+    // Fetch stories if lazyLoad is not enabled, the code is running on the server
+    if (!this.lazyLoad && isServerSide()) {
+      this.fetchStories(false);
+    }
   }
 
   componentDidMount() {

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -31,6 +31,7 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   __esModule: true,
   Image: () => <div />,
   LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 
 describe('The results list', () => {
@@ -474,9 +475,9 @@ describe('The results list', () => {
       });
 
       it('should call fetchContent when clicked', () => {
-        expect(ResultsList.prototype.fetchStories.mock.calls.length).toEqual(1);
-        wrapper.find('button.btn').simulate('click');
         expect(ResultsList.prototype.fetchStories.mock.calls.length).toEqual(2);
+        wrapper.find('button.btn').simulate('click');
+        expect(ResultsList.prototype.fetchStories.mock.calls.length).toEqual(3);
       });
     });
   });
@@ -585,9 +586,9 @@ describe('The results list from collection', () => {
     const wrapper = mount(<ResultsList customFields={customFields} arcSite="the-gazette" deployment={jest.fn((path) => path)} />);
     wrapper.setState({ resultList: collectionFirst10Items, seeMore: true }, () => {
       wrapper.update();
-      expect(ResultsList.prototype.fetchStories.mock.calls.length).toEqual(1);
-      wrapper.find('button.btn').simulate('click');
       expect(ResultsList.prototype.fetchStories.mock.calls.length).toEqual(2);
+      wrapper.find('button.btn').simulate('click');
+      expect(ResultsList.prototype.fetchStories.mock.calls.length).toEqual(3);
     });
   });
 

--- a/blocks/results-list-block/features/results-list/internalTests.test.jsx
+++ b/blocks/results-list-block/features/results-list/internalTests.test.jsx
@@ -22,6 +22,7 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   __esModule: true,
   Image: () => <div />,
   LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({
@@ -81,7 +82,7 @@ describe('fetchPlaceholder', () => {
     expect(mockDeployment).toHaveBeenCalledTimes(0);
     wrapper.instance().fetchPlaceholder();
 
-    expect(fetchContentMock).toHaveBeenCalledTimes(1);
+    expect(fetchContentMock).toHaveBeenCalledTimes(2);
     expect(fetchContentMock).toHaveBeenCalledWith('story-feed-query', { offset: '0', query: 'type: story', size: '1' });
   });
 });


### PR DESCRIPTION
## Description

Fix issue with features not having content on server side load when lazy load not enabled

## Jira Ticket
- [TMEDIA-169](https://arcpublishing.atlassian.net/browse/TMEDIA-169)


## Test Steps

1. Checkout this branch `git checkout TMEDIA-169-list-block-bug-fix`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/card-list-block,@wpmedia/numbered-list-block,@wpmedia/results-list-block,@wpmedia/simple-list-block,@wpmedia/search-results-list-block,@wpmedia/top-table-list-block`
3. On an existing page that have list blocks but no enabled for lazy load verify the blocks are loaded from the server - http://localhost/all-blocks/?_website=the-gazette
4. On a page with blocks that have lazy load enabled verify the blocks are not loaded on the server, but are loaded on client side render

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.