### PR TITLE
Themes 109 corrections translations

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -141,10 +141,16 @@ function parseArticleItem(item, index, arcSite, phrases, id) {
     }
 
     case 'correction': {
+      // can either be clarification or correction
+      const { correction_type: labelType } = item;
+      const labelText = labelType === 'clarification'
+        ? phrases.t('article-body-block.clarification')
+        : phrases.t('article-body-block.correction');
+
       return (item.text && item.text.length > 0) ? (
         <Fragment key={key}>
           <section className="correction">
-            <h2 className="h6-primary">{item.correction_type || 'Correction'}</h2>
+            <h2 className="h6-primary">{labelText}</h2>
             <p>{item.text}</p>
           </section>
         </Fragment>

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -924,6 +924,19 @@ describe('article-body chain', () => {
   });
 
   describe('correction text is rendered correctly', () => {
+    const correctionText = 'Correction!!';
+    const clarificationText = 'Clarification!!!!';
+
+    const mockPhrases = {
+      'article-body-block.clarification': clarificationText,
+      'article-body-block.correction': correctionText,
+    };
+
+    jest.mock('fusion:intl', () => ({
+      __esModule: true,
+      default: jest.fn(() => ({ t: jest.fn((phrase) => mockPhrases[phrase]) })),
+    }));
+
     it('should render correction text', () => {
       jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
       jest.mock('fusion:context', () => ({
@@ -951,6 +964,7 @@ describe('article-body chain', () => {
           customFields: { },
         })),
       }));
+
       const { default: ArticleBodyChain } = require('./default');
       const wrapper = mount(
         <ArticleBodyChain>
@@ -960,8 +974,49 @@ describe('article-body chain', () => {
         </ArticleBodyChain>,
       );
       expect(wrapper.find('.correction')).toHaveLength(1);
-      expect(wrapper.find('.correction h2')).toHaveLength(1);
+
+      const correctionLabel = wrapper.find('.correction h2');
+      expect(correctionLabel.text()).toBe(correctionText);
+      expect(correctionLabel).toHaveLength(1);
       expect(wrapper.find('.correction p')).toHaveLength(1);
+    });
+
+    it('should render clarification text', () => {
+      jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+      jest.mock('fusion:context', () => ({
+        useFusionContext: jest.fn(() => ({
+          globalContent: {
+            _id: '22ACHIRFI5CD5GRFON6AL3JSJE',
+            type: 'story',
+            version: '0.10.2',
+            content_elements: [
+              {
+                _id: 'TCBM2JRT4ZA27BU2X47KATFTFA',
+                type: 'correction',
+                correction_type: 'clarification',
+                additional_properties: {
+                  _id: 'DKRZMRK2ZZF7BI2XGZ3V7FDGEI',
+                  comments: [
+
+                  ],
+                },
+                text: 'This is a clarification. An editor might add this if the story had a small potential misunderstanding.',
+              },
+            ],
+          },
+          arcSite: 'the-sun',
+          customFields: { },
+        })),
+      }));
+
+      const { default: ArticleBodyChain } = require('./default');
+      const wrapper = mount(
+        <ArticleBodyChain />,
+      );
+      expect(wrapper.find('.correction')).toHaveLength(1);
+
+      const correctionLabel = wrapper.find('.correction h2');
+      expect(correctionLabel.text()).toBe(clarificationText);
     });
 
     it('should not render correction when no data is provided', () => {

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -974,7 +974,6 @@ describe('article-body chain', () => {
         </ArticleBodyChain>,
       );
       expect(wrapper.find('.correction')).toHaveLength(1);
-
       const correctionLabel = wrapper.find('.correction h2');
       expect(correctionLabel.text()).toBe(correctionText);
       expect(correctionLabel).toHaveLength(1);

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -964,7 +964,6 @@ describe('article-body chain', () => {
           customFields: { },
         })),
       }));
-
       const { default: ArticleBodyChain } = require('./default');
       const wrapper = mount(
         <ArticleBodyChain>

--- a/blocks/article-body-block/intl.json
+++ b/blocks/article-body-block/intl.json
@@ -1,0 +1,22 @@
+{
+  "article-body-block.correction": {
+    "en": "Correction",
+    "es": "Corrección",
+    "de": "Korrektur",
+    "fr": "Correction",
+    "ja": "修正",
+    "ko": "정정",
+    "no": "Korreksjon",
+    "sv": "Korrektion"
+  },
+  "article-body-block.clarification": {
+    "en": "Clarification",
+    "es": "Aclaración",
+    "de": "Klarstellung",
+    "fr": "Précision",
+    "ja": "説明",
+    "ko": "설명",
+    "no": "Avklaring",
+    "sv": "Klargörande"
+  }
+}

--- a/blocks/article-body-block/package.json
+++ b/blocks/article-body-block/package.json
@@ -10,7 +10,8 @@
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "chains"
+    "chains",
+    "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/intl-sample.json
+++ b/intl-sample.json
@@ -1,0 +1,12 @@
+{
+  "block-name.greeting": {
+    "en": "Hi",
+    "es": "Hola",
+    "de": "Hallo",
+    "fr": "salut",
+    "ja": "こんにちは",
+    "ko": "안녕",
+    "no": "Hei",
+    "sv": "Hej"
+  }
+}


### PR DESCRIPTION
## Description
- correction_type can either be clarification or correction
- translate based on locale accordingly 

## Jira Ticket
- [TMEDIA-109](https://arcpublishing.atlassian.net/browse/TMEDIA-109?focusedCommentId=547704&page=com.atlassian.jira.plugin.system.issuetabpanels%253Acomment-tabpanel%23comment-547704)

## Acceptance Criteria
When a correction (or clarification) is in the article body, the text should be translated to the given language depending on what is set for locale as a Theme Setting for that website. 

Tests and documentation are updated as necessary

## Test Steps

1. Checkout this branch `git checkout THEMES-109-corrections-translations`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/article-body-block`
3. Make sure you have an updated pb data
4. Create page with just an article body chain
5. Add content api id of `T4PIZLHRMZEFHL6P4X5VZ72CNQ` in global content
6. Go to arc-demo-1 with spanish translations `          "locale": "es"`

## Effect Of Changes
### Before

- shows plain correction and clarfication -- two options per ans 

<img width="1064" alt="Screen Shot 2021-03-29 at 17 33 50" src="https://user-images.githubusercontent.com/5950956/112908308-ed9e0000-90b4-11eb-853e-16334f4f792e.png">

### After

- shows translated clarification and correction 

<img width="1249" alt="Screen Shot 2021-03-29 at 17 30 41" src="https://user-images.githubusercontent.com/5950956/112908110-88e2a580-90b4-11eb-8e35-035786bdea56.png">

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added. -> added sample intl.json

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.