### PR TITLE
Tmedia 195 extract util trailing slash

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
@@ -6,6 +6,7 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
   LazyLoad: ({ children }) => <>{ children }</>,
   isServerSide: () => true,
+  formatURL: jest.fn((input) => input.toString()),
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -14,6 +14,7 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   VideoPlayer: ({ embedHTML, id }) => <div dangerouslySetInnerHTML={{ __html: embedHTML }} id={`video-${id}`} />,
   LazyLoad: ({ children }) => <>{ children }</>,
   isServerSide: () => true,
+  formatURL: jest.fn((input) => input.toString()),
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({
@@ -173,7 +174,6 @@ describe('the extra large promo feature', () => {
     expect(wrapperOverline.length).toBe(1);
 
     expect(wrapperOverline.find('a.overline').text()).toEqual('the-sun-name');
-    expect(wrapperOverline.find('a.overline').prop('href')).toEqual('the-sun-ID/');
     wrapper.unmount();
   });
 

--- a/blocks/footer-block/features/footer/default.test.jsx
+++ b/blocks/footer-block/features/footer/default.test.jsx
@@ -105,6 +105,7 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   RssIcon: () => <svg>RssIcon</svg>,
   LazyLoad: ({ children }) => <>{ children }</>,
   isServerSide: () => true,
+  formatURL: jest.fn((input) => input.toString()),
 }));
 
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));

--- a/blocks/header-nav-block/features/navigation/_children/section-nav.jsx
+++ b/blocks/header-nav-block/features/navigation/_children/section-nav.jsx
@@ -1,49 +1,19 @@
 import React from 'react';
-import ChevronRight from '@wpmedia/engine-theme-sdk/dist/es/components/icons/ChevronRightIcon';
+import { ChevronRight, formatURL } from '@wpmedia/engine-theme-sdk';
 
 function hasChildren(node) { return node.children && node.children.length > 0; }
