### PR TITLE
TMEDIA-171 - Implement Lazy Load on Full Author Bio Block

### DIFF
--- a/blocks/full-author-bio-block/features/full-author-bio/default.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
@@ -21,6 +22,8 @@ import {
   WhatsAppIcon,
   SoundCloudIcon,
   Image,
+  LazyLoad,
+  isServerSide,
 } from '@wpmedia/engine-theme-sdk';
 import './full-author-bio.scss';
 import constructSocialURL from './shared/constructSocialURL';
@@ -85,7 +88,7 @@ const logos = {
   />,
 };
 
-const FullAuthorBio = () => {
+const FullAuthorBioItem = () => {
   const { globalContent: content, arcSite } = useFusionContext();
   const { locale = 'en' } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
@@ -175,6 +178,28 @@ const FullAuthorBio = () => {
   );
 };
 
+const FullAuthorBio = ({ customFields = {} }) => {
+  const { isAdmin } = useFusionContext();
+  if (customFields.lazyLoad && isServerSide() && !isAdmin) { // On Server
+    return null;
+  }
+  return (
+    <LazyLoad enabled={customFields.lazyLoad && !isAdmin}>
+      <FullAuthorBioItem customFields={{ ...customFields }} />
+    </LazyLoad>
+  );
+};
+
 FullAuthorBio.label = 'FullAuthorBio – Arc Block';
+
+FullAuthorBio.propTypes = {
+  customFields: PropTypes.shape({
+    lazyLoad: PropTypes.bool.tag({
+      name: 'Lazy Load block?',
+      defaultValue: false,
+      description: 'Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.',
+    }),
+  }),
+};
 
 export default FullAuthorBio;

--- a/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
@@ -8,6 +8,26 @@ jest.mock('fusion:properties', () => (jest.fn(() => ({
   resizerURL: 'resizer',
 }))));
 
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  Image: () => <div />,
+  EnvelopeIcon: () => <svg>EnvelopeIcon</svg>,
+  LinkedInIcon: () => <svg>LinkedInIcon</svg>,
+  InstagramIcon: () => <svg>InstagramIcon</svg>,
+  TwitterIcon: () => <svg>TwitterIcon</svg>,
+  FacebookIcon: () => <svg>FacebookIcon</svg>,
+  RedditIcon: () => <svg>RedditIcon</svg>,
+  YoutubeIcon: () => <svg>YoutubeIcon</svg>,
+  MediumIcon: () => <svg>MediumIcon</svg>,
+  TumblrIcon: () => <svg>TumblrIcon</svg>,
+  PinterestIcon: () => <svg>PinterestIcon</svg>,
+  SnapchatIcon: () => <svg>SnapchatIcon</svg>,
+  WhatsAppIcon: () => <svg>WhatsAppIcon</svg>,
+  SoundCloudIcon: () => <svg>SoundCloudIcon</svg>,
+  RssIcon: () => <svg>RssIcon</svg>,
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
+}));
+
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:context', () => ({
   useFusionContext: jest.fn(() => ({
@@ -54,6 +74,11 @@ jest.mock('fusion:context', () => ({
 }));
 
 describe('the full author bio block', () => {
+  it('should return null if lazyLoad on the server and not in the admin', () => {
+    const wrapper = mount(<FullAuthorBio customFields={{ lazyLoad: true }} />);
+    expect(wrapper.html()).toBe(null);
+  });
+
   describe('when fields from globalContent are present', () => {
     it('should render a h1', () => {
       const wrapper = mount(<FullAuthorBio />);


### PR DESCRIPTION
## Description

Add Lazy Load functionality to the Full Author Bio Block


## Jira Ticket
- [TMEDIA-171](https://arcpublishing.atlassian.net/browse/TMEDIA-171)

## Acceptance Criteria
1. A new boolean custom field called Lazy load block? should be added to all blocks listed in the section above
    * If Lazy load block? is true, the block should lazy load on the page once it comes within 300px of the viewport
    * If Lazy load block? is false, the block should load immediately (it should not lazy load) – this is the existing behavior
2. The default value for this custom setting should be false
3. Server sider render of the feature will not return and HTML
4. Client side should fetch content if needed (Verify using network panel to see API call)
5. LazyLoad should not be active within the PageBuilder Editor UI

## Test Steps
1. Checkout this branch `git checkout TMEDIA-171-full-author-bio`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/full-author-bio-block`
3. Using the following page - http://localhost/pf/bio_page/?_website=the-gazette
4. Verify the page loads as intended
5. In PageBuilder edit the page and enabled the new Lazy Load custom field
6. Publish the page and visit the same page again and verify content is loaded and rendered client side

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.