### PR TITLE
Tmedia 39 header logo height

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -53,6 +53,9 @@ const StyledNav = styled.nav`
     z-index: ${navZIdx};
 
     &.nav-logo, & > .nav-logo {
+      &.svg-logo img {
+        height: 100%;
+      }
       img {
         height: auto;
         max-width: 240px;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -53,9 +53,6 @@ const StyledNav = styled.nav`
     z-index: ${navZIdx};
 
     &.nav-logo, & > .nav-logo {
-      &.svg-logo img {
-        height: 100%;
-      }
       img {
         height: auto;
         max-width: 240px;

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -195,62 +195,45 @@ body.nav-open {
     &:last-child {
       margin-right: 0;
     }
+  }
 
-    &.nav-left,
-    &.nav-right {
-      & > .nav-components {
-        &--mobile,
-        &--desktop {
-          align-items: center;
+  .nav-left,
+  .nav-right {
+    .nav-components--mobile {
+      display: none;
+      align-items: center;
+    }
 
-          & > .nav-widget {
-            margin-right: calculateRem(16px);
+    .nav-components--desktop {
+      display: inherit;
+      align-items: center;
+    }
 
-            &:last-child {
-              margin-right: 0;
-            }
-          }
-        }
+    @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+      .nav-components--mobile {
+        display: inherit;
+      }
 
-        &--mobile {
-          display: none;
-        }
-
-        &--desktop {
-          display: inherit;
-        }
-
-        @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
-          &--desktop {
-            display: none;
-          }
-
-          &--mobile {
-            display: inherit;
-          }
-        }
+      .nav-components--desktop {
+        display: none;
       }
     }
 
-    &.nav-left {
-      justify-content: flex-start;
+    .nav-widget {
+      margin-right: calculateRem(16px);
     }
 
-    &.nav-right {
-      justify-content: flex-end;
+    .nav-widget:last-child {
+      margin-right: 0;
     }
+  }
 
-    &.nav-logo-hidden {
-      opacity: 0;
-      transition: opacity 800ms ease, visibility 0s ease 800ms;
-      visibility: hidden;
-    }
+  .nav-left {
+    justify-content: flex-start;
+  }
 
-    &.nav-logo-show {
-      opacity: 1;
-      transition: opacity 800ms ease, visibility 0s ease 0s;
-      visibility: visible;
-    }
+  .nav-right {
+    justify-content: flex-end;
   }
 
   .nav-logo {
@@ -263,6 +246,18 @@ body.nav-open {
     img {
       height: 100%;
     }
+  }
+
+  .nav-logo-hidden {
+    opacity: 0;
+    transition: opacity 800ms ease, visibility 0s ease 800ms;
+    visibility: hidden;
+  }
+
+  .nav-logo-show {
+    opacity: 1;
+    transition: opacity 800ms ease, visibility 0s ease 0s;
+    visibility: visible;
   }
 
   &.logo {

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -240,10 +240,6 @@ body.nav-open {
       justify-content: flex-end;
     }
 
-    .nav-logo {
-      justify-content: center;
-    }
-
     &.nav-logo-hidden {
       opacity: 0;
       transition: opacity 800ms ease, visibility 0s ease 800ms;
@@ -255,6 +251,10 @@ body.nav-open {
       transition: opacity 800ms ease, visibility 0s ease 0s;
       visibility: visible;
     }
+  }
+
+  .nav-logo {
+    justify-content: center;
   }
 
   .nav-logo.svg-logo {

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -242,13 +242,6 @@ body.nav-open {
 
     &.nav-logo, & > .nav-logo {
       justify-content: center;
-
-      &.svg-logo {
-        flex: 0 1 auto;
-        img {
-          height: 100%;
-        }
-      }
     }
 
     &.nav-logo-hidden {
@@ -261,6 +254,14 @@ body.nav-open {
       opacity: 1;
       transition: opacity 800ms ease, visibility 0s ease 0s;
       visibility: visible;
+    }
+  }
+
+  .nav-logo.svg-logo {
+    flex: 0 1 auto;
+
+    img {
+      height: 100%;
     }
   }
 

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -240,7 +240,7 @@ body.nav-open {
       justify-content: flex-end;
     }
 
-    &.nav-logo, & > .nav-logo {
+    .nav-logo {
       justify-content: center;
     }
 

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -244,7 +244,10 @@ body.nav-open {
       justify-content: center;
 
       &.svg-logo {
-        flex: 1;
+        flex: 0 1 auto;
+        img {
+          height: 100%;
+        }
       }
     }
 


### PR DESCRIPTION
## Description
Changed CSS to make SVGs fill up 100% of available height.

## Jira Ticket
- [TMEDIA-39](https://arcpublishing.atlassian.net/browse/TMEDIA-39)

## Acceptance Criteria
The `svg` logo should assume the full height

## Test Steps
1. Ensure you have the latest `master` (if https://github.com/WPMedia/Fusion-News-Theme/pull/171 is merged) or `git checkout set-demo-2-logo-to-svg` from the WPMedia/Fusion-News-Theme repo.
2. Checkout this branch `git checkout TMEDIA-39-header-logo-height`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles`
4. Pull up any Page Builder page that utilized the `Arc Demo 2` site and inspect the logo at the top of the page.

## Effect Of Changes
### Before
When an SVG is specified for a site, the log appears too small.
![image](https://user-images.githubusercontent.com/2287238/120000157-84e1df80-bfa0-11eb-96cc-77a89f3db4e5.png)

### After
The SVG should fill the height of the header and not push the navigation over.
![image](https://user-images.githubusercontent.com/2287238/120000286-a9d65280-bfa0-11eb-8092-f8fec1c71a10.png)

## Dependencies or Side Effects
https://github.com/WPMedia/Fusion-News-Theme/pull/171

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
