### PR TITLE
Update sdk icon imports

### DIFF
--- a/blocks/header-nav-block/features/navigation/_children/search-box.jsx
+++ b/blocks/header-nav-block/features/navigation/_children/search-box.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import SearchIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/SearchIcon';
+import { SearchIcon } from '@wpmedia/engine-theme-sdk';
 
 export default ({
   alwaysOpen = false, iconSize = 16, placeholderText, navBarColor = 'dark', customSearchAction = null,

--- a/blocks/header-nav-block/features/navigation/default.jsx
+++ b/blocks/header-nav-block/features/navigation/default.jsx
@@ -6,8 +6,7 @@ import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getThemeStyle from 'fusion:themes';
 import getTranslatedPhrases from 'fusion:intl';
-import HamburgerMenuIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/HamburgerMenuIcon';
-import UserIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/UserIcon';
+import { HamburgerMenuIcon, UserIcon } from '@wpmedia/engine-theme-sdk';
 import SectionNav from './_children/section-nav';
 import SearchBox from './_children/search-box';
 // shares styles with header nav chain

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
-import HamburgerMenuIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/HamburgerMenuIcon';
+import { HamburgerMenuIcon } from '@wpmedia/engine-theme-sdk';
 import SearchBox from './search-box';
 import QuerylySearch from './queryly-search';
 import { WIDGET_CONFIG, PLACEMENT_AREAS } from '../nav-helper';

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/search-box.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/search-box.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import SearchIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/SearchIcon';
+import { SearchIcon } from '@wpmedia/engine-theme-sdk';
 
 export default ({
   alwaysOpen = false, iconSize = 16, placeholderText, navBarColor = 'dark', customSearchAction = null,

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ChevronRight from '@wpmedia/engine-theme-sdk/dist/es/components/icons/ChevronRightIcon';
+import { ChevronRight } from '@wpmedia/engine-theme-sdk';
 import Link from './link';
 
 function hasChildren(node) { return node.children && node.children.length > 0; }

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
@@ -80,6 +80,7 @@ const items = [
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   formatURL: jest.fn((input) => (input.toString())),
+  ChevronRight: jest.fn(() => <span />),
 }));
 
 describe('the SectionNav component', () => {

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -14,10 +14,10 @@ import {
   // presentational component does not do data fetching
   VideoPlayer as VideoPlayerPresentational,
   videoPlayerCustomFields,
+  FullscreenIcon,
 } from '@wpmedia/engine-theme-sdk';
 
 import './leadart.scss';
-import FullscreenIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/FullscreenIcon';
 
 const LeadArtWrapperDiv = styled.div`
   figcaption {

--- a/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
@@ -6,7 +6,7 @@ import getThemeStyle from 'fusion:themes';
 
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
-import SearchIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/SearchIcon';
+import { SearchIcon } from '@wpmedia/engine-theme-sdk';
 import SearchResult from './search-result';
 
 // shared with results list

--- a/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
@@ -4,7 +4,7 @@ import Consumer from 'fusion:consumer';
 import getThemeStyle from 'fusion:themes';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
-import SearchIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/SearchIcon';
+import { SearchIcon } from '@wpmedia/engine-theme-sdk';
 import { extractResizedParams } from '@wpmedia/resizer-image-block';
 
 import SearchResult from './search-result';

--- a/blocks/shared-styles/_children/promo-label/index.jsx
+++ b/blocks/shared-styles/_children/promo-label/index.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
 import styled from 'styled-components';
-import PlayIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/PlayIcon';
-import CameraIcon from '@wpmedia/engine-theme-sdk/dist/es/components/icons/CameraIcon';
+import { PlayIcon, CameraIcon } from '@wpmedia/engine-theme-sdk';
 import getTranslatedPhrases from 'fusion:intl';
 import getProperties from 'fusion:properties';
 


### PR DESCRIPTION
## Description
Update icon imports to use root package import

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout update-sdk-icon-imports`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles,@wpmedia/search-results-list-block,@wpmedia/lead-art-block,@wpmedia/header-nav-chain-block,@wpmedia/header-nav-block`
3. Validate icons still render as before, no change on output page


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