-
-function getLocation(uri) {
-  let url;
-  if (typeof window === 'undefined') {
-    url = new URL(uri, 'http://example.com');
-  } else {
-    url = document.createElement('a');
-    // IE doesn't populate all link properties when setting .href with a relative URL,
-    // however .href will return an absolute URL which then can be used on itself
-    // to populate these additional fields.
-    url.href = uri;
-    if (url.host === '') {
-      url.href = `${url.href}`;
-    }
-  }
-  return url;
-}
-
-function fixTrailingSlash(item) {
-  const url = getLocation(item);
-
-  if (url.hash || url.search || url.pathname.match(/\./)) {
-    return item;
-  }
-
-  if (item[item.length - 1] !== '/') {
-    return `${item}/`;
-  }
-  return item;
-}
 
 const Link = ({ href, name, child }) => {
   const externalUrl = /(http(s?)):\/\//i.test(href);
   return (
     externalUrl ? (
-      <a href={fixTrailingSlash(href)} target="_blank" rel="noopener noreferrer">
+      <a href={formatURL(href)} target="_blank" rel="noopener noreferrer">
         {name}
         <span className="sr-only">(Opens in new window)</span>
         {child}
       </a>
     ) : (
-      <a href={fixTrailingSlash(href)}>
+      <a href={formatURL(href)}>
         {name}
         {child}
       </a>

--- a/blocks/header-nav-block/features/navigation/_children/section-nav.test.jsx
+++ b/blocks/header-nav-block/features/navigation/_children/section-nav.test.jsx
@@ -78,6 +78,11 @@ const items = [
   },
 ];
 
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  formatURL: jest.fn((input) => (input.toString())),
+  ChevronRight: jest.fn(() => <span />),
+}));
+
 describe('the SectionNav component', () => {
   it('should render children', () => {
     const wrapper = shallow(<SectionNav><div className="child">Child Item</div></SectionNav>);
@@ -103,12 +108,6 @@ describe('the SectionNav component', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
     expect(wrapper.find('li.section-item > Link').at(0)).toIncludeText('Sports');
-  });
-
-  it('should render the href for a section node correctly', () => {
-    const wrapper = mount(<SectionNav sections={items} />);
-
-    expect(wrapper.find('li.section-item > Link > a').at(0)).toHaveProp('href', '/sports/');
   });
 
   it('should render the text for a link node correctly', () => {
@@ -160,40 +159,11 @@ describe('the SectionNav component', () => {
       expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > Link').at(0)).toIncludeText('Basketball');
     });
 
-    it('should render the href for a subsection link node correctly', () => {
-      const wrapper = mount(<SectionNav sections={items} />);
-
-      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > Link > a').at(0)).toHaveProp('href', '/basketball/');
-    });
-
     it('should render target and rel attribute for external links', () => {
       const wrapper = mount(<SectionNav sections={items} />);
 
       expect(wrapper.find('li.section-item > Link > a').at(2)).toHaveProp('target', '_blank');
       expect(wrapper.find('li.section-item > Link > a').at(2)).toHaveProp('rel', 'noopener noreferrer');
-    });
-  });
-
-  describe('when a link is not missing a trailing slash', () => {
-    const itemsNoSlash = [
-      {
-        _id: '/sports',
-        node_type: 'section',
-        name: 'Sports',
-        children: [
-          {
-            _id: 'foo',
-            node_type: 'link',
-            display_name: 'Basketball',
-            url: '/basketball/',
-          },
-        ],
-      },
-    ];
-    it('should not add a slash at the end of the link', () => {
-      const wrapper = mount(<SectionNav sections={itemsNoSlash} />);
-
-      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > Link').at(0)).toHaveProp('href', '/basketball/');
     });
   });
 });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 
 jest.mock('fusion:themes', () => jest.fn(() => ({})));
-
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  formatURL: jest.fn((input) => (input.toString())),
+}));
 describe('the links bar feature for the default output type', () => {
   afterEach(() => {
     jest.resetModules();
@@ -182,100 +184,5 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.find('nav > span')).toHaveLength(0);
-  });
-
-  describe('a link element ', () => {
-    it('should have the right name', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="/testurl" name="test" />);
-
-      expect(wrapper.props().name).toBe('test');
-      expect(wrapper.find('a').text()).toBe('test');
-    });
-  });
-
-  describe('when a link is missing a trailing slash', () => {
-    it('should add a slash at the end of the link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="/testurl" name="test" />);
-      expect(wrapper.props().href).toBe('/testurl');
-      expect(wrapper.find('[href="/testurl/"]').length).toBe(3);
-    });
-  });
-
-  describe('when a link is not missing a trailing slash', () => {
-    it('should not add a slash at the end of the link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="/testurl/" name="test" />);
-
-      expect(wrapper.props().href).toBe('/testurl/');
-      expect(wrapper.find('[href="/testurl/"]').length).toBe(4);
-    });
-  });
-
-  describe('when a link has query parameters', () => {
-    it('should not add a slash at the end of a internal link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="/testurl/?query=home" name="test" />);
-
-      expect(wrapper.props().href).toBe('/testurl/?query=home');
-      expect(wrapper.find('[href="/testurl/?query=home"]').length).toBe(4);
-    });
-  });
-
-  describe('when a link has query parameters', () => {
-    it('should not add a slash at the end of a external link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(
-        <Link href="http://example.com/testurl/?query=home" name="test" />,
-      );
-
-      expect(wrapper.props().href).toBe(
-        'http://example.com/testurl/?query=home',
-      );
-      expect(
-        wrapper.find('[href="http://example.com/testurl/?query=home"]').length,
-      ).toBe(4);
-    });
-  });
-
-  describe('when a link is to a page', () => {
-    it('should not add a slash at the end of the link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(
-        <Link href="https://example.com/category/page.html" name="test" />,
-      );
-
-      expect(wrapper.props().href).toBe(
-        'https://example.com/category/page.html',
-      );
-      expect(
-        wrapper.find('[href="https://example.com/category/page.html"]').length,
-      ).toBe(4);
-    });
-  });
-
-  describe('when a link has a hash', () => {
-    it('should not add a slash at the end of the link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="/category/page#myhash" name="test" />);
-
-      expect(wrapper.props().href).toBe('/category/page#myhash');
-      expect(wrapper.find('[href="/category/page#myhash"]').length).toBe(4);
-    });
-  });
-
-  describe('when a link has a mail', () => {
-    it('should not add a slash at the end of the link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(
-        <Link href="mailto:readers@washpost.com" name="test" />,
-      );
-
-      expect(wrapper.props().href).toBe('mailto:readers@washpost.com');
-      expect(wrapper.find('[href="mailto:readers@washpost.com"]').length).toBe(
-        4,
-      );
-    });
   });
 });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/link.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/link.jsx
@@ -1,34 +1,5 @@
 import React from 'react';
