### PR TITLE
TMEDIA-169 - Switch to using fetchContent to ensure render comes from server

### DIFF
--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -174,15 +174,20 @@ class ResultsList extends Component {
         focusItem: currentCount,
       });
     } else {
-      const { fetched } = this.getContent(listContentConfig.contentService, contentConfigValues);
-      fetched.then((response) => {
-        this.setState({ resultList: response });
-        if (response?.content_elements
-          && response?.count
-          && response.content_elements.length >= response.count) {
-          this.setState({ seeMore: false });
-        }
+      this.fetchContent({
+        resultList: {
+          source: listContentConfig.contentService,
+          query: contentConfigValues,
+        },
       });
+
+      const { resultList } = this.state;
+      if (resultList?.content_elements
+        && resultList?.count
+        && resultList.content_elements.length >= resultList.count) {
+        this.setState({ seeMore: false });
+      }
+
       if (listContentConfig.contentService === 'content-api-collections') {
         const query = { ...contentConfigValues };
         const from = parseInt(contentConfigValues.from, 10) || 0;

--- a/blocks/results-list-block/features/results-list/internalTests.test.jsx
+++ b/blocks/results-list-block/features/results-list/internalTests.test.jsx
@@ -74,8 +74,7 @@ describe('fetchPlaceholder', () => {
       resolve(content);
     });
     const fetchContentMock = jest.fn().mockReturnValue({ fetched: fetched({}) });
-    ResultsList.prototype.fetchContent = jest.fn().mockReturnValue({});
-    ResultsList.prototype.getContent = fetchContentMock;
+    ResultsList.prototype.fetchContent = fetchContentMock;
     const mockDeployment = jest.fn();
     const wrapper = shallow(<ResultsList arcSite="the-sun" deployment={mockDeployment} contextPath="/pf" customFields={customFields} />);
     mockDeployment.mockClear();
@@ -83,7 +82,7 @@ describe('fetchPlaceholder', () => {
     wrapper.instance().fetchPlaceholder();
 
     expect(fetchContentMock).toHaveBeenCalledTimes(2);
-    expect(fetchContentMock).toHaveBeenCalledWith('story-feed-query', { offset: '0', query: 'type: story', size: '1' });
+    expect(fetchContentMock).toHaveBeenCalledWith({ resultList: { query: { offset: '0', query: 'type: story', size: '1' }, source: 'story-feed-query' } });
   });
 });
 


### PR DESCRIPTION
## Description

Switch to `fetchContent` method to ensure content is rendered on the server side

## Jira Ticket
- [TMEDIA-169](https://arcpublishing.atlassian.net/browse/TMEDIA-169)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-169-result-list-server-side-bug`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/results-list-block`
3. On an existing page that has results list block but no enabled for lazy load verify the blocks are loaded from the server
4. On a page with blocks that have lazy load enabled verify the blocks are not loaded on the server, but are loaded on client side render

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.