### PR TITLE
Tmedia 207 clean packages failure

### DIFF
--- a/.github/workflows/delete-unused-canary-packages.yml
+++ b/.github/workflows/delete-unused-canary-packages.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "canary"
-      - "TMEDIA-207-clean-packages-failure"
 
 jobs:
   clear-packages:

--- a/.github/workflows/delete-unused-canary-packages.yml
+++ b/.github/workflows/delete-unused-canary-packages.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "canary"
+      - "TMEDIA-207-clean-packages-failure"
 
 jobs:
   clear-packages:
@@ -10,6 +11,7 @@ jobs:
     steps:
       - name: Delete many package oldest canaries pt 1
         uses: WPMedia/delete-github-package-versions@v0.4.10
+        continue-on-error: true
         with:
           version-pattern: "canary"
           keep: 5
@@ -39,6 +41,7 @@ jobs:
             headline-block
       - name: Delete many package oldest canaries pt 2
         uses: WPMedia/delete-github-package-versions@v0.4.10
+        continue-on-error: true
         with:
           version-pattern: "canary"
           keep: 5
@@ -68,6 +71,7 @@ jobs:
             simple-list-block
       - name: Delete many package oldest canaries pt 3
         uses: WPMedia/delete-github-package-versions@v0.4.10
+        continue-on-error: true
         with:
           version-pattern: "canary"
           keep: 5
@@ -97,6 +101,7 @@ jobs:
             story-feed-tag-content-source-block
       - name: Delete many package oldest canaries pt 4
         uses: WPMedia/delete-github-package-versions@v0.4.10
+        continue-on-error: true
         with:
           version-pattern: "canary"
           keep: 5
@@ -112,3 +117,6 @@ jobs:
             event-tester-block
             ad-taboola-bloc
             a11y-testing-block
+      - name: The job has failed, likely due to rate-limiting
+        if: ${{ failure() }}
+        run: exit 1


### PR DESCRIPTION
- There is a limit of about a 1 - 1.5k packages for deletion 
- So it will be a little bit before this action cleans out the back-inventory 
- In the meantime, I want to ensure that the action does not show disconcerting errors. (We can still see the actual errors in the action.)
example with error quieting: https://github.com/WPMedia/fusion-news-theme-blocks/runs/2578363314?check_suite_focus=true 