-
-function getLocation(uri) {
-  let url;
-  if (typeof window === 'undefined') {
-    url = new URL(uri, 'http://example.com');
-  } else {
-    url = document.createElement('a');
-    // IE doesn't populate all link properties when setting .href with a relative URL,
-    // however .href will return an absolute URL which then can be used on itself
-    // to populate these additional fields.
-    url.href = uri;
-    if (url.host === '') {
-      url.href = `${url.href}`;
-    }
-  }
-  return url;
-}
-
-function fixTrailingSlash(item) {
-  const url = getLocation(item);
-
-  if (url.hash || url.search || url.pathname.match(/\./)) {
-    return item;
-  }
-
-  if (item[item.length - 1] !== '/') {
-    return `${item}/`;
-  }
-  return item;
-}
+import { formatURL } from '@wpmedia/engine-theme-sdk';
 
 const Link = ({
   href, name, child, isHidden = false,
@@ -37,13 +8,13 @@ const Link = ({
   const linkAttributes = isHidden ? { tabIndex: -1 } : {};
   return (
     externalUrl ? (
-      <a href={fixTrailingSlash(href)} target="_blank" rel="noopener noreferrer" {...linkAttributes}>
+      <a href={formatURL(href)} target="_blank" rel="noopener noreferrer" {...linkAttributes}>
         {name}
         <span className="sr-only">(Opens in new window)</span>
         {child}
       </a>
     ) : (
-      <a href={fixTrailingSlash(href)} {...linkAttributes}>
+      <a href={formatURL(href)} {...linkAttributes}>
         {name}
         {child}
       </a>

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/link_node.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/link_node.test.jsx
@@ -8,31 +8,12 @@
 import { renderToString } from 'react-dom/server';
 import Link from './link';
 
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  formatURL: jest.fn((input) => (input.toString())),
+}));
 describe('When the link is generated SSR', () => {
-  it('must add a final slash to internal urls', () => {
-    const link = renderToString(Link({ href: '/entertaiment', name: 'Entertaiment', showSepartor: false }));
-    expect(link).toMatch(/\/entertaiment\//);
-    expect(link).toMatch(/>Entertaiment</);
-  });
-
-  it('must not add a final slash to links with query params', () => {
-    const link = renderToString(Link({ href: '/entertaiment?search=abc', name: 'Entertaiment', showSepartor: false }));
-    expect(link).toMatch(/\/entertaiment\?search=abc/);
-  });
-
-  it('must not add a final slash to links with hash params', () => {
-    const link = renderToString(Link({ href: '/entertaiment/page#some-anchor', name: 'Entertaiment', showSepartor: false }));
-    expect(link).toMatch(/\/entertaiment\/page#some-anchor/);
-  });
-
-  it('must not add a final slash to links with a htmlpage', () => {
-    const link = renderToString(Link({ href: '/entertaiment/page.html', name: 'Entertaiment', showSepartor: false }));
-    expect(link).toMatch(/\/entertaiment\/page\.html/);
-  });
-
   it('must add rel attriutes to external links', () => {
     const link = renderToString(Link({ href: 'https://example.com/some/page.html', name: 'Entertaiment', showSepartor: false }));
-    expect(link).toMatch(/href="https:\/\/example.com\/some\/page.html"/);
     expect(link).toMatch(/target="_blank"/);
     expect(link).toMatch(/rel="noopener noreferrer"/);
   });
@@ -41,7 +22,6 @@ describe('When the link is generated SSR', () => {
     const link = renderToString(Link({
       href: 'https://example.com/some/page.html', name: 'Entertaiment', isHidden: true,
     }));
-    expect(link).toMatch(/href="https:\/\/example.com\/some\/page.html"/);
     expect(link).toMatch(/target="_blank"/);
     expect(link).toMatch(/rel="noopener noreferrer"/);
     expect(link).toMatch(/tabindex="-1"/);

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
@@ -78,6 +78,10 @@ const items = [
   },
 ];
 
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  formatURL: jest.fn((input) => (input.toString())),
+}));
+
 describe('the SectionNav component', () => {
   it('should render children', () => {
     const wrapper = shallow(<SectionNav><div className="child">Child Item</div></SectionNav>);
@@ -105,33 +109,10 @@ describe('the SectionNav component', () => {
     expect(wrapper.find('li.section-item').at(0).find('Link > a').at(0)).toIncludeText('Sports');
   });
 
-  it('should render the href for a section node correctly', () => {
-    const wrapper = mount(<SectionNav sections={items} />);
-
-    expect(wrapper.find('li.section-item').at(0).find('Link > a').at(0)).toHaveProp('href', '/sports/');
-  });
-
   it('should render the text for a link node correctly', () => {
     const wrapper = mount(<SectionNav sections={items} />);
 
     expect(wrapper.find('li.section-item').at(1).find('Link > a')).toIncludeText('Entertainment');
-  });
-
-  it('should render the href for a link node correctly', () => {
-    const wrapper = mount(<SectionNav sections={items} />);
-
-    expect(wrapper.find('li.section-item').at(1).find('Link > a')).toHaveProp('href', '/entertainment/');
-  });
-
-  it('should render the href for a link without a final slash if has a query parameter', () => {
-    const wrapper = mount(<SectionNav sections={items} />);
-    const section = wrapper.find('li.section-item');
-
-    expect(section.at(3).find('Link > a')).toHaveProp('href', 'http://washingtonpost.com/entertainment/?test=2&foo=bar');
-    expect(section.at(4).find('Link > a')).toHaveProp('href', '/entertainment/?test=1');
-    expect(section.at(5).find('Link > a')).toHaveProp('href', 'https://example.com/category/page.html');
-    expect(section.at(6).find('Link > a')).toHaveProp('href', '/entertainment/page#myhash');
-    expect(section.at(7).find('Link > a')).toHaveProp('href', 'mailto:readers@washpost.com');
   });
 
   describe('when a section has child nodes', () => {
@@ -160,12 +141,6 @@ describe('the SectionNav component', () => {
       const wrapper = mount(<SectionNav sections={items} />);
 
       expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > Link').at(0)).toIncludeText('Basketball');
-    });
-
-    it('should render the href for a subsection link node correctly', () => {
-      const wrapper = mount(<SectionNav sections={items} />);
-
-      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > Link > a').at(0)).toHaveProp('href', '/basketball/');
     });
 
     it('should render target and rel attribute for external links', () => {
@@ -212,29 +187,6 @@ describe('the SectionNav component', () => {
       menuItem.simulate('click');
       wrapper.update();
       expect(sectionMenu.getDOMNode().classList.contains('open')).toBe(false);
-    });
-  });
-
-  describe('when a link is not missing a trailing slash', () => {
-    const itemsNoSlash = [
-      {
-        _id: '/sports',
-        node_type: 'section',
-        name: 'Sports',
-        children: [
-          {
-            _id: 'foo',
-            node_type: 'link',
-            display_name: 'Basketball',
-            url: '/basketball/',
-          },
-        ],
-      },
-    ];
-    it('should not add a slash at the end of the link', () => {
-      const wrapper = mount(<SectionNav sections={itemsNoSlash} />);
-
-      expect(wrapper.find('.subsection-container').at(0).find('li.subsection-item > Link').at(0)).toHaveProp('href', '/basketball/');
     });
   });
 });

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
@@ -6,6 +6,7 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
   LazyLoad: ({ children }) => <>{ children }</>,
   isServerSide: () => true,
+  formatURL: jest.fn((input) => input.toString()),
 }));
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:properties', () => (jest.fn(() => ({}))));

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -14,6 +14,7 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   VideoPlayer: ({ embedHTML, id }) => <div dangerouslySetInnerHTML={{ __html: embedHTML }} id={`video-${id}`} />,
   LazyLoad: ({ children }) => <>{ children }</>,
   isServerSide: () => true,
+  formatURL: jest.fn((input) => input.toString()),
 }));
 
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
@@ -296,7 +297,6 @@ describe('the large promo feature', () => {
     expect(wrapperOverline.length).toBe(1);
 
     expect(wrapperOverline.find('a.overline').text()).toEqual('the-sun-name');
-    expect(wrapperOverline.find('a.overline').prop('href')).toEqual('the-sun-ID/');
     wrapper.unmount();
   });
 

--- a/blocks/links-bar-block/features/links-bar/_children/link.jsx
+++ b/blocks/links-bar-block/features/links-bar/_children/link.jsx
@@ -1,46 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-function getLocation(uri) {
-  let url;
-  if (typeof window === 'undefined') {
-    url = new URL(uri, 'http://example.com');
-  } else {
-    url = document.createElement('a');
-    // IE doesn't populate all link properties when setting .href with a relative URL,
-    // however .href will return an absolute URL which then can be used on itself
-    // to populate these additional fields.
-    url.href = uri;
-    if (url.host === '') {
-      url.href = `${url.href}`;
-    }
-  }
-  return url;
-}
-
-function fixTrailingSlash(item) {
-  const url = getLocation(item);
-
-  if (url.hash || url.search || url.pathname.match(/\./)) {
-    return item;
-  }
-
-  if (item[item.length - 1] !== '/') {
-    return `${item}/`;
-  }
-  return item;
-}
+import { formatURL } from '@wpmedia/engine-theme-sdk';
 
 const Link = ({ href, name }) => {
   const externalUrl = /(http(s?)):\/\//i.test(href);
 
   return (
     externalUrl ? (
-      <a href={fixTrailingSlash(href)} target="_blank" rel="noopener noreferrer">
+      <a href={formatURL(href)} target="_blank" rel="noopener noreferrer">
         {`${name}`}
         <span className="sr-only">(Opens in new window)</span>
       </a>
-    ) : <a href={fixTrailingSlash(href)}>{`${name}`}</a>
+    ) : <a href={formatURL(href)}>{`${name}`}</a>
   );
 };
 

--- a/blocks/links-bar-block/features/links-bar/_children/link_node.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/_children/link_node.test.jsx
@@ -8,31 +8,12 @@
 import { renderToString } from 'react-dom/server';
 import Link from './link';
 
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  formatURL: jest.fn((input) => (input)),
+}));
 describe('When the link is generated SSR', () => {
-  it('must add a final slash to internal urls', () => {
-    const link = renderToString(Link({ href: '/entertaiment', name: 'Entertaiment' }));
-    expect(link).toMatch(/\/entertaiment\//);
-    expect(link).toMatch(/>Entertaiment</);
-  });
-
-  it('must not add a final slash to links with query params', () => {
-    const link = renderToString(Link({ href: '/entertaiment?search=abc', name: 'Entertaiment' }));
-    expect(link).toMatch(/\/entertaiment\?search=abc/);
-  });
-
-  it('must not add a final slash to links with hash params', () => {
-    const link = renderToString(Link({ href: '/entertaiment/page#some-anchor', name: 'Entertaiment' }));
-    expect(link).toMatch(/\/entertaiment\/page#some-anchor/);
-  });
-
-  it('must not add a final slash to links with a htmlpage', () => {
-    const link = renderToString(Link({ href: '/entertaiment/page.html', name: 'Entertaiment' }));
-    expect(link).toMatch(/\/entertaiment\/page\.html/);
-  });
-
-  it('must add rel attriutes to external links', () => {
+  it('must add rel attributes to external links', () => {
     const link = renderToString(Link({ href: 'https://example.com/some/page.html', name: 'Entertaiment' }));
-    expect(link).toMatch(/href="https:\/\/example.com\/some\/page.html"/);
     expect(link).toMatch(/target="_blank"/);
     expect(link).toMatch(/rel="noopener noreferrer"/);
   });

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -3,6 +3,10 @@ import { shallow, mount } from 'enzyme';
 
 jest.mock('fusion:themes', () => jest.fn(() => ({})));
 
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  formatURL: jest.fn((input) => input.toString()),
+}));
+
 describe('the links bar feature for the default output type', () => {
   afterEach(() => {
     jest.resetModules();
@@ -37,7 +41,12 @@ describe('the links bar feature for the default output type', () => {
       <LinksBar customFields={{ navigationConfig: 'links' }} />,
     );
 
-    expect(wrapper.children().at(0).type()).toBe('nav');
+    expect(
+      wrapper
+        .children()
+        .at(0)
+        .type(),
+    ).toBe('nav');
   });
 
   it('should not have separator when only one link', () => {
@@ -57,7 +66,7 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"links-bar\\"><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_1/\\">test link 1</a></span></nav><hr/>"',
+      '"<nav class=\\"links-bar\\"><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_1\\">test link 1</a></span></nav><hr/>"',
     );
   });
 
@@ -88,7 +97,7 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"links-bar\\"><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_1/\\">test link 1</a>  •  </span><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_2/\\">test link 2</a>  •  </span><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"/\\">Link Text</a></span></nav><hr/>"',
+      '"<nav class=\\"links-bar\\"><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_1\\">test link 1</a>  •  </span><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"id_2\\">test link 2</a>  •  </span><span class=\\"sc-bdVaJa epgcrJ links-menu\\"><a href=\\"/\\">Link Text</a></span></nav><hr/>"',
     );
   });
 
@@ -141,101 +150,5 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.find('nav > span')).toHaveLength(0);
-  });
-
-  describe('a link element ', () => {
-    it('should have the right name', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="/testurl" name="test" />);
-
-      expect(wrapper.props().name).toBe('test');
-      expect(wrapper.find('a').text()).toBe('test');
-    });
-  });
-
-  describe('when a link is missing a trailing slash', () => {
-    it('should add a slash at the end of the link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="/testurl" name="test" />);
-
-      expect(wrapper.props().href).toBe('/testurl');
-      expect(wrapper.find('[href="/testurl/"]').length).toBe(1);
-    });
-  });
-
-  describe('when a link is not missing a trailing slash', () => {
-    it('should not add a slash at the end of the link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="/testurl/" name="test" />);
-
-      expect(wrapper.props().href).toBe('/testurl/');
-      expect(wrapper.find('[href="/testurl/"]').length).toBe(2);
-    });
-  });
-
-  describe('when a link has query parameters', () => {
-    it('should not add a slash at the end of a internal link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="/testurl/?query=home" name="test" />);
-
-      expect(wrapper.props().href).toBe('/testurl/?query=home');
-      expect(wrapper.find('[href="/testurl/?query=home"]').length).toBe(2);
-    });
-  });
-
-  describe('when a link has query parameters', () => {
-    it('should not add a slash at the end of a external link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(
-        <Link href="http://example.com/testurl/?query=home" name="test" />,
-      );
-
-      expect(wrapper.props().href).toBe(
-        'http://example.com/testurl/?query=home',
-      );
-      expect(
-        wrapper.find('[href="http://example.com/testurl/?query=home"]').length,
-      ).toBe(2);
-    });
-  });
-
-  describe('when a link is to a page', () => {
-    it('should not add a slash at the end of the link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(
-        <Link href="https://example.com/category/page.html" name="test" />,
-      );
-
-      expect(wrapper.props().href).toBe(
-        'https://example.com/category/page.html',
-      );
-      expect(
-        wrapper.find('[href="https://example.com/category/page.html"]').length,
-      ).toBe(2);
-    });
-  });
-
-  describe('when a link has a hash', () => {
-    it('should not add a slash at the end of the link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(<Link href="/category/page#myhash" name="test" />);
-
-      expect(wrapper.props().href).toBe('/category/page#myhash');
-      expect(wrapper.find('[href="/category/page#myhash"]').length).toBe(2);
-    });
-  });
-
-  describe('when a link has a mail', () => {
-    it('should not add a slash at the end of the link', () => {
-      const { default: Link } = require('./_children/link');
-      const wrapper = mount(
-        <Link href="mailto:readers@washpost.com" name="test" />,
-      );
-
-      expect(wrapper.props().href).toBe('mailto:readers@washpost.com');
-      expect(wrapper.find('[href="mailto:readers@washpost.com"]').length).toBe(
-        2,
-      );
-    });
   });
 });

