### PR TITLE
TMEDIA-207 remove excess canary packages

### DIFF
--- a/.github/workflows/delete-unused-canary-packages.yml
+++ b/.github/workflows/delete-unused-canary-packages.yml
@@ -1,0 +1,115 @@
+name: Delete unused canary packages
+on:
+  push:
+    branches:
+      - "TMEDIA-207-delete-unused-canary-packages"
+      - "canary"
+
+jobs:
+  clear-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete many package oldest canaries pt 1
+        uses: JackHowa/delete-github-package-versions@v0.4.9
+        with:
+          version-pattern: "canary"
+          keep: 5
+          dry-run: true
+          # 20 packages max
+          names: |
+            global-phrases-block
+            ads-block
+            alert-bar-block
+            article-body-block
+            alert-bar-content-source-block
+            article-tag-block
+            author-bio-block
+            byline-block
+            card-list-block
+            date-block
+            default-output-block
+            double-chain-block
+            extra-large-manual-promo-block
+            extra-large-promo-block
+            footer-block
+            full-author-bio-block
+            gallery-block
+            header-block
+            header-nav-chain-block
+            headline-block
+          version-query-order: "first"
+      - name: Delete many package oldest canaries pt 2
+        uses: JackHowa/delete-github-package-versions@v0.4.9
+        with:
+          version-pattern: "canary"
+          keep: 5
+          dry-run: true
+          # 20 packages max
+          names: |
+            htmlbox-block
+            large-manual-promo-block
+            large-promo-block
+            lead-art-block
+            links-bar-block
+            masthead-block
+            medium-manual-promo-block
+            medium-promo-block
+            numbered-list-block
+            overline-block
+            quad-chain-block
+            related-content-content-source-block
+            results-list-block
+            right-rail-block
+            right-rail-advanced-block
+            search-results-list-block
+            section-title-block
+            share-bar-block
+            shared-styles
+            simple-list-block
+          version-query-order: "first"
+      - name: Delete many package oldest canaries pt 3
+        uses: JackHowa/delete-github-package-versions@v0.4.9
+        with:
+          version-pattern: "canary"
+          keep: 5
+          dry-run: true
+          # 20 packages max
+          names: |
+            single-chain-block
+            small-manual-promo-block
+            small-promo-block
+            subheadline-block
+            tag-title-block
+            text-output-block
+            textfile-block
+            top-table-list-block
+            triple-chain-block
+            video-player-block
+            video-promo-block
+            content-api-source-block
+            collections-content-source-block
+            author-content-source-block
+            search-content-source-block
+            site-hierarchy-content-block
+            story-feed-author-content-source-block
+            story-feed-query-content-source-block
+            story-feed-sections-content-source-block
+            story-feed-tag-content-source-block
+          version-query-order: "first"
+      - name: Delete many package oldest canaries pt 4
+        uses: JackHowa/delete-github-package-versions@v0.4.9
+        with:
+          version-pattern: "canary"
+          keep: 5
+          dry-run: true
+          # 20 packages max
+          names: |
+            tags-content-source-block
+            unpublished-content-source-block
+            resizer-image-block
+            resizer-image-content-source-block
+            placeholder-image-block
+            event-tester-block
+            ad-taboola-bloc
+            a11y-testing-block
+          version-query-order: "first"

--- a/.github/workflows/delete-unused-canary-packages.yml
+++ b/.github/workflows/delete-unused-canary-packages.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete many package oldest canaries pt 1
-        uses: JackHowa/delete-github-package-versions@v0.4.9
+        uses: WPMedia/delete-github-package-versions@v0.4.10
         with:
           version-pattern: "canary"
           keep: 5
@@ -38,7 +38,7 @@ jobs:
             header-nav-chain-block
             headline-block
       - name: Delete many package oldest canaries pt 2
-        uses: JackHowa/delete-github-package-versions@v0.4.9
+        uses: WPMedia/delete-github-package-versions@v0.4.10
         with:
           version-pattern: "canary"
           keep: 5
@@ -67,7 +67,7 @@ jobs:
             shared-styles
             simple-list-block
       - name: Delete many package oldest canaries pt 3
-        uses: JackHowa/delete-github-package-versions@v0.4.9
+        uses: WPMedia/delete-github-package-versions@v0.4.10
         with:
           version-pattern: "canary"
           keep: 5
