### PR TITLE
Tmedia 85 testing fix

### DIFF
--- a/blocks/text-output-block/output-types/text.js
+++ b/blocks/text-output-block/output-types/text.js
@@ -4,7 +4,7 @@ const TextOutputType = ({ children }) => {
   const generateText = (child) => {
     if (Array.isArray(child)) return child.map(generateText).join('\n');
     return child;
-  }
+  };
   return generateText(children);
 };
 

--- a/blocks/text-output-block/output-types/text.js
+++ b/blocks/text-output-block/output-types/text.js
@@ -1,6 +1,12 @@
 import PropTypes from 'prop-types';
 
-const TextOutputType = (props) => props.children;
+const TextOutputType = ({ children }) => {
+  const generateText = (child) => {
+    if (Array.isArray(child)) return child.map(generateText).join('\n');
+    return child;
+  }
+  return generateText(children);
+};
 
 TextOutputType.contentType = 'text/plain';
 TextOutputType.fallback = false;

--- a/blocks/textfile-block/features/textfile/text.js
+++ b/blocks/textfile-block/features/textfile/text.js
@@ -1,11 +1,10 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
+// capital Text used here because (Jason Young: editor saves that key into their db)
+// This file was changed from a jsx to js file
 const Textfile = ({ customFields }) => {
   const { Text = '' } = customFields || {};
-  return (
-    <>{ Text }</>
-  );
+  return Text;
 };
 
 Textfile.label = 'Text File – Arc Block';


### PR DESCRIPTION
## Description
This is a fix for an issue that was raised in testing with [TMEDIA-85](https://arcpublishing.atlassian.net/browse/TMEDIA-85) re: textfile-block using text-output-block's output type

## Jira Ticket
- [TMEDIA-85](https://arcpublishing.atlassian.net/browse/TMEDIA-85)

## Acceptance Criteria
textfile-block should properly output text using the text output type.

## Test Steps
1. Checkout this branch `git checkout TMEDIA-85-testing-fix`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/text-output-block,@wpmedia/textfile-block`
3. Open http://localhost/pagebuilder/editor/curate?p=pttbqjhVPwEzqWD6s&v=v5DlpCUcgEzqWD6s and change the output type to text then preview.

## Effect Of Changes
### Before
![image](https://user-images.githubusercontent.com/2287238/123120247-29c1d200-d412-11eb-84fa-12b3f5346730.png)

### After
![image](https://user-images.githubusercontent.com/2287238/123120431-4d851800-d412-11eb-98bc-ac45b4acef98.png)

## Dependencies or Side Effects
N/A

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
