### PR TITLE
RC - Wrong value for searchableField

### DIFF
--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -54,7 +54,7 @@ const MediumManualPromoItem = ({ customFields }) => {
       <article className="container-fluid medium-promo" style={{ position: isAdmin ? 'relative' : null }}>
         <div
           className={`medium-promo-wrapper ${hasImage ? 'md-promo-image' : ''}`}
-          {...searchableField('imageOverrideURL')}
+          {...searchableField('imageURL')}
         >
           {hasImage && resizedImageOptions && renderWithLink(
             <Image
@@ -149,7 +149,7 @@ MediumManualPromo.propTypes = {
       defaultValue: true,
       group: 'Show promo elements',
     }),
-    ...imageRatioCustomField('imageRatio', 'Art', '3:2'),
+    ...imageRatioCustomField('imageRatio', 'Art', '16:9'),
     lazyLoad: PropTypes.bool.tag({
       name: 'Lazy Load block?',
       defaultValue: false,


### PR DESCRIPTION
## Description

Error in the custom field name in manual promo - copy paste error between promos where naming is different.

Update image ratio to be correct while in here

## Jira Ticket
- [TMEDIA-104](https://arcpublishing.atlassian.net/browse/TMEDIA-104)

## Test Steps
Requires update .env settings to be added/updated in your fusion repo

```
FUSION_RELEASE=2.7.1-photo-search-beta
PB_EDITOR=rc
PB_RELEASE=3.3-photo-search-beta
```

Also requires canary version on the Fusion cli - in Fusion repo run

```npm install @arc-fusion/cli@canary```

1. Checkout this branch `git checkout TMEDIA-104-integrated-search-promo-blocks`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/medium-manual-promo-block`
3. From PageBuilder editor - http://localhost/pagebuilder/pages 
4. Edit Page - All Promos
5. As you hover over each promo block you will see a "Replace Image" button appear
6. Clicking on the button will open the integrated photo center search panel
7. Hovering over each image will update the editor view to show the image in the block
8. Clicking on the image in the photo center panel will set the custom field value for the image URL
9. Publishing the page with the updated image will show the new image on the published page


## Dependencies or Side Effects
Requires update .env settings to be added/updated in your fusion repo

```
FUSION_RELEASE=2.7.1-photo-search-beta
PB_EDITOR=rc
PB_RELEASE=3.3-photo-search-beta
```

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
