### PR TITLE
TMEDIA-261 - Simple List Wrapper fix

### DIFF
--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -167,7 +167,7 @@ const SimpleList = (props) => {
   const Wrapper = title ? HeadingSection : React.Fragment;
 
   return (
-    <Wrapper>
+    <>
       <div key={id} className="list-container layout-section">
         { title
           ? (
@@ -175,32 +175,32 @@ const SimpleList = (props) => {
               {title}
             </Heading>
           ) : null}
-        {
-        contentElements.reduce(unserializeStory(arcSite), []).map(({
-          id: listItemId, itemTitle, imageURL, websiteURL, resizedImageOptions,
-        }) => (
-          <React.Fragment key={listItemId}>
-            <StoryItem
-              key={listItemId}
-              id={listItemId}
-              itemTitle={itemTitle}
-              imageURL={imageURL}
-              websiteURL={websiteURL}
-              websiteDomain={websiteDomain}
-              showHeadline={showHeadline}
-              showImage={showImage}
-              resizedImageOptions={resizedImageOptions}
-              placeholderResizedImageOptions={placeholderResizedImageOptions}
-              targetFallbackImage={targetFallbackImage}
-              arcSite={arcSite}
-              imageProps={imageProps}
-            />
-            <hr />
-          </React.Fragment>
-        ))
-      }
+        <Wrapper>
+          {contentElements.reduce(unserializeStory(arcSite), []).map(({
+            id: listItemId, itemTitle, imageURL, websiteURL, resizedImageOptions,
+          }) => (
+            <React.Fragment key={listItemId}>
+              <StoryItem
+                key={listItemId}
+                id={listItemId}
+                itemTitle={itemTitle}
+                imageURL={imageURL}
+                websiteURL={websiteURL}
+                websiteDomain={websiteDomain}
+                showHeadline={showHeadline}
+                showImage={showImage}
+                resizedImageOptions={resizedImageOptions}
+                placeholderResizedImageOptions={placeholderResizedImageOptions}
+                targetFallbackImage={targetFallbackImage}
+                arcSite={arcSite}
+                imageProps={imageProps}
+              />
+              <hr />
+            </React.Fragment>
+          ))}
+        </Wrapper>
       </div>
-    </Wrapper>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description
@JackHowa Noticed an issue with Simple List and the headings starting at `h3` whereas the title should be `h2` and list article headings should be `h3`. This PR address that issue

## Jira Ticket
- [TMEDIA-261](https://arcpublishing.atlassian.net/browse/TMEDIA-261)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-261-simple-list-bug`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/simple-list-block`
3. Verify simple list with title has `h2` for title and `h3` for article headings - http://localhost/homepage/?_website=the-gazette

## Effect Of Changes

<img width="1055" alt="TMEDIA-261-simple-list-bug" src="https://user-images.githubusercontent.com/868127/122899792-0b8da080-d344-11eb-9d11-c4df8731e73d.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
