### PR TITLE
TMEDIA-170 - Lazy Load gallery and footer blocks

### DIFF
--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -6,9 +6,14 @@ import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getThemeStyle from 'fusion:themes';
 import Link from '@wpmedia/links-bar-block';
-import FacebookAltIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/FacebookAltIcon';
-import TwitterIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/TwitterIcon';
-import RssIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/RssIcon';
+
+import {
+  FacebookAltIcon,
+  TwitterIcon,
+  RssIcon,
+  LazyLoad,
+  isServerSide,
+} from '@wpmedia/engine-theme-sdk';
 
 import './footer.scss';
 
@@ -25,7 +30,7 @@ export const StyledSocialContainer = styled.div`
   }
 `;
 
-const Footer = ({ customFields: { navigationConfig } }) => {
+const FooterItem = ({ customFields: { navigationConfig } }) => {
   const { arcSite, deployment, contextPath } = useFusionContext();
   const {
     facebookPage,
@@ -166,11 +171,28 @@ const Footer = ({ customFields: { navigationConfig } }) => {
   );
 };
 
+const Footer = ({ customFields }) => {
+  const { isAdmin } = useFusionContext();
+  if (customFields.lazyLoad && isServerSide() && !isAdmin) { // On Server
+    return null;
+  }
+  return (
+    <LazyLoad enabled={customFields.lazyLoad && !isAdmin}>
+      <FooterItem customFields={{ ...customFields }} />
+    </LazyLoad>
+  );
+};
+
 Footer.propTypes = {
   customFields: PropTypes.shape({
     navigationConfig: PropTypes.contentConfig('navigation-hierarchy').tag({
       group: 'Configure Content',
       label: 'Navigation',
+    }),
+    lazyLoad: PropTypes.bool.tag({
+      name: 'Lazy Load block?',
+      defaultValue: false,
+      description: 'Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.',
     }),
   }),
 };

--- a/blocks/footer-block/features/footer/default.test.jsx
+++ b/blocks/footer-block/features/footer/default.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import getProperties from 'fusion:properties';
 import { useContent } from 'fusion:content';
 import Footer from './default';
@@ -99,6 +99,14 @@ const mockPayload = {
   ],
 };
 
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  FacebookAltIcon: () => <svg>FacebookAltIcon</svg>,
+  TwitterIcon: () => <svg>TwitterIcon</svg>,
+  RssIcon: () => <svg>RssIcon</svg>,
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
+}));
+
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
 jest.mock('fusion:context', () => ({
@@ -126,6 +134,14 @@ describe('the footer feature for the default output type', () => {
     }));
   });
 
