### PR TITLE
Add logic and tests to cover story prop taking priority over global c…

### DIFF
--- a/blocks/shared-styles/_children/overline/default.test.jsx
+++ b/blocks/shared-styles/_children/overline/default.test.jsx
@@ -281,4 +281,30 @@ describe('overline feature for default output type', () => {
       expect(wrapper.find('a').prop('href')).toEqual(mockStory.websites.site.website_section._id);
     });
   });
+
+  describe('use story object instead of global content', () => {
+    const storyObject = {
+      _id: '12345',
+      websites: {
+        site: {
+          website_section: {
+            _id: '/news',
+            name: 'Story Object',
+          },
+        },
+      },
+    };
+
+    it.only('if story object is null renders nothing', () => {
+      const wrapper = mount(<Overline story={null} />);
+
+      expect(wrapper.html()).toBe(null);
+    });
+
+    it('should dangerously set the inner HTML to the website_section content', () => {
+      const wrapper = mount(<Overline story={storyObject} />);
+
+      expect(wrapper.text()).toMatch('Story Object');
+    });
+  });
 });

--- a/blocks/shared-styles/_children/overline/index.jsx
+++ b/blocks/shared-styles/_children/overline/index.jsx
@@ -16,7 +16,12 @@ const Overline = (props) => {
     editable,
     story,
   } = props;
-  const sourceContent = story || (Object.prototype.hasOwnProperty.call(content, '_id') && content) || {};
+
+  let sourceContent = story || {};
+
+  if ((story && !Object.keys(story).length) && Object.prototype.hasOwnProperty.call(content, '_id')) {
+    sourceContent = content;
+  }
 
   const {
     display: labelDisplay,
@@ -33,9 +38,9 @@ const Overline = (props) => {
     && sourceContent.websites[arcSite].website_section) || {};
 
   const shouldUseProps = !!(customText || customUrl);
-  const useGlobalContent = shouldUseLabel ? [labelText, labelUrl] : [sectionText, sectionUrl];
+  const overlineContent = shouldUseLabel ? [labelText, labelUrl] : [sectionText, sectionUrl];
   const editableContentPath = shouldUseLabel ? 'headlines.basic' : `websites.${arcSite}.website_section.name`;
-  const [text, url] = shouldUseProps ? [customText, customUrl] : useGlobalContent;
+  const [text, url] = shouldUseProps ? [customText, customUrl] : overlineContent;
 
   let edit = {};
   if (editable) {


### PR DESCRIPTION
## Description

Overline component would fallback to global content when story prop was passed as null

## Test Steps

1. Checkout this branch `git checkout overline-account-for-null-story`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles`
3. On a new page 
    * add global content - content-api - website_url = /news/2021/04/19/cabbage-is-always-there-for-you-heres-how-to-give-it-the-respect-it-deserves/
    * Add Overline block
    * Add XL and Large Promo
    * Verify the Overline block would use global content
    * Verify Promo's do not inherit global content
    * Set promo's to use content-api - website_url = /news/2021/01/05/story-with-images-with-different-caption-options/
    * Verify they use story overline data

## Effect Of Changes
### Before

Page with global content and XL promo and Large Promo

<img width="970" alt="overline-global-content-before" src="https://user-images.githubusercontent.com/868127/115548652-9fd57b80-a29f-11eb-9948-aeb32d50fa08.png">


### After

Same page with updates, now promo's do not inherit global content value

<img width="972" alt="overline-global-content-after" src="https://user-images.githubusercontent.com/868127/115548709-af54c480-a29f-11eb-8ef8-170fe9a464af.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