@@ -96,7 +96,7 @@ jobs:
             story-feed-sections-content-source-block
             story-feed-tag-content-source-block
       - name: Delete many package oldest canaries pt 4
-        uses: JackHowa/delete-github-package-versions@v0.4.9
+        uses: WPMedia/delete-github-package-versions@v0.4.10
         with:
           version-pattern: "canary"
           keep: 5

--- a/.github/workflows/delete-unused-canary-packages.yml
+++ b/.github/workflows/delete-unused-canary-packages.yml
@@ -2,123 +2,113 @@ name: Delete unused canary packages
 on:
   push:
     branches:
-      - "TMEDIA-207-delete-unused-canary-packages"
       - "canary"
 
 jobs:
   clear-packages:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete one unused package oldest canaries
+      - name: Delete many package oldest canaries pt 1
         uses: JackHowa/delete-github-package-versions@v0.4.9
         with:
           version-pattern: "canary"
           keep: 5
-          # 20 packages max
-          names: a11y-testing-block
+          dry-run: false
           version-query-order: "first"
-      # comment back in below when confirmed
-      # - name: Delete many package oldest canaries pt 1
-      #   uses: JackHowa/delete-github-package-versions@v0.4.9
-      #   with:
-      #     version-pattern: "canary"
-      #     keep: 5
-      #     dry-run: true
-      #     # 20 packages max
-      #     names: |
-      #       global-phrases-block
-      #       ads-block
-      #       alert-bar-block
-      #       article-body-block
-      #       alert-bar-content-source-block
-      #       article-tag-block
-      #       author-bio-block
-      #       byline-block
-      #       card-list-block
-      #       date-block
-      #       default-output-block
-      #       double-chain-block
-      #       extra-large-manual-promo-block
-      #       extra-large-promo-block
-      #       footer-block
-      #       full-author-bio-block
-      #       gallery-block
-      #       header-block
-      #       header-nav-chain-block
-      #       headline-block
-      #     version-query-order: "first"
-      # - name: Delete many package oldest canaries pt 2
-      #   uses: JackHowa/delete-github-package-versions@v0.4.9
-      #   with:
-      #     version-pattern: "canary"
-      #     keep: 5
-      #     dry-run: true
-      #     # 20 packages max
-      #     names: |
-      #       htmlbox-block
-      #       large-manual-promo-block
-      #       large-promo-block
-      #       lead-art-block
-      #       links-bar-block
-      #       masthead-block
-      #       medium-manual-promo-block
-      #       medium-promo-block
-      #       numbered-list-block
-      #       overline-block
-      #       quad-chain-block
-      #       related-content-content-source-block
-      #       results-list-block
-      #       right-rail-block
-      #       right-rail-advanced-block
-      #       search-results-list-block
-      #       section-title-block
-      #       share-bar-block
-      #       shared-styles
-      #       simple-list-block
-      #     version-query-order: "first"
-      # - name: Delete many package oldest canaries pt 3
-      #   uses: JackHowa/delete-github-package-versions@v0.4.9
-      #   with:
-      #     version-pattern: "canary"
-      #     keep: 5
-      #     dry-run: true
-      #     # 20 packages max
-      #     names: |
-      #       single-chain-block
-      #       small-manual-promo-block
-      #       small-promo-block
-      #       subheadline-block
-      #       tag-title-block
-      #       text-output-block
-      #       textfile-block
-      #       top-table-list-block
-      #       triple-chain-block
-      #       video-player-block
-      #       video-promo-block
-      #       content-api-source-block
-      #       collections-content-source-block
-      #       author-content-source-block
-      #       search-content-source-block
-      #       site-hierarchy-content-block
-      #       story-feed-author-content-source-block
-      #       story-feed-query-content-source-block
-      #       story-feed-sections-content-source-block
-      #       story-feed-tag-content-source-block
-      #     version-query-order: "first"
-      # - name: Delete many package oldest canaries pt 4
-      #   uses: JackHowa/delete-github-package-versions@v0.4.9
-      #   with:
-      #     version-pattern: "canary"
-      #     keep: 5
-      #     dry-run: true
-      #     # 20 packages max
-      #     names: |
-      #       tags-content-source-block
-      #       unpublished-content-source-block
-      #       resizer-image-block
-      #       resizer-image-content-source-block
-      #       placeholder-image-block
-      #       event-tester-block
-      #       ad-taboola-bloc
-      #       a11y-testing-block
-      #     version-query-order: "first"
+          # 20 packages max
+          names: |
+            global-phrases-block
+            ads-block
+            alert-bar-block
+            article-body-block
+            alert-bar-content-source-block
+            article-tag-block
+            author-bio-block
+            byline-block
+            card-list-block
+            date-block
+            default-output-block
+            double-chain-block
+            extra-large-manual-promo-block
+            extra-large-promo-block
+            footer-block
+            full-author-bio-block
+            gallery-block
+            header-block
+            header-nav-chain-block
+            headline-block
+      - name: Delete many package oldest canaries pt 2
+        uses: JackHowa/delete-github-package-versions@v0.4.9
+        with:
+          version-pattern: "canary"
+          keep: 5
+          dry-run: false
+          version-query-order: "first"
+          # 20 packages max
+          names: |
+            htmlbox-block
+            large-manual-promo-block
+            large-promo-block
+            lead-art-block
+            links-bar-block
+            masthead-block
+            medium-manual-promo-block
+            medium-promo-block
+            numbered-list-block
+            overline-block
+            quad-chain-block
+            related-content-content-source-block
+            results-list-block
+            right-rail-block
+            right-rail-advanced-block
+            search-results-list-block
+            section-title-block
+            share-bar-block
+            shared-styles
+            simple-list-block
+      - name: Delete many package oldest canaries pt 3
+        uses: JackHowa/delete-github-package-versions@v0.4.9
+        with:
+          version-pattern: "canary"
+          keep: 5
+          dry-run: false
+          version-query-order: "first"
+          # 20 packages max
+          names: |
+            single-chain-block
+            small-manual-promo-block
+            small-promo-block
+            subheadline-block
+            tag-title-block
+            text-output-block
+            textfile-block
+            top-table-list-block
+            triple-chain-block
+            video-player-block
+            video-promo-block
+            content-api-source-block
+            collections-content-source-block
+            author-content-source-block
+            search-content-source-block
+            site-hierarchy-content-block
+            story-feed-author-content-source-block
+            story-feed-query-content-source-block
+            story-feed-sections-content-source-block
+            story-feed-tag-content-source-block
+      - name: Delete many package oldest canaries pt 4
+        uses: JackHowa/delete-github-package-versions@v0.4.9
+        with:
+          version-pattern: "canary"
+          keep: 5
+          dry-run: false
+          version-query-order: "first"
+          # 20 packages max
+          names: |
+            tags-content-source-block
+            unpublished-content-source-block
+            resizer-image-block
+            resizer-image-content-source-block
+            placeholder-image-block
+            event-tester-block
+            ad-taboola-bloc
+            a11y-testing-block

