### PR TITLE
TMEDIA-212 basic text fix

### DIFF
--- a/blocks/shared-styles/_children/overline/index.jsx
+++ b/blocks/shared-styles/_children/overline/index.jsx
@@ -44,7 +44,7 @@ const Overline = (props) => {
   let [text, url] = [sectionText, sectionUrl];
 
   if (sourceContent?.owner?.sponsored) {
-    text = sourceContent?.label?.basic || phrases.t('overline.sponsored-content');
+    text = sourceContent?.label?.basic?.text || phrases.t('overline.sponsored-content');
     url = null;
   } else if (shouldUseProps) {
     text = customText;

--- a/blocks/shared-styles/_children/overline/index.test.jsx
+++ b/blocks/shared-styles/_children/overline/index.test.jsx
@@ -360,7 +360,9 @@ describe('overline feature for default output type', () => {
         sponsored: true,
       },
       label: {
-        basic: 'Custom label override',
+        basic: {
+          text: 'Custom label override',
+        },
       },
       websites: {
         site: {
@@ -381,7 +383,7 @@ describe('overline feature for default output type', () => {
     it('set text to be Sponsored Content', () => {
       const wrapper = mount(<Overline story={storyObject} />);
 
-      expect(wrapper.text()).toMatch(storyObject.label.basic);
+      expect(wrapper.text()).toMatch(storyObject.label.basic.text);
     });
 
     it('not be a link', () => {


### PR DESCRIPTION
## Description

Label.basic is an object - made a mistake in previous PR.

Updated to pull the text from the basic object

## Jira Ticket
- [TMEDIA-212](https://arcpublishing.atlassian.net/browse/TMEDIA-212)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-212-basic-text-fix`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles`
3. Add a large promo block with the story - `/local/2021/05/14/second-story-with-tall-vertical-video/`
4. Verify promo block loads

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
