### PR TITLE
ci: Only run on canary block publish

### DIFF
--- a/.github/workflows/delete-unused-canary-packages.yml
+++ b/.github/workflows/delete-unused-canary-packages.yml
@@ -1,8 +1,10 @@
 name: Delete unused canary packages
+# Only trigger, when the canary build workflow succeeded
 on:
-  push:
-    branches:
-      - "canary"
+  workflow_run:
+    workflows: ["Canary block"]
+    types:
+      - completed
 
 jobs:
   clear-packages:


### PR DESCRIPTION
- depend on canary publish finishing before deleting unnecessary canary packages
- https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run