### PR TITLE
Themes 49 separator links focus

### DIFF
--- a/blocks/section-title-block/features/section-title/_children/section-title.jsx
+++ b/blocks/section-title-block/features/section-title/_children/section-title.jsx
@@ -17,13 +17,15 @@ const StyledLink = styled.a`
 const Separator = '  \u00a0 • \u00a0  ';
 
 const styledLinkTmpl = (name, id, separator, arcSite) => (
-  <StyledLink
-    primaryFont={getThemeStyle(arcSite)['primary-font-family']}
-    href={id}
-    key={id}
-  >
-    {`${name}${separator}`}
-  </StyledLink>
+  <span key={id}>
+    <StyledLink
+      primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+      href={id}
+    >
+      {name}
+    </StyledLink>
+    {separator}
+  </span>
 );
 
 const SectionTitle = (props) => {

--- a/blocks/section-title-block/features/section-title/_children/section-title.jsx
+++ b/blocks/section-title-block/features/section-title/_children/section-title.jsx
@@ -1,38 +1,26 @@
 import React from 'react';
-import styled from 'styled-components';
-import { useFusionContext } from 'fusion:context';
-import getThemeStyle from 'fusion:themes';
+import { PrimaryFont } from '@wpmedia/shared-styles';
+
 import './section-title.scss';
-
-const StyledTitle = styled.h1`
-  font-family: ${(props) => props.primaryFont};
-  font-weight: bold;
-`;
-
-const StyledLink = styled.a`
-  font-family: ${(props) => props.primaryFont};
-  text-decoration: none;
-`;
 
 const Separator = '  \u00a0 • \u00a0  ';
 
 // using the class twice to ensure the • and the text are both same font-size and
-const styledLinkTmpl = (name, id, separator, arcSite) => (
+const styledLinkTmpl = (name, id, separator) => (
   <span key={id} className="section-title--styled-link">
-    <StyledLink
-      primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+    <PrimaryFont
+      as="a"
       href={id}
       className="section-title--styled-link"
     >
       {name}
-    </StyledLink>
+    </PrimaryFont>
     {separator}
   </span>
 );
 
 const SectionTitle = (props) => {
   const { content } = props;
-  const { arcSite } = useFusionContext();
   const showSeparator = !!(
     content
     && content.children
@@ -42,20 +30,20 @@ const SectionTitle = (props) => {
   return (
     !!(content && (content.name || content.display_name)) && (
       <>
-        <StyledTitle
-          primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+        <PrimaryFont
+          as="h1"
           className="section-title"
         >
           {content.name || content.display_name}
-        </StyledTitle>
+        </PrimaryFont>
         <div className="section-container">
           {
             !!(content.children && content.children.length > 0)
             && (content.children.map((child, index) => (
               (child.node_type && child.node_type === 'link' && (
-                styledLinkTmpl(child.display_name, child.url, ((content.children.length !== index + 1 && showSeparator) ? Separator : ''), arcSite)
+                styledLinkTmpl(child.display_name, child.url, ((content.children.length !== index + 1 && showSeparator) ? Separator : ''))
               )) || (
-                styledLinkTmpl(child.name, child._id, ((content.children.length !== index + 1 && showSeparator) ? Separator : ''), arcSite)
+                styledLinkTmpl(child.name, child._id, ((content.children.length !== index + 1 && showSeparator) ? Separator : ''))
               )
             )))
           }

--- a/blocks/section-title-block/features/section-title/_children/section-title.jsx
+++ b/blocks/section-title-block/features/section-title/_children/section-title.jsx
@@ -16,11 +16,13 @@ const StyledLink = styled.a`
 
 const Separator = '  \u00a0 • \u00a0  ';
 
