### PR TITLE
TMEDIA-29/31 - Gallery label updates

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -194,6 +194,13 @@ function parseArticleItem(item, index, arcSite, phrases, id) {
         </section>
       );
     case 'gallery':
+      // When we have all translated languages we can uncomment this line and
+      // the Gallery property autoplayPhraseLabels
+      // const autoplayPhraseLabels = {
+      //   start: this.phrases.t('global.gallery-autoplay-label-start'),
+      //   stop: this.phrases.t('global.gallery-autoplay-label-stop'),
+      // };
+
       return (
         <section key={key} className="block-margin-bottom gallery">
           <Gallery
@@ -201,6 +208,7 @@ function parseArticleItem(item, index, arcSite, phrases, id) {
             resizerURL={getProperties(arcSite)?.resizerURL}
             ansId={item._id}
             ansHeadline={item.headlines.basic ? item.headlines.basic : ''}
+            // autoplayPhraseLabels={autoplayPhraseLabels}
             expandPhrase={phrases.t('global.gallery-expand-button')}
             autoplayPhrase={phrases.t('global.gallery-autoplay-button')}
             pausePhrase={phrases.t('global.gallery-pause-autoplay-button')}

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -48,6 +48,13 @@ const GalleryFeatureItem = (
 
   const interstitialClicks = parseInt(galleryCubeClicks, 10);
 
+  // When we have all translated languages we can uncomment this line and
+  // the Gallery property autoplayPhraseLabels
+  // const autoplayPhraseLabels = {
+  //   start: this.phrases.t('global.gallery-autoplay-label-start'),
+  //   stop: this.phrases.t('global.gallery-autoplay-label-stop'),
+  // };
+
   return (
     <Gallery
       galleryElements={contentElements}
@@ -55,6 +62,7 @@ const GalleryFeatureItem = (
       ansId={id}
       ansHeadline={headlines?.basic ? headlines.basic : ''}
       expandPhrase={phrases.t('global.gallery-expand-button')}
+      // autoplayPhraseLabels={autoplayPhraseLabels}
       autoplayPhrase={phrases.t('global.gallery-autoplay-button')}
       pausePhrase={phrases.t('global.gallery-pause-autoplay-button')}
       pageCountPhrase={/* istanbul ignore next */ (current, total) => phrases.t('global.gallery-page-count-text', { current, total })}

--- a/blocks/global-phrases-block/intl.json
+++ b/blocks/global-phrases-block/intl.json
@@ -10,7 +10,7 @@
       "ko": "더보기"
    },
    "global.gallery-page-count-text":{
-      "en":"%{current} of %{total}",
+      "en":"<span class='sr-only'>Image</span> %{current} of %{total}",
       "sv":"%{current} av %{total}",
       "no":"%{current} av %{total}",
       "fr":"%{current} de %{total}",
@@ -38,5 +38,11 @@
       "es": "Pausar reproducción automática",
       "ja": "自動再生の一時停止",
       "ko": "자동 재생 일시 중지"
+   },
+   "global.gallery-autoplay-label-start": {
+     "en": "Start automatic slide show"
+   },
+   "global.gallery-autoplay-label-stop": {
+     "en": "Stop automatic slide show"
    }
 }

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -204,6 +204,13 @@ class LeadArt extends Component {
         const galleryCubeClicks = getProperties(arcSite)?.galleryCubeClicks;
         const interstitialClicks = parseInt(galleryCubeClicks, 10);
 
+        // When we have all translated languages we can uncomment this line and
+        // the Gallery property autoplayPhraseLabels
+        // const autoplayPhraseLabels = {
+        //   start: this.phrases.t('global.gallery-autoplay-label-start'),
+        //   stop: this.phrases.t('global.gallery-autoplay-label-stop'),
+        // };
+
         return (
           <Gallery
             galleryElements={lead_art.content_elements}
@@ -211,6 +218,7 @@ class LeadArt extends Component {
             ansId={lead_art._id}
             ansHeadline={lead_art.headlines.basic ? lead_art.headlines.basic : ''}
             expandPhrase={this.phrases.t('global.gallery-expand-button')}
+            // autoplayPhraseLabels={autoplayPhraseLabels}
             autoplayPhrase={this.phrases.t('global.gallery-autoplay-button')}
             pausePhrase={this.phrases.t('global.gallery-pause-autoplay-button')}
             pageCountPhrase={(current, total) => this.phrases.t('global.gallery-page-count-text', { current, total })}


### PR DESCRIPTION
## Description
Updated blocks to account for upcoming changes in Gallery SDK component

## Jira Ticket
- [TMEDIA-29](https://arcpublishing.atlassian.net/browse/TMEDIA-29)
- [TMEDIA-31](https://arcpublishing.atlassian.net/browse/TMEDIA-31)

## Test Steps
- Add test steps a reviewer must complete to test this PR

Link Engine Theme SDK from PR - https://github.com/WPMedia/engine-theme-sdk/pull/330

1. Checkout this branch `git checkout TMEDIA-31-TMEDIA-29-label-updates`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/global-phrases-block`
3. View story with Gallery - http://localhost/gallery/2021/02/09/the-scene-as-astronaut-christina-koch-returns-to-earth-after-historic-tour-aboard-the-international-space-station/?_website=the-gazette
4. Verify the count 1 of 13 is still showing and the text element shows "Image 1 of 13" when inspected 


## Dependencies or Side Effects
Engine Theme SDK update made in PR - https://github.com/WPMedia/engine-theme-sdk/pull/330

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
