### PR TITLE
Masthead styled components version change

### DIFF
--- a/blocks/masthead-block/package.json
+++ b/blocks/masthead-block/package.json
@@ -16,7 +16,7 @@
   "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "canary",
     "@wpmedia/news-theme-css": "stable",
-    "styled-components": "^5.0.1"
+    "styled-components": "^4.4.0"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9538,9 +9538,9 @@
       }
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.9.2-canary.4",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.9.2-canary.4/fd51ed8228231489ec5cb81d0142d767f1af04a0c2cf5c4808e21bb2cc6747c3",
-      "integrity": "sha512-e8yRUHiBejFevLtn/AvNAgJIzfm4oStKAstn3hynrGRaTCQcFAvRH1eFU/7RhLDIH/n7O+EbCiD6ZlG9YN8j9A==",
+      "version": "2.9.4-canary.0",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.9.4-canary.0/ea42e6e23252985e4625a8fa1bb6d0c7ada5c01f6ade5bf7b593ec1c638c9778",
+      "integrity": "sha512-RCfg0aIMaVxr32xYvhYELDhGQeL3Ioh9+nm3+yXuKqOg1KSzbtIVCrmhnAesYd8A+2PIgfTSwht5tlVxQk3Ybw==",
       "dev": true,
       "requires": {
         "dom-parser": "^0.1.6",
@@ -9555,7 +9555,7 @@
         "react-swipeable": "^5.5.0",
         "styled-components": "^4.4.1",
         "thumbor-lite": "^0.1.6",
-        "timezone": "^1.0.23"
+        "timezone": "1.0.23"
       },
       "dependencies": {
         "@babel/runtime": {


### PR DESCRIPTION
Updating version of styled-component package listed in peerDependencies.

1. It's higher than all other blocks
2. Causes some local linking issues