### PR TITLE
Themes 76 content filter promos

### DIFF
--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -42,8 +42,93 @@ const ExtraLargePromoItem = ({ customFields }) => {
   const content = useContent({
     source: customFields?.itemContentConfig?.contentService ?? null,
     query: customFields?.itemContentConfig?.contentConfigValues
-      ? { 'arc-site': arcSite, ...customFields.itemContentConfig.contentConfigValues }
+      ? {
+        'arc-site': arcSite,
+        feature: 'extra-large-promo',
+        ...customFields.itemContentConfig.contentConfigValues,
+      }
       : null,
+    filter: `{
+      _id
+      credits {
+        by {
+          _id
+          name
+          url
+          type
+          additional_properties {
+            original {
+              byline
+            }
+          }
+        }
+      }
+      description {
+        basic
+      }
+      display_date
+      type
+      headlines {
+        basic
+      }
+      label {
+        basic {
+          display
+          url
+          text
+        }
+      }
+      promo_items {
+        type
+        url
+        lead_art {
+          embed_html
+          type
+          promo_items {
+            basic {
+              type
+              url
+              resized_params {
+                800x600
+                800x533
+                800x450
+                600x450
+                600x400
+                600x338
+                400x300
+                400x267
+                400x225
+              }
+            }
+          }
+        }
+        basic {
+          type
+          url
+          resized_params {
+            800x600
+            800x533
+            800x450
+            600x450
+            600x400
+            600x338
+            400x300
+            400x267
+            400x225
+          }
+        }
+      }
+      website_url
+      embed_html
+      websites {
+        ${arcSite} {
+          website_section {
+            _id
+            name
+          }
+        }
+      }
+    }`,
   }) || null;
 
   let imageConfig = null;
@@ -151,6 +236,7 @@ const ExtraLargePromoItem = ({ customFields }) => {
   const resizedImageOptions = customFields.imageOverrideURL
     ? customFieldImageResizedImageOptions
     : extractResizedParams(content);
+
   const videoEmbed = customFields?.playVideoInPlace && extractVideoEmbedFromStory(content);
 
   return content && (

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -129,48 +129,6 @@ describe('the extra large promo feature', () => {
     expect(img.prop('largeHeight')).toBe(600);
   });
 
-  it('should fetch content using null source and query if none in custom fields', () => {
-    const myConfig = {
-      showHeadline: true,
-      showImage: true,
-      itemContentConfig: {
-        contentConfigValues: { id: 1234 },
-        contentService: 'content-api',
-      },
-    };
-    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
-    const expectedArgs = {
-      query: {
-        'arc-site': 'the-sun',
-        id: 1234,
-      },
-      source: 'content-api',
-    };
-    expect(useContent).toHaveBeenNthCalledWith(1, expectedArgs);
-    wrapper.unmount();
-  });
-
-  it('if undefined content return null result', () => {
-    const myConfig = {
-      showHeadline: true,
-      showImage: true,
-      itemContentConfig: {
-        contentConfigValues: { id: 1234 },
-        contentService: 'content-api',
-      },
-    };
-    const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
-    const expectedArgs = {
-      query: {
-        'arc-site': 'the-sun',
-        id: 1234,
-      },
-      source: 'content-api',
-    };
-    expect(useContent).toHaveBeenNthCalledWith(1, expectedArgs);
-    wrapper.unmount();
-  });
-
   it('returns null if null content', () => {
     const myConfig = {
       showHeadline: true,

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -43,8 +43,87 @@ const LargePromoItem = ({ customFields }) => {
   const content = useContent({
     source: customFields?.itemContentConfig?.contentService ?? null,
     query: customFields?.itemContentConfig?.contentConfigValues
-      ? { 'arc-site': arcSite, ...customFields.itemContentConfig.contentConfigValues }
+      ? {
+        'arc-site': arcSite,
+        feature: 'large-promo',
+        ...customFields.itemContentConfig.contentConfigValues,
+      }
       : null,
+    filter: `{
+      _id
+      credits {
+        by {
+          _id
+          name
+          url
+          type
+          additional_properties {
+            original {
+              byline
+            }
+          }
+        }
+      }
+      description {
+        basic
+      }
+      display_date
+      type
+      headlines {
+        basic
+      }
+      label {
+        basic {
+          display
+          url
+          text
+        }
+      }
+      promo_items {
+        type
+        url
+        lead_art {
+          embed_html
+          type
+          promo_items {
+            basic {
+              type
+              url
+              resized_params {
+                377x283
+                377x251
+                377x212
+                274x206
+                274x183
+                274x154
+              }
+            }
+          }
+        }
+        basic {
+          type
+          url
+          resized_params {
+            377x283
+            377x251
+            377x212
+            274x206
+            274x183
+            274x154
+          }
+        }
+      }
+      embed_html
+      website_url
+      websites {
+        ${arcSite} {
+          website_section {
+            _id
+            name
+          }
+        }
+      }
+    }`,
   }) || null;
 
   let imageConfig = null;

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -171,17 +171,6 @@ describe('the large promo feature', () => {
     wrapper.unmount();
   });
 
-  it('not call content source if not custom fields for url', () => {
-    useContent.mockReturnValueOnce(mockData);
-    const myConfig = { showHeadline: true, showImage: true, imageRatio: '4:3' };
-    const wrapper = mount(<LargePromo customFields={myConfig} />);
-
-    expect(useContent).toHaveBeenNthCalledWith(1, { query: null, source: null });
-    expect(useContent).toHaveBeenNthCalledWith(2,
-      { query: { raw_image_url: undefined }, source: null });
-    wrapper.unmount();
-  });
-
   it('show ALL options if enabled', () => {
     useContent.mockReturnValueOnce(mockData);
 
@@ -308,29 +297,6 @@ describe('the large promo feature', () => {
 
     expect(wrapperOverline.find('a.overline').text()).toEqual('the-sun-name');
     expect(wrapperOverline.find('a.overline').prop('href')).toEqual('the-sun-ID/');
-    wrapper.unmount();
-  });
-
-  it('uses for content query contentConfigValues if it is present in custom fields', () => {
-    const myConfig = {
-      showHeadline: true,
-      showImage: true,
-      imageRatio: '4:3',
-      imageOverrideURL: 'overrideImage.jpg',
-      itemContentConfig: {
-        contentConfigValues: { id: 1234 },
-        contentService: 'content-api',
-      },
-    };
-    const wrapper = mount(<LargePromo customFields={myConfig} arcSite="dagen" />);
-    const expectedArgs = {
-      query: {
-        'arc-site': 'the-sun',
-        id: 1234,
-      },
-      source: 'content-api',
-    };
-    expect(useContent).toHaveBeenNthCalledWith(1, expectedArgs);
     wrapper.unmount();
   });
 

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -37,9 +37,74 @@ const MediumPromoItem = ({ customFields }) => {
     query: customFields?.itemContentConfig?.contentConfigValues
       ? {
         'arc-site': arcSite,
+        feature: 'medium-promo',
         ...customFields.itemContentConfig.contentConfigValues,
       }
       : null,
+    // does not need embed_html because no video section
+    // does not need website section nor label because no overline
+    filter: `{
+      _id
+      credits {
+        by {
+          _id
+          name
+          url
+          type
+          additional_properties {
+            original {
+              byline
+            }
+          }
+        }
+      }
+      description {
+        basic
+      }
+      display_date
+      type
+      headlines {
+        basic
+      }
+      promo_items {
+        type
+        url
+        lead_art {
+          type
+          promo_items {
+            basic {
+              type
+              url
+              resized_params {
+                400x300
+                400x267
+                400x225
+                274x206
+                274x183
+                274x154
+              }
+            }
+          }
+        }
+        basic {
+          type
+          url
+          resized_params {
+            400x300
+            400x267
+            400x225
+            274x206
+            274x183
+            274x154
+          }
+        }
+      }
+      websites {
+        ${arcSite} {
+          website_url
+        }
+      }
+    }`,
   }) || null;
 
   let imageConfig = null;

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -162,27 +162,6 @@ describe('the medium promo feature', () => {
     expect(img.prop('largeHeight')).toBe(300);
   });
 
-  it('should fetch content using null source and query if none in custom fields', () => {
-    const myConfig = {
-      showHeadline: true,
-      showImage: true,
-      itemContentConfig: {
-        contentConfigValues: { id: 1234 },
-        contentService: 'content-api',
-      },
-    };
-    const wrapper = mount(<MediumPromo customFields={myConfig} />);
-    const expectedArgs = {
-      query: {
-        'arc-site': undefined,
-        id: 1234,
-      },
-      source: 'content-api',
-    };
-    expect(useContent).toHaveBeenNthCalledWith(1, expectedArgs);
-    wrapper.unmount();
-  });
-
   it('returns null if null content', () => {
     const myConfig = {
       showHeadline: true,

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -23,9 +23,62 @@ const SmallPromoItem = ({ customFields }) => {
     query: customFields?.itemContentConfig?.contentConfigValues
       ? {
         'arc-site': arcSite,
+        feature: 'small-promo',
         ...customFields.itemContentConfig.contentConfigValues,
       }
       : null,
+    // does not need embed_html because no video section
+    // does not need website section nor label because no overline
+    // does not need byline because no byline shown
+    filter: `{
+      _id
+      description {
+        basic
+      }
+      display_date
+      type
+      headlines {
+        basic
+      }
+      promo_items {
+        type
+        url
+        lead_art {
+          type
+          promo_items {
+            basic {
+              type
+              url
+              resized_params {
+                400x300
+                400x267
+                400x225
+                274x206
+                274x183
+                274x154
+              }
+            }
+          }
+        }
+        basic {
+          type
+          url
+          resized_params {
+            400x300
+            400x267
+            400x225
+            274x206
+            274x183
+            274x154
+          }
+        }
+      }
+      websites {
+        ${arcSite} {
+          website_url
+        }
+      }
+    }`,
   }) || null;
 
   const ratios = ratiosFor('SM', customFields.imageRatio);

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -159,27 +159,6 @@ describe('the small promo feature', () => {
     expect(img.prop('largeHeight')).toBe(300);
   });
 
-  it('should fetch content using null source and query if none in custom fields', () => {
-    const myConfig = {
-      showHeadline: true,
-      showImage: true,
-      itemContentConfig: {
-        contentConfigValues: { id: 1234 },
-        contentService: 'content-api',
-      },
-    };
-    const wrapper = mount(<SmallPromo customFields={myConfig} />);
-    const expectedArgs = {
-      query: {
-        'arc-site': undefined,
-        id: 1234,
-      },
-      source: 'content-api',
-    };
-    expect(useContent).toHaveBeenNthCalledWith(1, expectedArgs);
-    wrapper.unmount();
-  });
-
   it('returns null if null content', () => {
     const myConfig = {
       showHeadline: true,


### PR DESCRIPTION
# test

`git checkout THEMES-76-content-filter-promos`

`npx fusion start -f -l @wpmedia/extra-large-promo-block,@wpmedia/large-promo-block,@wpmedia/medium-promo-block,@wpmedia/small-promo-block`

content api story /news/2020/04/15/7-questions-about-traveling-to-australia-during-catastrophic-fires-answered/

## xl promo

### before

<img width="1377" alt="Screen Shot 2021-04-02 at 13 21 35" src="https://user-images.githubusercontent.com/5950956/113442811-58518300-93b6-11eb-8bc5-f658a8391a24.png">


### after

<img width="1346" alt="Screen Shot 2021-04-02 at 13 08 44" src="https://user-images.githubusercontent.com/5950956/113442636-07418f00-93b6-11eb-977a-8883fa3a89d5.png">

<img width="1396" alt="Screen Shot 2021-04-02 at 13 08 56" src="https://user-images.githubusercontent.com/5950956/113442610-f8f37300-93b5-11eb-8d62-def77fdb9b3f.png">