+  it('should return null if lazyLoad on the server and not in the admin', () => {
+    const config = {
+      lazyLoad: true,
+    };
+    const wrapper = mount(<Footer customFields={config} />);
+    expect(wrapper.html()).toBe(null);
+  });
+
   it('should have 5 column headers', () => {
     const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
 
@@ -145,7 +161,7 @@ describe('the footer feature for the default output type', () => {
   });
 
   it('should have empty column when empty payload is given', () => {
-    const wrapper = shallow(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+    const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
 
     jest.mock('fusion:content', () => ({
       useContent: jest.fn(() => ({})),
@@ -155,7 +171,7 @@ describe('the footer feature for the default output type', () => {
   });
 
   it('should have empty column without error when undefined payload is given', () => {
-    const wrapper = shallow(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+    const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
 
     jest.mock('fusion:content', () => ({
       useContent: jest.fn(() => (undefined)),
@@ -166,7 +182,7 @@ describe('the footer feature for the default output type', () => {
 
   describe('the content source configuration', () => {
     it('should have a default set of query values', () => {
-      shallow(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfigValues: {} } }} />);
+      mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfigValues: {} } }} />);
 
       expect(useContent).toHaveBeenCalledWith({
         query: {
@@ -177,7 +193,7 @@ describe('the footer feature for the default output type', () => {
     });
 
     it('should overwrite those values with configured values', () => {
-      shallow(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfigValues: { hierarchy: 'not-a-footer', extraval: 11111 } } }} />);
+      mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfigValues: { hierarchy: 'not-a-footer', extraval: 11111 } } }} />);
 
       expect(useContent).toHaveBeenCalledWith({
         query: {
@@ -300,7 +316,7 @@ describe('the footer feature for the default output type', () => {
     describe('when copyright text is provided', () => {
       it('should show copyright text', () => {
         getProperties.mockImplementation(() => ({ copyrightText: 'my copyright text' }));
-        const wrapper = shallow(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+        const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
 
         expect((wrapper.find('#copyright-top')).text()).toStrictEqual('my copyright text');
       });
@@ -309,7 +325,7 @@ describe('the footer feature for the default output type', () => {
     describe('when copyright text is not provided', () => {
       it('should not show copyright text', () => {
         getProperties.mockImplementation(() => ({ }));
-        const wrapper = shallow(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
+        const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
 
         expect((wrapper.find('#copyright-top')).text()).toStrictEqual('');
       });

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -5,9 +5,9 @@ import { useFusionContext, useAppContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 
-import { Gallery } from '@wpmedia/engine-theme-sdk';
+import { Gallery, LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 
-const GalleryFeature = (
+const GalleryFeatureItem = (
   {
     customFields: {
       inheritGlobalContent,
@@ -64,6 +64,18 @@ const GalleryFeature = (
   );
 };
 
+const GalleryFeature = ({ customFields = {} }) => {
+  const { isAdmin } = useFusionContext();
+  if (customFields.lazyLoad && isServerSide() && !isAdmin) { // On Server
+    return null;
+  }
+  return (
+    <LazyLoad enabled={customFields.lazyLoad && !isAdmin}>
+      <GalleryFeatureItem customFields={{ ...customFields }} />
+    </LazyLoad>
+  );
+};
+
 GalleryFeature.propTypes = {
   customFields: PropTypes.shape({
     galleryContentConfig: PropTypes.contentConfig().tag({
@@ -73,6 +85,11 @@ GalleryFeature.propTypes = {
     inheritGlobalContent: PropTypes.bool.tag({
       group: 'Configure Content',
       defaultValue: true,
+    }),
+    lazyLoad: PropTypes.bool.tag({
+      name: 'Lazy Load block?',
+      defaultValue: false,
+      description: 'Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.',
     }),
   }),
 };

--- a/blocks/gallery-block/features/gallery/default.test.jsx
+++ b/blocks/gallery-block/features/gallery/default.test.jsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 const mockPhrases = {
   'global.gallery-expand-button': 'Expand',
@@ -14,18 +14,37 @@ jest.mock('fusion:properties', () => (jest.fn(() => ({
   resizerURL: 'https://fake.cdn.com/resizer',
   galleryCubeClicks: 5,
 }))));
+
 jest.mock('fusion:context', () => ({
+  useAppContext: jest.fn(() => ({})),
   useFusionContext: jest.fn(() => ({})),
 }));
 
+jest.mock('fusion:content', () => ({
+  useContent: jest.fn(() => ([])),
+}));
+
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
-  Gallery: (props, children) => (<div {...props}>{ children }</div>),
+  Gallery: function Gallery() {
+    return <div />;
+  },
+  LazyLoad: ({ children }) => <>{ children }</>,
+  isServerSide: () => true,
 }));
 
 jest.mock('fusion:intl', () => ({
   __esModule: true,
   default: jest.fn(() => ({ t: jest.fn((phrase) => mockPhrases[phrase]) })),
 }));
+
+describe('gallery feature block - lazy load', () => {
+  it('should not return on server side with lazy load true', () => {
+    const { default: GalleryFeature } = require('./default');
+    const wrapper = mount(<GalleryFeature customFields={{ lazyLoad: true }} />);
+
+    expect(wrapper.html()).toBe(null);
+  });
+});
 
 describe('gallery feature block - no custom fields', () => {
   beforeEach(() => {
@@ -37,13 +56,13 @@ describe('gallery feature block - no custom fields', () => {
     }));
 
     jest.mock('fusion:content', () => ({
-      useContent: jest.fn(() => ({})),
+      useContent: jest.fn(() => ([])),
     }));
   });
 
   it('should render the global content gallery', () => {
     const { default: GalleryFeature } = require('./default');
-    const wrapper = shallow(<GalleryFeature />);
+    const wrapper = mount(<GalleryFeature />);
 
     expect(wrapper.find('Gallery').props().ansHeadline).toEqual('');
     expect(wrapper.find('Gallery').props().galleryElements).toStrictEqual([]);
@@ -79,13 +98,13 @@ describe('gallery feature block - globalContent', () => {
     }));
 
     jest.mock('fusion:content', () => ({
-      useContent: jest.fn(() => ({})),
+      useContent: jest.fn(() => ([])),
     }));
   });
 
   it('should render the global content gallery', () => {
     const { default: GalleryFeature } = require('./default');
-    const wrapper = shallow(<GalleryFeature customFields={{ inheritGlobalContent: true }} />);
+    const wrapper = mount(<GalleryFeature customFields={{ inheritGlobalContent: true }} />);
 
     expect(wrapper.find('Gallery').props().ansHeadline).toEqual('This is a global content headline');
     expect(wrapper.find('Gallery').props().galleryElements).toStrictEqual(
@@ -126,7 +145,7 @@ describe('gallery feature block - contentConfig', () => {
       })),
     }));
     const { default: GalleryFeature } = require('./default');
-    const wrapper = shallow(<GalleryFeature customFields={{ galleryContentConfig: { contentService: 'cool-api', contentConfigValues: 'cool-config' } }} />);
+    const wrapper = mount(<GalleryFeature customFields={{ galleryContentConfig: { contentService: 'cool-api', contentConfigValues: 'cool-config' } }} />);
     expect(wrapper.find('Gallery').props().ansHeadline).toEqual('This is a headline');
     expect(wrapper.find('Gallery').props().pageCountPhrase).toBeInstanceOf(Function);
     expect(wrapper.find('Gallery').props().galleryElements).toStrictEqual(
@@ -152,7 +171,7 @@ describe('gallery feature block - contentConfig', () => {
       })),
     }));
     const { default: GalleryFeature } = require('./default');
-    const wrapper = shallow(<GalleryFeature customFields={{ galleryContentConfig: { contentService: 'cool-api', contentConfigValues: 'cool-config' } }} />);
+    const wrapper = mount(<GalleryFeature customFields={{ galleryContentConfig: { contentService: 'cool-api', contentConfigValues: 'cool-config' } }} />);
     expect(wrapper.find('Gallery').props().ansHeadline).toEqual('');
     expect(wrapper.find('Gallery').props().galleryElements).toStrictEqual(
       [
@@ -176,7 +195,7 @@ describe('gallery feature block - contentConfig', () => {
       })),
     }));
     const { default: GalleryFeature } = require('./default');
-    const wrapper = shallow(<GalleryFeature customFields={{ galleryContentConfig: { contentService: 'cool-api', contentConfigValues: 'cool-config' } }} />);
+    const wrapper = mount(<GalleryFeature customFields={{ galleryContentConfig: { contentService: 'cool-api', contentConfigValues: 'cool-config' } }} />);
     expect(wrapper.find('Gallery').props().ansId).toEqual('');
     expect(wrapper.find('Gallery').props().ansHeadline).toEqual('');
     expect(wrapper.find('Gallery').props().galleryElements).toStrictEqual(
@@ -191,10 +210,10 @@ describe('gallery feature block - contentConfig', () => {
 
   it('should have no gallery elements if no content_elements', () => {
     jest.mock('fusion:content', () => ({
-      useContent: jest.fn(() => ({})),
+      useContent: jest.fn(() => ([])),
     }));
     const { default: GalleryFeature } = require('./default');
-    const wrapper = shallow(<GalleryFeature customFields={{ galleryContentConfig: { contentService: 'cool-api', contentConfigValues: 'cool-config' } }} />);
+    const wrapper = mount(<GalleryFeature customFields={{ galleryContentConfig: { contentService: 'cool-api', contentConfigValues: 'cool-config' } }} />);
     expect(wrapper.find('Gallery').props().ansId).toEqual('');
     expect(wrapper.find('Gallery').props().ansHeadline).toEqual('');
     expect(wrapper.find('Gallery').props().galleryElements).toStrictEqual([]);


### PR DESCRIPTION
## Description

Add Lazy Load functionality to the follow blocks

* Gallery
* Footer

## Jira Ticket
- [TMEDIA-170](https://arcpublishing.atlassian.net/browse/TMEDIA-170)

## Acceptance Criteria
1. A new boolean custom field called Lazy load block? should be added to all blocks listed in the section above
    * If Lazy load block? is true, the block should lazy load on the page once it comes within 300px of the viewport
    * If Lazy load block? is false, the block should load immediately (it should not lazy load) – this is the existing behavior
2. The default value for this custom setting should be false
3. Server sider render of the feature will not return and HTML
4. Client side should fetch content if needed (Verify using network panel to see API call)
5. LazyLoad should not be active within the PageBuilder Editor UI

## Test Steps
1. Checkout this branch `git checkout TMEDIA-170-lazy-load-gallery-and-footer`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/gallery-block,@wpmedia/footer-block`
3. Using the following page - http://localhost/local/2020/01/14/five-affordable-destinations-for-a-do-it-yourself-wellness-vacation/?_website=the-gazette
4. Verify the page loads as intended
5. In PageBuilder edit the template `article right rail` and enabled lazy load custom field for the three blocks
    * Gallery
    * Footer
6. Publish the page and visit the same page again and verify content is loaded and rendered client side


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working. 
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist 
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr. 
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.