--- a/.github/workflows/delete-unused-canary-packages.yml
+++ b/.github/workflows/delete-unused-canary-packages.yml
@@ -9,107 +9,116 @@ jobs:
   clear-packages:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete many package oldest canaries pt 1
+      - name: Delete one unused package oldest canaries
         uses: JackHowa/delete-github-package-versions@v0.4.9
         with:
           version-pattern: "canary"
           keep: 5
-          dry-run: true
           # 20 packages max
-          names: |
-            global-phrases-block
-            ads-block
-            alert-bar-block
-            article-body-block
-            alert-bar-content-source-block
-            article-tag-block
-            author-bio-block
-            byline-block
-            card-list-block
-            date-block
-            default-output-block
-            double-chain-block
-            extra-large-manual-promo-block
-            extra-large-promo-block
-            footer-block
-            full-author-bio-block
-            gallery-block
-            header-block
-            header-nav-chain-block
-            headline-block
+          names: a11y-testing-block
           version-query-order: "first"
-      - name: Delete many package oldest canaries pt 2
-        uses: JackHowa/delete-github-package-versions@v0.4.9
-        with:
-          version-pattern: "canary"
-          keep: 5
-          dry-run: true
-          # 20 packages max
-          names: |
-            htmlbox-block
-            large-manual-promo-block
-            large-promo-block
-            lead-art-block
-            links-bar-block
-            masthead-block
-            medium-manual-promo-block
-            medium-promo-block
-            numbered-list-block
-            overline-block
-            quad-chain-block
-            related-content-content-source-block
-            results-list-block
-            right-rail-block
-            right-rail-advanced-block
-            search-results-list-block
-            section-title-block
-            share-bar-block
-            shared-styles
-            simple-list-block
-          version-query-order: "first"
-      - name: Delete many package oldest canaries pt 3
-        uses: JackHowa/delete-github-package-versions@v0.4.9
-        with:
-          version-pattern: "canary"
-          keep: 5
-          dry-run: true
-          # 20 packages max
-          names: |
-            single-chain-block
-            small-manual-promo-block
-            small-promo-block
-            subheadline-block
-            tag-title-block
-            text-output-block
-            textfile-block
-            top-table-list-block
-            triple-chain-block
-            video-player-block
-            video-promo-block
-            content-api-source-block
-            collections-content-source-block
-            author-content-source-block
-            search-content-source-block
-            site-hierarchy-content-block
-            story-feed-author-content-source-block
-            story-feed-query-content-source-block
-            story-feed-sections-content-source-block
-            story-feed-tag-content-source-block
-          version-query-order: "first"
-      - name: Delete many package oldest canaries pt 4
-        uses: JackHowa/delete-github-package-versions@v0.4.9
-        with:
-          version-pattern: "canary"
-          keep: 5
-          dry-run: true
-          # 20 packages max
-          names: |
-            tags-content-source-block
-            unpublished-content-source-block
-            resizer-image-block
-            resizer-image-content-source-block
-            placeholder-image-block
-            event-tester-block
-            ad-taboola-bloc
-            a11y-testing-block
-          version-query-order: "first"
+      # comment back in below when confirmed
+      # - name: Delete many package oldest canaries pt 1
+      #   uses: JackHowa/delete-github-package-versions@v0.4.9
+      #   with:
+      #     version-pattern: "canary"
+      #     keep: 5
+      #     dry-run: true
+      #     # 20 packages max
+      #     names: |
+      #       global-phrases-block
+      #       ads-block
+      #       alert-bar-block
+      #       article-body-block
+      #       alert-bar-content-source-block
+      #       article-tag-block
+      #       author-bio-block
+      #       byline-block
+      #       card-list-block
+      #       date-block
+      #       default-output-block
+      #       double-chain-block
+      #       extra-large-manual-promo-block
+      #       extra-large-promo-block
+      #       footer-block
+      #       full-author-bio-block
+      #       gallery-block
+      #       header-block
+      #       header-nav-chain-block
+      #       headline-block
+      #     version-query-order: "first"
+      # - name: Delete many package oldest canaries pt 2
+      #   uses: JackHowa/delete-github-package-versions@v0.4.9
+      #   with:
+      #     version-pattern: "canary"
+      #     keep: 5
+      #     dry-run: true
+      #     # 20 packages max
+      #     names: |
+      #       htmlbox-block
+      #       large-manual-promo-block
+      #       large-promo-block
+      #       lead-art-block
+      #       links-bar-block
+      #       masthead-block
+      #       medium-manual-promo-block
+      #       medium-promo-block
+      #       numbered-list-block
+      #       overline-block
+      #       quad-chain-block
+      #       related-content-content-source-block
+      #       results-list-block
+      #       right-rail-block
+      #       right-rail-advanced-block
+      #       search-results-list-block
+      #       section-title-block
+      #       share-bar-block
+      #       shared-styles
+      #       simple-list-block
+      #     version-query-order: "first"
+      # - name: Delete many package oldest canaries pt 3
+      #   uses: JackHowa/delete-github-package-versions@v0.4.9
+      #   with:
+      #     version-pattern: "canary"
+      #     keep: 5
+      #     dry-run: true
+      #     # 20 packages max
+      #     names: |
+      #       single-chain-block
+      #       small-manual-promo-block
+      #       small-promo-block
+      #       subheadline-block
+      #       tag-title-block
+      #       text-output-block
+      #       textfile-block
+      #       top-table-list-block
+      #       triple-chain-block
+      #       video-player-block
+      #       video-promo-block
+      #       content-api-source-block
+      #       collections-content-source-block
+      #       author-content-source-block
+      #       search-content-source-block
+      #       site-hierarchy-content-block
+      #       story-feed-author-content-source-block
+      #       story-feed-query-content-source-block
+      #       story-feed-sections-content-source-block
+      #       story-feed-tag-content-source-block
+      #     version-query-order: "first"
+      # - name: Delete many package oldest canaries pt 4
+      #   uses: JackHowa/delete-github-package-versions@v0.4.9
+      #   with:
+      #     version-pattern: "canary"
+      #     keep: 5
+      #     dry-run: true
+      #     # 20 packages max
+      #     names: |
+      #       tags-content-source-block
+      #       unpublished-content-source-block
+      #       resizer-image-block
+      #       resizer-image-content-source-block
+      #       placeholder-image-block
+      #       event-tester-block
+      #       ad-taboola-bloc
+      #       a11y-testing-block
+      #     version-query-order: "first"

