### PR TITLE
TMEDIA-235 - Update PromoImage to allow rendering images client side

### DIFF
--- a/blocks/shared-styles/_children/promo-image/index.jsx
+++ b/blocks/shared-styles/_children/promo-image/index.jsx
@@ -3,7 +3,7 @@ import { useComponentContext, useFusionContext } from 'fusion:context';
 import { useContent } from 'fusion:content';
 import getProperties from 'fusion:properties';
 import { extractImageFromStory, extractResizedParams, ratiosFor } from '@wpmedia/resizer-image-block';
-import { Image } from '@wpmedia/engine-theme-sdk';
+import { Image, isServerSide } from '@wpmedia/engine-theme-sdk';
 import PlaceholderImage from '@wpmedia/placeholder-image-block';
 import { PromoLabel } from '@wpmedia/shared-styles';
 import discoverPromoType from './discover';
@@ -41,7 +41,8 @@ const PromoImage = ({
   let imageConfig = null;
   if (
     (customImageURL && lazyLoad)
-    || (customImageURL && isAdmin)) {
+    || (customImageURL && isAdmin)
+    || (customImageURL && !isServerSide())) {
     imageConfig = 'resize-image-api-client';
   } else if (customImageURL) {
     imageConfig = 'resize-image-api';

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
     },
   },
   collectCoverageFrom: [
-    '**/(features|chains|layouts|sources|output-types)/**/*.{js,jsx}',
+    '**/(features|chains|layouts|sources|output-types|_children)/**/*.{js,jsx}',
     // for resizer image block
     '**/extractImageFromStory.js',
     '**/imageRatioCustomField.js',


### PR DESCRIPTION
## Description

Bandito relies on client side rendering for showing variants and if a promo block is using an override image the promo block fails to load the image. To overcome this I update the PromoImage component to use the client side resizer content source if it's being rendered on the client side


## Jira Ticket
- [TMEDIA-235](https://arcpublishing.atlassian.net/browse/TMEDIA-235)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-235-bandito-client-side-render-support`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles`
3. Add a promo block to a page and verify it still works as intended


_Working on documenting on how to run Bandito variant tests locally to allow for better testing steps_


## Effect Of Changes
### Before

Placeholder image is rendered not override image

**Image is a GIF**

![TMEDIA-235-before](https://user-images.githubusercontent.com/868127/118315299-3e46ac80-b4ed-11eb-851f-86fa8d5afaa1.gif)

### After

Images render on page load and when bandito loads variant

**Image is a GIF**

![TMEDIA-235-after](https://user-images.githubusercontent.com/868127/118315021-dc864280-b4ec-11eb-82e6-23e2968f556f.gif)


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
