### PR TITLE
Bugfix small promo image override

### DIFF
--- a/blocks/small-promo-block/features/small-promo/_children/promo_image.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_image.jsx
@@ -11,7 +11,11 @@ import getPromoStyle from './promo_style';
 
 const PromoImage = (props) => {
   const {
-    content, customFields, ratios, customFieldImageResizedImageOptions,
+    content,
+    customFieldImageResizedImageOptions,
+    customFields,
+    imageConfig,
+    ratios,
   } = props;
 
   const { arcSite, isAdmin } = useFusionContext();
@@ -61,7 +65,6 @@ const PromoImage = (props) => {
           </a>
         </div>
       </div>
-
     ) : null;
 };
 export default PromoImage;

--- a/blocks/small-promo-block/features/small-promo/_children/promo_image.jsx
+++ b/blocks/small-promo-block/features/small-promo/_children/promo_image.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useFusionContext } from 'fusion:context';
-import { useContent, useEditableContent } from 'fusion:content';
+import { useEditableContent } from 'fusion:content';
 import getProperties from 'fusion:properties';
 import { extractImageFromStory, extractResizedParams } from '@wpmedia/resizer-image-block';
 import { Image } from '@wpmedia/engine-theme-sdk';
@@ -10,24 +10,13 @@ import discoverPromoType from './discover';
 import getPromoStyle from './promo_style';
 
 const PromoImage = (props) => {
-  const { content, customFields, ratios } = props;
+  const {
+    content, customFields, ratios, customFieldImageResizedImageOptions,
+  } = props;
+
   const { arcSite, isAdmin } = useFusionContext();
   const { searchableField } = useEditableContent();
   const promoType = discoverPromoType(content);
-
-  let imageConfig = null;
-  if (
-    (customFields.imageOverrideURL && customFields.lazyLoad)
-    || (customFields.imageOverrideURL && isAdmin)) {
-    imageConfig = 'resize-image-api-client';
-  } else if (customFields.imageOverrideURL) {
-    imageConfig = 'resize-image-api';
-  }
-
-  const customFieldImageResizedImageOptions = useContent({
-    source: imageConfig,
-    query: { raw_image_url: customFields.imageOverrideURL },
-  }) || undefined;
 
   const imageURL = customFields.imageOverrideURL
     ? customFields.imageOverrideURL : extractImageFromStory(content);

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -109,6 +109,7 @@ const SmallPromoItem = ({ customFields }) => {
       customFields={customFields}
       ratios={ratios}
       customFieldImageResizedImageOptions={customFieldImageResizedImageOptions}
+      imageConfig={imageConfig}
     />
   );
 

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -81,6 +81,22 @@ const SmallPromoItem = ({ customFields }) => {
     }`,
   }) || null;
 
+  let imageConfig = null;
+  const { isAdmin } = useFusionContext();
+
+  if (
+    (customFields.imageOverrideURL && customFields.lazyLoad)
+    || (customFields.imageOverrideURL && isAdmin)) {
+    imageConfig = 'resize-image-api-client';
+  } else if (customFields.imageOverrideURL) {
+    imageConfig = 'resize-image-api';
+  }
+
+  const customFieldImageResizedImageOptions = useContent({
+    source: imageConfig,
+    query: { raw_image_url: customFields.imageOverrideURL },
+  }) || undefined;
+
   const ratios = ratiosFor('SM', customFields.imageRatio);
 
   const headline = customFields?.showHeadline && (
@@ -88,7 +104,12 @@ const SmallPromoItem = ({ customFields }) => {
   );
 
   const image = customFields?.showImage && (
-    <PromoImage content={content} customFields={customFields} ratios={ratios} />
+    <PromoImage
+      content={content}
+      customFields={customFields}
+      ratios={ratios}
+      customFieldImageResizedImageOptions={customFieldImageResizedImageOptions}
+    />
   );
 
   const imagePosition = customFields?.imagePosition || 'right';

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "npm run test:coverage && npm run lint"
+      "pre-push": "npm run lint && npm run test:coverage"
     }
   },
   "license": "CC-BY-NC-ND-4.0",


### PR DESCRIPTION
- use small promo block
- set a content api like `/local/2020/01/14/in-albania-age-old-traditions-and-mediterranean-beaches-on-the-cheap/`
- see the headline and image on publish
- then update the content override image `https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/QI6YYS4M7VAAXLMN6R6J6FFCQY.jpg`
- then publish
- previously, we wouldn't see the image override in the published version. all admin works as expected