--- a/News Theme Development.md
+++ b/News Theme Development.md
@@ -87,6 +87,23 @@ To check if blocks are being properly linked, run:
 
   NOTE:  'npm fusion' will use the  globally available fusion, but using 'npx fusion' will use the local fusion available from within the folder
 
+### Creating New Block Checklist 
+
+- [ ] Make sure it is added to the `names` field of `.github/workflows/delete-unused-canary-packages.yml`. Please add the block name (without org name WPMedia, similar to others) to the last step's name field as there can only be 20 packages per step.
+- [ ] The block has a valid file path. Please see [documentation](https://github.com/WPMedia/fusion/blob/2.7/documentation/recipes/creating-feature-component.md) for best practices around file paths and development
+- [ ] The block is locally linked to ensure tests and linking run as expected. See `package.json`'s `dependencies` field for examples
+- [ ] Your new block has a readme that describes its purpose. The `blocks/results-list-block/README.md` is pretty good.
+- [ ] Your devDependencies in the block's package.json are installed in the `Fusion-News-Theme` or elsewhere. `devDependencies` are not installed by the [Fusion block installer](https://github.com/WPMedia/fusion/blob/2.7/engine/scripts/block-installer.js#L57)
+- [ ] You have a valid `jest.config.js` in your package to ensure that any tests (and they should exist) are run
+
+```js
+// cool-new-block/jest.config.js
+const base = require('../../jest/jest.config.base');
+
+module.exports = {
+  ...base,
+};
+```
 
 ### Internationalization
 


### PR DESCRIPTION
## Description
Programmatically Clear Unused Published Canary Releases In Blocks
Takes in the newest 100 versions of a package and matches to delete based on the canary text in the string


## Jira Ticket
- [TMEDIA-207](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-207)

## Acceptance Criteria

- You don't delete any stable nor beta releases 
- Every canary publish should clear out non-used ones 
- Should apply to every block

## Test Steps
- Look at previous run deleting one block's matching version
- Look at previous runs matching many blocks versions that should be deleted https://github.com/WPMedia/fusion-news-theme-blocks/runs/2569543175?check_suite_focus=true#step:2:53
- All blocks included in list. Note: there's a max of 20 per run. I haven't hit github rate-limiting yet. But the author of the package (which I forked) noted that the limit can be hit

## Effect Of Changes
### Before

- Growing amount of blocks with canary in their version. We should only need a few most recent ones. Hurdling toward the cliff of having too many packages for Github packages

### After
- See nonused block deleting "canary"-matching versions among newest 100 https://github.com/WPMedia/fusion-news-theme-blocks/runs/2570107225?check_suite_focus=true . five most recent matches not deleted for continuity of local development
- See the dry-run runs matching blocks (20 per step max for extension) but not deleting the five most recent https://github.com/WPMedia/fusion-news-theme-blocks/runs/2569543175?check_suite_focus=true#step:2:53 (note: this is a dry-run, no blocks actually deleted)

## Dependencies or Side Effects
- If you're using locally a canary block that gets deleted, I feel like that cached block may force you to re-run `npx fusion start -f`
- On push to canary, the github action is run pruning unused canary tags
- Had to fork a preexisting github action that was missing a feature we'd need (at least to start)https://github.com/SmartsquareGmbH/delete-old-packages 
- the official github action wouldn't work as we wanted https://github.com/actions/delete-package-versions

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block. -> ran in github actions 
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
