### PR TITLE
Tmedia 258 styled theme

### DIFF
--- a/blocks/article-body-block/chains/article-body/_articlebody.scss
+++ b/blocks/article-body-block/chains/article-body/_articlebody.scss
@@ -3,13 +3,7 @@
 }
 
 .article-body-wrapper {
-  color: $ui-primary-font-color;
   margin-top: map-get($spacers, 'lg');
-
-  a,
-  a * {
-    @include link-color-active-hover($ui-primary-font-color);
-  }
 
   & > h1,
   & > h2,
@@ -126,7 +120,7 @@
     table {
       border: 1px solid $border-rule-color;
       border-collapse: collapse;
-      color: $ui-primary-font-color;
+      
       width: 100%;
 
       thead {
@@ -179,7 +173,7 @@
     }
 
     .citation-text {
-      color: $ui-primary-font-color;
+      
       display: block;
       font-family: $primary-font-family;
       font-size: calculateRem(16px);
@@ -236,7 +230,7 @@
     margin: 0 0 map-get($spacers, 'md');
 
     a {
-      @include link-color-active-hover($ui-primary-font-color);
+      
       text-decoration: none;
 
       &:active,

--- a/blocks/card-list-block/features/card-list/card-list.scss
+++ b/blocks/card-list-block/features/card-list/card-list.scss
@@ -34,7 +34,6 @@
 }
 
 .card-list-overline {
-  color: $ui-primary-font-color;
   font-size: 16px;
   font-weight: bold;
   line-height: 24px;
@@ -48,7 +47,7 @@
   padding: 10px 18px 0 16px;
 
   a {
-    color: $ui-primary-font-color;
+    
   }
 }
 
@@ -57,7 +56,7 @@
   padding: 16px 16px 0;
 
   .story-date {
-    color: $ui-primary-font-color;
+    
     display: inline;
     font-size: calculateRem(14px);
     line-height: calculateRem(16px);
@@ -82,7 +81,7 @@
   padding: 0 16px;
 
   .list-item-number {
-    color: $ui-primary-font-color;
+    
     font-size: 20px;
     font-weight: bold;
     line-height: 24px;
@@ -107,8 +106,8 @@
     text-decoration: none;
 
     .headline-text {
-      @include link-color-active-hover($ui-primary-font-color);
-      color: $ui-primary-font-color;
+      
+      
       font-size: 16px;
       font-weight: normal;
       line-height: 24px;

--- a/blocks/header-block/features/header/header.scss
+++ b/blocks/header-block/features/header/header.scss
@@ -1,5 +1,4 @@
 .header-block {
-  color: $ui-primary-font-color;
   font-weight: bold;
 
   h2 {

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
@@ -22,7 +22,7 @@
   justify-content: center;
 
   a {
-    @include link-color-active-hover($ui-primary-font-color);
+    @include link-color-active-hover();
     font-family: $theme-primary-font-family;
     line-height: 14px;
     margin: 8px 0;

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -60,9 +60,7 @@ describe('the links bar feature for the default output type', () => {
       <LinksBar customFields={{ navigationConfig: 'links' }} />,
     );
 
-    expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"links-bar\\" aria-label=\\"More Links\\"><span class=\\"sc-bdVaJa bFuGRU links-menu\\"><a href=\\"id_1\\">test link 1</a></span></nav><hr/>"',
-    );
+    expect(wrapper.html().includes('•')).toBe(false);
   });
 
   it('should have separator when more than one link', () => {
@@ -91,9 +89,7 @@ describe('the links bar feature for the default output type', () => {
       <LinksBar customFields={{ navigationConfig: 'links' }} />,
     );
 
-    expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"links-bar\\" aria-label=\\"More Links\\"><span class=\\"sc-bdVaJa bFuGRU links-menu\\"><a href=\\"id_1\\">test link 1</a>  •  </span><span class=\\"sc-bdVaJa bFuGRU links-menu\\"><a href=\\"id_2\\">test link 2</a>  •  </span><span class=\\"sc-bdVaJa bFuGRU links-menu\\"><a href=\\"/\\">Link Text</a></span></nav><hr/>"',
-    );
+    expect(wrapper.html().includes('•')).toBe(true);
   });
 
   it('should contain the equal number of links between input and output', () => {

--- a/blocks/links-bar-block/features/links-bar/links-bar.scss
+++ b/blocks/links-bar-block/features/links-bar/links-bar.scss
@@ -11,8 +11,6 @@
     padding: 8px 0;
 
     a {
-      @include link-color-active-hover($ui-primary-font-color);
-      color: $ui-primary-font-color;
       font-size: 14px;
       height: 100%;
       line-height: 14px;

--- a/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
+++ b/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
@@ -1,8 +1,8 @@
 .numbered-list-container {
   @include block-margin-bottom;
   @include block-internal-spacing;
+
   .list-title {
-    color: $ui-primary-font-color;
     font-size: calculateRem(20px);
     font-weight: bold;
     line-height: calculateRem(24px);
@@ -44,8 +44,6 @@
   }
 
   .headline-list-anchor {
-    @include link-color-active-hover($ui-primary-font-color);
-    color: $ui-primary-font-color;
     display: flex;
     padding-right: calculateRem(16px);
     text-decoration: none;

--- a/blocks/right-rail-block/layouts/right-rail/css-vars.css
+++ b/blocks/right-rail-block/layouts/right-rail/css-vars.css
@@ -1,0 +1,8 @@
+body[data-theme='light'] {
+  --colors-primary: deeppink;
+  --colors-background: tan;
+}
+body[data-theme='dark'] {
+  --colors-primary: lightpink;
+  --colors-background: black;
+}

--- a/blocks/right-rail-block/layouts/right-rail/default.jsx
+++ b/blocks/right-rail-block/layouts/right-rail/default.jsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { useAppContext } from 'fusion:context';
+import { useAppContext, useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
+
 import './default.scss';
 import './css-vars.css';
 
@@ -19,23 +21,16 @@ const RightRailLayout = ({ children }) => {
   const [navigation, fullWidth1, main, rightRail, fullWidth2, footer] = children;
   const featureList = useFeatueList();
 
-  const [theme, setTheme] = useState('light');
+  const { arcSite } = useFusionContext();
 
-  const nextTheme = theme === 'light' ? 'dark' : 'light';
+  const themeColor = getThemeStyle(arcSite)['theme-color'] || 'light';
 
   React.useEffect(() => {
-    document.body.dataset.theme = theme;
-  }, [theme]);
+    document.body.dataset.theme = themeColor;
+  }, [themeColor]);
 
   return (
     <>
-      <button onClick={() => setTheme(nextTheme)} type="button">
-        Change to
-        {' '}
-        {nextTheme}
-        {' '}
-        mode
-      </button>
       <header className="page-header">{navigation}</header>
       <section role="main" className="main">
         <div className="container layout-section">

--- a/blocks/right-rail-block/layouts/right-rail/default.jsx
+++ b/blocks/right-rail-block/layouts/right-rail/default.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useAppContext } from 'fusion:context';
 import './default.scss';
+import './css-vars.css';
 
 const useFeatueList = () => {
   const { renderables } = useAppContext();
@@ -18,8 +19,23 @@ const RightRailLayout = ({ children }) => {
   const [navigation, fullWidth1, main, rightRail, fullWidth2, footer] = children;
   const featureList = useFeatueList();
 
+  const [theme, setTheme] = useState('light');
+
+  const nextTheme = theme === 'light' ? 'dark' : 'light';
+
+  React.useEffect(() => {
+    document.body.dataset.theme = theme;
+  }, [theme]);
+
   return (
     <>
+      <button onClick={() => setTheme(nextTheme)} type="button">
+        Change to
+        {' '}
+        {nextTheme}
+        {' '}
+        mode
+      </button>
       <header className="page-header">{navigation}</header>
       <section role="main" className="main">
         <div className="container layout-section">

--- a/blocks/right-rail-block/layouts/right-rail/default.test.jsx
+++ b/blocks/right-rail-block/layouts/right-rail/default.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { useAppContext } from 'fusion:context';
+import { useAppContext, useFusionContext } from 'fusion:context';
+import getThemeStyle from 'fusion:themes';
 
 import RightRailLayout from './default';
 
@@ -63,6 +64,9 @@ const renderablesNoFullWidth2 = [{
 describe('the right rail layout for the default output type', () => {
   it('should place the child nodes into the right places', () => {
     useAppContext.mockReturnValue({ renderables: allRenderables });
+    useFusionContext.mockReturnValue({ arcSite: '' });
+    getThemeStyle.mockImplementation(() => ({ }));
+
     const wrapper = shallow(
       <RightRailLayout>
         <div id="navigation" />
@@ -81,6 +85,8 @@ describe('the right rail layout for the default output type', () => {
 
   it('should not show fullWidth2 section', () => {
     useAppContext.mockReturnValue({ renderables: renderablesNoFullWidth2 });
+    useFusionContext.mockReturnValue({ arcSite: '' });
+    getThemeStyle.mockImplementation(() => ({ }));
     const wrapper = shallow(
       <RightRailLayout>
         <div id="navigation" />

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-results-list.scss
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-results-list.scss
@@ -38,7 +38,6 @@
 }
 
 .search-results-text {
-  color: $ui-primary-font-color;
   font-size: 14px;
   margin-top: 20px;
   text-align: left;

--- a/blocks/section-title-block/features/section-title/_children/section-title.scss
+++ b/blocks/section-title-block/features/section-title/_children/section-title.scss
@@ -1,5 +1,4 @@
 .section-title {
-  color: $ui-primary-font-color;
   display: block;
   font-weight: bold;
 }
@@ -10,7 +9,6 @@
 
 .section-title--styled-link {
   font-size: calculateRem(14px);
-  color: $ui-primary-font-color;
   text-decoration: none;
 }
 

--- a/blocks/shared-styles/_children/byline/index.scss
+++ b/blocks/shared-styles/_children/byline/index.scss
@@ -10,12 +10,7 @@
     line-height: 1rem;
 
     #{$self}__by {
-      color: #3b3b3b;
       margin-right: 0;
-    }
-
-    #{$self}__names {
-      color: #434343;
     }
   }
 
@@ -24,7 +19,6 @@
   }
 
   a {
-    color: $ui-primary-font-color;
     text-decoration: none;
   }
 

--- a/blocks/shared-styles/_children/headings/index.test.jsx
+++ b/blocks/shared-styles/_children/headings/index.test.jsx
@@ -17,7 +17,7 @@ describe('Heading', () => {
     const wrapper = mount(<Heading />);
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<h1 class=\\"sc-bdVaJa bFuGRU\\"></h1>"',
+      '"<h1 class=\\"sc-bdVaJa AtUVl\\"></h1>"',
     );
   });
 });
@@ -31,7 +31,7 @@ describe('HeadingSection', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<h2 class=\\"sc-bdVaJa bFuGRU\\"></h2>"',
+      '"<h2 class=\\"sc-bdVaJa AtUVl\\"></h2>"',
     );
   });
   it('increases the heading level for each HeadingSection', () => {
@@ -45,7 +45,7 @@ describe('HeadingSection', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<div><h1 class=\\"sc-bdVaJa bFuGRU\\">h1 text</h1><h2 class=\\"sc-bdVaJa bFuGRU\\">h2 text</h2></div>"',
+      '"<div><h1 class=\\"sc-bdVaJa AtUVl\\">h1 text</h1><h2 class=\\"sc-bdVaJa AtUVl\\">h2 text</h2></div>"',
     );
   });
 });

--- a/blocks/shared-styles/_children/overline/overline.scss
+++ b/blocks/shared-styles/_children/overline/overline.scss
@@ -1,13 +1,8 @@
 .overline {
-  color: $ui-primary-font-color;
   display: inline-block;
   font-size: calculateRem(20px);
   font-weight: bold;
   line-height: calculateRem(24px);
   padding-bottom: map-get($spacers, 'sm');
   text-decoration: none;
-
-  &--link {
-    @include link-color-active-hover($ui-primary-font-color);
-  }
 }

--- a/blocks/shared-styles/_children/primary-font.jsx
+++ b/blocks/shared-styles/_children/primary-font.jsx
@@ -5,18 +5,10 @@ import { useFusionContext } from 'fusion:context';
 
 const PrimaryFontStyles = styled.div.attrs((props) => ({
   arcSite: props.arcSite,
-  fontColor: props.fontColor || null,
-  backgroundColor: props.backgroundColor || null,
 }))`
   font-family: ${({ arcSite }) => getThemeStyle(arcSite)['primary-font-family']};
-
-  ${({ arcSite, fontColor }) => fontColor && `
-    color: ${getThemeStyle(arcSite)[fontColor]};
-  `}
-
-  ${({ arcSite, backgroundColor }) => backgroundColor && `
-    background-color: ${getThemeStyle(arcSite)[backgroundColor]};
-  `}
+  color: var(--colors-primary);
+  background-color: var(--colors-background);
 `;
 
 const PrimaryFont = (props) => {

--- a/blocks/shared-styles/_children/primary-font.jsx
+++ b/blocks/shared-styles/_children/primary-font.jsx
@@ -5,10 +5,13 @@ import { useFusionContext } from 'fusion:context';
 
 const PrimaryFontStyles = styled.div.attrs((props) => ({
   arcSite: props.arcSite,
+  overrideColor: props.overrideColor,
 }))`
   font-family: ${({ arcSite }) => getThemeStyle(arcSite)['primary-font-family']};
-  color: var(--colors-primary);
   background-color: var(--colors-background);
+  color: ${(props) => (
+    props.overrideColor ? props.overrideColor : 'var(--colors-primary)'
+  )};
 `;
 
 const PrimaryFont = (props) => {

--- a/blocks/shared-styles/_children/secondary-font.jsx
+++ b/blocks/shared-styles/_children/secondary-font.jsx
@@ -5,18 +5,11 @@ import { useFusionContext } from 'fusion:context';
 
 const SecondaryFontStyles = styled.div.attrs((props) => ({
   arcSite: props.arcSite,
-  fontColor: props.fontColor || null,
-  backgroundColor: props.backgroundColor || null,
 }))`
   font-family: ${({ arcSite }) => getThemeStyle(arcSite)['secondary-font-family']};
 
-  ${({ arcSite, fontColor }) => fontColor && `
-    color: ${getThemeStyle(arcSite)[fontColor]};
-  `}
-
-  ${({ arcSite, backgroundColor }) => backgroundColor && `
-    background-color: ${getThemeStyle(arcSite)[backgroundColor]};
-  `}
+  color: var(--colors-primary);
+  background-color: var(--colors-background);
 `;
 
 const SecondaryFont = (props) => {

--- a/blocks/shared-styles/scss/_extra-large-promo.scss
+++ b/blocks/shared-styles/scss/_extra-large-promo.scss
@@ -1,8 +1,5 @@
 .xl-large-promo {
-  color: $ui-primary-font-color;
-
   a {
-    color: $ui-primary-font-color;
     position: relative;
   }
 
@@ -20,7 +17,6 @@
   }
 
   .xl-promo-headline {
-    @include link-color-active-hover($ui-primary-font-color);
     display: block;
     font-size: calculateRem(32px);
     font-weight: bold;

--- a/blocks/shared-styles/scss/_large-promo.scss
+++ b/blocks/shared-styles/scss/_large-promo.scss
@@ -1,8 +1,5 @@
 .large-promo {
-  color: $ui-primary-font-color;
-
   a {
-    color: $ui-primary-font-color;
     position: relative;
   }
 
@@ -23,7 +20,6 @@
   }
 
   .lg-promo-headline {
-    @include link-color-active-hover($ui-primary-font-color);
     font-size: calculateRem(22px);
     font-weight: bold;
     line-height: calculateRem(24px);

--- a/blocks/shared-styles/scss/_medium-promo.scss
+++ b/blocks/shared-styles/scss/_medium-promo.scss
@@ -1,8 +1,5 @@
 .medium-promo {
-  color: $ui-primary-font-color;
-
   a {
-    color: $ui-primary-font-color;
     position: relative;
     text-decoration: none;
 
@@ -12,7 +9,6 @@
   }
 
   .md-promo-headline {
-    @include link-color-active-hover($ui-primary-font-color);
     display: block;
     margin-bottom: map-get($spacers, 'sm');
     text-decoration: none;

--- a/blocks/shared-styles/scss/_results-list-desktop.scss
+++ b/blocks/shared-styles/scss/_results-list-desktop.scss
@@ -31,7 +31,6 @@
       }
 
       .story-date {
-        color: $ui-primary-font-color;
         display: inline;
         font-size: calculateRem(14px);
         line-height: calculateRem(16px);

--- a/blocks/shared-styles/scss/_results-list-mobile.scss
+++ b/blocks/shared-styles/scss/_results-list-mobile.scss
@@ -27,7 +27,6 @@
       line-height: calculateRem(16px);
 
       .story-date {
-        color: $ui-primary-font-color;
         display: inline;
         font-size: calculateRem(14px);
         line-height: calculateRem(16px);

--- a/blocks/shared-styles/scss/_results-list.scss
+++ b/blocks/shared-styles/scss/_results-list.scss
@@ -19,19 +19,13 @@
   padding: map-get($spacers, 'sm') 0 map-get($spacers, 'sm') 0;
 
   a {
-    @include link-color-active-hover($ui-primary-font-color);
-    color: $ui-primary-font-color;
     text-decoration: none;
-
-    & * {
-      @include link-color-active-hover($ui-primary-font-color);
-    }
   }
 
   a,
   h2,
   p {
-    color: $ui-primary-font-color;
+    
   }
 
   img {

--- a/blocks/shared-styles/scss/_small-promo.scss
+++ b/blocks/shared-styles/scss/_small-promo.scss
@@ -1,5 +1,4 @@
 .small-promo {
-  color: $ui-primary-font-color;
   margin-top: 0;
 
   @media screen and (min-width: map-get($grid-breakpoints, 'sm')) {
@@ -13,7 +12,6 @@
   }
 
   a {
-    color: $ui-primary-font-color;
     position: relative;
 
     h2 {
@@ -27,7 +25,6 @@
   }
 
   .sm-promo-headline {
-    @include link-color-active-hover($ui-primary-font-color);
     font-size: calculateRem(16px);
     font-weight: normal;
     line-height: calculateRem(24px);

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -102,6 +102,7 @@ const SimpleList = (props) => {
       title = '',
       showHeadline = true,
       showImage = true,
+      primaryColor,
     } = {},
     id = '',
     placeholderResizedImageOptions,
@@ -158,7 +159,11 @@ const SimpleList = (props) => {
     <div key={id} className="list-container layout-section">
       { title
         && (
-        <PrimaryFont as="div" className="list-title">
+        <PrimaryFont
+          as="div"
+          className="list-title"
+          overrideColor={primaryColor}
+        >
           {title}
         </PrimaryFont>
         )}
@@ -212,6 +217,11 @@ SimpleListWrapper.propTypes = {
       name: 'Lazy Load block?',
       defaultValue: false,
       description: 'Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.',
+    }),
+    primaryColor: PropTypes.string.tag({
+      label: 'Primary Color',
+      group: 'Style Settings',
+      defaultValue: '',
     }),
   }),
 };

--- a/blocks/simple-list-block/features/simple-list/simple-list.scss
+++ b/blocks/simple-list-block/features/simple-list/simple-list.scss
@@ -6,7 +6,6 @@
   padding-top: 0;
 
   .list-title {
-    color: $ui-primary-font-color;
     font-size: calculateRem(20px);
     font-weight: bold;
     line-height: calculateRem(24px);
@@ -39,8 +38,6 @@
     }
 
     .simple-list-headline-anchor {
-      @include link-color-active-hover($ui-primary-font-color);
-      color: $ui-primary-font-color;
       display: flex;
       padding-left: calculateRem(16px);
       text-decoration: none;

--- a/blocks/subheadline-block/features/subheadline/subheadline.scss
+++ b/blocks/subheadline-block/features/subheadline/subheadline.scss
@@ -1,6 +1,4 @@
 .h4-primary.sub-headline {
-  color: $ui-primary-font-color;
-
   font-size: calculateRem(19px);
   font-weight: normal;
   line-height: calculateRem(24px);

--- a/blocks/tag-title-block/features/tag-title/tag-title.scss
+++ b/blocks/tag-title-block/features/tag-title/tag-title.scss
@@ -1,5 +1,4 @@
 h1.tag-name {
-  color: $ui-primary-font-color;
   margin-bottom: map-get($spacers, 'xs');
 }
 

--- a/blocks/video-player-block/features/video-player/default.test.jsx
+++ b/blocks/video-player-block/features/video-player/default.test.jsx
@@ -126,7 +126,7 @@ describe('VideoPlayer', () => {
 
     const titleText = 'Test Title';
     const descriptionText = 'Test Description';
-    const alertBadgeText = 'Test Alert  Badge';
+    const alertBadgeText = 'Test Alert Badge';
 
     const customFields = {
       inheritGlobalContent: false,
@@ -142,17 +142,15 @@ describe('VideoPlayer', () => {
       enableAutoplay
     />);
 
-    // todo: write snapshot or styled components style checks for this
-    // would be better with checking text via rtl
-    const expectedAlertBadge = '<span class="sc-bZQynM kYPPZY">Test Alert  Badge</span>';
-    const expectedTitle = '<h2 class="sc-bdVaJa nAQSq xl-promo-headline">Test Title</h2>';
-    const expectedDescription = '<p class="sc-EHOje gSSoLN description-text">Test Description</p>';
+    const expectedAlertBadge = 'Test Alert Badge';
+    const expectedTitle = 'Test Title';
+    const expectedDescription = 'Test Description';
     const foundStyledComponents = wrapper.find('StyledComponent');
 
     expect(foundStyledComponents.length).toEqual(3);
-    expect(foundStyledComponents.at(0).html()).toEqual(expectedAlertBadge);
-    expect(foundStyledComponents.at(1).html()).toEqual(expectedTitle);
-    expect(foundStyledComponents.at(2).html()).toEqual(expectedDescription);
+    expect(foundStyledComponents.at(0).text()).toEqual(expectedAlertBadge);
+    expect(foundStyledComponents.at(1).text()).toEqual(expectedTitle);
+    expect(foundStyledComponents.at(2).text()).toEqual(expectedDescription);
   });
 
   it('if no video content, show empty space ', () => {


### PR DESCRIPTION
- Remove non-site-specific colors that primary font was not overriding 
- Refactor tests just to be easier in the future 
- Use css variables and styled components 
-> css variables  (custom properties) for flexibility in a solution
-> use css variables bc doesn't require heavy js execution
-> change body data tag on arcsite and theme-style o (dark or light at the moment) https://github.com/WPMedia/Fusion-News-Theme/pull/174 ->-> good because have to be dynamic for arc sites and needs js

`npx fusion start -f -l @wpmedia/shared-styles,@wpmedia/right-rail-block,@wpmedia/subheadline-block,@wpmedia/article-body-block,@wpmedia/card-list-block,@wpmedia/header-block,@wpmedia/links-bar-block,@wpmedia/numbered-list-block,@wpmedia/search-results-list-block,@wpmedia/section-title-block,@wpmedia/simple-list-block,@wpmedia/tag-title-block,@wpmedia/header-nav-chain-block`

<img width="1429" alt="0 httplocalhostpfdemo-homepage_website=the-prophet" src="https://user-images.githubusercontent.com/5950956/121098420-6d360280-c7bb-11eb-80da-bdb70ac13f1e.png">

<img width="1403" alt="0 httplocalhostpfdemo-homepage_website=the-gazette" src="https://user-images.githubusercontent.com/5950956/121098429-71fab680-c7bb-11eb-9ebf-53aecd9da3f1.png">


blocker: 
- could not use *.css files in the output type. would've preferred to have it in the default-output-type

resources: 
- css variables https://epicreact.dev/css-variables/
- https://github.com/JackHowa/marvel-color-switcher