### PR TITLE
Fix results list error with image prop

### DIFF
--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -323,9 +323,10 @@ class ResultsList extends Component {
                   >
                     <Image
                       {...this.imageProps}
-                      url={imageURL !== '' ? imageURL : targetFallbackImage}
-                      alt={imageURL !== '' ? headlineText : this.imageProps?.primaryLogoAlt}
-                      resizedImageOptions={imageURL !== '' ? extractResizedParams(element) : placeholderResizedImageOptions}
+                      url={imageURL !== null ? imageURL : targetFallbackImage}
+                      alt={imageURL !== null ? headlineText : this.imageProps?.primaryLogoAlt}
+                      resizedImageOptions={imageURL !== null
+                        ? extractResizedParams(element) : placeholderResizedImageOptions}
                     />
                   </a>
                 </div>


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Results list was throwing an error and not rendering due to image prop issues

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout results-list-image-error`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/results-list-block`
3. Validate results list block renders on - http://localhost/pf/all-blocks/?_website=the-gazette

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
