### PR TITLE
TMEDIA-184 - List blocks content level filtering

### DIFF
--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -55,6 +55,30 @@ class CardList extends React.Component {
     this.lazyLoad = lazyLoad;
     this.isAdmin = props.isAdmin;
 
+    this.siteProperties = getProperties(props.arcSite);
+
+    this.largeImageOptions = {
+      smallWidth: 377,
+      smallHeight: 283,
+      mediumWidth: 377,
+      mediumHeight: 283,
+      largeWidth: 377,
+      largeHeight: 283,
+      breakpoints: this.siteProperties?.breakpoints,
+      resizerURL: this.siteProperties?.resizerURL,
+    };
+
+    this.samllImageOptions = {
+      smallWidth: 105,
+      smallHeight: 70,
+      mediumWidth: 105,
+      mediumHeight: 70,
+      largeWidth: 274,
+      largeHeight: 183,
+      breakpoints: this.siteProperties?.breakpoints,
+      resizerURL: this.siteProperties?.resizerURL,
+    };
+
     this.state = {
       cardList: {},
       placeholderResizedImageOptions: {},
@@ -73,8 +97,8 @@ class CardList extends React.Component {
   }
 
   getFallbackImageURL() {
-    const { arcSite, deployment, contextPath } = this.props;
-    let targetFallbackImage = getProperties(arcSite).fallbackImage;
+    const { deployment, contextPath } = this.props;
+    let targetFallbackImage = this.siteProperties.fallbackImage;
 
     if (!targetFallbackImage.includes('http')) {
       targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
@@ -102,7 +126,61 @@ class CardList extends React.Component {
     this.fetchContent({
       cardList: {
         source: contentService,
-        query: contentConfigValues,
+        query: { ...contentConfigValues, feature: 'card-list' },
+        filter: `{
+          content_elements {
+            _id,
+            display_date
+            credits {
+              by {
+                _id
+                name
+                url
+                type
+                additional_properties {
+                  original {
+                    byline
+                  }
+                }
+              }
+            }
+            headlines {
+              basic
+            }
+            promo_items {
+              basic {
+                type
+                url
+                resized_params {
+                  377x283
+                  274x183
+                  105x70
+                }
+              }
+              lead_art {
+                promo_items {
+                  basic {
+                    type
+                    url
+                    resized_params {
+                      377x283
+                      274x183
+                      105x70
+                    }
+                  }
+                }
+              }
+            }
+            websites {
+              ${this.arcSite} {
+                website_url
+                website_section {
+                  name
+                }
+              }
+            }
+          }
+        }`,
       },
     });
   }
@@ -152,7 +230,7 @@ class CardList extends React.Component {
               }
               <article
                 className="list-item-simple"
-                key={`result-card-${contentElements[0].websites[arcSite].website_url}`}
+                key={`card-list-${contentElements[0].websites[arcSite].website_url}`}
               >
                 <a
                   href={contentElements[0].websites[arcSite].website_url}
@@ -165,30 +243,15 @@ class CardList extends React.Component {
                      <Image
                        url={extractImage(contentElements[0].promo_items)}
                        alt={contentElements[0].headlines.basic}
-                       smallWidth={377}
-                       smallHeight={283}
-                       mediumWidth={377}
-                       mediumHeight={283}
-                       largeWidth={377}
-                       largeHeight={283}
+                       {...this.largeImageOptions}
                        resizedImageOptions={getResizedImage(contentElements[0].promo_items)}
-                       breakpoints={getProperties(arcSite)?.breakpoints}
-                       resizerURL={getProperties(arcSite)?.resizerURL}
                      />
                    ) : (
                      <Image
-                       smallWidth={377}
-                       smallHeight={283}
-                       mediumWidth={377}
-                       mediumHeight={283}
-                       largeWidth={377}
-                       largeHeight={283}
-                       alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
                        url={targetFallbackImage}
-                       breakpoints={getProperties(arcSite)?.breakpoints}
+                       alt={this.siteProperties.primaryLogoAlt || 'Placeholder logo'}
+                       {...this.largeImageOptions}
                        resizedImageOptions={placeholderResizedImageOptions}
-                       resizerURL={getProperties(arcSite)?.resizerURL}
-
                      />
                    )
                   }
@@ -233,11 +296,11 @@ class CardList extends React.Component {
                   } = element;
                   const url = element.websites[arcSite].website_url;
                   return (
-                    <React.Fragment key={`result-card-${url}`}>
+                    <React.Fragment key={`card-list-${url}`}>
                       <hr />
                       <article
                         className="card-list-item card-list-item-margins"
-                        key={`result-card-${url}`}
+                        key={`card-list-${url}`}
                         type="1"
                       >
                         <a
@@ -263,31 +326,16 @@ class CardList extends React.Component {
                                 <Image
                                   url={extractImage(element.promo_items)}
                                   alt={headlineText}
-                                  // small, matches numbered list, is 3:2 aspect ratio
-                                  smallWidth={105}
-                                  smallHeight={70}
-                                  mediumWidth={105}
-                                  mediumHeight={70}
-                                  largeWidth={274}
-                                  largeHeight={183}
+                                  {...this.samllImageOptions}
                                   resizedImageOptions={extractResizedParams(element)}
-                                  breakpoints={getProperties(arcSite)?.breakpoints}
-                                  resizerURL={getProperties(arcSite)?.resizerURL}
                                 />
                               )
                               : (
                                 <Image
-                                  smallWidth={105}
-                                  smallHeight={70}
-                                  mediumWidth={105}
-                                  mediumHeight={70}
-                                  largeWidth={274}
-                                  largeHeight={183}
-                                  alt={getProperties(arcSite).primaryLogoAlt || 'Placeholder logo'}
                                   url={targetFallbackImage}
-                                  breakpoints={getProperties(arcSite)?.breakpoints}
+                                  alt={this.siteProperties.primaryLogoAlt || 'Placeholder logo'}
+                                  {...this.samllImageOptions}
                                   resizedImageOptions={placeholderResizedImageOptions}
-                                  resizerURL={getProperties(arcSite)?.resizerURL}
                                 />
                               )
                           }

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -51,12 +51,35 @@ class NumberedList extends Component {
   }
 
   fetchStories() {
-    const { customFields: { listContentConfig } } = this.props;
+    const { customFields: { listContentConfig, showImage } } = this.props;
     const { contentService, contentConfigValues } = listContentConfig;
     this.fetchContent({
       resultList: {
         source: contentService,
-        query: contentConfigValues,
+        query: { ...contentConfigValues, feature: 'numbered-list' },
+        filter: `{
+          content_elements {
+            _id,
+            headlines {
+              basic
+            }
+            ${showImage ? `promo_items {
+              basic {
+                type
+                url
+                resized_params {
+                  274x183
+                  105x70
+                }
+              }
+            }` : null}
+            websites {
+              ${this.arcSite} {
+                website_url
+              }
+            }
+          }
+        }`,
       },
     });
   }
@@ -114,8 +137,8 @@ class NumberedList extends Component {
           const url = websites[arcSite].website_url;
 
           return (
-            <React.Fragment key={`result-card-${url}`}>
-              <div className="numbered-list-item numbered-item-margins" key={`result-card-${url}`} type="1">
+            <React.Fragment key={`numbered-list-${url}`}>
+              <div className="numbered-list-item numbered-item-margins">
                 {showHeadline
                 && (
                 <a href={url} className="headline-list-anchor">

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -107,6 +107,52 @@ class ResultsList extends Component {
     }
   }
 
+  contentSourceFilter() {
+    return `{
+      count
+      next
+      content_elements {
+        _id,
+        type
+        display_date
+        credits {
+          by {
+            _id
+            name
+            url
+            type
+            additional_properties {
+              original {
+                byline
+              }
+            }
+          }
+        }
+        headlines {
+          basic
+        }
+        description {
+          basic
+        }
+        promo_items {
+          basic {
+            type
+            url
+            resized_params {
+              274x154
+              158x89
+            }
+          }
+        }
+        websites {
+          ${this.arcSite} {
+            website_url
+          }
+        }
+      }
+    }`;
+  }
+
   fetchStories(additionalStoryAmount) {
     const { customFields: { listContentConfig } } = this.props;
     const { contentService, contentConfigValues } = listContentConfig;
@@ -136,7 +182,8 @@ class ResultsList extends Component {
         this.fetchContent({
           resultList: {
             source: contentService,
-            query: contentConfigValues,
+            query: { ...contentConfigValues, feature: 'results-list' },
+            filter: this.contentSourceFilter(),
             transform: (data) => fetchStoriesTransform(data, resultList),
           },
         });
@@ -153,18 +200,20 @@ class ResultsList extends Component {
         this.fetchContent({
           resultList: {
             source: contentService,
-            query: contentConfigValues,
+            query: { ...contentConfigValues, feature: 'results-list' },
+            filter: this.contentSourceFilter(),
             transform: (data) => fetchStoriesTransform(data, resultList),
           },
         });
 
-        const query = { ...contentConfigValues };
+        const query = { ...contentConfigValues, feature: 'results-list' };
         from = parseInt(contentConfigValues.from, 10) || 0;
         query.from = String(from + size);
         this.fetchContent({
           seeMore: {
             source: contentService,
             query,
+            filter: this.contentSourceFilter(),
             transform: (data) => !!(data?.content_elements?.length),
           },
         });
@@ -177,7 +226,8 @@ class ResultsList extends Component {
       this.fetchContent({
         resultList: {
           source: listContentConfig.contentService,
-          query: contentConfigValues,
+          query: { ...contentConfigValues, feature: 'results-list' },
+          filter: this.contentSourceFilter(),
         },
       });
 
@@ -253,7 +303,7 @@ class ResultsList extends Component {
                 >
                   {extractImage(promoItems) ? (
                     <Image
-                  // results list is 16:9 by default
+                      // results list is 16:9 by default
                       resizedImageOptions={extractResizedParams(element)}
                       url={extractImage(element.promo_items)}
                       alt={headlineText}

--- a/blocks/results-list-block/features/results-list/internalTests.test.jsx
+++ b/blocks/results-list-block/features/results-list/internalTests.test.jsx
@@ -82,7 +82,15 @@ describe('fetchPlaceholder', () => {
     wrapper.instance().fetchPlaceholder();
 
     expect(fetchContentMock).toHaveBeenCalledTimes(2);
-    expect(fetchContentMock).toHaveBeenCalledWith({ resultList: { query: { offset: '0', query: 'type: story', size: '1' }, source: 'story-feed-query' } });
+    expect(fetchContentMock).toHaveBeenCalledWith({
+      resultList: {
+        query: {
+          offset: '0', query: 'type: story', size: '1', feature: 'results-list',
+        },
+        source: 'story-feed-query',
+        filter: expect.any(String),
+      },
+    });
   });
 });
 
@@ -118,9 +126,11 @@ describe('fetchStories', () => {
           offset: '2',
           query: 'type: story',
           size: '1',
+          feature: 'results-list',
         },
         source: 'story-feed-query',
         transform: expect.any(Function),
+        filter: expect.any(String),
       },
     };
     expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
@@ -175,9 +185,11 @@ describe('fetchStories', () => {
           offset: '0',
           query: 'type: story',
           size: '1',
+          feature: 'results-list',
         },
         source: 'story-feed-author',
         transform: expect.any(Function),
+        filter: expect.any(String),
       },
     };
     expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
@@ -214,11 +226,14 @@ describe('fetchStories', () => {
           offset: '0',
           query: 'type: story',
           size: '1',
+          feature: 'results-list',
         },
         source: 'other',
         transform: expect.any(Function),
+        filter: expect.any(String),
       },
     };
+
     expect(fetchContentMock.mock.calls[0][0]).toEqual(expect.objectContaining(partialObj));
   });
 

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -117,7 +117,41 @@ const SimpleList = (props) => {
   // need to inject the arc site here into use content
   const { content_elements: contentElements = [] } = useContent({
     source: contentService,
-    query: { 'arc-site': arcSite, ...contentConfigValues },
+    query: { ...contentConfigValues, feature: 'simple-list' },
+    filter: `{
+      content_elements {
+        _id
+        headlines {
+          basic
+        }
+        website_url
+        ${showImage ? `promo_items {
+          basic {
+            type
+            url
+            resized_params {
+              274x183
+            }
+          }
+          lead_art {
+            promo_items {
+              basic {
+                type
+                url
+                resized_params {
+                  274x183
+                }
+              }
+            }
+          }
+        }` : null}
+        websites {
+          ${arcSite} {
+            website_url
+          }
+        }
+      }
+    }`,
   }) || {};
 
   return (

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -165,7 +165,94 @@ const TopTableList = (props) => {
 
   const { content_elements: contentElements = [] } = useContent({
     source: contentService,
-    query: { 'arc-site': arcSite, ...contentConfigValues },
+    query: { ...contentConfigValues, feature: 'top-table-list' },
+    filter: `{
+      content_elements {
+        _id,
+        type
+        display_date
+        credits {
+          by {
+            _id
+            name
+            url
+            type
+            additional_properties {
+              original {
+                byline
+              }
+            }
+          }
+        }
+        headlines {
+          basic
+        }
+        description {
+          basic
+        }
+        label {
+          basic
+        }
+        promo_items {
+          basic {
+            type
+            url
+            resized_params {
+              800x600
+              800x533
+              600x450
+              600x400
+              600x338
+              400x300
+              400x267
+              400x225
+              377x283
+              377x251
+              377x212
+              274x206
+              274x183
+              274x154
+            }
+          }
+          lead_art {
+            type
+            embed_html
+            promo_items {
+              basic {
+                type
+                url
+                resized_params {
+                  800x600
+                  800x533
+                  600x450
+                  600x400
+                  600x338
+                  400x300
+                  400x267
+                  400x225
+                  377x283
+                  377x251
+                  377x212
+                  274x206
+                  274x183
+                  274x154
+                }
+              }
+            }
+          }
+        }
+        embed_html
+        websites {
+          ${arcSite} {
+            website_url
+            website_section {
+              _id
+              name
+            }
+          }
+        }
+      }
+    }`,
   }) || {};
 
   const siteContent = contentElements.reduce((acc, element, index) => {


### PR DESCRIPTION
## Description

Add feature level content source filtering to list blocks

* Card List
* Numbered List
* Results List
* Simple List
* Top Table List

## Jira Ticket
- [TMEDIA-184](https://arcpublishing.atlassian.net/browse/TMEDIA-184)

## Acceptance Criteria

1. Feature-level content filtering is applied to List blocks, so that only the data that is actually used in displaying the block is included: 
    * Top Table List
    * Simple List
    * Numbered List
    * Card List
    * Results List
2. Tests and documentation are written to cover this functionality

## Test Steps

1. Checkout this branch `git checkout TMEDIA-184-list-blocks-content-level-filtering`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/top-table-list-block,@wpmedia/simple-list-block,@wpmedia/numbered-list-block,@wpmedia/card-list-block,@wpmedia/results-list-block`
3. On a test page add each block and configure content custom fields
4. Verify blocks still function as expected and content cache is smaller

Some test pages


Page | Core Components | Local | Core Components Size | local size
------------ | ------------- | ------------ | ------------- | ------------
Home Page | https://corecomponents.arcpublishing.com/pf/homepage/?_website=the-gazette | http://localhost/pf/homepage/?_website=the-gazette | 1322.96 KB | 392.20 KB 
All Blocks | https://corecomponents.arcpublishing.com/pf/all-blocks/?_website=the-gazette | http://localhost/pf/all-blocks/?_website=the-gazette | 1663.99 KB | 261.35 KB
Top Table List Configs | https://corecomponents.arcpublishing.com/pf/top-table-list-configs/?_website=the-gazette | http://localhost/top-table-list-configs/?_website=the-gazette | 470.45 KB | 58.52 KB


## Effect Of Changes
### Before

No filter applied
<img width="762" alt="TMEDIA-184-before" src="https://user-images.githubusercontent.com/868127/113113445-3b744e80-9202-11eb-8885-eab29c6e8f3c.png">


### After

Content source data sent to client is only of the required block items, thus reducing the payload size
<img width="782" alt="TMEDIA-184-after" src="https://user-images.githubusercontent.com/868127/113113409-31eae680-9202-11eb-91df-6039461788e5.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
