### PR TITLE
Fix import to be correct

### DIFF
--- a/blocks/header-nav-block/features/navigation/_children/section-nav.jsx
+++ b/blocks/header-nav-block/features/navigation/_children/section-nav.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChevronRight, formatURL } from '@wpmedia/engine-theme-sdk';
+import { ChevronRightIcon, formatURL } from '@wpmedia/engine-theme-sdk';
 
 function hasChildren(node) { return node.children && node.children.length > 0; }
 
@@ -25,7 +25,7 @@ const SectionItem = ({ item }) => {
   const child = (hasChildren(item)
   && (
     <span className="submenu-caret">
-      <ChevronRight fill="rgba(255, 255, 255, 0.5)" height={12} width={12} />
+      <ChevronRightIcon fill="rgba(255, 255, 255, 0.5)" height={12} width={12} />
     </span>
   ));
   return (

--- a/blocks/header-nav-block/features/navigation/_children/section-nav.test.jsx
+++ b/blocks/header-nav-block/features/navigation/_children/section-nav.test.jsx
@@ -80,7 +80,7 @@ const items = [
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   formatURL: jest.fn((input) => (input.toString())),
-  ChevronRight: jest.fn(() => <span />),
+  ChevronRightIcon: jest.fn(() => <span />),
 }));
 
 describe('the SectionNav component', () => {

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChevronRight } from '@wpmedia/engine-theme-sdk';
+import { ChevronRightIcon } from '@wpmedia/engine-theme-sdk';
 import Link from './link';
 
 function hasChildren(node) { return node.children && node.children.length > 0; }
@@ -56,7 +56,7 @@ const SubSectionAnchor = ({ item, isOpen, isHidden }) => (
       aria-controls={`header_sub_section_${item._id.replace('/', '')}`}
       {...(isHidden ? { tabIndex: -1 } : {})}
     >
-      <ChevronRight height={20} width={20} />
+      <ChevronRightIcon height={20} width={20} />
     </button>
   </div>
 );

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/section-nav.test.jsx
@@ -80,7 +80,7 @@ const items = [
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
   formatURL: jest.fn((input) => (input.toString())),
-  ChevronRight: jest.fn(() => <span />),
+  ChevronRightIcon: jest.fn(() => <span />),
 }));
 
 describe('the SectionNav component', () => {


### PR DESCRIPTION
## Description
Fix import issue with Icon not using correct named import

## Test Steps

1. Checkout this branch `git checkout update-chevron-right-icon`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block,@wpmedia/header-nav-block`
3. Check homepage loads and shows menu bar and sub sections menu - http://localhost/homepage/?_website=the-gazette

## Effect Of Changes
### Before

<img width="799" alt="Visual Studio Code-2021-06-03-12-04 19" src="https://user-images.githubusercontent.com/868127/120635717-b5c08980-c464-11eb-8c80-5aad0427c9e7.png">


### After

No error in console, and sub section loads


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
