### PR TITLE
TMEDIA-240 - Add custom field description for editor

### DIFF
--- a/blocks/alert-bar-block/features/alert-bar/default.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.jsx
@@ -183,6 +183,7 @@ AlertBar.propTypes = {
     ariaLabel: PropTypes.string.tag({
       label: 'Aria-label',
       defaultValue: 'Breaking News Alert',
+      description: 'The label is provided to assistive technologies to provide it with a unique name for the breaking news nav landmark - defaults to "Breaking News Alert" if left blank',
     }),
   }),
 };

--- a/blocks/alert-bar-block/features/alert-bar/default.test.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.test.jsx
@@ -336,6 +336,35 @@ describe('when add the alert to main section', () => {
     expect(wrapper.find('nav').props()).toHaveProperty('aria-label', 'Breaking News Alert');
   });
 
+  it('should render the block with the default aria-label if blank', () => {
+    const { default: AlertBar } = require('./default');
+    const content = {
+      _id: 'VTKOTRJXEVATHG7MELTPZ2RIBU',
+      type: 'collection',
+      content_elements:
+        [{
+          _id: '55FCWHR6SRCQ3OIJJKWPWUGTBM',
+          headlines: {
+            basic: 'This is a test headline',
+          },
+          websites: {
+            'the-sun': {
+              website_url: '/2019/12/02/baby-panda-born-at-the-zoo/',
+            },
+          },
+        }],
+    };
+
+    AlertBar.prototype.getContent = jest.fn().mockReturnValue({
+      cached: content,
+      fetched: new Promise((r) => r(content)),
+    });
+    const wrapper = shallow(<AlertBar arcSite="the-sun" customFields={{ ariaLabel: '' }} />);
+    jest.advanceTimersByTime(1000);
+    wrapper.update();
+    expect(wrapper.find('nav').props()).toHaveProperty('aria-label', 'Breaking News Alert');
+  });
+
   it('should render the block with the custom aria-label', () => {
     const { default: AlertBar } = require('./default');
     const content = {

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
@@ -5,7 +5,6 @@ import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 import getThemeStyle from 'fusion:themes';
-import PropTypes from 'prop-types';
 import Link from './_children/link';
 
 import './links-bar.scss';
@@ -20,7 +19,7 @@ const LinkBarSpan = styled.span`
 `;
 
 const HorizontalLinksBar = ({
-  hierarchy, navBarColor, showHorizontalSeperatorDots, customFields: { ariaLabel } = {},
+  hierarchy, navBarColor, showHorizontalSeperatorDots, ariaLabel,
 }) => {
   const { id, arcSite } = useFusionContext();
   const { locale = 'en' } = getProperties(arcSite);
@@ -55,7 +54,6 @@ const HorizontalLinksBar = ({
 
   return (
     <>
-      {}
       <nav
         key={id}
         className="horizontal-links-bar"
@@ -91,15 +89,6 @@ const HorizontalLinksBar = ({
       </nav>
     </>
   );
-};
-
-HorizontalLinksBar.propTypes = {
-  customFields: PropTypes.shape({
-    ariaLabel: PropTypes.string.tag({
-      label: 'Aria-label',
-      defaultValue: 'Top Links',
-    }),
-  }),
 };
 
 export default HorizontalLinksBar;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
@@ -218,7 +218,7 @@ describe('the links bar feature for the default output type', () => {
     }));
     const { default: LinksBar } = require('./default');
     const wrapper = shallow(
-      <LinksBar customFields={{ ariaLabel: 'Links' }} />,
+      <LinksBar ariaLabel="Links" />,
     );
 
     expect(wrapper.find('nav').props()).toHaveProperty('aria-label', 'Links');

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -402,6 +402,7 @@ const Nav = (props) => {
               hierarchy={horizontalLinksHierarchy}
               navBarColor={navColor}
               showHorizontalSeperatorDots={showDotSeparators}
+              ariaLabel={ariaLabel}
             />
           )}
           <NavSection side="right" />
@@ -499,6 +500,7 @@ Nav.propTypes = {
     ariaLabel: PropTypes.string.tag({
       label: 'Aria-label',
       defaultValue: 'Sections Menu',
+      description: 'The label is provided to assistive technologies to provide it with a unique name for the header nav landmark - defaults to "Sections Menu" if left blank',
     }),
     ...generateNavComponentPropTypes(),
   }),

--- a/blocks/links-bar-block/features/links-bar/default.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.jsx
@@ -77,6 +77,7 @@ LinksBar.propTypes = {
     ariaLabel: PropTypes.string.tag({
       label: 'Aria-label',
       defaultValue: 'More Links',
+      description: 'The label is provided to assistive technologies to provide it with a unique name for the links bar nav landmark - defaults to "More Links" if left blank',
     }),
   }),
 };

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -173,6 +173,23 @@ describe('the links bar feature for the default output type', () => {
     );
   });
 
+  it('should render the block with the default aria-label if custom field is empty', () => {
+    jest.mock('fusion:content', () => ({
+      useContent: jest.fn(() => ({
+        children: [],
+      })),
+    }));
+    const { default: LinksBar } = require('./default');
+    const wrapper = shallow(
+      <LinksBar customFields={{ navigationConfig: 'links', ariaLabel: '' }} />,
+    );
+
+    expect(wrapper.find('nav').props()).toHaveProperty(
+      'aria-label',
+      'More Links',
+    );
+  });
+
   it('should render the block with the custom aria-label', () => {
     jest.mock('fusion:content', () => ({
       useContent: jest.fn(() => ({


### PR DESCRIPTION
## Description
* Add description to custom field to provide editor information
* Fix issue where blank custom field not shown for horizontalLinksBar

## Jira Ticket
- [TMEDIA-240](https://arcpublishing.atlassian.net/browse/TMEDIA-240)

## Acceptance Criteria
_User should be notified of what the default value is for that block's custom aria-label, perhaps using an info icon explaining how this field works..._

## Test Steps

1. Checkout this branch `git checkout TMEDIA-240-aria-label-custom-field-updates`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/alert-bar-block,@wpmedia/header-nav-chain-block,@wpmedia/links-bar-block`
3. Validate the following features - alert bar, header nav chain and links bar
    * Have `aria-label` on their `<nav>` element
    * Uses the default if feature is newly added to a page
    * Uses the default if an editor leaves the Aria Label custom field blank
    * Uses the value entered in the custom field 

## Effect Of Changes

Added editor info -

<img width="267" alt="TMEDIA-240-editor" src="https://user-images.githubusercontent.com/868127/122073669-827ce380-cdf0-11eb-990c-3f2467beba31.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
