### PR TITLE
HOTFIX - TMEDIA-214 - Add filter item for 16:9 image ratio

### DIFF
--- a/blocks/a11y-testing-block/package-lock.json
+++ b/blocks/a11y-testing-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/a11y-testing-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/a11y-testing-block/package.json
+++ b/blocks/a11y-testing-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/a11y-testing-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme A11y Testing block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/ad-taboola-block/package.json
+++ b/blocks/ad-taboola-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/ad-taboola-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Taboola Widget",
   "author": "nelson fernandez <nelson.fernandez@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/ads-block/package-lock.json
+++ b/blocks/ads-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/ads-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/ads-block/package.json
+++ b/blocks/ads-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/ads-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "> TODO: description",
   "author": "nealmalkani <nealm939@gmail.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/alert-bar-block/package-lock.json
+++ b/blocks/alert-bar-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/alert-bar-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/alert-bar-block/package.json
+++ b/blocks/alert-bar-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/alert-bar-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme alert bar block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/alert-bar-content-source-block/package-lock.json
+++ b/blocks/alert-bar-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/alert-bar-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/alert-bar-content-source-block/package.json
+++ b/blocks/alert-bar-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/alert-bar-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme collections content API content source block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/article-body-block/package-lock.json
+++ b/blocks/article-body-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/article-body-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/article-body-block/package.json
+++ b/blocks/article-body-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/article-body-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme article body block",
   "author": "Brent Miller <brent.miller@washport.com>",
   "contributors": [

--- a/blocks/article-tag-block/package-lock.json
+++ b/blocks/article-tag-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/article-tag-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/article-tag-block/package.json
+++ b/blocks/article-tag-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/article-tag-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion Article Tag block",
   "author": "Rohit Gande <rohit.gande@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/author-bio-block/package-lock.json
+++ b/blocks/author-bio-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/author-bio-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/author-bio-block/package.json
+++ b/blocks/author-bio-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/author-bio-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme byline block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/author-content-source-block/package-lock.json
+++ b/blocks/author-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/author-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/author-content-source-block/package.json
+++ b/blocks/author-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/author-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme author API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/byline-block/package-lock.json
+++ b/blocks/byline-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/byline-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/byline-block/package.json
+++ b/blocks/byline-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/byline-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme byline block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "contributors": [

--- a/blocks/card-list-block/package-lock.json
+++ b/blocks/card-list-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/card-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/card-list-block/package.json
+++ b/blocks/card-list-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/card-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion themes card list block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/collections-content-source-block/package-lock.json
+++ b/blocks/collections-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/collections-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/collections-content-source-block/package.json
+++ b/blocks/collections-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/collections-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme collections content API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/content-api-source-block/package-lock.json
+++ b/blocks/content-api-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/content-api-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/content-api-source-block/package.json
+++ b/blocks/content-api-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/content-api-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Content source block for Content API queries",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "contributors": [

--- a/blocks/date-block/package-lock.json
+++ b/blocks/date-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/date-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/date-block/package.json
+++ b/blocks/date-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/date-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme date block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/default-output-block/package-lock.json
+++ b/blocks/default-output-block/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@wpmedia/default-output-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1
 }

--- a/blocks/default-output-block/package.json
+++ b/blocks/default-output-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/default-output-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme default output type",
   "author": "Brent Miller <brent.miller@washport.com>",
   "contributors": [

--- a/blocks/double-chain-block/package-lock.json
+++ b/blocks/double-chain-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/double-chain-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/double-chain-block/package.json
+++ b/blocks/double-chain-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/double-chain-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Double Chain – Arc Block",
   "author": "Luke Mason <luke.mason@washpost.com>",
   "contributors": [

--- a/blocks/event-tester-block/package-lock.json
+++ b/blocks/event-tester-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/event-tester-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/event-tester-block/package.json
+++ b/blocks/event-tester-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/event-tester-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme event tester-block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/extra-large-manual-promo-block/package-lock.json
+++ b/blocks/extra-large-manual-promo-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/extra-large-manual-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/extra-large-manual-promo-block/package.json
+++ b/blocks/extra-large-manual-promo-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/extra-large-manual-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Extra Large Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/extra-large-promo-block/package-lock.json
+++ b/blocks/extra-large-promo-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/extra-large-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/extra-large-promo-block/package.json
+++ b/blocks/extra-large-promo-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/extra-large-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Extra Large Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/footer-block/package-lock.json
+++ b/blocks/footer-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/footer-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/footer-block/package.json
+++ b/blocks/footer-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/footer-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme footer block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/full-author-bio-block/package-lock.json
+++ b/blocks/full-author-bio-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/full-author-bio-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/full-author-bio-block/package.json
+++ b/blocks/full-author-bio-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/full-author-bio-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme full author bio block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/gallery-block/package-lock.json
+++ b/blocks/gallery-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/gallery-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/gallery-block/package.json
+++ b/blocks/gallery-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/gallery-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme gallery block",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/global-phrases-block/package-lock.json
+++ b/blocks/global-phrases-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/global-phrases-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/global-phrases-block/package.json
+++ b/blocks/global-phrases-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/global-phrases-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "A package containing a list of translation phrases expected to be global.",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/header-block/package-lock.json
+++ b/blocks/header-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/header-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/header-block/package.json
+++ b/blocks/header-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/header-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion themes header block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/header-nav-block/package-lock.json
+++ b/blocks/header-nav-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/header-nav-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/header-nav-block/package.json
+++ b/blocks/header-nav-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/header-nav-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme header nav block",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "contributors": [

--- a/blocks/header-nav-chain-block/package-lock.json
+++ b/blocks/header-nav-chain-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/header-nav-chain-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/header-nav-chain-block/package.json
+++ b/blocks/header-nav-chain-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/header-nav-chain-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme header nav chain block",
   "author": "Sean Shannon <sean.shannon@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/headline-block/package-lock.json
+++ b/blocks/headline-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/headline-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/headline-block/package.json
+++ b/blocks/headline-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/headline-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme headline block",
   "author": "Brent Miller <brent.miller@washport.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/htmlbox-block/package-lock.json
+++ b/blocks/htmlbox-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/htmlbox-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/htmlbox-block/package.json
+++ b/blocks/htmlbox-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/htmlbox-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme HTMLBox block",
   "author": "Rohit Gande <rohit.gande@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/large-manual-promo-block/package-lock.json
+++ b/blocks/large-manual-promo-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/large-manual-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/large-manual-promo-block/package.json
+++ b/blocks/large-manual-promo-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/large-manual-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Large Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/large-promo-block/package-lock.json
+++ b/blocks/large-promo-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/large-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/large-promo-block/package.json
+++ b/blocks/large-promo-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/large-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Large Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/lead-art-block/package-lock.json
+++ b/blocks/lead-art-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/lead-art-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/lead-art-block/package.json
+++ b/blocks/lead-art-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/lead-art-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme lead art block",
   "author": "Brent Miller <brent.miller@washport.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/links-bar-block/package-lock.json
+++ b/blocks/links-bar-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/links-bar-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/links-bar-block/package.json
+++ b/blocks/links-bar-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/links-bar-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme links bar block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "contributors": [

--- a/blocks/masthead-block/package-lock.json
+++ b/blocks/masthead-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/masthead-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/masthead-block/package.json
+++ b/blocks/masthead-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/masthead-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Masthead – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/medium-manual-promo-block/package-lock.json
+++ b/blocks/medium-manual-promo-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/medium-manual-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/medium-manual-promo-block/package.json
+++ b/blocks/medium-manual-promo-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/medium-manual-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Medium Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/medium-promo-block/package-lock.json
+++ b/blocks/medium-promo-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/medium-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/medium-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Medium Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/numbered-list-block/package-lock.json
+++ b/blocks/numbered-list-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/numbered-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/numbered-list-block/package.json
+++ b/blocks/numbered-list-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/numbered-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme numbered list block",
   "author": "Rohit Gande <rohit.gande@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/overline-block/package-lock.json
+++ b/blocks/overline-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/overline-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/overline-block/package.json
+++ b/blocks/overline-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/overline-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion themes block containing an overline block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/placeholder-image-block/package-lock.json
+++ b/blocks/placeholder-image-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/placeholder-image-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/placeholder-image-block/package.json
+++ b/blocks/placeholder-image-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/placeholder-image-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Returns a placeholder image based on the fallback image in feature pack",
   "main": "index.js",
   "scripts": {

--- a/blocks/quad-chain-block/package-lock.json
+++ b/blocks/quad-chain-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/quad-chain-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/quad-chain-block/package.json
+++ b/blocks/quad-chain-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/quad-chain-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Quad Chain – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/related-content-content-source-block/package.json
+++ b/blocks/related-content-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/related-content-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Content source block to get stories related content.",
   "author": "nelson fernandez <nelson.fernandez@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/resizer-image-block/package-lock.json
+++ b/blocks/resizer-image-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/resizer-image-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/resizer-image-block/package.json
+++ b/blocks/resizer-image-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/resizer-image-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Takes a raw image url and uses thumbor to create resize urls",
   "main": "index.js",
   "scripts": {

--- a/blocks/resizer-image-content-source-block/package-lock.json
+++ b/blocks/resizer-image-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/resizer-image-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/resizer-image-content-source-block/package.json
+++ b/blocks/resizer-image-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/resizer-image-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Pass in a raw image url, get some size options for that image generated via thumbor-lite",
   "main": "index.js",
   "scripts": {

--- a/blocks/results-list-block/package-lock.json
+++ b/blocks/results-list-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/results-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/results-list-block/package.json
+++ b/blocks/results-list-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/results-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme results list block",
   "author": "Rohit Gande <rohit.gande@washpost.com>",
   "contributors": [

--- a/blocks/right-rail-advanced-block/package-lock.json
+++ b/blocks/right-rail-advanced-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/right-rail-advanced-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/right-rail-advanced-block/package.json
+++ b/blocks/right-rail-advanced-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/right-rail-advanced-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion themes block containing an advanced right-rail layout.",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/right-rail-block/package-lock.json
+++ b/blocks/right-rail-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/right-rail-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/right-rail-block/package.json
+++ b/blocks/right-rail-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/right-rail-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion themes block containing a right-rail layout.",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/search-content-source-block/package-lock.json
+++ b/blocks/search-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/search-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/search-content-source-block/package.json
+++ b/blocks/search-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/search-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme search API content source block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/search-results-list-block/package-lock.json
+++ b/blocks/search-results-list-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/search-results-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/search-results-list-block/package.json
+++ b/blocks/search-results-list-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/search-results-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme search results list block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/section-title-block/package-lock.json
+++ b/blocks/section-title-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/section-title-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/section-title-block/package.json
+++ b/blocks/section-title-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/section-title-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme section title block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/share-bar-block/package-lock.json
+++ b/blocks/share-bar-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/share-bar-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/share-bar-block/package.json
+++ b/blocks/share-bar-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/share-bar-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme share bar block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/shared-styles/package-lock.json
+++ b/blocks/shared-styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/shared-styles",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/shared-styles/package.json
+++ b/blocks/shared-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/shared-styles",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Shared Styles",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/simple-list-block/package-lock.json
+++ b/blocks/simple-list-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/simple-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/simple-list-block/package.json
+++ b/blocks/simple-list-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/simple-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Simple List – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "contributors": [

--- a/blocks/single-chain-block/package-lock.json
+++ b/blocks/single-chain-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/single-chain-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/single-chain-block/package.json
+++ b/blocks/single-chain-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/single-chain-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Single Chain – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/site-hierarchy-content-block/package-lock.json
+++ b/blocks/site-hierarchy-content-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/site-hierarchy-content-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/site-hierarchy-content-block/package.json
+++ b/blocks/site-hierarchy-content-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/site-hierarchy-content-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Block containing a site service hierarchy content source",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "contributors": [

--- a/blocks/small-manual-promo-block/package-lock.json
+++ b/blocks/small-manual-promo-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/small-manual-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/small-manual-promo-block/package.json
+++ b/blocks/small-manual-promo-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/small-manual-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Small Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/small-promo-block/package-lock.json
+++ b/blocks/small-promo-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/small-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/small-promo-block/package.json
+++ b/blocks/small-promo-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/small-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Small Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/story-feed-author-content-source-block/package-lock.json
+++ b/blocks/story-feed-author-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/story-feed-author-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/story-feed-author-content-source-block/package.json
+++ b/blocks/story-feed-author-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/story-feed-author-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Content source block for story feed queries by author",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/story-feed-query-content-source-block/package-lock.json
+++ b/blocks/story-feed-query-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/story-feed-query-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/story-feed-query-content-source-block/package.json
+++ b/blocks/story-feed-query-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/story-feed-query-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Content source block for story feed queries by Elasticsearch queries",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/story-feed-sections-content-source-block/package-lock.json
+++ b/blocks/story-feed-sections-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/story-feed-sections-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/story-feed-sections-content-source-block/package.json
+++ b/blocks/story-feed-sections-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/story-feed-sections-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Content source block for story feed queries by section",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/story-feed-tag-content-source-block/package-lock.json
+++ b/blocks/story-feed-tag-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/story-feed-tag-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/story-feed-tag-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Content source block for story feed queries by tag",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/subheadline-block/package-lock.json
+++ b/blocks/subheadline-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/subheadline-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/subheadline-block/package.json
+++ b/blocks/subheadline-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/subheadline-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme sub-headline block",
   "author": "Brent Miller <brent.miller@washport.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/tag-title-block/package-lock.json
+++ b/blocks/tag-title-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/tag-title-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/tag-title-block/package.json
+++ b/blocks/tag-title-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/tag-title-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion themes block containing a tag title block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",

--- a/blocks/tags-content-source-block/package-lock.json
+++ b/blocks/tags-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/tags-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/tags-content-source-block/package.json
+++ b/blocks/tags-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/tags-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme tags API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/text-output-block/package-lock.json
+++ b/blocks/text-output-block/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@wpmedia/text-output-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1
 }

--- a/blocks/text-output-block/package.json
+++ b/blocks/text-output-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/text-output-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme text output type",
   "author": "nelson fernandez <nelson.fernandez@washport.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/textfile-block/package-lock.json
+++ b/blocks/textfile-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/textfile-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/textfile-block/package.json
+++ b/blocks/textfile-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/textfile-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme text file block",
   "author": "nelson fernandez <nelson.fernandez@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -200,6 +200,7 @@ const TopTableList = (props) => {
             resized_params {
               800x600
               800x533
+              800x450
               600x450
               600x400
               600x338
@@ -224,6 +225,7 @@ const TopTableList = (props) => {
                 resized_params {
                   800x600
                   800x533
+                  800x450
                   600x450
                   600x400
                   600x338

--- a/blocks/top-table-list-block/package-lock.json
+++ b/blocks/top-table-list-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/top-table-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/top-table-list-block/package.json
+++ b/blocks/top-table-list-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/top-table-list-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Top Table List – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "contributors": [

--- a/blocks/triple-chain-block/package-lock.json
+++ b/blocks/triple-chain-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/triple-chain-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/triple-chain-block/package.json
+++ b/blocks/triple-chain-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/triple-chain-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Triple Chain – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/unpublished-content-source-block/package-lock.json
+++ b/blocks/unpublished-content-source-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/unpublished-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/unpublished-content-source-block/package.json
+++ b/blocks/unpublished-content-source-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/unpublished-content-source-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme unpublished API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "contributors": [

--- a/blocks/video-player-block/package-lock.json
+++ b/blocks/video-player-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/video-player-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/video-player-block/package.json
+++ b/blocks/video-player-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/video-player-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme video player block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/blocks/video-promo-block/package-lock.json
+++ b/blocks/video-promo-block/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/video-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blocks/video-promo-block/package.json
+++ b/blocks/video-promo-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/video-promo-block",
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "description": "Fusion News Theme Video Promo block",
   "author": "Cheng-Hsin Weng <cheng-hsin.weng@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "blocks/*",
     "components/*"
   ],
-  "version": "5.11.0",
+  "version": "5.11.1-hotfix.0",
   "ignoreChanges": [
     "**/node_modules/**",
     "**/package-lock.json"


### PR DESCRIPTION
## Description
Add missing resized image param values for 16:9 image ratio that's causing extra large top table list image to not render when selecting 16:9 ratio

## Jira Ticket
- [TMEDIA-214](https://arcpublishing.atlassian.net/browse/TMEDIA-214)


## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout HOTFIX-TMEDIA-214-16-9-top-table-list`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/top-table-list-block`
3. Add a top table list block to a page and verify the extra large story can have image ratio of 16:9

## Effect Of Changes

<img width="1251" alt="TMEDIA-214-fix" src="https://user-images.githubusercontent.com/868127/115888772-34301180-a44b-11eb-8204-2fe308cbeb81.png">



## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
