### PR TITLE
TMEDIA-261 - List blocks heading updates

### DIFF
--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -272,8 +272,8 @@ class CardList extends React.Component {
                               {...this.samllImageOptions}
                               url={imageURL || targetFallbackImage}
                               alt={imageURL ? headlineText : this.siteProperties.primaryLogoAlt || ''}
-                              resizedImageOptions={extractResizedParams(element)
-                                || placeholderResizedImageOptions}
+                              resizedImageOptions={imageURL
+                                ? extractResizedParams(element) : placeholderResizedImageOptions}
                             />
                           </a>
                         </article>

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -31,7 +31,8 @@ jest.mock('@wpmedia/shared-styles', () => ({
   __esModule: true,
   Byline: () => <div />,
   Overline: () => <div />,
-  PrimaryFont: (props) => <div {...props} />,
+  Heading: ({ children }) => children,
+  HeadingSection: ({ children }) => children,
 }));
 
 describe('Card list', () => {
@@ -121,12 +122,8 @@ describe('Card list', () => {
         expect(wrapper.find('.card-list-container').length).toEqual(1);
       });
 
-      it('should render a title', () => {
-        expect(wrapper.find('div.card-list-title').length).toEqual(1);
-      });
-
       it('should render a title with the right text', () => {
-        expect(wrapper.find('div.card-list-title').text()).toEqual('Test Title');
+        expect(wrapper.find('.card-list-title').first().text()).toEqual('Test Title');
       });
 
       it('should render two anchor tags - one around image one for the title', () => {
@@ -157,7 +154,7 @@ describe('Card list', () => {
       });
 
       it('should render a main headline', () => {
-        expect(wrapper.find('div.card-list-headline').length).toEqual(1);
+        expect(wrapper.find('.card-list-headline').length).toEqual(1);
       });
 
       it('should render an author and a publish date section', () => {
@@ -210,8 +207,8 @@ describe('Card list', () => {
 
       it('should render a headline', () => {
         expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').length).toEqual(27);
-        expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').find('PrimaryFont.headline-text').length).toEqual(27);
-        expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').find('PrimaryFont.headline-text').first()
+        expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').find('.headline-text').length).toEqual(27);
+        expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').find('.headline-text').first()
           .text()).toEqual('Jon’s Prod Story');
         expect(
           wrapper.find('article.card-list-item').find('.headline-list-anchor').at(0).prop('href'),
@@ -268,7 +265,7 @@ describe('Card list', () => {
         expect(wrapper.find('.overline').length).toBe(0);
       });
       it('should render headline', () => {
-        expect(wrapper.find('PrimaryFont.card-list-headline').length).toBe(1);
+        expect(wrapper.find('.card-list-headline').length).toBe(1);
       });
       it('should render author-date', () => {
         expect(wrapper.find('.author-date').length).toBe(1);

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -246,7 +246,7 @@ describe('the extra large promo feature', () => {
     const wrapper = mount(<ExtraLargePromo customFields={myConfig} />);
 
     expect(wrapper.find('Overline').length).toBe(1);
-    expect(wrapper.find('.xl-promo-headline').length).toBe(5);
+    expect(wrapper.find('.xl-promo-headline').exists()).toBe(true);
     expect(wrapper.find('.description-text').length).toBe(5);
     expect(wrapper.find('Byline').length).toBe(1);
     expect(wrapper.find('PromoDate').length).toBe(1);

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -191,7 +191,7 @@ describe('the large promo feature', () => {
     const wrapper = mount(<LargePromo customFields={myConfig} arcSite="dagen" />);
 
     expect(wrapper.find('Overline').length).toBe(1);
-    expect(wrapper.find('.lg-promo-headline').length).toBe(5);
+    expect(wrapper.find('.lg-promo-headline').exists()).toBe(true);
     expect(wrapper.find('.description-text').length).toBe(5);
     expect(wrapper.find('Byline').length).toBe(1);
     expect(wrapper.find('PromoDate').length).toBe(1);

--- a/blocks/numbered-list-block/features/numbered-list/default.test.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.test.jsx
@@ -20,8 +20,9 @@ jest.mock('fusion:themes', () => (
 ));
 
 jest.mock('@wpmedia/shared-styles', () => ({
-  PrimaryFont: ({ children }) => <div id="primary-font-mock">{ children }</div>,
   SecondaryFont: ({ children }) => <div id="secondary-font-mock">{ children }</div>,
+  Heading: ({ children }) => children,
+  HeadingSection: ({ children }) => children,
 }));
 
 describe('The numbered-list-block', () => {

--- a/blocks/resizer-image-block/extractImageFromStory.js
+++ b/blocks/resizer-image-block/extractImageFromStory.js
@@ -22,10 +22,10 @@ const extractImageFromStory = (storyObject) => {
     return promoImage;
   }
 
-  if (promoItems.lead_art?.type === 'video') {
-    const videoPromo = extractImageFromPromo(promoItems.lead_art.promo_items);
-    if (videoPromo) {
-      return videoPromo;
+  if (promoItems.lead_art) {
+    const leadArtPromoImage = extractImageFromPromo(promoItems.lead_art.promo_items);
+    if (leadArtPromoImage) {
+      return leadArtPromoImage;
     }
   }
 

--- a/blocks/resizer-image-block/extractImageFromStory.test.js
+++ b/blocks/resizer-image-block/extractImageFromStory.test.js
@@ -3,6 +3,7 @@ import extractImageFromStory from './extractImageFromStory';
 import mockLeadArtVideo from './mocks/mockLeadArtVideo';
 import mockLeadArtVideoNoImage from './mocks/mockLeadArtVideoNoImage';
 import mockLeadArtVideoPromoBasic from './mocks/mockLeadArtVideoPromoBasic';
+import mockStoryPromoItemsGalleryFocalPoint from './mocks/mockStoryPromoItemsGalleryFocalPoint';
 
 describe('when extract an image from a story', () => {
   it('must extract image from lead_art.promo_items if is present', () => {
@@ -23,5 +24,13 @@ describe('when extract an image from a story', () => {
     const url = extractImageFromStory(mockLeadArtVideoNoImage);
 
     expect(url).toBeNull();
+  });
+
+  it('must extract image from basic if lead_art is gallery', () => {
+    const url = extractImageFromStory(mockStoryPromoItemsGalleryFocalPoint);
+    const imageUrl = mockStoryPromoItemsGalleryFocalPoint
+      .promo_items.lead_art.promo_items.basic.url;
+
+    expect(url).toEqual(imageUrl);
   });
 });

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -38,7 +38,7 @@ class ResultsList extends Component {
     super(props);
     const { lazyLoad = false } = props.customFields || {};
     const {
-      websiteDomain, fallbackImage, primaryLogoAlt, breakpoints, resizerURL,
+      websiteDomain, fallbackImage, primaryLogoAlt, breakpoints, resizerURL, locale,
     } = getProperties(props.arcSite) || {};
 
     this.arcSite = props.arcSite;
@@ -48,7 +48,7 @@ class ResultsList extends Component {
       placeholderResizedImageOptions: {},
       focusItem: 0,
     };
-    this.phrases = getTranslatedPhrases(getProperties(props.arcSite).locale || 'en');
+    this.phrases = getTranslatedPhrases(locale || 'en');
     this.listItemRefs = {};
 
     this.lazyLoad = lazyLoad;

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -33,8 +33,9 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
 jest.mock('@wpmedia/shared-styles', () => ({
   __esModule: true,
   Byline: () => <div />,
-  PrimaryFont: ({ children }) => <div id="primary-font-mock">{children}</div>,
   SecondaryFont: ({ children }) => <div id="secondary-font-mock">{children}</div>,
+  Heading: ({ children }) => <>{children}</>,
+  HeadingSection: ({ children }) => children,
 }));
 
 describe('The results list', () => {

--- a/blocks/results-list-block/features/results-list/internalTests.test.jsx
+++ b/blocks/results-list-block/features/results-list/internalTests.test.jsx
@@ -20,6 +20,8 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
 jest.mock('@wpmedia/shared-styles', () => ({
   __esModule: true,
   Byline: () => <div />,
+  Heading: ({ children }) => <>{children}</>,
+  HeadingSection: ({ children }) => children,
 }));
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({

--- a/blocks/search-results-list-block/features/search-results-list/_children/custom-content.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/custom-content.test.jsx
@@ -31,14 +31,6 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   Image: () => <div />,
 }));
 
-const fullPromoElements = {
-  showHeadline: true,
-  showImage: true,
-  showDescription: true,
-  showByline: true,
-  showDate: true,
-};
-
 describe('The search results list', () => {
   describe('renders a search bar', () => {
     const { default: SearchResultsList } = require('./custom-content');
@@ -71,22 +63,11 @@ describe('The search results list', () => {
         });
 
         it('should call fetchContent when clicked', () => {
-          expect(SearchResultsList.prototype.fetchStories.mock.calls.length).toEqual(0);
-          wrapper.find('.btn').at(0).simulate('click');
           expect(SearchResultsList.prototype.fetchStories.mock.calls.length).toEqual(1);
+          wrapper.find('.btn').at(0).simulate('click');
+          expect(SearchResultsList.prototype.fetchStories.mock.calls.length).toEqual(2);
         });
       });
-    });
-  });
-
-  it('should render a list of stories', () => {
-    const { default: SearchResultsList } = require('./custom-content');
-    SearchResultsList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
-    const wrapper = shallow(<SearchResultsList arcSite="the-sun" promoElements={fullPromoElements} deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ resultList: mockData }, () => {
-      wrapper.update();
-      expect(wrapper.find('.results-list-container').length).toEqual(1);
-      expect(wrapper.find('SearchResult').length).toEqual(28);
     });
   });
 
@@ -107,9 +88,9 @@ describe('The search results list', () => {
       });
 
       it('should call fetchContent when clicked', () => {
-        expect(SearchResultsList.prototype.fetchStories.mock.calls.length).toEqual(1);
-        (wrapper.find('.see-more')).childAt(0).simulate('click');
         expect(SearchResultsList.prototype.fetchStories.mock.calls.length).toEqual(2);
+        (wrapper.find('.see-more')).childAt(0).simulate('click');
+        expect(SearchResultsList.prototype.fetchStories.mock.calls.length).toEqual(3);
       });
     });
   });

--- a/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
@@ -3,11 +3,10 @@ import Consumer from 'fusion:consumer';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 import { SearchIcon } from '@wpmedia/engine-theme-sdk';
-import { extractResizedParams } from '@wpmedia/resizer-image-block';
+import { extractResizedParams, extractImageFromStory } from '@wpmedia/resizer-image-block';
 import { PrimaryFont } from '@wpmedia/shared-styles';
 
 import SearchResult from './search-result';
-import { extractImage } from './helpers';
 import '@wpmedia/shared-styles/scss/_results-list.scss';
 import '@wpmedia/shared-styles/scss/_results-list-desktop.scss';
 import '@wpmedia/shared-styles/scss/_results-list-mobile.scss';
@@ -27,8 +26,27 @@ class GlobalSearchResultsList extends React.Component {
       placeholderResizedImageOptions: {},
       focusItem: 0,
     };
-    this.locale = getProperties(this.arcSite).locale || 'en';
-    this.phrases = getTranslatedPhrases(this.locale);
+
+    const {
+      websiteDomain, fallbackImage, primaryLogoAlt, breakpoints, resizerURL, locale = 'en',
+    } = getProperties(props.arcSite) || {};
+
+    this.phrases = getTranslatedPhrases(locale);
+    this.websiteDomain = websiteDomain;
+    this.fallbackImage = fallbackImage;
+
+    this.imageProps = {
+      smallWidth: 158,
+      smallHeight: 89,
+      mediumWidth: 274,
+      mediumHeight: 154,
+      largeWidth: 274,
+      largeHeight: 154,
+      primaryLogoAlt,
+      breakpoints,
+      resizerURL,
+    };
+
     this.fetchPlaceholder();
     this.customSearchAction = props.customSearchAction || null;
     this.listItemRefs = {};
@@ -173,7 +191,7 @@ class GlobalSearchResultsList extends React.Component {
         <div className="results-list-container">
           {
             results && results.length > 0 && results.map((element) => {
-              const resizedImageOptions = extractImage(element.promoItems)
+              const resizedImageOptions = extractImageFromStory(element)
                 ? extractResizedParams(element)
                 : placeholderResizedImageOptions;
 
@@ -188,9 +206,9 @@ class GlobalSearchResultsList extends React.Component {
                     element={element}
                     arcSite={arcSite}
                     targetFallbackImage={targetFallbackImage}
-                    placeholderResizedImageOptions={placeholderResizedImageOptions}
                     resizedImageOptions={resizedImageOptions}
                     promoElements={promoElements}
+                    imageProps={this.imageProps}
                   />
                 </div>
               );

--- a/blocks/search-results-list-block/features/search-results-list/_children/helpers.js
+++ b/blocks/search-results-list-block/features/search-results-list/_children/helpers.js
@@ -9,8 +9,6 @@ const constructHref = (websiteUrl, arcSite) => {
     : `${websiteDomain}/${websiteUrl}`;
 };
 
-const extractImage = (promo) => promo && promo.basic && promo.basic.type === 'image' && promo.basic.url;
-
 const resolveDefaultPromoElements = (customFields = {}) => {
   const fields = {
     showHeadline: true,
@@ -30,4 +28,4 @@ const resolveDefaultPromoElements = (customFields = {}) => {
   }, fields);
 };
 
-export { constructHref, extractImage, resolveDefaultPromoElements };
+export { constructHref, resolveDefaultPromoElements };

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
@@ -1,33 +1,30 @@
 import React from 'react';
+import getProperties from 'fusion:properties';
+
 import ArticleDate from '@wpmedia/date-block';
 import { Image } from '@wpmedia/engine-theme-sdk';
-import { extractResizedParams } from '@wpmedia/resizer-image-block';
-import { Byline, PrimaryFont, SecondaryFont } from '@wpmedia/shared-styles';
-
-import getProperties from 'fusion:properties';
-import { extractImage } from './helpers';
+import { extractImageFromStory } from '@wpmedia/resizer-image-block';
+import { Byline, Heading, SecondaryFont } from '@wpmedia/shared-styles';
 
 const SearchResult = ({
   element,
   arcSite,
   targetFallbackImage,
-  placeholderResizedImageOptions,
+  resizedImageOptions,
   promoElements = {},
+  imageProps,
 }) => {
   const {
     description: { basic: descriptionText } = {},
     headlines: { basic: headlineText } = {},
     display_date: displayDate,
-    promo_items: promoItems,
     websites = {},
   } = element;
-
   if (!websites[arcSite]) {
     return null;
   }
 
   const url = websites[arcSite].website_url;
-  const resizedImageOptions = extractResizedParams(element);
   const {
     showHeadline,
     showImage,
@@ -38,71 +35,44 @@ const SearchResult = ({
 
   return (
     <div className="list-item" key={`result-card-${url}`}>
-      { showImage && (
+      {showImage ? (
         <div className="results-list--image-container mobile-order-2 mobile-image">
           <a href={url} className="list-anchor" aria-hidden="true" tabIndex="-1">
-            {extractImage(promoItems) ? (
-              <Image
-                url={extractImage(promoItems)}
-                alt={headlineText}
-                smallWidth={274}
-                smallHeight={154}
-                mediumWidth={274}
-                mediumHeight={154}
-                largeWidth={274}
-                largeHeight={154}
-                resizedImageOptions={resizedImageOptions}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-                breakpoints={getProperties(arcSite)?.breakpoints}
-              />
-            ) : (
-              <Image
-                smallWidth={274}
-                smallHeight={154}
-                mediumWidth={274}
-                mediumHeight={154}
-                largeWidth={274}
-                largeHeight={154}
-                alt={getProperties(arcSite).primaryLogoAlt || ''}
-                url={targetFallbackImage}
-                breakpoints={getProperties(arcSite)?.breakpoints}
-                resizedImageOptions={placeholderResizedImageOptions}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-              />
-            )}
+            <Image
+              {...imageProps}
+              url={extractImageFromStory(element)
+                ? extractImageFromStory(element) : targetFallbackImage}
+              alt={extractImageFromStory(element)
+                ? headlineText : getProperties(arcSite).primaryLogoAlt}
+              resizedImageOptions={resizedImageOptions}
+            />
           </a>
         </div>
-      )}
-      { showHeadline && (
+      ) : null}
+      {showHeadline ? (
         <div className="results-list--headline-container mobile-order-1">
           <a href={url} className="list-anchor">
-            <PrimaryFont
-              as="h2"
-              className="headline-text"
-            >
+            <Heading className="headline-text">
               {headlineText}
-            </PrimaryFont>
+            </Heading>
           </a>
         </div>
-      )}
-      { (showDescription || showDate || showByline) && (
+      ) : null}
+      {(showDescription || showDate || showByline) ? (
         <div className="results-list--description-author-container mobile-order-3">
-          { showDescription && (
-            <SecondaryFont
-              as="p"
-              className="description-text"
-            >
+          {showDescription ? (
+            <SecondaryFont as="p" className="description-text">
               {descriptionText}
             </SecondaryFont>
-          )}
-          { (showDate || showByline) && (
+          ) : null}
+          {(showDate || showByline) ? (
             <div className="results-list--author-date">
-              { showByline && <Byline content={element} list separator={showDate} font="Primary" /> }
-              { showDate && <ArticleDate classNames="story-date" date={displayDate} /> }
+              {showByline ? <Byline content={element} list separator={showDate} font="Primary" /> : null}
+              {showDate ? <ArticleDate classNames="story-date" date={displayDate} /> : null}
             </div>
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.test.jsx
@@ -6,6 +6,11 @@ import { mount } from 'enzyme';
 import { oneListItem, LineItemWithOutDescription } from '../mock-data';
 import SearchResult from './search-result';
 
+jest.mock('@wpmedia/date-block', () => ({
+  __esModule: true,
+  default: function ArticleDate() { return <div />; },
+}));
+
 jest.mock('fusion:themes', () => jest.fn(() => ({})));
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({
@@ -23,8 +28,8 @@ jest.mock('fusion:context', () => ({
 jest.mock('@wpmedia/shared-styles', () => ({
   __esModule: true,
   Byline: () => <div />,
-  PrimaryFont: ({ children }) => <h2 className="headline-text">{children}</h2>,
   SecondaryFont: ({ children }) => <p className="description-text">{children}</p>,
+  Heading: ({ children }) => <>{children}</>,
 }));
 
 describe('The search results', () => {
@@ -46,7 +51,6 @@ describe('The search results', () => {
         element={element}
         arcSite="the-sun"
         targetFallbackImage="/resource/example.jpg"
-        placeholderResizedImageOptions={{}}
         promoElements={fullElements}
       />,
     );
@@ -72,8 +76,7 @@ describe('The search results', () => {
     it('should render a headline and a description', () => {
       expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
       expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').length).toEqual(1);
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('PrimaryFont').length).toEqual(1);
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('PrimaryFont')
+      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('Heading')
         .text()).toEqual('Article with a YouTube embed in it');
       expect(wrapper.find('.list-item').find('.results-list--description-author-container').find('p.description-text')
         .text()).toEqual('Test article for YouTube responsiveness');
@@ -110,7 +113,6 @@ describe('The search results', () => {
         element={element}
         arcSite="the-sun"
         targetFallbackImage="/resource/example.jpg"
-        placeholderResizedImageOptions={{}}
         promoElements={fullElements}
       />,
     );
@@ -122,8 +124,8 @@ describe('The search results', () => {
     it('should render a headline', () => {
       expect(wrapper.find('.list-item').find('.results-list--description-author-container').length).toEqual(1);
       expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').length).toEqual(1);
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('h2.headline-text').length).toEqual(1);
-      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('h2.headline-text')
+      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.headline-text').length).toEqual(1);
+      expect(wrapper.find('.list-item').find('.results-list--headline-container').find('.list-anchor').find('.headline-text')
         .text()).toEqual('Article with a YouTube embed in it');
     });
 
@@ -152,7 +154,6 @@ describe('The search results', () => {
           element={element}
           arcSite="the-sun"
           targetFallbackImage="/resource/example.jpg"
-          placeholderResizedImageOptions={{}}
           promoElements={promoElements}
         />,
       );
@@ -175,7 +176,6 @@ describe('The search results', () => {
           element={element}
           arcSite="the-sun"
           targetFallbackImage="/resource/example.jpg"
-          placeholderResizedImageOptions={{}}
           promoElements={promoElements}
         />,
       );
@@ -183,7 +183,7 @@ describe('The search results', () => {
       const headline = wrapper.find('.list-item').find('.results-list--headline-container');
       expect(headline.length).toEqual(1);
       expect(headline.find('.list-anchor').length).toEqual(1);
-      expect(headline.find('h2.headline-text').length).toEqual(1);
+      expect(headline.find('.headline-text').length).toEqual(1);
       expect(headline.text()).toEqual('Article with a YouTube embed in it');
     });
 
@@ -201,7 +201,6 @@ describe('The search results', () => {
           element={element}
           arcSite="the-sun"
           targetFallbackImage="/resource/example.jpg"
-          placeholderResizedImageOptions={{}}
           promoElements={promoElements}
         />,
       );
@@ -227,7 +226,6 @@ describe('The search results', () => {
           element={element}
           arcSite="the-sun"
           targetFallbackImage="/resource/example.jpg"
-          placeholderResizedImageOptions={{}}
           promoElements={promoElements}
         />,
       );
@@ -253,7 +251,6 @@ describe('The search results', () => {
           element={element}
           arcSite="the-sun"
           targetFallbackImage="/resource/example.jpg"
-          placeholderResizedImageOptions={{}}
           promoElements={promoElements}
         />,
       );
@@ -278,7 +275,6 @@ describe('The search results', () => {
           element={element}
           arcSite="the-sun"
           targetFallbackImage="/resource/example.jpg"
-          placeholderResizedImageOptions={{}}
           promoElements={promoElements}
         />,
       );
@@ -305,7 +301,6 @@ describe('The search results', () => {
         element={element}
         arcSite="the-sun"
         targetFallbackImage="/resource/example.jpg"
-        placeholderResizedImageOptions={{}}
         promoElements={fullElements}
       />,
     );

--- a/blocks/search-results-list-block/features/search-results-list/default.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/default.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useAppContext, useFusionContext } from 'fusion:context';
 import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
+import { HeadingSection } from '@wpmedia/shared-styles';
 import CustomSearchResultsList from './_children/custom-content';
 import GlobalContentSearch from './_children/global-content';
 import { resolveDefaultPromoElements } from './_children/helpers';
@@ -30,20 +31,24 @@ const SearchResultsListContainer = (
   if (showGlobalContent) {
     return (
       <LazyLoad enabled={lazyLoad && !isAdmin}>
-        <GlobalContentSearch
-          arcSite={arcSite}
-          customSearchAction={customSearchAction}
-          promoElements={resolveDefaultPromoElements(customFields)}
-        />
+        <HeadingSection>
+          <GlobalContentSearch
+            arcSite={arcSite}
+            customSearchAction={customSearchAction}
+            promoElements={resolveDefaultPromoElements(customFields)}
+          />
+        </HeadingSection>
       </LazyLoad>
     );
   }
   return (
     <LazyLoad enabled={lazyLoad && !isAdmin}>
-      <CustomSearchResultsList
-        arcSite={arcSite}
-        promoElements={resolveDefaultPromoElements(customFields)}
-      />
+      <HeadingSection>
+        <CustomSearchResultsList
+          arcSite={arcSite}
+          promoElements={resolveDefaultPromoElements(customFields)}
+        />
+      </HeadingSection>
     </LazyLoad>
   );
 };

--- a/blocks/search-results-list-block/features/search-results-list/default.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/default.test.jsx
@@ -23,6 +23,11 @@ jest.mock('fusion:properties', () => (jest.fn(() => ({
   fallbackImage: 'placeholder.jpg',
 }))));
 
+jest.mock('@wpmedia/shared-styles', () => ({
+  __esModule: true,
+  HeadingSection: ({ children }) => <>{children}</>,
+}));
+
 const defaultPromos = {
   showByline: true,
   showDate: true,

--- a/blocks/shared-styles/_children/headings/index.story.mdx
+++ b/blocks/shared-styles/_children/headings/index.story.mdx
@@ -34,7 +34,7 @@ corrent hierarchy ensure the use of `<HeadingSection>` is used.
 
 ```jsx
 
-import Heading from '@wpmedia/shared-styles';
+import { Heading } from '@wpmedia/shared-styles';
 
 const BlockFeature = () => (
   <Heading>Heading Text</Heading>
@@ -57,7 +57,7 @@ for a group of stories then using the `<HeadingSection>` will increase the
 
 ```jsx
 
-import Heading from '@wpmedia/shared-styles';
+import { Heading, HeadingSection } from '@wpmedia/shared-styles';
 
 const SectionBlockFeature = () => (
   <HeadingSection>

--- a/blocks/shared-styles/_children/promo-headline/index.jsx
+++ b/blocks/shared-styles/_children/promo-headline/index.jsx
@@ -3,7 +3,8 @@
 import React from 'react';
 import { useEditableContent } from 'fusion:content';
 import { useComponentContext, useFusionContext } from 'fusion:context';
-import { PrimaryFont } from '@wpmedia/shared-styles';
+import Heading from '../headings/heading';
+import HeadingSection from '../headings/section';
 
 const PromoHeadline = (props) => {
   const {
@@ -26,24 +27,25 @@ const PromoHeadline = (props) => {
   const editableItem = content?.headlines && editable ? editableContent(content, 'headlines.basic') : {};
 
   return linkText ? (
-    <div className={`promo-headline ${className}`}>
-      <PrimaryFont
-        as="h2"
-        className={headingClassName}
-        {...editableItem}
-        suppressContentEditableWarning
-      >
-        <a
-          href={linkURL}
-          target={newTab ? '_blank' : '_self'}
-          rel={newTab ? 'noreferrer noopener' : ''}
-          className={linkClassName}
-          onClick={registerSuccessEvent}
+    <HeadingSection>
+      <div className={`promo-headline ${className}`}>
+        <Heading
+          className={headingClassName}
+          {...editableItem}
+          suppressContentEditableWarning
         >
-          {linkText}
-        </a>
-      </PrimaryFont>
-    </div>
+          <a
+            href={linkURL}
+            target={newTab ? '_blank' : '_self'}
+            rel={newTab ? 'noreferrer noopener' : ''}
+            className={linkClassName}
+            onClick={registerSuccessEvent}
+          >
+            {linkText}
+          </a>
+        </Heading>
+      </div>
+    </HeadingSection>
   ) : null;
 };
 

--- a/blocks/shared-styles/scss/_results-list-desktop.scss
+++ b/blocks/shared-styles/scss/_results-list-desktop.scss
@@ -26,10 +26,6 @@
       font-size: calculateRem(10px);
       line-height: calculateRem(16px);
 
-      .dot-separator {
-        color: transparent;
-      }
-
       .story-date {
         color: $ui-primary-font-color;
         display: inline;

--- a/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
+++ b/blocks/simple-list-block/features/simple-list/_children/story-item.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PrimaryFont } from '@wpmedia/shared-styles';
+import { Heading } from '@wpmedia/shared-styles';
 import { Image } from '@wpmedia/engine-theme-sdk';
 
 const StoryItem = (props) => {
@@ -38,9 +38,9 @@ const StoryItem = (props) => {
           className="simple-list-headline-anchor"
           href={websiteURL}
         >
-          <PrimaryFont as="h2" className="simple-list-headline-text">
+          <Heading className="simple-list-headline-text">
             {itemTitle}
-          </PrimaryFont>
+          </Heading>
         </a>
       ) : null}
     </article>

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useContent } from 'fusion:content';
 import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { extractResizedParams, extractImageFromStory } from '@wpmedia/resizer-image-block';
-import { PrimaryFont } from '@wpmedia/shared-styles';
+import { Heading, HeadingSection } from '@wpmedia/shared-styles';
 import getProperties from 'fusion:properties';
 import Consumer from 'fusion:consumer';
 import StoryItem from './_children/story-item';
@@ -90,13 +90,15 @@ class SimpleListWrapper extends Component {
 
     return (
       <LazyLoad enabled={this.lazyLoad && !this.isAdmin}>
-        <SimpleList
-          {...this.props}
-          placeholderResizedImageOptions={placeholderResizedImageOptions}
-          targetFallbackImage={targetFallbackImage}
-          websiteDomain={this.websiteDomain}
-          imageProps={this.imageProps}
-        />
+        <HeadingSection>
+          <SimpleList
+            {...this.props}
+            placeholderResizedImageOptions={placeholderResizedImageOptions}
+            targetFallbackImage={targetFallbackImage}
+            websiteDomain={this.websiteDomain}
+            imageProps={this.imageProps}
+          />
+        </HeadingSection>
       </LazyLoad>
     );
   }
@@ -115,7 +117,7 @@ const SimpleList = (props) => {
       showHeadline = true,
       showImage = true,
     } = {},
-    id = '',
+    id,
     placeholderResizedImageOptions,
     targetFallbackImage,
     imageProps,
@@ -162,15 +164,18 @@ const SimpleList = (props) => {
     }`,
   }) || {};
 
+  const Wrapper = title ? HeadingSection : React.Fragment;
+
   return (
-    <div key={id} className="list-container layout-section">
-      { title
-        ? (
-          <PrimaryFont as="div" className="list-title">
-            {title}
-          </PrimaryFont>
-        ) : null}
-      {
+    <Wrapper>
+      <div key={id} className="list-container layout-section">
+        { title
+          ? (
+            <Heading className="list-title">
+              {title}
+            </Heading>
+          ) : null}
+        {
         contentElements.reduce(unserializeStory(arcSite), []).map(({
           id: listItemId, itemTitle, imageURL, websiteURL, resizedImageOptions,
         }) => (
@@ -194,7 +199,8 @@ const SimpleList = (props) => {
           </React.Fragment>
         ))
       }
-    </div>
+      </div>
+    </Wrapper>
   );
 };
 

--- a/blocks/simple-list-block/features/simple-list/default.test.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.test.jsx
@@ -120,7 +120,7 @@ describe('Simple list', () => {
       deployment={jest.fn((path) => path)}
     />);
 
-    expect(wrapper.find('div.list-title').text()).toBe(testText);
+    expect(wrapper.find('.list-title').first().text()).toBe(testText);
   });
 
   it('should show no title if there is no title provided', () => {
@@ -131,7 +131,7 @@ describe('Simple list', () => {
     }));
     const wrapper = mount(<SimpleList deployment={jest.fn((path) => path)} />);
 
-    expect(wrapper.find('div.list-title').length).toBe(0);
+    expect(wrapper.find('.list-title').length).toBe(0);
   });
 
   it('should fetch an array of data when content service is provided', () => {


### PR DESCRIPTION
## Description
Updated the following list blocks to use Heading and HeadingSection components for heading hierarchy management

- Numbered List
- Simple List
- Card List
- Top Table List
- Results List
- Search Results List

## Jira Ticket
- [TMEDIA-261](https://arcpublishing.atlassian.net/browse/TMEDIA-261)

## Acceptance Criteria
* Each block should be wrapped in a `<HeadingSection>` element, and each Heading should use the `<Heading>` element.
* When a block has a section heading the children elements should be wrapped in a `<HeadingSection>` to ensure the Heading level hierarchy is maintained
* If there is CSS tied to that existing Headings that use direct selectors. ie. `h2 {...}` update to use class names


## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-261-list-blocks-heading-updates`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/simple-list-block,@wpmedia/numbered-list-block,@wpmedia/card-list-block,@wpmedia/top-table-list-block,@wpmedia/results-list-block,@wpmedia/search-results-list-block,@wpmedia/default-output-block,@wpmedia/resizer-image-block,@wpmedia/shared-styles`
3. Visit pages that have each of the blocks on to validate
    * No visual changes
    * Heading Hierarchy is increased within each block (Simple List - title is h2, and all article headlines are h3)

Test Pages - 

Homepage - http://localhost/homepage/?_website=the-gazette
Search - http://localhost/search/video/?_website=the-sun
All Blocks Page - http://localhost/pf/all-blocks/?_website=the-gazette 

## Effect Of Changes
### Before

Numbered List before

<img width="1704" alt="TMEDIA-261-numbered-list-before" src="https://user-images.githubusercontent.com/868127/122380710-0d302080-cf60-11eb-8286-b45666bba65d.png">


### After

Numbered List after

<img width="1644" alt="TMEDIA-261-numbered-list-after" src="https://user-images.githubusercontent.com/868127/122380729-14572e80-cf60-11eb-9175-83fbd7df206b.png">

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
