### PR TITLE
Themes 4 section title href

### DIFF
--- a/blocks/section-title-block/features/section-title/_children/section-title.jsx
+++ b/blocks/section-title-block/features/section-title/_children/section-title.jsx
@@ -1,23 +1,28 @@
 import React from 'react';
 import { PrimaryFont } from '@wpmedia/shared-styles';
+import { formatURL } from '@wpmedia/engine-theme-sdk';
 
 import './section-title.scss';
 
 const Separator = '  \u00a0 • \u00a0  ';
 
 // using the class twice to ensure the • and the text are both same font-size and
-const styledLinkTmpl = (name, id, separator) => (
-  <span key={id} className="section-title--styled-link">
-    <PrimaryFont
-      as="a"
-      href={id}
-      className="section-title--styled-link"
-    >
-      {name}
-    </PrimaryFont>
-    {separator}
-  </span>
-);
+const styledLinkTmpl = (name, id, separator) => {
+  const formattedURL = formatURL(id);
+
+  return (
+    <span key={id} className="section-title--styled-link">
+      <PrimaryFont
+        as="a"
+        href={formattedURL}
+        className="section-title--styled-link"
+      >
+        {name}
+      </PrimaryFont>
+      {separator}
+    </span>
+  );
+};
 
 const SectionTitle = (props) => {
   const { content } = props;

--- a/blocks/section-title-block/features/section-title/_children/section-title.test.jsx
+++ b/blocks/section-title-block/features/section-title/_children/section-title.test.jsx
@@ -12,6 +12,10 @@ jest.mock('fusion:context', () => ({
   useAppContext: jest.fn(() => mockTwoSection),
 }));
 
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  formatURL: jest.fn((input) => (input.toString())),
+}));
+
 describe('the section title block', () => {
   describe('when content from globalContent is present', () => {
     it('should render a title', () => {

--- a/blocks/section-title-block/features/section-title/default.test.jsx
+++ b/blocks/section-title-block/features/section-title/default.test.jsx
@@ -11,6 +11,10 @@ jest.mock('prop-types', () => ({
   contentConfig: () => {},
 }));
 
+jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  formatURL: jest.fn((input) => (input.toString())),
+}));
+
 describe('the section title feature block', () => {
   describe('when it is configured to inherit global content', () => {
     it('should render the global content section title', () => {


### PR DESCRIPTION
## Description
_Information about what you changed for this PR_

## Jira Ticket
- [TMEDIA-4](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-4)

## Acceptance Criteria
_copy from ticket_

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-4-section-title-href`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/section-title-block`
3. http://localhost/pf/news/?_website=the-gazette

## Effect Of Changes
### Before
- urls wrongly formatted
- - https://corecomponents-the-gazette-prod.cdn.arcpublishing.com/news/ shows the section links 


### After

![Screen Shot 2021-04-19 at 10 12 29](https://user-images.githubusercontent.com/5950956/115260762-a83f8200-a0f8-11eb-9239-30503224fbf8.png)
- urls formatted with trailing slash

## Dependencies or Side Effects
- don't need to link, already published this util

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
