### PR TITLE
TMEDIA-204 - primary secondary background color

### DIFF
--- a/blocks/shared-styles/_children/primary-font.jsx
+++ b/blocks/shared-styles/_children/primary-font.jsx
@@ -6,11 +6,16 @@ import { useFusionContext } from 'fusion:context';
 const PrimaryFontStyles = styled.div.attrs((props) => ({
   arcSite: props.arcSite,
   fontColor: props.fontColor || null,
+  backgroundColor: props.backgroundColor || null,
 }))`
   font-family: ${({ arcSite }) => getThemeStyle(arcSite)['primary-font-family']};
 
   ${({ arcSite, fontColor }) => fontColor && `
     color: ${getThemeStyle(arcSite)[fontColor]};
+  `}
+
+  ${({ arcSite, backgroundColor }) => backgroundColor && `
+    background-color: ${getThemeStyle(arcSite)[backgroundColor]};
   `}
 `;
 

--- a/blocks/shared-styles/_children/secondary-font.jsx
+++ b/blocks/shared-styles/_children/secondary-font.jsx
@@ -6,11 +6,16 @@ import { useFusionContext } from 'fusion:context';
 const SecondaryFontStyles = styled.div.attrs((props) => ({
   arcSite: props.arcSite,
   fontColor: props.fontColor || null,
+  backgroundColor: props.backgroundColor || null,
 }))`
   font-family: ${({ arcSite }) => getThemeStyle(arcSite)['secondary-font-family']};
 
   ${({ arcSite, fontColor }) => fontColor && `
     color: ${getThemeStyle(arcSite)[fontColor]};
+  `}
+
+  ${({ arcSite, backgroundColor }) => backgroundColor && `
+    background-color: ${getThemeStyle(arcSite)[backgroundColor]};
   `}
 `;
 

--- a/blocks/shared-styles/index.story.jsx
+++ b/blocks/shared-styles/index.story.jsx
@@ -20,6 +20,7 @@ export const primaryFontBlock = () => {
   const data = {
     as: text('"as"', 'h1'),
     fontColor: select(label, options, defaultValue),
+    backgroundColor: select('Background Color', options, defaultValue),
   };
 
   const textString = text('Text', 'When this baby hits 88mph...');
@@ -40,6 +41,7 @@ export const secondaryFontBlock = () => {
   const data = {
     as: text('"as"', 'p'),
     fontColor: select(label, options, defaultValue),
+    backgroundColor: select('Background Color', options, defaultValue),
   };
 
   const textString = text('Text', 'When this baby hits 88mph...');


### PR DESCRIPTION
## Description
Allow PrimaryFont and SecondaryFont components to set background-color

## Jira Ticket
- [TMEDIA-204](https://arcpublishing.atlassian.net/browse/TMEDIA-204)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-204-primary-secondary-background-color`
2. Use storybook to validate - http://localhost:60554/?path=/story/shared-styles--primary-font-block


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
