### PR TITLE
perf: Don't publish snapshot files in blocks

### DIFF
--- a/blocks/search-results-list-block/features/.npmignore
+++ b/blocks/search-results-list-block/features/.npmignore
@@ -1,3 +1,4 @@
 *.test.js
 *.test.jsx
 mock*.*
+*.snap

--- a/blocks/small-manual-promo-block/features/.npmignore
+++ b/blocks/small-manual-promo-block/features/.npmignore
@@ -1,3 +1,4 @@
 *.test.js
 *.test.jsx
 mock*.*
+*.snap

--- a/blocks/small-promo-block/features/.npmignore
+++ b/blocks/small-promo-block/features/.npmignore
@@ -1,3 +1,4 @@
 *.test.js
 *.test.jsx
 mock*.*
+*.snap


### PR DESCRIPTION
- See issue #806 
- Before, were publishing 4 snapshot files. Now none.