### PR TITLE
Tmedia 5 set html lang

### DIFF
--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -171,6 +171,31 @@ describe('root html layout', () => {
     expect(html.children('head').length).toBe(1);
     expect(html.children('body').length).toBe(1);
   });
+
+  it('must take in a language', () => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({
+      locale: 'fr',
+    }))));
+
+    const { default: DefaultOutputType } = require('../default');
+
+    const wrapper = shallow(
+      <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} {...mockFuntions} />,
+    );
+
+    expect(wrapper.find('html').prop('lang')).toBe('fr');
+  });
+
+  it('must fallback to en without a locale', () => {
+    jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+    const { default: DefaultOutputType } = require('../default');
+
+    const wrapper = shallow(
+      <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} {...mockFuntions} />,
+    );
+
+    expect(wrapper.find('html').prop('lang')).toBe('en');
+  });
 });
 
 describe('head content', () => {

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -118,6 +118,7 @@ const SampleOutputType = ({
     comscoreID,
     querylyId,
     querylyOrg,
+    locale = 'en',
   } = getProperties(arcSite);
 
   const pageType = metaValue('page-type');
@@ -158,7 +159,7 @@ const SampleOutputType = ({
   const chartBeat = chartBeatCode(chartBeatAccountId, chartBeatDomain);
 
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         {gtmID


### PR DESCRIPTION
## Description
Apply the site specific language locale tag to the HTML element in the default output type.

## Jira Ticket
- [TMEDIA-5](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-5&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
The `<html>` tag within the output type has the correct locale set for the lang attribute

If a site has their locale set to French (fr) the html tag should be `<html lang="fr">`

If no locale is set for a site fallback to English "en" `<html lang="en">`

## Test Steps

1. Checkout this branch `git checkout TMEDIA-5-set-html-lang`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/default-output-block`
3. Go to page with lang en like gazette http://localhost/pf/news/?_website=the-gazette
4. Go to page with lang fr http://localhost/pf/news/?_website=the-sun per blocks json in news theme feature pack

## Effect Of Changes
### Before
- always lang en 

### After

- set by locale 

![Screen Shot 2021-04-09 at 16 02 09](https://user-images.githubusercontent.com/5950956/114241840-7c313d80-994f-11eb-8da8-365688be26a7.png)
![Screen Shot 2021-04-09 at 16 01 46](https://user-images.githubusercontent.com/5950956/114241848-7dfb0100-994f-11eb-891f-85ee111a3d1d.png)

- added a test for fallback 

## Dependencies or Side Effects
- client could potentially put in an invalid locale. didn't have a checker but this wouldn't have drastic effects 

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
