### PR TITLE
TMEDIA-272 - Simple list React optimisations

### DIFF
--- a/blocks/resizer-image-block/index.js
+++ b/blocks/resizer-image-block/index.js
@@ -308,19 +308,8 @@ const getResizedImageParams = (data, options) => {
   return data;
 };
 
-export const extractResizedParams = (storyObject) => {
-  const basicStoryObject = storyObject?.promo_items?.basic
-                        || storyObject?.promo_items?.lead_art?.promo_items?.basic;
-  if (!basicStoryObject) {
-    return [];
-  }
-
-  if (basicStoryObject.type === 'image') {
-    return basicStoryObject.resized_params;
-  }
-
-  return [];
-};
+export const extractResizedParams = (storyObject) => storyObject?.promo_items?.basic?.resized_params
+  || storyObject?.promo_items?.lead_art?.promo_items?.basic?.resized_params || [];
 
 // top level for transforming data
 // takes in content source story data via ans

--- a/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
+++ b/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
@@ -28,6 +28,7 @@ const StoryItem = (props) => {
           <Image
             {...imageProps}
             url={imageURL !== '' ? imageURL : targetFallbackImage}
+            alt={imageURL !== '' ? itemTitle : imageProps?.primaryLogoAlt}
             resizedImageOptions={imageURL !== '' ? resizedImageOptions : placeholderResizedImageOptions}
           />
         </a>

--- a/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
+++ b/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { PrimaryFont } from '@wpmedia/shared-styles';
 import { Image } from '@wpmedia/engine-theme-sdk';
-import getProperties from 'fusion:properties';
 
 const StoryItem = (props) => {
   const {
@@ -11,10 +10,10 @@ const StoryItem = (props) => {
     websiteURL,
     showHeadline,
     showImage,
-    arcSite,
     resizedImageOptions,
     placeholderResizedImageOptions,
     targetFallbackImage,
+    imageProps,
   } = props;
 
   return (
@@ -26,40 +25,13 @@ const StoryItem = (props) => {
           aria-hidden="true"
           tabIndex="-1"
         >
-          {imageURL !== '' ? (
-            <Image
-              resizedImageOptions={resizedImageOptions}
-              url={imageURL}
-              alt={itemTitle}
-              // used this from simple results list
-              // small, including simple list, 3:2 aspect ratio
-              smallWidth={274}
-              smallHeight={183}
-              mediumWidth={274}
-              mediumHeight={183}
-              largeWidth={274}
-              largeHeight={183}
-              className="simple-list-img"
-              breakpoints={getProperties(arcSite)?.breakpoints}
-              resizerURL={getProperties(arcSite)?.resizerURL}
-            />
-          ) : (
-            <Image
-              smallWidth={274}
-              smallHeight={183}
-              mediumWidth={274}
-              mediumHeight={183}
-              largeWidth={274}
-              largeHeight={183}
-              alt={getProperties(arcSite).primaryLogoAlt || ''}
-              url={targetFallbackImage}
-              breakpoints={getProperties(arcSite)?.breakpoints}
-              resizedImageOptions={placeholderResizedImageOptions}
-              resizerURL={getProperties(arcSite)?.resizerURL}
-            />
-          )}
+          <Image
+            {...imageProps}
+            url={imageURL !== '' ? imageURL : targetFallbackImage}
+            resizedImageOptions={imageURL !== '' ? resizedImageOptions : placeholderResizedImageOptions}
+          />
         </a>
-      ) : <div className="simple-list-placeholder" />}
+      ) : null}
       {showHeadline && itemTitle !== '' ? (
         <a
           className="simple-list-headline-anchor"

--- a/blocks/simple-list-block/features/simple-list/_children/story-item.test.jsx
+++ b/blocks/simple-list-block/features/simple-list/_children/story-item.test.jsx
@@ -14,20 +14,11 @@ jest.mock('fusion:context', () => ({
   })),
 }));
 
-jest.mock('fusion:properties', () => (jest.fn(() => ({
-  fallbackImage: 'placeholder.jpg',
-}))));
-
 describe('Story item', () => {
   it('renders title if title provided', () => {
     const testText = 'Man Bites Dog';
     const wrapper = mount(<StoryItem itemTitle={testText} showHeadline showImage />);
     expect(wrapper.text()).toBe(testText);
-  });
-  it('renders placeholder if no props provided', () => {
-    const wrapper = mount(<StoryItem />);
-
-    expect(wrapper.find('.simple-list-placeholder').length).toBe(1);
   });
   it('renders no title if no title provided', () => {
     const wrapper = mount(<StoryItem />);

--- a/blocks/simple-list-block/features/simple-list/default.test.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.test.jsx
@@ -146,6 +146,7 @@ describe('Simple list', () => {
 
     const wrapper = mount(<SimpleList
       customFields={customFields}
+      arcSite="the-sun"
       deployment={jest.fn((path) => path)}
     />);
 
@@ -166,6 +167,7 @@ describe('Simple list', () => {
 
     const wrapper = mount(<SimpleList
       customFields={customFields}
+      arcSite="the-sun"
       deployment={jest.fn((path) => path)}
     />);
 
@@ -175,7 +177,10 @@ describe('Simple list', () => {
 
 describe('Simple list', () => {
   it('should render content only for the arcSite', () => {
-    const wrapper = mount(<SimpleList deployment={jest.fn((path) => path)} />);
+    const wrapper = mount(<SimpleList
+      arcSite="the-sun"
+      deployment={jest.fn((path) => path)}
+    />);
 
     expect(wrapper.find('StoryItem')).toHaveLength(2);
   });


### PR DESCRIPTION
## Description

Update Simple List block with the following optimisations
* Story Item
   * Simplified component to be pure presentational
   * Ensure all props are passed down to make component not need to make calls to get properties
 * Simple List Wrapper (default.jsx)
   *  Utilise `extractImageFromStory` function to get image from story - This fixes a bug where video lead art images where not showing
   * Set imageProps in constructor to pass to StoryItem
   * Get all required children component properties in the construct to pass down
   * Update title conditional render to use ternary to render `null` if no title is present 
   * Fixed a potential bug in the `useContent` filter with the conditional promoItems logic - which could cause multiple calls to the same content source to have missing images

## Jira Ticket
- [TMEDIA-272](https://arcpublishing.atlassian.net/browse/TMEDIA-272)

## Acceptance Criteria
1. Review the Simple List for the items mentioned in TMEDIA-154 and TMEDIA-155 
2. If there are small level-of-effort things to change, do so in this ticket. If there are larger-scope things to change, you can create tickets in the backlog for those (and we can discuss/groom/estimate them separately) 

## Test Steps

1. Checkout this branch `git checkout TMEDIA-272-simple-list-optimisations`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/simple-list-block,@wpmedia/resizer-image-block`
3. Create page with the simple list block on it and validate it still functions as before
4. Validate existing pages that use simple list still render as expected - http://localhost/homepage/?_website=the-gazette 


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
