### PR TITLE
TMEDIA-102 - Accessible queryly button

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -30,10 +30,12 @@ const NavWidget = ({
         alwaysOpen={WIDGET_CONFIG[placement]?.expandSearch}
       />
     )) || (type === 'queryly' && (
-      <QuerylySearch theme={
+      <QuerylySearch
+        theme={
         placement === PLACEMENT_AREAS.SECTION_MENU
           ? 'dark' : navColor
         }
+        label={phrases.t('header-nav-chain-block.search-text')}
       />
     )) || (type === 'menu' && (
       <button

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
@@ -22,9 +22,9 @@ const querylySearchClick = () => {
   document.getElementById('queryly_toggle').dispatchEvent(event);
 };
 
-const QuerylySearch = ({ theme = 'dark', iconSize = 16 }) => (
+const QuerylySearch = ({ theme = 'dark', iconSize = 16, label = 'Search' }) => (
   <div className={`nav-search ${theme} queryly`}>
-    <button className={`nav-btn nav-btn-${theme} transparent border`} type="button" onClick={querylySearchClick}>
+    <button className={`nav-btn nav-btn-${theme} transparent border`} type="button" onClick={querylySearchClick} aria-label={label}>
       <label htmlFor="queryly_toggle">
         <SearchIcon height={iconSize} width={iconSize} />
       </label>

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
@@ -1,10 +1,30 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import React from 'react';
-import SearchIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/SearchIcon';
+import { SearchIcon } from '@wpmedia/engine-theme-sdk';
+
+/*
+  This querylySearchClick event isn't the ideal solution -
+
+  Queryly uses a hidden checkbox in the DOM which they have an
+  onChange event listener attached to. As we are using a label
+  with the htmlFor attribute that is linked to the ID of their
+  checkbox the change event is fired using the mouse.
+
+  The issue is label's are not a focusable element. But a
+  button is. But events do not bubble downwards, and also
+  due to their use of the checkbox we have to manaully
+  check the checkbox and they dispatch a change event so their
+  code picks it up and loads the queryly search UI.
+*/
+const querylySearchClick = () => {
+  const event = new Event('change');
+  document.getElementById('queryly_toggle').checked = true;
+  document.getElementById('queryly_toggle').dispatchEvent(event);
+};
 
 const QuerylySearch = ({ theme = 'dark', iconSize = 16 }) => (
   <div className={`nav-search ${theme} queryly`}>
-    <button className={`nav-btn nav-btn-${theme} transparent border`} type="button">
+    <button className={`nav-btn nav-btn-${theme} transparent border`} type="button" onClick={querylySearchClick}>
       <label htmlFor="queryly_toggle">
         <SearchIcon height={iconSize} width={iconSize} />
       </label>

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.test.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import QuerylySearch from './queryly-search';
 
-const testQuerylySearch = ({ root, theme, iconSize = 16 }) => {
+const testQuerylySearch = ({
+  root, theme, iconSize = 16, label = 'Search',
+}) => {
   const container = root.find('.nav-search');
   expect(container).toHaveLength(1);
   expect(container).toHaveClassName(theme);
@@ -19,6 +21,9 @@ const testQuerylySearch = ({ root, theme, iconSize = 16 }) => {
   expect(searchIcon).toHaveLength(1);
   expect(searchIcon.prop('height')).toEqual(iconSize);
   expect(searchIcon.prop('width')).toEqual(iconSize);
+
+  const button = container.find('button');
+  expect(button.prop('aria-label')).toBe(label);
 };
 
 describe('<QuerylySearch/>', () => {
@@ -40,5 +45,12 @@ describe('<QuerylySearch/>', () => {
   it('renders with custom icon size', () => {
     const wrapper = shallow(<QuerylySearch theme="dark" iconSize={24} />);
     testQuerylySearch({ root: wrapper, theme: 'dark', iconSize: 24 });
+  });
+
+  it('custom label', () => {
+    const wrapper = shallow(<QuerylySearch theme="dark" iconSize={24} label="Suche" />);
+    testQuerylySearch({
+      root: wrapper, theme: 'dark', iconSize: 24, label: 'Suche',
+    });
   });
 });


### PR DESCRIPTION
## Description
Add click handler event to queryly button to enable keyboard accessibility for queryly search button

## Jira Ticket
- [TMEDIA-102](https://arcpublishing.atlassian.net/browse/TMEDIA-102)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-102-queryly-button-not-accessible`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. On a page with the header nav chain and queryly integration - http://localhost/pf/homepage/?_website=the-gazette
4. Verify you can use the queryly search button with your keyboard (enter and space key) to activate the queryly search integrations

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
