### PR TITLE
TMEDIA-183 Add author service url to client side resizer content source

### DIFF
--- a/blocks/resizer-image-content-source-block/sources/resize-image-api-client.test.js
+++ b/blocks/resizer-image-content-source-block/sources/resize-image-api-client.test.js
@@ -35,6 +35,9 @@ describe('the resizer image api client source block', () => {
     contentSource.fetch({ raw_image_url: 'https://s3.amazonaws.com/arc-authors/marty-mcfly.jpg' });
     expect(mockFn.mock.calls.length).toBe(3);
 
+    contentSource.fetch({ raw_image_url: 'https://s3.amazonaws.com/arcauthors/marty-mcfly.jpg' });
+    expect(mockFn.mock.calls.length).toBe(3);
+
     contentSource.fetch({ raw_image_url: 'https://example.com/image.jpg' });
     expect(mockFn.mock.calls.length).toBe(3);
   });

--- a/blocks/resizer-image-content-source-block/sources/resize-image-api-client.test.js
+++ b/blocks/resizer-image-content-source-block/sources/resize-image-api-client.test.js
@@ -32,8 +32,11 @@ describe('the resizer image api client source block', () => {
     contentSource.fetch({ raw_image_url: 'http://images.arcpublishing.com/image.jpg' });
     expect(mockFn.mock.calls.length).toBe(2);
 
+    contentSource.fetch({ raw_image_url: 'https://s3.amazonaws.com/arc-authors/marty-mcfly.jpg' });
+    expect(mockFn.mock.calls.length).toBe(3);
+
     contentSource.fetch({ raw_image_url: 'https://example.com/image.jpg' });
-    expect(mockFn.mock.calls.length).toBe(2);
+    expect(mockFn.mock.calls.length).toBe(3);
   });
 
   it('should call getResizedImageData if image and domain match with environment domains', () => {


### PR DESCRIPTION
## Description

Update logic to allow for author-service image domain + path

## Jira Ticket
- [TMEDIA-183](https://arcpublishing.atlassian.net/browse/TMEDIA-183)

## Acceptance Criteria
* Client side content source returns resized params when using an author service generated photo url

## Test Steps

1. Unit tests cover new case

Manually checking - 
1. Checkout this branch `git checkout TMEDIA-183-author-service-url-resizer-content-source`
2. Run fusion repo with `npx fusion start -f -l @wpmedia/resizer-image-content-source-block`
3. Goto debugger - http://localhost/pagebuilder/tools/debugger
4. Using the content source `resizer-image-api-client`
5. Verify you can get response object container resized params for the following URL - https://s3.amazonaws.com/arc-authors/marty-mcfly.jpg
6. Verify you do not get a response object of resized params for the following URL - https://s3.amazonaws.com/arcauthors/marty-mcfly.jpg

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
