### PR TITLE
TMEDIA-166 - Search content source encoding

### DIFF
--- a/blocks/search-content-source-block/sources/search-api.js
+++ b/blocks/search-content-source-block/sources/search-api.js
@@ -5,7 +5,7 @@ export default {
   resolve(contentOptions) {
     const { query, page, 'arc-site': arcSite } = contentOptions;
     if (query) {
-      return `https://search.arcpublishing.com/search?&q=${query}&page=${page || 1}${arcSite ? `&website_id=${arcSite}` : ''}${SEARCH_KEY ? `&key=${SEARCH_KEY}` : ''}`;
+      return `https://search.arcpublishing.com/search?&q=${encodeURIComponent(query)}&page=${page || 1}${arcSite ? `&website_id=${arcSite}` : ''}${SEARCH_KEY ? `&key=${SEARCH_KEY}` : ''}`;
     }
     return '';
   },

--- a/blocks/search-content-source-block/sources/search-api.js
+++ b/blocks/search-content-source-block/sources/search-api.js
@@ -5,7 +5,7 @@ export default {
   resolve(contentOptions) {
     const { query, page, 'arc-site': arcSite } = contentOptions;
     if (query) {
-      return `https://search.arcpublishing.com/search?&q=${encodeURIComponent(query)}&page=${page || 1}${arcSite ? `&website_id=${arcSite}` : ''}${SEARCH_KEY ? `&key=${SEARCH_KEY}` : ''}`;
+      return `https://search.arcpublishing.com/search?&q=${encodeURIComponent(decodeURIComponent(query))}&page=${page || 1}${arcSite ? `&website_id=${arcSite}` : ''}${SEARCH_KEY ? `&key=${SEARCH_KEY}` : ''}`;
     }
     return '';
   },

--- a/blocks/search-content-source-block/sources/search-api.test.js
+++ b/blocks/search-content-source-block/sources/search-api.test.js
@@ -16,6 +16,14 @@ describe('the search content source block', () => {
       });
       expect(url).toEqual('https://search.arcpublishing.com/search?&q=test&page=1&website_id=the-sun&key=ABCDEF');
     });
+
+    it('should encode the query value', () => {
+      const url = contentSource.resolve({
+        query: 'vidèo',
+        'arc-site': 'the-sun',
+      });
+      expect(url).toEqual('https://search.arcpublishing.com/search?&q=vid%C3%A8o&page=1&website_id=the-sun&key=ABCDEF');
+    });
   });
 
   describe('when a page number is provided', () => {


### PR DESCRIPTION
## Description

Encode the query string value being used to call the search API 

## Jira Ticket
- [TMEDIA-166](https://arcpublishing.atlassian.net/browse/TMEDIA-166)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-166-search-content-source-encoding`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/search-content-source-block`
3. Using content debugger - http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=search-api
4. Using the following value - `vidèo` verify results are now returned
5. Verify you see a search result in the theme search results page - http://localhost/search/vid%C3%A8o/?_website=the-gazette

## Effect Of Changes
### Before

Search results not found -

<img width="1612" alt="TMEDIA-166-after" src="https://user-images.githubusercontent.com/868127/114539441-6ae87980-9c4c-11eb-8eae-4b6ade580963.png">


### After

Search results now found - 
<img width="1612" alt="TMEDIA-166-after" src="https://user-images.githubusercontent.com/868127/114539477-720f8780-9c4c-11eb-8423-a4cd654ac881.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