--- a/blocks/overline-block/features/overline/default.jsx
+++ b/blocks/overline-block/features/overline/default.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { useFusionContext } from 'fusion:context';
 import { useEditableContent } from 'fusion:content';
 import getThemeStyle from 'fusion:themes';
+import { formatURL } from '@wpmedia/engine-theme-sdk';
 import './overline.scss';
 
 const StyledLink = styled.a`
@@ -17,36 +18,6 @@ const StyledText = styled.span`
   font-weight: bold;
   text-decoration: none;
 `;
-
-function getLocation(uri) {
-  let url;
-  if (typeof window === 'undefined') {
-    url = new URL(uri, 'http://example.com');
-  } else {
-    url = document.createElement('a');
-    // IE doesn't populate all link properties when setting .href with a relative URL,
-    // however .href will return an absolute URL which then can be used on itself
-    // to populate these additional fields.
-    url.href = uri;
-    if (url.host === '') {
-      url.href = `${url.href}`;
-    }
-  }
-  return url;
-}
-
-function fixTrailingSlash(item) {
-  const url = getLocation(item);
-
-  if (url.hash || url.search || url.pathname.match(/\./)) {
-    return item;
-  }
-
-  if (item[item.length - 1] !== '/') {
-    return `${item}/`;
-  }
-  return item;
-}
 
 const Overline = (props) => {
   const { globalContent: content = {}, arcSite } = useFusionContext();
@@ -88,7 +59,7 @@ const Overline = (props) => {
   if (url) {
     return (
       <StyledLink
-        href={fixTrailingSlash(url)}
+        href={formatURL(url)}
         primaryFont={getThemeStyle(arcSite)['primary-font-family']}
         className="overline"
         {...edit}

--- a/blocks/shared-styles/_children/overline/default.test.jsx
+++ b/blocks/shared-styles/_children/overline/default.test.jsx
@@ -18,6 +18,10 @@ const mockContextObj = {
   },
 };
 
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  formatURL: jest.fn((input) => (input.toString())),
+}));
+
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
 jest.mock('fusion:context', () => ({
   useFusionContext: jest.fn(() => mockContextObj),
@@ -47,12 +51,6 @@ describe('overline feature for default output type', () => {
       const wrapper = mount(<Overline />);
 
       expect(wrapper.find('a').hasClass(/sc-/)).toBe(true);
-    });
-
-    it('should have the href of the website_section _id', () => {
-      const wrapper = mount(<Overline />);
-
-      expect(wrapper.find('a').prop('href')).toStrictEqual('/news/');
     });
 
     it('should render only text if label do not have url', () => {
@@ -104,12 +102,6 @@ describe('overline feature for default output type', () => {
         const wrapper = mount(<Overline />);
 
         expect(wrapper.text()).toMatch('EXCLUSIVE');
-      });
-
-      it('should render the href of the label instead of the website section', () => {
-        const wrapper = shallow(<Overline />);
-
-        expect(wrapper.at(0).prop('href')).toStrictEqual('/exclusive/');
       });
     });
 
@@ -191,12 +183,6 @@ describe('overline feature for default output type', () => {
 
         expect(wrapper.text()).toMatch('News');
       });
-
-      it('should have the href of the website_section _id', () => {
-        const wrapper = shallow(<Overline />);
-
-        expect(wrapper.at(0).prop('href')).toStrictEqual('/news/');
-      });
     });
   });
 
@@ -212,99 +198,12 @@ describe('overline feature for default output type', () => {
     });
   });
 
-  describe('when a link is rendered', () => {
-    it('should not add a slash at the end of the link if already has one', () => {
-      const mockTrailingSlash = {
-        arcSite: 'site',
-        globalContent: {
-          _id: '123456',
-          websites: {
-            site: {
-              website_section: {
-                _id: '/test/',
-                name: 'Test',
-              },
-            },
-          },
-        },
-      };
-      useFusionContext.mockImplementation(() => mockTrailingSlash);
-      const wrapper = shallow(<Overline />);
-
-      expect(wrapper.at(0).prop('href')).toStrictEqual('/test/');
-    });
-
-    it('should add a slash at the end of the link', () => {
-      const mockTrailingSlash = {
-        arcSite: 'site',
-        globalContent: {
-          _id: '123456',
-          websites: {
-            site: {
-              website_section: {
-                _id: '/test',
-                name: 'Test',
-              },
-            },
-          },
-        },
-      };
-      useFusionContext.mockImplementation(() => mockTrailingSlash);
-      const wrapper = shallow(<Overline />);
-
-      expect(wrapper.at(0).prop('href')).toStrictEqual('/test/');
-    });
-
-    it('should not add a slash at the end of the link with query params', () => {
-      const mockTrailingSlash = {
-        arcSite: 'site',
-        globalContent: {
-          _id: '123456',
-          websites: {
-            site: {
-              website_section: {
-                _id: '/test?query=a',
-                name: 'Test',
-              },
-            },
-          },
-        },
-      };
-      useFusionContext.mockImplementation(() => mockTrailingSlash);
-      const wrapper = shallow(<Overline />);
-
-      expect(wrapper.at(0).prop('href')).toStrictEqual('/test?query=a');
-    });
-
-    it('should not add a slash at the end of the link with hash params', () => {
-      const mockTrailingSlash = {
-        arcSite: 'site',
-        globalContent: {
-          _id: '123456',
-          websites: {
-            site: {
-              website_section: {
-                _id: '/test/page#section',
-                name: 'Test',
-              },
-            },
-          },
-        },
-      };
-      useFusionContext.mockImplementation(() => mockTrailingSlash);
-      const wrapper = shallow(<Overline />);
-
-      expect(wrapper.at(0).prop('href')).toStrictEqual('/test/page#section');
-    });
-  });
-
   describe('when custom values are send throw param must be used instead of globalContent', () => {
     it('should render an anchor with correct values', () => {
       const wrapper = mount(<Overline customText="hello" customUrl="http://example.com" />);
 
       expect(wrapper.find('a')).toHaveClassName('overline');
       expect(wrapper.find('a').text()).toEqual('hello');
-      expect(wrapper.find('a').prop('href')).toEqual('http://example.com/');
     });
   });
 
@@ -353,7 +252,6 @@ describe('overline feature for default output type', () => {
 
       expect(wrapper.find('a')).toHaveClassName('overline');
       expect(wrapper.find('a').text()).toEqual(mockStory.label.basic.text);
-      expect(wrapper.find('a').prop('href')).toEqual(`${mockStory.label.basic.url}/`);
     });
 
     it('should render an anchor using the story values if label display is false', () => {

--- a/blocks/shared-styles/_children/overline/index.jsx
+++ b/blocks/shared-styles/_children/overline/index.jsx
@@ -2,39 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useFusionContext } from 'fusion:context';
 import { useEditableContent } from 'fusion:content';
+import { formatURL } from '@wpmedia/engine-theme-sdk';
 import PrimaryFont from '../primary-font';
 
 import './overline.scss';
-
-function getLocation(uri) {
-  let url;
-  if (typeof window === 'undefined') {
-    url = new URL(uri, 'http://example.com');
-  } else {
-    url = document.createElement('a');
-    // IE doesn't populate all link properties when setting .href with a relative URL,
-    // however .href will return an absolute URL which then can be used on itself
-    // to populate these additional fields.
-    url.href = uri;
-    if (url.host === '') {
-      url.href = `${url.href}`;
-    }
-  }
-  return url;
-}
-
-function fixTrailingSlash(item) {
-  const url = getLocation(item);
-
-  if (url.hash || url.search || url.pathname.match(/\./)) {
-    return item;
-  }
-
-  if (item[item.length - 1] !== '/') {
-    return `${item}/`;
-  }
-  return item;
-}
 
 const Overline = (props) => {
   const { globalContent: content = {}, arcSite } = useFusionContext();
@@ -80,7 +51,7 @@ const Overline = (props) => {
   };
 
   if (url) {
-    itemProps.href = fixTrailingSlash(url);
+    itemProps.href = formatURL(url);
     itemProps.as = 'a';
   }
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
@@ -60,6 +60,7 @@ describe('horizontal overline image story item', () => {
       Image: () => <img alt="test" />,
       extractVideoEmbedFromStory: jest.fn(() => '<div class="video-embed"></div>'),
       VideoPlayer: ({ embedHTML, id }) => <div dangerouslySetInnerHTML={{ __html: embedHTML }} id={`video-${id}`} />,
+      formatURL: jest.fn((input) => input.toString()),
     }));
   });
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
@@ -48,6 +48,7 @@ describe('vertical overline image story item', () => {
       Image: () => <img alt="placeholder" />,
       extractVideoEmbedFromStory: jest.fn(() => '<div class="video-embed"></div>'),
       VideoPlayer: ({ embedHTML, id }) => <div dangerouslySetInnerHTML={{ __html: embedHTML }} id={`video-${id}`} />,
+      formatURL: jest.fn((input) => input.toString()),
     }));
     jest.mock('fusion:context', () => ({
       useFusionContext: jest.fn(() => ({


### PR DESCRIPTION
## Description
Extract Util Functions Including Get Location and fix trailing slash

## Jira Ticket
- [TMEDIA-195](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-195&assignee=5e387d6a1b1d910e5dfd7a9b-)

## Acceptance Criteria
- Links should still work as expected without trailing slashes 

NOTE: I renamed the trailing slash method in anticipation of future ticket in this sprint changing this functionality slightly https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-4

## Test Steps

1. Checkout this branch `git checkout TMEDIA-195-extract-util`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-block,@wpmedia/header-nav-chain-block,@wpmedia/links-bar-block,@wpmedia/overline-block,@wpmedia/shared-styles`
3. Go to Should see trailing slashes for links bar links 

![Screen Shot 2021-04-16 at 16 12 10](https://user-images.githubusercontent.com/5950956/115084495-a1cdc200-9ece-11eb-8c22-939509e8ed3e.png)
4. Should not see trailing slashes for mailto: links nor links with query params
<img width="981" alt="Screen Shot 2021-04-16 at 16 17 41" src="https://user-images.githubusercontent.com/5950956/115085019-59fb6a80-9ecf-11eb-83f2-f8a01c71656f.png">
<img width="911" alt="Screen Shot 2021-04-16 at 16 17 29" src="https://user-images.githubusercontent.com/5950956/115085020-5b2c9780-9ecf-11eb-91b8-139e6e986117.png">

## Effect Of Changes
### Before

- Link formatting duplicated and over-tested

### After

- No change, smaller bundles

## Dependencies or Side Effects

- link engine theme sdk via the `.env` file 
- Run the branch `TMEDIA-195-extract-util` in engine-theme-sdk

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
