### PR TITLE
TMEDIA-83 - Use queryly's minified JavaScript file

### DIFF
--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -48,7 +48,7 @@ const querylyCode = (querylyId, querylyOrg, pageType) => {
   `;
   return (
     <>
-      <script data-integration="queryly" src="https://www.queryly.com/js/queryly.v4.js" />
+      <script data-integration="queryly" src="https://www.queryly.com/js/queryly.v4.min.js" />
       <script data-integration="queryly" dangerouslySetInnerHTML={{ __html: querylyInit }} />
       { pageType === 'queryly-search'
         ? <script data-integration="queryly" src={`https://www.queryly.com/js/${querylyOrg}-advanced-search.js`} />


### PR DESCRIPTION
## Description

Update script tag to use minified JavaScript file for queryly

## Jira Ticket
- [TMEDIA-83](https://arcpublishing.atlassian.net/browse/TMEDIA-83)

## Acceptance Criteria

1. Given I am Chrome Lighthouse
    * When I scan a Theme site page
    * Then I can see the Queryly JS is minified

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-83-queryly-minified-js `
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/default-output-block`
3. Load homepage - http://localhost/pf/homepage/?_website=the-gazette
4. Verify the JavaScript file for queryly is using the .min.js version

## Effect Of Changes
### Before

<img width="888" alt="TMEDIA-83-before" src="https://user-images.githubusercontent.com/868127/113304391-e4ea3b80-92f9-11eb-8182-3e23711bb0ab.png">


### After

<img width="990" alt="TMEDIA-83-after" src="https://user-images.githubusercontent.com/868127/113304433-f0d5fd80-92f9-11eb-95b9-f54690bce1aa.png">

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
