### PR TITLE
TMEDIA-194 - Ad Block reserve space

### DIFF
--- a/blocks/ads-block/features/ads/ads.scss
+++ b/blocks/ads-block/features/ads/ads.scss
@@ -1,5 +1,7 @@
-.arcad_feature {
-  .arcad_container {
+.arcad-feature {
+  margin-bottom: calculateRem(32px);
+
+  .arcad-container {
     margin-left: auto;
     margin-right: auto;
     width: min-content;
@@ -8,22 +10,12 @@
     line-height: calculateRem(16px);
 
     .arcad {
-      div[id^='google_ads_iframe'] {
-        & > iframe[id^='google_ads_iframe'] {
-          margin-bottom: calculateRem(32px);
-        }
-      }
-
       &.pb-ad-admin {
         margin-bottom: calculateRem(32px);
         font-size: calculateRem(14px);
         line-height: calculateRem(18px);
-        color: white;
+        color: rgb(255, 255, 255);
       }
     }
   }
-}
-
-.layout-section .arcad_feature {
-  margin-bottom: 0;
 }

--- a/blocks/ads-block/features/ads/ads.scss
+++ b/blocks/ads-block/features/ads/ads.scss
@@ -4,7 +4,6 @@
   .arcad-container {
     margin-left: auto;
     margin-right: auto;
-    width: min-content;
     color: $ui-medium-gray;
     font-size: calculateRem(12px);
     line-height: calculateRem(16px);

--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -77,6 +77,11 @@ const ArcAd = (props) => {
   // Height is + 17px to account line-height of advertisment string of 17px;
   const heightWithAdjustments = parseInt(height, 10) + ((displayAdLabel) ? 17 : 0);
 
+  const sizing = {
+    width: `${width}px`,
+    minHeight: reserveSpace ? `${heightWithAdjustments}px` : null,
+  };
+
   return (
     <StyledAdUnit
       id={`arcad-feature-${instanceId}`}
@@ -84,7 +89,7 @@ const ArcAd = (props) => {
       adLabel={siteProperties?.advertisementLabel || 'ADVERTISEMENT'}
       displayAdLabel={!isAdmin && displayAdLabel && !isAMP()}
     >
-      <div className="arcad-container" style={reserveSpace ? { minHeight: `${heightWithAdjustments}px`, width: `${width}px` } : {}}>
+      <div className="arcad-container" style={sizing}>
         {!isAdmin && !isAMP() && (
           <LazyLoad enabled={lazyLoad}>
             <AdUnit

--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/rules-of-hooks */
 import React, { useState } from 'react';
 import PropTypes from '@arc-fusion/prop-types';
 import styled from 'styled-components';

--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -74,16 +74,17 @@ const ArcAd = (props) => {
   );
 
   const [width, height] = config.adClass ? config.adClass.split('x') : [];
+  // Height is + 17px to account line-height of advertisment string of 17px;
+  const heightWithAdjustments = parseInt(height, 10) + ((displayAdLabel) ? 17 : 0);
 
   return (
     <StyledAdUnit
-      id={`arcad_feature-${instanceId}`}
-      className="arcad_feature"
+      id={`arcad-feature-${instanceId}`}
+      className="arcad-feature"
       adLabel={siteProperties?.advertisementLabel || 'ADVERTISEMENT'}
       displayAdLabel={!isAdmin && displayAdLabel && !isAMP()}
-      style={reserveSpace ? { minHeight: `calc(${height}px + 2rem)`, width: `${width}px` } : {}}
     >
-      <div className="arcad_container">
+      <div className="arcad-container" style={reserveSpace ? { minHeight: `${heightWithAdjustments}px`, width: `${width}px` } : {}}>
         {!isAdmin && !isAMP() && (
           <LazyLoad enabled={lazyLoad}>
             <AdUnit

--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -33,7 +33,6 @@ const StyledAdUnit = styled.div`
 `;
 
 const ArcAd = (props) => {
-  if (typeof window === 'undefined') return null;
   const fusionContext = useFusionContext();
   const [instanceId] = useState(() => generateInstanceId(fusionContext.id || '0000'));
   const propsWithContext = {
@@ -42,7 +41,7 @@ const ArcAd = (props) => {
     instanceId,
   };
   const { customFields, isAdmin, siteProperties } = propsWithContext;
-  const { displayAdLabel, lazyLoad = true } = customFields;
+  const { displayAdLabel, lazyLoad = true, reserveSpace = true } = customFields;
   const [config] = useState(
     getAdObject({
       ...customFields,
@@ -74,12 +73,15 @@ const ArcAd = (props) => {
     )
   );
 
+  const [width, height] = config.adClass ? config.adClass.split('x') : [];
+
   return (
     <StyledAdUnit
       id={`arcad_feature-${instanceId}`}
       className="arcad_feature"
       adLabel={siteProperties?.advertisementLabel || 'ADVERTISEMENT'}
       displayAdLabel={!isAdmin && displayAdLabel && !isAMP()}
+      style={reserveSpace ? { minHeight: `calc(${height}px + 2rem)`, width: `${width}px` } : {}}
     >
       <div className="arcad_container">
         {!isAdmin && !isAMP() && (
@@ -121,6 +123,10 @@ ArcAd.propTypes = {
     }),
     displayAdLabel: PropTypes.boolean.tag({
       name: 'Display Advertisement Label?',
+      defaultValue: true,
+    }),
+    reserveSpace: PropTypes.boolean.tag({
+      name: 'Reserve space for Ad',
       defaultValue: true,
     }),
   }),

--- a/blocks/ads-block/features/ads/default.test.jsx
+++ b/blocks/ads-block/features/ads/default.test.jsx
@@ -21,6 +21,7 @@ const AD_PROPS_MOCK = {
     adType: '300x250',
     displayAdLabel: true,
     lazyLoad: false,
+    reserveSpace: true,
   },
   displayProperties: {},
   variants: {},
@@ -40,7 +41,7 @@ describe('<ArcAd>', () => {
     it('renders no ad unit in admin dashboard', () => {
       const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
       expect(wrapper).toBeDefined();
-      const arcAdminAd = wrapper.find('.arcad_feature .arcad_container > ArcAdminAd');
+      const arcAdminAd = wrapper.find('.arcad-feature .arcad-container > ArcAdminAd');
       expect(arcAdminAd.prop('adClass')).toEqual(AD_PROPS_MOCK.customFields.adType);
       expect(arcAdminAd.prop('adType')).toEqual('cube');
       expect(arcAdminAd.prop('slotName')).toEqual('news');
@@ -62,7 +63,7 @@ describe('<ArcAd>', () => {
       it('renders ad unit with disabled lazy-load container', () => {
         const wrapper = mount(<ArcAd {...AD_PROPS_MOCK} />);
         expect(wrapper).toBeDefined();
-        const lazyLoaderEl = wrapper.find('div.arcad_feature LazyLoad');
+        const lazyLoaderEl = wrapper.find('div.arcad-feature LazyLoad');
         expect(lazyLoaderEl).toHaveLength(1);
         expect(lazyLoaderEl.prop('enabled')).toBe(false);
         const adUnitEl = lazyLoaderEl.find('AdUnit');
@@ -82,7 +83,7 @@ describe('<ArcAd>', () => {
         };
         const wrapper = mount(<ArcAd {...adProps} />);
         expect(wrapper).toBeDefined();
-        const lazyLoaderEl = wrapper.find('div.arcad_feature LazyLoad');
+        const lazyLoaderEl = wrapper.find('div.arcad-feature LazyLoad');
         expect(lazyLoaderEl).toHaveLength(1);
         expect(lazyLoaderEl.prop('enabled')).toBe(true);
       });
@@ -96,11 +97,33 @@ describe('<ArcAd>', () => {
         };
         const wrapper = shallow(<ArcAd {...adProps} />);
         expect(wrapper).toBeDefined();
-        const adUnitEl = wrapper.find('.arcad_feature LazyLoad AdUnit');
+        const adUnitEl = wrapper.find('.arcad-feature LazyLoad AdUnit');
         expect(adUnitEl).toHaveLength(1);
         expect(typeof adUnitEl.prop('adConfig')).toEqual('object');
         expect(typeof adUnitEl.prop('featureConfig')).toEqual('object');
       });
+    });
+  });
+
+  describe('Reserve Space', () => {
+    it('renders without style data', () => {
+      const adProps = {
+        ...AD_PROPS_MOCK,
+        customFields: {
+          reserveSpace: false,
+        },
+      };
+      const wrapper = shallow(<ArcAd {...adProps} />);
+      const container = wrapper.find('.arcad-container');
+      expect(container).toHaveLength(1);
+      expect(container.prop('style')).toEqual({});
+    });
+
+    it('renders with style data', () => {
+      const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
+      const container = wrapper.find('.arcad-container');
+      expect(container).toHaveLength(1);
+      expect(container.prop('style')).not.toEqual({});
     });
   });
 
@@ -113,7 +136,7 @@ describe('<ArcAd>', () => {
         },
       };
       const wrapper = shallow(<ArcAd {...adProps} />);
-      const container = wrapper.find('.arcad_feature');
+      const container = wrapper.find('.arcad-feature');
       expect(container).toHaveLength(1);
       expect(container.prop('displayAdLabel')).toBe(false);
       expect(container.prop('adLabel')).toEqual('ADVERTISEMENT');
@@ -121,7 +144,7 @@ describe('<ArcAd>', () => {
 
     it('renders advertisement label when enabled', () => {
       const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
-      const container = wrapper.find('.arcad_feature');
+      const container = wrapper.find('.arcad-feature');
       expect(container).toHaveLength(1);
       expect(container.prop('displayAdLabel')).toBe(true);
       expect(container.prop('adLabel')).toEqual('ADVERTISEMENT');
@@ -136,7 +159,7 @@ describe('<ArcAd>', () => {
         },
       });
       const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
-      const container = wrapper.find('.arcad_feature');
+      const container = wrapper.find('.arcad-feature');
       expect(container).toHaveLength(1);
       expect(container.prop('displayAdLabel')).toBe(true);
       expect(container.prop('adLabel')).toEqual(advertisementLabel);

--- a/blocks/ads-block/features/ads/default.test.jsx
+++ b/blocks/ads-block/features/ads/default.test.jsx
@@ -106,7 +106,7 @@ describe('<ArcAd>', () => {
   });
 
   describe('Reserve Space', () => {
-    it('renders without style data', () => {
+    it('renders with width only', () => {
       const adProps = {
         ...AD_PROPS_MOCK,
         customFields: {
@@ -116,14 +116,16 @@ describe('<ArcAd>', () => {
       const wrapper = shallow(<ArcAd {...adProps} />);
       const container = wrapper.find('.arcad-container');
       expect(container).toHaveLength(1);
-      expect(container.prop('style')).toEqual({});
+      expect(container.prop('style').width).toBeDefined();
+      expect(container.prop('style').minHeight).toBe(null);
     });
 
-    it('renders with style data', () => {
+    it('renders with height and width', () => {
       const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
       const container = wrapper.find('.arcad-container');
       expect(container).toHaveLength(1);
-      expect(container.prop('style')).not.toEqual({});
+      expect(container.prop('style').width).toBeDefined();
+      expect(container.prop('style').minHeight).not.toBe(null);
     });
   });
 

--- a/blocks/shared-styles/_children/promo-date/index.test.jsx
+++ b/blocks/shared-styles/_children/promo-date/index.test.jsx
@@ -15,7 +15,7 @@ jest.mock('fusion:properties', () => jest.fn(() => (
 )));
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
-  localizeDateTime: jest.fn(() => new Date().toDateString()),
+  localizeDateTime: jest.fn((x) => new Date(x).toDateString()),
 }));
 
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
@@ -41,8 +41,8 @@ describe('PromoDate', () => {
 
     const wrapper = mount(<PromoDate {...props} />);
 
-    expect(wrapper.find('time').text()).toBe('Fri Apr 16 2021');
-    expect(wrapper.find('time').prop('dateTime')).toBe('Fri Apr 16 2021');
+    expect(wrapper.find('time').text()).toBe('Sun Aug 11 2019');
+    expect(wrapper.find('time').prop('dateTime')).toBe('Sun Aug 11 2019');
   });
 
   it('renders description from ANS Story object', () => {
@@ -54,7 +54,7 @@ describe('PromoDate', () => {
 
     const wrapper = mount(<PromoDate {...props} />);
 
-    expect(wrapper.find('time').text()).toBe('Fri Apr 16 2021');
-    expect(wrapper.find('time').prop('dateTime')).toBe('Fri Apr 16 2021');
+    expect(wrapper.find('time').text()).toBe('Sun Aug 11 2019');
+    expect(wrapper.find('time').prop('dateTime')).toBe('Sun Aug 11 2019');
   });
 });


### PR DESCRIPTION
## Description

Add new custom field to ad-block which defaults to true - which ads logic to reserve space for the ad to fill to avoid layout shifting.

## Jira Ticket
- [TMEDIA-194](https://arcpublishing.atlassian.net/browse/TMEDIA-194)

## Acceptance Criteria
1. A new boolean Custom Field is added to the Ad Block called Reserve space for ad? 
    * If the value is true then the block should reserve enough space for the ad to fill in on client side load
    * If the value is false or not present then no change in behavior needs to happen, it behaves as it does now (not reserving space) 
    * The field should default to true
2. If there are multiple heights requested for the ad, it should reserve the smaller height. It should reserve the relevant height by breakpoint.

## Test Steps

1. Checkout this branch `git checkout TMEDIA-194-reserve-ad-space`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/ads-block`
3. Visit a page with ads on and verify page loads with space for the ad to fill, and then ads are loaded and do not cause layout shifting - http://localhost/pf/adstesting/?_website=the-gazette
4. Article page with Ads - http://localhost/2019/09/17/global-kitchen-sink-article/?_website=the-gazette
5. Edit the ads testing page to disabled reserve space and verify layout shifting is back - Not custom fields for existing blocks on a page do inherit default values.

## Effect Of Changes
### Before

Ads caused lot of layout shifting

<img width="762" alt="TMEDIA-194-before" src="https://user-images.githubusercontent.com/868127/115238380-87395a00-a115-11eb-9da3-a447f093377f.png">


### After

Reduced layout shifting - still see some layout shift based on what ad is being served in slot that have multiple sizes allocated to them

<img width="831" alt="TMEDIA-194-after" src="https://user-images.githubusercontent.com/868127/115238411-902a2b80-a115-11eb-9f54-e5d495ed6049.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
