### PR TITLE
TMEDIA-104 Integrated photo center search on promo blocks

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -8,7 +8,7 @@ import { imageRatioCustomField, ratiosFor } from '@wpmedia/resizer-image-block';
 
 import '@wpmedia/shared-styles/scss/_extra-large-promo.scss';
 import { Image, LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
-import { useContent } from 'fusion:content';
+import { useContent, useEditableContent } from 'fusion:content';
 
 const HeadlineText = styled.h2`
   font-family: ${(props) => props.primaryFont};
@@ -31,10 +31,11 @@ const OverlineHeader = styled.h2`
 `;
 
 const ExtraLargeManualPromoItem = ({ customFields }) => {
-  const { arcSite } = useFusionContext();
+  const { arcSite, isAdmin } = useFusionContext();
+  const { searchableField } = useEditableContent();
 
   const resizedImageOptions = useContent({
-    source: customFields.lazyLoad ? 'resize-image-api-client' : 'resize-image-api',
+    source: (customFields.lazyLoad || isAdmin) ? 'resize-image-api-client' : 'resize-image-api',
     query: { raw_image_url: customFields.imageURL, 'arc-site': arcSite },
   });
   const ratios = ratiosFor('XL', customFields.imageRatio);
@@ -61,7 +62,7 @@ const ExtraLargeManualPromoItem = ({ customFields }) => {
           {(customFields.showHeadline || customFields.showDescription
             || customFields.showOverline)
           && (
-            <div className="col-sm-xl-12 flex-col">
+            <div className="col-sm-xl-12 flex-col" style={{ position: isAdmin ? 'relative' : null }}>
               {(customFields.showOverline && customFields.overline && customFields.overlineURL)
               && (
                 <OverlineLink
@@ -100,7 +101,7 @@ const ExtraLargeManualPromoItem = ({ customFields }) => {
                   breakpoints={getProperties(arcSite)?.breakpoints}
                   resizerURL={getProperties(arcSite)?.resizerURL}
                   resizedImageOptions={resizedImageOptions}
-                />, {}, { 'aria-hidden': 'true', tabIndex: '-1' },
+                />, {}, { 'aria-hidden': 'true', tabIndex: '-1', ...searchableField('imageURL') },
               )}
               {(customFields.showDescription && customFields.description)
               && (
@@ -153,6 +154,7 @@ ExtraLargeManualPromo.propTypes = {
     imageURL: PropTypes.string.tag({
       label: 'Image URL',
       group: 'Configure Content',
+      searchable: 'image',
     }),
     linkURL: PropTypes.string.tag({
       label: 'Link URL',

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
@@ -15,6 +15,9 @@ jest.mock('fusion:context', () => ({
 }));
 jest.mock('fusion:content', () => ({
   useContent: jest.fn(() => ({})),
+  useEditableContent: jest.fn(() => ({
+    searchableField: () => {},
+  })),
 }));
 
 const config = {

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -36,8 +36,8 @@ const DescriptionText = styled.p`
 `;
 
 const ExtraLargePromoItem = ({ customFields }) => {
-  const { arcSite, id } = useFusionContext();
-  const { editableContent } = useEditableContent();
+  const { arcSite, id, isAdmin } = useFusionContext();
+  const { editableContent, searchableField } = useEditableContent();
 
   const content = useContent({
     source: customFields?.itemContentConfig?.contentService ?? null,
@@ -47,7 +47,7 @@ const ExtraLargePromoItem = ({ customFields }) => {
   }) || null;
 
   let imageConfig = null;
-  if (customFields.imageOverrideURL && customFields.lazyLoad) {
+  if ((customFields.imageOverrideURL && customFields.lazyLoad) || isAdmin) {
     imageConfig = 'resize-image-api-client';
   } else if (customFields.imageOverrideURL) {
     imageConfig = 'resize-image-api';
@@ -160,7 +160,7 @@ const ExtraLargePromoItem = ({ customFields }) => {
           {(customFields.showHeadline || customFields.showDescription
             || customFields.showByline || customFields.showDate)
           && (
-            <div className="col-sm-xl-12 flex-col">
+            <div className="col-sm-xl-12 flex-col" style={{ position: isAdmin ? 'relative' : null }}>
               {overlineTmpl()}
               {headlineTmpl()}
               {
@@ -175,7 +175,7 @@ const ExtraLargePromoItem = ({ customFields }) => {
                 ) || (
                   customFields.showImage
                     && (
-                      <a href={content.website_url} aria-hidden="true" tabIndex="-1">
+                      <a href={content.website_url} aria-hidden="true" tabIndex="-1" {...searchableField('imageOverrideURL')}>
                         {imageURL && resizedImageOptions
                           ? (
                             <Image
@@ -289,6 +289,7 @@ ExtraLargePromo.propTypes = {
     imageOverrideURL: PropTypes.string.tag({
       label: 'Image URL',
       group: 'Image',
+      searchable: 'image',
     }),
     ...imageRatioCustomField('imageRatio', 'Art', '4:3'),
     playVideoInPlace: PropTypes.bool.tag({

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -24,7 +24,10 @@ jest.mock('fusion:context', () => ({
 }));
 jest.mock('fusion:content', () => ({
   useContent: jest.fn(() => (mockData)),
-  useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),
+  useEditableContent: jest.fn(() => ({
+    editableContent: () => ({ contentEditable: 'true' }),
+    searchableField: () => {},
+  })),
 }));
 
 const config = {

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -6,7 +6,7 @@ import getProperties from 'fusion:properties';
 import { useFusionContext } from 'fusion:context';
 import { Image, LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { imageRatioCustomField, ratiosFor } from '@wpmedia/resizer-image-block';
-import { useContent } from 'fusion:content';
+import { useContent, useEditableContent } from 'fusion:content';
 
 import '@wpmedia/shared-styles/scss/_large-promo.scss';
 
@@ -31,11 +31,12 @@ const OverlineHeader = styled.h2`
 `;
 
 const LargeManualPromoItem = ({ customFields }) => {
-  const { arcSite } = useFusionContext();
+  const { arcSite, isAdmin } = useFusionContext();
+  const { searchableField } = useEditableContent();
   const textClass = customFields.showImage ? 'col-sm-12 col-md-xl-6 flex-col' : 'col-sm-xl-12 flex-col';
 
   const resizedImageOptions = useContent({
-    source: customFields.lazyLoad ? 'resize-image-api-client' : 'resize-image-api',
+    source: (customFields.lazyLoad || isAdmin) ? 'resize-image-api-client' : 'resize-image-api',
     query: { raw_image_url: customFields.imageURL, 'arc-site': arcSite },
   });
   const ratios = ratiosFor('LG', customFields.imageRatio);
@@ -58,10 +59,10 @@ const LargeManualPromoItem = ({ customFields }) => {
   return (
     <>
       <article className="container-fluid large-promo">
-        <div className="row lg-promo-padding-bottom">
+        <div className="row lg-promo-padding-bottom" style={{ position: isAdmin ? 'relative' : null }}>
           {(customFields.showImage && customFields.imageURL && resizedImageOptions)
           && (
-            <div className="col-sm-12 col-md-xl-6">
+            <div className="col-sm-12 col-md-xl-6" {...searchableField('imageURL')}>
               { renderWithLink(
                 <Image
                   url={customFields.imageURL}

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -160,6 +160,7 @@ LargeManualPromo.propTypes = {
     imageURL: PropTypes.string.tag({
       label: 'Image URL',
       group: 'Configure Content',
+      searchable: 'image',
     }),
     linkURL: PropTypes.string.tag({
       label: 'Link URL',

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
@@ -16,6 +16,9 @@ jest.mock('fusion:context', () => ({
 
 jest.mock('fusion:content', () => ({
   useContent: jest.fn(() => ({})),
+  useEditableContent: jest.fn(() => ({
+    searchableField: () => {},
+  })),
 }));
 
 const config = {

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -283,10 +283,7 @@ LargePromo.propTypes = {
     imageOverrideURL: PropTypes.string.tag({
       label: 'Image URL',
       group: 'Image',
-    }),
-    imageOverrideAlt: PropTypes.string.tag({
-      label: 'Image Alt',
-      group: 'Image',
+      searchable: 'image',
     }),
     ...imageRatioCustomField('imageRatio', 'Art', '4:3'),
     playVideoInPlace: PropTypes.bool.tag({

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -37,8 +37,8 @@ const DescriptionText = styled.p`
 `;
 
 const LargePromoItem = ({ customFields }) => {
-  const { arcSite, id } = useFusionContext();
-  const { editableContent } = useEditableContent();
+  const { arcSite, id, isAdmin } = useFusionContext();
+  const { editableContent, searchableField } = useEditableContent();
 
   const content = useContent({
     source: customFields?.itemContentConfig?.contentService ?? null,
@@ -48,7 +48,7 @@ const LargePromoItem = ({ customFields }) => {
   }) || null;
 
   let imageConfig = null;
-  if (customFields.imageOverrideURL && customFields.lazyLoad) {
+  if ((customFields.imageOverrideURL && customFields.lazyLoad) || isAdmin) {
     imageConfig = 'resize-image-api-client';
   } else if (customFields.imageOverrideURL) {
     imageConfig = 'resize-image-api';
@@ -160,7 +160,7 @@ const LargePromoItem = ({ customFields }) => {
       <article className="container-fluid large-promo">
         <div className="row">
           { customFields.showImage && (
-            <div className="col-sm-12 col-md-xl-6 flex-col">
+            <div className="col-sm-12 col-md-xl-6 flex-col" style={{ position: isAdmin ? 'relative' : null }}>
               {
                 videoEmbed ? (
                   <VideoPlayerPresentational
@@ -169,7 +169,12 @@ const LargePromoItem = ({ customFields }) => {
                     enableAutoplay={false}
                   />
                 ) : (
-                  <a href={content.website_url} aria-hidden="true" tabIndex="-1">
+                  <a
+                    href={content.website_url}
+                    aria-hidden="true"
+                    tabIndex="-1"
+                    {...searchableField('imageOverrideURL')}
+                  >
                     {
                       imageURL && resizedImageOptions
                         ? (
@@ -277,6 +282,10 @@ LargePromo.propTypes = {
     }),
     imageOverrideURL: PropTypes.string.tag({
       label: 'Image URL',
+      group: 'Image',
+    }),
+    imageOverrideAlt: PropTypes.string.tag({
+      label: 'Image Alt',
       group: 'Image',
     }),
     ...imageRatioCustomField('imageRatio', 'Art', '4:3'),

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -39,7 +39,10 @@ jest.mock('fusion:context', () => ({
 
 jest.mock('fusion:content', () => ({
   useContent: jest.fn(() => (mockData)),
-  useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),
+  useEditableContent: jest.fn(() => ({
+    editableContent: () => ({ contentEditable: 'true' }),
+    searchableField: () => {},
+  })),
 }));
 
 describe('the large promo feature', () => {

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -4,9 +4,9 @@ import styled from 'styled-components';
 import getThemeStyle from 'fusion:themes';
 import getProperties from 'fusion:properties';
 import { useFusionContext } from 'fusion:context';
+import { useContent, useEditableContent } from 'fusion:content';
 import { Image, LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { imageRatioCustomField, ratiosFor } from '@wpmedia/resizer-image-block';
-import { useContent } from 'fusion:content';
 
 import '@wpmedia/shared-styles/scss/_medium-promo.scss';
 
@@ -19,10 +19,11 @@ const DescriptionText = styled.p`
 `;
 
 const MediumManualPromoItem = ({ customFields }) => {
-  const { arcSite } = useFusionContext();
+  const { arcSite, isAdmin } = useFusionContext();
+  const { searchableField } = useEditableContent();
 
   const resizedImageOptions = useContent({
-    source: customFields.lazyLoad ? 'resize-image-api-client' : 'resize-image-api',
+    source: (customFields.lazyLoad || isAdmin) ? 'resize-image-api-client' : 'resize-image-api',
     query: { raw_image_url: customFields.imageURL, 'arc-site': arcSite },
   });
 
@@ -50,8 +51,14 @@ const MediumManualPromoItem = ({ customFields }) => {
 
   return (
     <>
-      <article className="container-fluid medium-promo">
-        <div className={`medium-promo-wrapper ${hasImage ? 'md-promo-image' : ''}`}>
+      <article className="container-fluid medium-promo" style={{ position: isAdmin ? 'relative' : null }}>
+        <div
+          className={`medium-promo-wrapper ${hasImage ? 'md-promo-image' : ''}`}
+          {...searchableField({
+            imageURL: 'url',
+            imageAlt: 'alt_text',
+          })}
+        >
           {hasImage && resizedImageOptions && renderWithLink(
             <Image
               // medium is 16:9
@@ -120,6 +127,10 @@ MediumManualPromo.propTypes = {
       label: 'Image URL',
       group: 'Configure Content',
     }),
+    imageAlt: PropTypes.string.tag({
+      label: 'Image Alt',
+      group: 'Image',
+    }),
     linkURL: PropTypes.string.tag({
       label: 'Link URL',
       group: 'Configure Content',
@@ -129,27 +140,21 @@ MediumManualPromo.propTypes = {
       defaultValue: false,
       group: 'Configure Content',
     }),
-    showHeadline: PropTypes.bool.tag(
-      {
-        label: 'Show headline',
-        defaultValue: true,
-        group: 'Show promo elements',
-      },
-    ),
-    showImage: PropTypes.bool.tag(
-      {
-        label: 'Show image',
-        defaultValue: true,
-        group: 'Show promo elements',
-      },
-    ),
-    showDescription: PropTypes.bool.tag(
-      {
-        label: 'Show description',
-        defaultValue: true,
-        group: 'Show promo elements',
-      },
-    ),
+    showHeadline: PropTypes.bool.tag({
+      label: 'Show headline',
+      defaultValue: true,
+      group: 'Show promo elements',
+    }),
+    showImage: PropTypes.bool.tag({
+      label: 'Show image',
+      defaultValue: true,
+      group: 'Show promo elements',
+    }),
+    showDescription: PropTypes.bool.tag({
+      label: 'Show description',
+      defaultValue: true,
+      group: 'Show promo elements',
+    }),
     ...imageRatioCustomField('imageRatio', 'Art', '3:2'),
     lazyLoad: PropTypes.bool.tag({
       name: 'Lazy Load block?',

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -54,10 +54,7 @@ const MediumManualPromoItem = ({ customFields }) => {
       <article className="container-fluid medium-promo" style={{ position: isAdmin ? 'relative' : null }}>
         <div
           className={`medium-promo-wrapper ${hasImage ? 'md-promo-image' : ''}`}
-          {...searchableField({
-            imageURL: 'url',
-            imageAlt: 'alt_text',
-          })}
+          {...searchableField('imageOverrideURL')}
         >
           {hasImage && resizedImageOptions && renderWithLink(
             <Image
@@ -127,10 +124,6 @@ MediumManualPromo.propTypes = {
       label: 'Image URL',
       group: 'Configure Content',
       searchable: 'image',
-    }),
-    imageAlt: PropTypes.string.tag({
-      label: 'Image Alt',
-      group: 'Image',
     }),
     linkURL: PropTypes.string.tag({
       label: 'Link URL',

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -126,6 +126,7 @@ MediumManualPromo.propTypes = {
     imageURL: PropTypes.string.tag({
       label: 'Image URL',
       group: 'Configure Content',
+      searchable: 'image',
     }),
     imageAlt: PropTypes.string.tag({
       label: 'Image Alt',

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
@@ -15,6 +15,10 @@ jest.mock('fusion:context', () => ({
 }));
 jest.mock('fusion:content', () => ({
   useContent: jest.fn(() => ({})),
+  useEditableContent: jest.fn(() => ({
+    editableContent: () => ({ contentEditable: 'true' }),
+    searchableField: () => {},
+  })),
 }));
 
 const config = {

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -243,6 +243,7 @@ MediumPromo.propTypes = {
     imageOverrideURL: PropTypes.string.tag({
       label: 'Image URL',
       group: 'Image',
+      searchable: 'image',
     }),
     imageOverrideAlt: PropTypes.string.tag({
       label: 'Image Alt',

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -138,10 +138,7 @@ const MediumPromoItem = ({ customFields }) => {
               href={content.website_url}
               aria-hidden="true"
               tabIndex="-1"
-              {...searchableField({
-                imageOverrideURL: 'url',
-                imageOverrideAlt: 'alt_text',
-              })}
+              {...searchableField('imageOverrideURL')}
             >
               {
                 imageURL && resizedImageOptions
@@ -244,10 +241,6 @@ MediumPromo.propTypes = {
       label: 'Image URL',
       group: 'Image',
       searchable: 'image',
-    }),
-    imageOverrideAlt: PropTypes.string.tag({
-      label: 'Image Alt',
-      group: 'Image',
     }),
     ...imageRatioCustomField('imageRatio', 'Art', '16:9'),
     lazyLoad: PropTypes.bool.tag({

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -29,8 +29,8 @@ const DescriptionText = styled.p`
 `;
 
 const MediumPromoItem = ({ customFields }) => {
-  const { arcSite } = useFusionContext();
-  const { editableContent } = useEditableContent();
+  const { arcSite, isAdmin } = useFusionContext();
+  const { editableContent, searchableField } = useEditableContent();
 
   const content = useContent({
     source: customFields?.itemContentConfig?.contentService ?? null,
@@ -43,7 +43,7 @@ const MediumPromoItem = ({ customFields }) => {
   }) || null;
 
   let imageConfig = null;
-  if (customFields.imageOverrideURL && customFields.lazyLoad) {
+  if ((customFields.imageOverrideURL && customFields.lazyLoad) || isAdmin) {
     imageConfig = 'resize-image-api-client';
   } else if (customFields.imageOverrideURL) {
     imageConfig = 'resize-image-api';
@@ -130,10 +130,19 @@ const MediumPromoItem = ({ customFields }) => {
   return content ? (
     <>
       <article className="container-fluid medium-promo">
-        <div className={`medium-promo-wrapper ${customFields.showImage ? 'md-promo-image' : ''}`}>
+        <div className={`medium-promo-wrapper ${customFields.showImage ? 'md-promo-image' : ''}`} style={{ position: isAdmin ? 'relative' : null }}>
           {customFields.showImage
           && (
-            <a className="image-link" href={content.website_url} aria-hidden="true" tabIndex="-1">
+            <a
+              className="image-link"
+              href={content.website_url}
+              aria-hidden="true"
+              tabIndex="-1"
+              {...searchableField({
+                imageOverrideURL: 'url',
+                imageOverrideAlt: 'alt_text',
+              })}
+            >
               {
                 imageURL && resizedImageOptions
                   ? (
@@ -233,6 +242,10 @@ MediumPromo.propTypes = {
     }),
     imageOverrideURL: PropTypes.string.tag({
       label: 'Image URL',
+      group: 'Image',
+    }),
+    imageOverrideAlt: PropTypes.string.tag({
+      label: 'Image Alt',
       group: 'Image',
     }),
     ...imageRatioCustomField('imageRatio', 'Art', '16:9'),

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -20,7 +20,10 @@ jest.mock('fusion:context', () => ({
 }));
 jest.mock('fusion:content', () => ({
   useContent: jest.fn(() => (mockData)),
-  useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),
+  useEditableContent: jest.fn(() => ({
+    editableContent: () => ({ contentEditable: 'true' }),
+    searchableField: () => {},
+  })),
 }));
 
 const config = {

--- a/blocks/small-manual-promo-block/features/small-manual-promo/_children/__snapshots__/promo_container.test.jsx.snap
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/_children/__snapshots__/promo_container.test.jsx.snap
@@ -13,6 +13,11 @@ exports[`the promo container default to headline first dom structure by default 
   </div>
   <div
     className="col-sm-xl-4"
+    style={
+      Object {
+        "position": null,
+      }
+    }
   >
     <img
       alt="mock image"
@@ -35,6 +40,11 @@ exports[`the promo container render headline first if image position is below 1`
   </div>
   <div
     className="col-sm-xl-4"
+    style={
+      Object {
+        "position": null,
+      }
+    }
   >
     <img
       alt="mock image"
@@ -57,6 +67,11 @@ exports[`the promo container render headline first if image position is right 1`
   </div>
   <div
     className="col-sm-xl-4"
+    style={
+      Object {
+        "position": null,
+      }
+    }
   >
     <img
       alt="mock image"
@@ -72,6 +87,11 @@ exports[`the promo container render image first if image position is above 1`] =
 >
   <div
     className="col-sm-xl-4"
+    style={
+      Object {
+        "position": null,
+      }
+    }
   >
     <img
       alt="mock image"
@@ -94,6 +114,11 @@ exports[`the promo container render image first if image position is on left 1`]
 >
   <div
     className="col-sm-xl-4"
+    style={
+      Object {
+        "position": null,
+      }
+    }
   >
     <img
       alt="mock image"
@@ -112,7 +137,13 @@ exports[`the promo container render image first if image position is on left 1`]
 
 exports[`the promo container return empty dom value while no value pass in 1`] = `
 <div>
-  <div>
+  <div
+    style={
+      Object {
+        "position": null,
+      }
+    }
+  >
     
   </div>
   <div>

--- a/blocks/small-manual-promo-block/features/small-manual-promo/_children/promo_container.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/_children/promo_container.jsx
@@ -1,29 +1,23 @@
 import React from 'react';
 
-function getPromoContainer(headline, image, promoContainersStyles, imagePosition = 'right') {
-  // image left, above
-  if (imagePosition === 'left' || imagePosition === 'above') {
-    return (
-      <div className={promoContainersStyles?.containerClass}>
-        <div className={promoContainersStyles?.imageClass}>
-          {image}
-        </div>
-        <div className={promoContainersStyles?.headlineClass}>
-          {headline}
-        </div>
-      </div>
-    );
-  }
+function getPromoContainer(headline, image, promoContainersStyles, imagePosition = 'right', isAdmin) {
+  const imageLeftOrAbove = (imagePosition === 'left' || imagePosition === 'above');
+  const HeadlineOutput = (
+    <div className={promoContainersStyles?.headlineClass}>
+      {headline}
+    </div>
+  );
 
-  // image right, below
+  const ImageOutput = (
+    <div className={promoContainersStyles?.imageClass} style={{ position: isAdmin ? 'relative' : null }}>
+      {image}
+    </div>
+  );
+
   return (
     <div className={promoContainersStyles?.containerClass}>
-      <div className={promoContainersStyles?.headlineClass}>
-        {headline}
-      </div>
-      <div className={promoContainersStyles?.imageClass}>
-        {image}
-      </div>
+      {imageLeftOrAbove ? ImageOutput : HeadlineOutput}
+      {imageLeftOrAbove ? HeadlineOutput : ImageOutput}
     </div>
   );
 }

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -72,15 +72,12 @@ const SmallManualPromoItem = ({ customFields = {} }) => {
     && (
       <div
         className={imageMarginClass}
-        {...searchableField({
-          imageURL: 'url',
-          imageAlt: 'alt_text',
-        })}
+        {...searchableField('imageURL')}
       >
         { renderWithLink(
           <Image
             url={customFields.imageURL}
-            alt={customFields.imageAlt || customFields.headline}
+            alt={customFields.headline}
             // small should be 3:2 aspect ratio
             {...ratios}
             breakpoints={getProperties(arcSite)?.breakpoints}
@@ -124,10 +121,6 @@ SmallManualPromo.propTypes = {
       label: 'Image URL',
       group: 'Configure Content',
       searchable: 'image',
-    }),
-    imageAlt: PropTypes.string.tag({
-      label: 'Image Alt Text',
-      group: 'Configure Content',
     }),
     linkURL: PropTypes.string.tag({
       label: 'Link URL',

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
@@ -15,6 +15,9 @@ jest.mock('fusion:context', () => ({
 }));
 jest.mock('fusion:content', () => ({
   useContent: jest.fn(() => ({})),
+  useEditableContent: jest.fn(() => ({
+    searchableField: () => {},
+  })),
 }));
 
 const config = {

--- a/blocks/small-promo-block/features/small-promo/_children/promo_image.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_image.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useFusionContext } from 'fusion:context';
-import { useContent } from 'fusion:content';
+import { useContent, useEditableContent } from 'fusion:content';
 import getProperties from 'fusion:properties';
 import { extractImageFromStory, extractResizedParams } from '@wpmedia/resizer-image-block';
 import { Image } from '@wpmedia/engine-theme-sdk';
@@ -11,11 +11,14 @@ import getPromoStyle from './promo_style';
 
 const PromoImage = (props) => {
   const { content, customFields, ratios } = props;
-  const { arcSite } = useFusionContext();
+  const { arcSite, isAdmin } = useFusionContext();
+  const { searchableField } = useEditableContent();
   const promoType = discoverPromoType(content);
 
   let imageConfig = null;
-  if (customFields.imageOverrideURL && customFields.lazyLoad) {
+  if (
+    (customFields.imageOverrideURL && customFields.lazyLoad)
+    || (customFields.imageOverrideURL && isAdmin)) {
     imageConfig = 'resize-image-api-client';
   } else if (customFields.imageOverrideURL) {
     imageConfig = 'resize-image-api';
@@ -36,14 +39,13 @@ const PromoImage = (props) => {
   return content
     ? (
       <div className={`promo-image ${getPromoStyle(imagePosition, 'margin')}`}>
-        <div className="flex no-image-padding">
-          <a href={content?.website_url || ''} aria-hidden="true" tabIndex="-1">
+        <div className="flex no-image-padding" style={{ position: isAdmin ? 'relative' : null }}>
+          <a href={content?.website_url || ''} aria-hidden="true" tabIndex="-1" {...searchableField('imageOverrideURL')}>
             {imageURL && resizedImageOptions
               ? (
                 <Image
                   url={imageURL}
                   alt={content && content.headlines ? content.headlines.basic : ''}
-                    // small should be 3:2 aspect ratio
                   smallWidth={ratios.smallWidth}
                   smallHeight={ratios.smallHeight}
                   mediumWidth={ratios.mediumWidth}

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -89,6 +89,7 @@ SmallPromo.propTypes = {
     imageOverrideURL: PropTypes.string.tag({
       label: 'Image URL',
       group: 'Image',
+      searchable: 'image',
     }),
     imagePosition: PropTypes.oneOf([
       'right', 'left', 'above', 'below',

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -19,7 +19,10 @@ jest.mock('fusion:context', () => ({
 }));
 jest.mock('fusion:content', () => ({
   useContent: jest.fn(() => (mockData)),
-  useEditableContent: jest.fn(() => ({ editableContent: () => ({ contentEditable: 'true' }) })),
+  useEditableContent: jest.fn(() => ({
+    editableContent: () => ({ contentEditable: 'true' }),
+    searchableField: () => {},
+  })),
 }));
 
 const config = {


### PR DESCRIPTION
## Description

Update all promo blocks to have the new integrated photo center search feature available in PageBuilder editor

## Jira Ticket
- [TMEDIA-104](https://arcpublishing.atlassian.net/browse/TMEDIA-104)

## Acceptance Criteria

1. PageBuilder users can use the Integrated Image Search functionality when choosing images for the Image URL custom field in blocks specified above
2. The chosen image should be resized with our resizer the same way it is now (i.e. this functionality should not change) 
3. If customers have previously placed one of these blocks on a page/template and filled out an Image URL, that choice should still apply to the block (so that this update is backwards compatible) 
4. Tests and documentation are updated to cover this functionality

## Test Steps
Requires update .env settings to be added/updated in your fusion repo

```
FUSION_RELEASE=2.7.1-photo-search-beta
PB_EDITOR=rc
PB_RELEASE=3.3-photo-search-beta
```

Also requires canary version on the Fusion cli - in Fusion repo run

```npm install @arc-fusion/cli@canary```

1. Checkout this branch `git checkout TMEDIA-104-integrated-search-promo-blocks`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/extra-large-promo-block,@wpmedia/large-promo-block,@wpmedia/medium-promo-block,@wpmedia/small-promo-block,@wpmedia/extra-large-manual-promo-block,@wpmedia/large-manual-promo-block,@wpmedia/medium-manual-promo-block,@wpmedia/small-manual-promo-block`
3. From PageBuilder editor - http://localhost/pagebuilder/pages 
4. Edit Page - All Promos
5. As you hover over each promo block you will see a "Replace Image" button appear
6. Clicking on the button will open the integrated photo center search panel
7. Hovering over each image will update the editor view to show the image in the block
8. Clicking on the image in the photo center panel will set the custom field value for the image URL
9. Publishing the page with the updated image will show the new image on the published page

## Effect Of Changes

![TMEDA-104-pagebuilder-editor](https://user-images.githubusercontent.com/868127/112002369-b7420d00-8b17-11eb-93a9-5bdc5601c059.gif)


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
