### PR TITLE
Update peer dep naming shared style

### DIFF
--- a/blocks/full-author-bio-block/package.json
+++ b/blocks/full-author-bio-block/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",
-    "@wpmedia/shared-style": "*"
+    "@wpmedia/shared-styles": "*"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"


### PR DESCRIPTION

/opt/engine/scripts/block-installer.js:68
    throw new Error(`\`npm install\` process for blocks exited with status code ${status}: ${stderr.toString()}`)
    ^
Error: `npm install` process for blocks exited with status code 1: npm ERR! code E404
npm ERR! 404 Not Found - GET https://npm.pkg.github.com/@wpmedia%2fshared-style - npm package "shared-style" does not exist under owner "wpmedia"
npm ERR! 404 
npm ERR! 404  '@wpmedia/shared-style@*' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

ht @badmintonkid 