+// using the class twice to ensure the • and the text are both same font-size and
 const styledLinkTmpl = (name, id, separator, arcSite) => (
-  <span key={id}>
+  <span key={id} className="section-title--styled-link">
     <StyledLink
       primaryFont={getThemeStyle(arcSite)['primary-font-family']}
       href={id}
+      className="section-title--styled-link"
     >
       {name}
     </StyledLink>

--- a/blocks/section-title-block/features/section-title/_children/section-title.scss
+++ b/blocks/section-title-block/features/section-title/_children/section-title.scss
@@ -5,10 +5,10 @@
 
 .section-container {
   margin-top: map-get($spacers, 'sm');
+}
 
-  > a {
-    color: $ui-primary-font-color;
-    font-size: 14px;
-  }
+.section-title--styled-link {
+  font-size: 14px;
+  color: $ui-primary-font-color;
 }
 

--- a/blocks/section-title-block/features/section-title/_children/section-title.scss
+++ b/blocks/section-title-block/features/section-title/_children/section-title.scss
@@ -1,6 +1,7 @@
 .section-title {
   color: $ui-primary-font-color;
   display: block;
+  font-weight: bold;
 }
 
 .section-container {
@@ -10,5 +11,6 @@
 .section-title--styled-link {
   font-size: 14px;
   color: $ui-primary-font-color;
+  text-decoration: none;
 }
 

--- a/blocks/section-title-block/features/section-title/_children/section-title.scss
+++ b/blocks/section-title-block/features/section-title/_children/section-title.scss
@@ -9,7 +9,7 @@
 }
 
 .section-title--styled-link {
-  font-size: 14px;
+  font-size: calculateRem(14px);
   color: $ui-primary-font-color;
   text-decoration: none;
 }

--- a/blocks/section-title-block/features/section-title/_children/section-title.scss
+++ b/blocks/section-title-block/features/section-title/_children/section-title.scss
@@ -1,4 +1,4 @@
-h1.section-title {
+.section-title {
   color: $ui-primary-font-color;
   display: block;
 }

--- a/blocks/section-title-block/features/section-title/_children/section-title.test.jsx
+++ b/blocks/section-title-block/features/section-title/_children/section-title.test.jsx
@@ -43,7 +43,8 @@ describe('the section title block', () => {
       it('should have the correct href', () => {
         const wrapper = mount(<SectionTitle content={mockTwoSection.globalContent} />);
 
-        expect(wrapper.find('.section-container').childAt(0).prop('href')).toEqual('/news');
+        // nesting within a span to find the a tag
+        expect(wrapper.find('.section-container').childAt(0).find('a').prop('href')).toEqual('/news');
       });
 
       it('should have a last element without a separator', () => {

--- a/blocks/section-title-block/package.json
+++ b/blocks/section-title-block/package.json
@@ -23,8 +23,9 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "peerDependencies": {
-    "@wpmedia/engine-theme-sdk": "canary",
-    "@wpmedia/news-theme-css": "stable"
+    "@wpmedia/engine-theme-sdk": "*",
+    "@wpmedia/news-theme-css": "*",
+    "@wpmedia/shared-styles": "*"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"


### PR DESCRIPTION
## Description
Focus only the link in section title 

## Jira Ticket
- [TMEDIA-49](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-49&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
Separator is to not form part of the link text.

## Test Steps

1. Checkout this branch `git checkout THEMES-49-separator-links-focus`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/section-title-block`
- go to http://localhost/pf/news/?_website=the-gazette
- tab until section text
- make sure section separator dot is not included in focus 

## Effect Of Changes
### Before

<img width="1389" alt="Screen Shot 2021-04-09 at 15 04 50" src="https://user-images.githubusercontent.com/5950956/114235011-2ce60f80-9945-11eb-89e5-a7a5d0bdb778.png">

### After

<img width="990" alt="Screen Shot 2021-04-09 at 15 04 23" src="https://user-images.githubusercontent.com/5950956/114235130-5868fa00-9945-11eb-96d4-65d9a3adcca7.png">


## Dependencies or Side Effects
- none 

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
