### PR TITLE
Update class name of shared styles byline component to make it isolated

### DIFF
--- a/blocks/shared-styles/_children/byline/index.jsx
+++ b/blocks/shared-styles/_children/byline/index.jsx
@@ -78,10 +78,10 @@ const Byline = (props) => {
   return bylineString !== ' ' ? (
     <FontType
       as="section"
-      className={`byline ${className} ${list ? 'byline--list' : ''}`}
+      className={`ts-byline ${className} ${list ? 'ts-byline--list' : ''}`}
     >
-      <span className="byline__by">{phrases.t('byline.by-text')}</span>
-      <span className="byline__names" dangerouslySetInnerHTML={{ __html: bylineString }} />
+      <span className="ts-byline__by">{phrases.t('byline.by-text')}</span>
+      <span className="ts-byline__names" dangerouslySetInnerHTML={{ __html: bylineString }} />
       { separator && bylineString !== ' ' ? <span className="dot-separator"> &#9679;</span> : null }
     </FontType>
   ) : null;

--- a/blocks/shared-styles/_children/byline/index.scss
+++ b/blocks/shared-styles/_children/byline/index.scss
@@ -1,4 +1,4 @@
-.byline {
+.ts-byline {
   $self: &;
   color: #191919;
   font-size: 1.25rem;


### PR DESCRIPTION
## Description
Update the shared styles component to use a prefixed class naming convention to keep it isolated.

`.ts-` is short hand for **T**heme block**S**

## Test Steps

1. Checkout this branch `git checkout update-overline-class`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles`
3. Verify card list byline is as expected in editor - use page "Test - PR - All Blocks Copy"

## Effect Of Changes
### Before

Editor is showing the wrong styling for byline within blocks not using the shared styles block

<img width="400" alt="byline-editor-before" src="https://user-images.githubusercontent.com/868127/115876982-dd243f80-a43e-11eb-9811-9b123cec0ed4.png">


### After

Editor after 

<img width="382" alt="byline-editor-after" src="https://user-images.githubusercontent.com/868127/115877047-ed3c1f00-a43e-11eb-9fa5-21037710905b.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
