### PR TITLE
TMEDIA-188 GitHub Action - Handle failed publish of blocks

### DIFF
--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -35,7 +35,11 @@ jobs:
       - name: Run tests
         run: npm run test
 
-      - run: npx lerna publish 0.0.0-canary.$(git rev-parse --short HEAD) --no-git-tag-version --no-push --dist-tag canary --yes
+      - name: Get current datetime for re-running publish if necessary
+        id: get-datetime
+        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
+
+      - run: npx lerna publish 0.0.0-canary.$(git rev-parse --short HEAD)${{ steps.get-datetime.outputs.date }}  --no-git-tag-version --no-push --dist-tag canary --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- A bit harder than expected with bash and lerna and github actions 
- Working had the git not failed, presumably from not merging or the tag not existing https://github.com/WPMedia/fusion-news-theme-blocks/actions/runs/749351586 
- working as expected testing it https://github.com/WPMedia/fusion-news-theme-blocks/runs/2346583777?check_suite_focus=true