### PR TITLE
TMEDIA-194 mobile fix

### DIFF
--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -22,6 +22,7 @@ const setAdLabelVisibility = (props) => {
 const StyledAdUnit = styled.div`
   .arcad > [id^='google_ads_iframe']:not(:empty)::before {
     content: '${(props) => props.adLabel}';
+    display: block;
     ${(props) => setAdLabelVisibility(props)}
   }
 
@@ -77,7 +78,7 @@ const ArcAd = (props) => {
   const heightWithAdjustments = parseInt(height, 10) + ((displayAdLabel) ? 17 : 0);
 
   const sizing = {
-    width: `${width}px`,
+    maxWidth: `${width}px`,
     minHeight: reserveSpace ? `${heightWithAdjustments}px` : null,
   };
 

--- a/blocks/ads-block/features/ads/default.test.jsx
+++ b/blocks/ads-block/features/ads/default.test.jsx
@@ -116,7 +116,7 @@ describe('<ArcAd>', () => {
       const wrapper = shallow(<ArcAd {...adProps} />);
       const container = wrapper.find('.arcad-container');
       expect(container).toHaveLength(1);
-      expect(container.prop('style').width).toBeDefined();
+      expect(container.prop('style').maxWidth).toBeDefined();
       expect(container.prop('style').minHeight).toBe(null);
     });
 
@@ -124,7 +124,7 @@ describe('<ArcAd>', () => {
       const wrapper = shallow(<ArcAd {...AD_PROPS_MOCK} />);
       const container = wrapper.find('.arcad-container');
       expect(container).toHaveLength(1);
-      expect(container.prop('style').width).toBeDefined();
+      expect(container.prop('style').maxWidth).toBeDefined();
       expect(container.prop('style').minHeight).not.toBe(null);
     });
   });


### PR DESCRIPTION
## Description

Found an issue with reserving ad space while testing something else

Change width to be maxWidth to account for all screen devices

## Jira Ticket
- [TMEDIA-194](https://arcpublishing.atlassian.net/browse/TMEDIA-194)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-194-mobile-fix`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/ads-block`
3. Use page - http://localhost/pf/adstesting/?_website=the-gazette
4. Open the page on desktop and verify all works as intended
5. Open the page on mobile breakpoint and verify there is no overflow/scrolling

## Effect Of Changes
### Before

Video showing overflow/scrolling issue

https://user-images.githubusercontent.com/868127/116218553-8a9a9a00-a742-11eb-8a54-e78f311e9d1a.mp4


### After

Video showing update with no overflow/scrolling issue


https://user-images.githubusercontent.com/868127/116218617-9e460080-a742-11eb-8d8d-e19788f962a9.mp4


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [x] Linting code actions have passed.
- [x] Ran the code locally based on the test instructions.
  - [x] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [x] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [x] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
