### PR TITLE
Expose header links bar aria-label via custom field

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
@@ -217,9 +217,7 @@ describe('the links bar feature for the default output type', () => {
       })),
     }));
     const { default: LinksBar } = require('./default');
-    const wrapper = shallow(
-      <LinksBar ariaLabel="Links" />,
-    );
+    const wrapper = shallow(<LinksBar ariaLabel="Links" />);
 
     expect(wrapper.find('nav').props()).toHaveProperty('aria-label', 'Links');
   });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -138,6 +138,7 @@ const Nav = (props) => {
     shrinkDesktopNavivationHeight,
     showHorizontalSeperatorDots,
     ariaLabel,
+    ariaLabelLink,
   } = customFields;
 
   const displayLinks = horizontalLinksHierarchy && logoAlignment === 'left';
@@ -402,7 +403,7 @@ const Nav = (props) => {
               hierarchy={horizontalLinksHierarchy}
               navBarColor={navColor}
               showHorizontalSeperatorDots={showDotSeparators}
-              ariaLabel={ariaLabel}
+              ariaLabel={ariaLabelLink}
             />
           )}
           <NavSection side="right" />
@@ -501,6 +502,11 @@ Nav.propTypes = {
       label: 'Aria-label',
       defaultValue: 'Sections Menu',
       description: 'The label is provided to assistive technologies to provide it with a unique name for the header nav landmark - defaults to "Sections Menu" if left blank',
+    }),
+    ariaLabelLink: PropTypes.string.tag({
+      label: 'Links Bar - Aria-label',
+      defaultValue: 'Top Links',
+      description: 'The label is provided to assistive technologies to provide it with a unique name for the header links nav landmark - defaults to "Top Links" if left blank',
     }),
     ...generateNavComponentPropTypes(),
   }),


### PR DESCRIPTION
## Description
Expose header nav chain links bar aria-label as a custom field for editors

## Jira Ticket
- [TMEDIA-240](https://arcpublishing.atlassian.net/browse/TMEDIA-240)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-240-header-links-bar-aria-label`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Edit a page with header nav chain, and verify new custom field that allows an editor to update the aria label of the links bar in the header nav chain

## Effect Of Changes

<img width="268" alt="TMEDIA-240-header-nav-chain-links-aria-label" src="https://user-images.githubusercontent.com/868127/122469092-6e81df00-cfb4-11eb-8ac3-a06719cfbba6.png">

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
