### PR TITLE
Revert "ci: Only run on canary block publish"

### DIFF
--- a/.github/workflows/delete-unused-canary-packages.yml
+++ b/.github/workflows/delete-unused-canary-packages.yml
@@ -1,10 +1,8 @@
 name: Delete unused canary packages
-# Only trigger, when the canary build workflow succeeded
 on:
-  workflow_run:
-    workflows: ["Canary block"]
-    types:
-      - completed
+  push:
+    branches:
+      - "canary"
 
 jobs:
   clear-packages:


### PR DESCRIPTION
- Revert commit for on canary publish workflow. would need to merge into default branch 'stable' to get this to work