### PR TITLE
TMEDIA-268: Add class layout section to advanced right rail

### DIFF
--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
@@ -43,7 +43,7 @@ const RightRailAdvancedLayout = ({ children }) => {
               <RenderChild Item={main} tabletPlacement="2" />
               <RenderChild Item={main2} tabletPlacement="4" />
             </section>
-            <section className="col-sm-md-12 col-lg-xl-4">
+            <section className="col-sm-md-12 col-lg-xl-4 layout-section">
               <RenderChild Item={rightRailTop} tabletPlacement="1" />
               <RenderChild Item={rightRailMiddle} tabletPlacement="3" />
               <RenderChild Item={rightRailBottom} tabletPlacement="5" />


### PR DESCRIPTION
## Description
Advanced Right Rail - Missing spacing in right rail

## Jira Ticket
- [TMEDIA-268](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-268&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
- Adequate spacing between items on the right rail in right rail advanced 

## Test Steps

1. Checkout this branch `git checkout TMEDIA-268-advanced-rail-spacing`
2. Run fusion repo with linked blocks `npx fusion start -f -l  @wpmedia/right-rail-advanced`
3. Go to page with advanced right rail layout like http://localhost/pf/homepage/?_website=the-gazette
4. See the nice spacing betwen the right side between the end of the first list and the top of the second header

## Effect Of Changes
### Before

<img width="722" alt="Screen Shot 2021-06-16 at 16 10 46" src="https://user-images.githubusercontent.com/5950956/122294122-5aa78180-cebd-11eb-9245-565bd2c6fb0b.png">

### After
<img width="1439" alt="Screen Shot 2021-06-16 at 16 10 18" src="https://user-images.githubusercontent.com/5950956/122294062-49f70b80-cebd-11eb-9b11-42f361cea2e7.png">

## Dependencies or Side Effects


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
