### PR TITLE
Tmedia 221 promos 

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,6 +1,7 @@
 {
   "plugins": [
     ["@babel/plugin-proposal-private-property-in-object", { "loose": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }]
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-nullish-coalescing-operator"
   ]
 }

--- a/.storybook/alias/content.js
+++ b/.storybook/alias/content.js
@@ -25,10 +25,10 @@ export const useContent = ({ query }) => {
 		return mediumPromoMock;
 	}
 
-  if (query.feature === 'large-promo') {
-    return largePromoMock;
-  }
-  
+	if (query.feature === 'large-promo') {
+		return largePromoMock;
+	}
+
 	if (query.feature === 'extra-large-promo') {
 		return extraLargePromo;
 	}

--- a/.storybook/alias/content.js
+++ b/.storybook/alias/content.js
@@ -1,5 +1,6 @@
 import { footerContentMock } from '../mock-content/footer';
 import { smallPromoMock } from '../mock-content/smallPromo';
+import { extraLargePromo } from '../mock-content/extraLargePromo';
 
 export const useEditableContent = () => {
 	return {
@@ -18,6 +19,10 @@ export const useContent = ({ query }) => {
 	if ( query.feature === 'small-promo' ) {
 		return smallPromoMock;
 	}
+
+  if (query.feature === 'extra-large-promo') {
+    return extraLargePromo;
+  }
 
 	if (query.raw_image_url === 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG' ) {
 		return {

--- a/.storybook/alias/content.js
+++ b/.storybook/alias/content.js
@@ -1,5 +1,6 @@
 import { footerContentMock } from '../mock-content/footer';
 import { smallPromoMock } from '../mock-content/smallPromo';
+import { mediumPromoMock } from '../mock-content/mediumPromo';
 import { extraLargePromo } from '../mock-content/extraLargePromo';
 
 export const useEditableContent = () => {
@@ -19,10 +20,12 @@ export const useContent = ({ query }) => {
 	if ( query.feature === 'small-promo' ) {
 		return smallPromoMock;
 	}
-
-  if (query.feature === 'extra-large-promo') {
-    return extraLargePromo;
-  }
+	if ( query.feature === 'medium-promo' ) {
+		return mediumPromoMock;
+	}
+	if (query.feature === 'extra-large-promo') {
+		return extraLargePromo;
+	}
 
 	if (query.raw_image_url === 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG' ) {
 		return {

--- a/.storybook/alias/content.js
+++ b/.storybook/alias/content.js
@@ -2,6 +2,7 @@ import { footerContentMock } from '../mock-content/footer';
 import { smallPromoMock } from '../mock-content/smallPromo';
 import { mediumPromoMock } from '../mock-content/mediumPromo';
 import { extraLargePromo } from '../mock-content/extraLargePromo';
+import { largePromoMock } from '../mock-content/largePromo';
 
 export const useEditableContent = () => {
 	return {
@@ -23,6 +24,11 @@ export const useContent = ({ query }) => {
 	if ( query.feature === 'medium-promo' ) {
 		return mediumPromoMock;
 	}
+
+  if (query.feature === 'large-promo') {
+    return largePromoMock;
+  }
+  
 	if (query.feature === 'extra-large-promo') {
 		return extraLargePromo;
 	}

--- a/.storybook/alias/content.js
+++ b/.storybook/alias/content.js
@@ -3,12 +3,24 @@ import { footerContentMock } from '../mock-content/footer';
 export const useEditableContent = () => {
 	return {
 		editableContent: () => {},
+		searchableField: () => {},
 	}
 };
 
 export const useContent = ({ query }) => {
-  if ( query.feature === 'footer' ) {
-    return footerContentMock;
-  }
+	if ( query.feature === 'footer' ) {
+		return footerContentMock;
+	}
+
+	if (query.raw_image_url === 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG' ) {
+		return {
+			'274x154': 'LBTiSxaxr1Eo-tEz9BKFCnZNArw=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+			'274x183': 'Z3YDeb5U67phnWn-jjZ1D3raqLg=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+			'274x206': 'bg-hZozUyDasSC82dzGY6h7OzQE=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+			'377x212': 'Cs3j2blNOos8oV4gL9mNQQGcVOo=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+			'377x251': 'YoPu3mRVQwa3LClZJb0auXux-Fc=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+			'377x283': 'DIOvLGCX55M5sj_OH0IcRNvugP4=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+		}
+	}
 	return {}
 };

--- a/.storybook/alias/content.js
+++ b/.storybook/alias/content.js
@@ -1,4 +1,5 @@
 import { footerContentMock } from '../mock-content/footer';
+import { smallPromoMock } from '../mock-content/smallPromo';
 
 export const useEditableContent = () => {
 	return {
@@ -8,8 +9,14 @@ export const useEditableContent = () => {
 };
 
 export const useContent = ({ query }) => {
+	if (!query) {
+		return {};
+	}
 	if ( query.feature === 'footer' ) {
 		return footerContentMock;
+	}
+	if ( query.feature === 'small-promo' ) {
+		return smallPromoMock;
 	}
 
 	if (query.raw_image_url === 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG' ) {

--- a/.storybook/alias/properties.js
+++ b/.storybook/alias/properties.js
@@ -1,4 +1,5 @@
 export default (site) => ({
+	resizerURL: 'https://corecomponents-the-prophet-prod.cdn.arcpublishing.com/resizer',
 	websiteDomain: '',
 	websiteName: '',
 	facebookPage: true,

--- a/.storybook/mock-content/extraLargePromo.js
+++ b/.storybook/mock-content/extraLargePromo.js
@@ -1,0 +1,62 @@
+export const extraLargePromo = {
+  "_id": "K2FFSIYSVRC7HIBZBXLQ2CUPTY",
+  "credits": {
+    "by": [
+      {
+        "_id": "saracarothers",
+        "additional_properties": {
+          "original": {
+            "byline": "Sara Lynn Carothers"
+          }
+        },
+        "name": "Sara Carothers",
+        "type": "author",
+        "url": "/author/sara-carothers/"
+      }
+    ]
+  },
+  "description": {
+    "basic": "This story has only a basic promo image (a large rock on the beach). This image should be seen in promo blocks, as well as in the Lead Art spot on the article page, and as the social promo image."
+  },
+  "display_date": "2021-04-23T21:13:31.477Z",
+  "headlines": {
+    "basic": "basic promo image"
+  },
+  "label": {
+    "basic": {
+      "display": true,
+      "text": "Free"
+    }
+  },
+  "owner": {
+    "sponsored": false
+  },
+  "promo_items": {
+    "basic": {
+      "resized_params": {
+        "400x225": "Ajb8uwIAZ0XSQ8IPqWGLLW7NifQ=filters:format(jpg):quality(70)/",
+        "400x267": "_iFZPwsbU19A0A9D1xRlPLhVx8A=filters:format(jpg):quality(70)/",
+        "400x300": "i-eI-H-xOkI6EyCk-Ph98hBjjRg=filters:format(jpg):quality(70)/",
+        "600x338": "cwoIRHNCzgkrRQCiW3SogwZS1AY=filters:format(jpg):quality(70)/",
+        "600x400": "WxcB_Wff18LDqZt1wd3JH8vPTZI=filters:format(jpg):quality(70)/",
+        "600x450": "LRgGYobwJDQZyfeEhtalyrn3Ad0=filters:format(jpg):quality(70)/",
+        "800x450": "vvQrhtG0ck1TcO519Mo2dZQCRTE=filters:format(jpg):quality(70)/",
+        "800x533": "LQ2EhhmbD5brfMTBNwl_PT8Tkdg=filters:format(jpg):quality(70)/",
+        "800x600": "AjVgpLNL9WYSLNei-Ks_kwDEa7Q=filters:format(jpg):quality(70)/"
+      },
+      "type": "image",
+      "url": "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/RYNL5SXYCVDH7LCJPXAHYF3DJI.JPG"
+    }
+  },
+  "type": "story",
+  "website_url": "/test/promo-image-variations/2021/04/23/basic-promo-image/",
+  "websites": {
+    "the-gazette": {
+      "website_section": {
+        "_id": "/test/promo-image-variations",
+        "name": "Promo image variations"
+      },
+      "website_url": "/test/promo-image-variations/2021/04/23/basic-promo-image/"
+    }
+  }
+}

--- a/.storybook/mock-content/largePromo.js
+++ b/.storybook/mock-content/largePromo.js
@@ -1,0 +1,81 @@
+export const largePromoMock = {
+  _id: "GHRBLTO6MNGV5G65F5D5XFX4SU",
+  "credits": {
+  "by": [
+    {
+    "_id": "saracarothers",
+    "additional_properties": {
+      "original": {
+        "byline": "Sara Lynn Carothers"
+      }
+          },
+          "name": "Sara Carothers",
+          "type": "author",
+          "url": "/author/sara-carothers/"
+        },
+        {
+          "_id": "5IWXTLUXWNAZTN45YUTJBZM3JM",
+          "additional_properties": {
+            "original": {
+              "byline": "Taylor Doe"
+            }
+          },
+          "name": "Taylor Doe",
+          "type": "author",
+          "url": "/author/taylor-doe/"
+        },
+        {
+          "_id": "john-doe",
+          "additional_properties": {
+            "original": {
+              "byline": "John M Doe"
+            }
+          },
+          "name": "John Doe",
+          "type": "author",
+          "url": "/author/john-m-doe/"
+        }
+      ]
+  },
+  "description": {
+    "basic": "This is a test story that can be used for breaking news situations like if a new baby panda was born."
+  },
+  "display_date": "2019-12-02T18:58:11.638Z",
+  "headlines": {
+    "basic": "Baby panda born at the zoo"
+  },
+  "label": {
+    "basic": {
+      "display": true,
+      "text": "Exclusive"
+    }
+  },
+  "owner": {
+    "sponsored": false
+  },
+  "promo_items": {
+    "basic": {
+      "resized_params": {
+        "274x154": "EfMJE6Iiv4GxwSe15iCDxBnN2ag=filters:format(jpg):quality(70)/",
+        "274x183": "a0vSW5PVOKTguW9d5fVcZO-61L4=filters:format(jpg):quality(70)/",
+        "274x206": "Uq6qFBw-w6VLN6hhAt0sjSt5UXs=filters:format(jpg):quality(70)/",
+        "377x212": "6hCESxDFY823IfORYxfAE__fhPw=filters:format(jpg):quality(70)/",
+        "377x251": "oKOQKByIKv7SDRQ3XezELPSAs_o=filters:format(jpg):quality(70)/",
+        "377x283": "kJ48hfQYVtqL6H_kUy06_Od9GIU=filters:format(jpg):quality(70)/"
+      },
+      "type": "image",
+      "url": "https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CLPUNWMKOZHWPLFYKRZXW6XTNU.jpg"
+    }
+  },
+  "type": "story",
+  "website_url": "/2019/12/02/baby-panda-born-at-the-zoo/",
+  "websites": {
+    "the-sun": {
+      "website_section": {
+        "_id": "/health",
+        "name": "Health"
+      },
+      "website_url": "/2019/12/02/baby-panda-born-at-the-zoo/"
+    }
+  }
+};

--- a/.storybook/mock-content/mediumPromo.js
+++ b/.storybook/mock-content/mediumPromo.js
@@ -1,0 +1,54 @@
+export const mediumPromoMock = {
+	_id: "DLFEXGWKDFF5PI2PCYT2G7VUZI",
+	credits: {
+		by: [{
+			"_id": "saracarothers",
+			"additional_properties": {
+				"original": {
+					"byline": "Sara Lynn Carothers"
+				}
+			},
+			"name": "Sara Carothers",
+			type: "author",
+			"url": "/author/sara-carothers/"
+		},
+		{
+			"_id": "armust",
+			"additional_properties": {
+				"original": {
+					"byline": "Teo Armus"
+				}
+			},
+			"name": "Teo Armus",
+			"type": "author",
+			"url": "/author/teo-armus/"
+		}]
+	},
+	"description": {
+		"basic": "One of the highest paved roads in Europe, this mountain pass makes for a thrilling road trip into the misty mountains above the Adriatic and Ionian seas."
+	},
+	"display_date": "2020-01-14T18:57:08.388Z",
+	"headlines": {
+		"basic": "In Albania, age-old traditions and Mediterranean beaches on the cheap "
+	},
+	"promo_items": {
+		"basic": {
+			"resized_params": {
+				"274x154": "LBTiSxaxr1Eo-tEz9BKFCnZNArw=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/",
+				"274x183": "Z3YDeb5U67phnWn-jjZ1D3raqLg=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/",
+				"274x206": "bg-hZozUyDasSC82dzGY6h7OzQE=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/",
+				"400x225": "0h3vL_qyc8pjZN_cnwYgHECxICA=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/",
+				"400x267": "SBSiikbg6B9BLxiEqnZhBDbOelY=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/",
+				"400x300": "4oA14YOFAWISqfWe7GayPCW-l9k=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/"
+			},
+			"type": "image",
+			"url": "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG"
+		}
+	},
+	"type": "story",
+	"websites": {
+		"the-gazette": {
+			"website_url": "/local/2020/01/14/in-albania-age-old-traditions-and-mediterranean-beaches-on-the-cheap/"
+		}
+	}
+};

--- a/.storybook/mock-content/smallPromo.js
+++ b/.storybook/mock-content/smallPromo.js
@@ -1,0 +1,30 @@
+export const smallPromoMock = {
+	_id: 'DLFEXGWKDFF5PI2PCYT2G7VUZI',
+	description: {
+		basic: 'One of the highest paved roads in Europe, this mountain pass makes for a thrilling road trip into the misty mountains above the Adriatic and Ionian seas.'
+	},
+	display_date: '2020-01-14T18:57:08.388Z',
+	headlines: {
+		basic: 'In Albania, age-old traditions and Mediterranean beaches on the cheap '
+	},
+	promo_items: {
+		basic: {
+			resized_params: {
+				'274x154': 'LBTiSxaxr1Eo-tEz9BKFCnZNArw=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+				'274x183': 'Z3YDeb5U67phnWn-jjZ1D3raqLg=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+				'274x206': 'bg-hZozUyDasSC82dzGY6h7OzQE=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+				'400x225': '0h3vL_qyc8pjZN_cnwYgHECxICA=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+				'400x267': 'SBSiikbg6B9BLxiEqnZhBDbOelY=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+				'400x300': '4oA14YOFAWISqfWe7GayPCW-l9k=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/'
+			},
+			type: 'image',
+			url: 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG'
+		}
+	},
+	type: 'story',
+	websites: {
+		'the-gazette': {
+			website_url: '/local/2020/01/14/in-albania-age-old-traditions-and-mediterranean-beaches-on-the-cheap/'
+		}
+	}
+}

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
 import { useEditableContent, useContent } from 'fusion:content';
 
 import { useFusionContext } from 'fusion:context';

--- a/blocks/extra-large-promo-block/index.story.jsx
+++ b/blocks/extra-large-promo-block/index.story.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import Promo from './features/extra-large-promo/default';
+
+export default {
+  title: 'Blocks/Extra Large Promo',
+};
+
+export const noRenderPromo = () => (
+  <Promo customFields={null} />
+);

--- a/blocks/extra-large-promo-block/index.story.jsx
+++ b/blocks/extra-large-promo-block/index.story.jsx
@@ -1,11 +1,107 @@
 import React from 'react';
-
 import Promo from './features/extra-large-promo/default';
 
 export default {
   title: 'Blocks/Extra Large Promo',
 };
 
+const allCustomFields = {
+  itemContentConfig: {
+    contentService:
+    'content-api',
+    contentConfigValues: { _id: 'K2FFSIYSVRC7HIBZBXLQ2CUPTY' },
+  },
+  showOverline: false,
+  showHeadline: false,
+  showImage: false,
+  showDescription: false,
+  showByline: false,
+  showDate: false,
+  imageRatio: '3:2',
+  pbInternal_cloneId: 'f0fCpmDYaTYpUa',
+};
+
 export const noRenderPromo = () => (
-  <Promo customFields={null} />
+  <Promo customFields={allCustomFields} />
 );
+
+export const allFields = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showOverline: true,
+    showHeadline: true,
+    showImage: true,
+    showDescription: true,
+    showByline: true,
+    showDate: true,
+  };
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const onlyImage = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showImage: true,
+  };
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const showOverline = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showOverline: true,
+  };
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const showHeadline = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showHeadline: true,
+  };
+
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const showDescription = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showDescription: true,
+  };
+
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const imageAndHeadline = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const imageAndDescription = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showDescription: true,
+    showImage: true,
+  };
+
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};

--- a/blocks/extra-large-promo-block/index.story.jsx
+++ b/blocks/extra-large-promo-block/index.story.jsx
@@ -21,10 +21,6 @@ const allCustomFields = {
   pbInternal_cloneId: 'f0fCpmDYaTYpUa',
 };
 
-export const noRenderPromo = () => (
-  <Promo customFields={allCustomFields} />
-);
-
 export const allFields = () => {
   const updatedCustomFields = {
     ...allCustomFields,

--- a/blocks/extra-large-promo-block/package.json
+++ b/blocks/extra-large-promo-block/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/byline-block": "*",
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/shared-styles": "*",

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
 import { useFusionContext } from 'fusion:context';
 import { useEditableContent } from 'fusion:content';
 import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';

--- a/blocks/large-manual-promo-block/index.story.jsx
+++ b/blocks/large-manual-promo-block/index.story.jsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import LargeManualPromo from './features/large-manual-promo/default';
+
+export default {
+  title: 'Blocks/Large Manual Promo',
+  decorators: [withKnobs],
+};
+
+const sampleData = {
+  showOverline: false,
+  showHeadline: false,
+  showImage: false,
+  showDescription: false,
+  headline: 'This is the headline',
+  description: 'This is the description',
+  overline: 'overline',
+  overlineURL: 'www.google.com',
+  imageURL: 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG',
+  linkURL: 'www.google.com',
+};
+
+export const allFields = () => {
+  const customFields = {
+    ...sampleData,
+    showOverline: true,
+    showHeadline: true,
+    showImage: true,
+    showDescription: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const onlyImage = () => {
+  const customFields = {
+    ...sampleData,
+    showImage: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const imageAndHeadline = () => {
+  const customFields = {
+    ...sampleData,
+    showImage: true,
+    showHeadline: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const imageAndOverline = () => {
+  const customFields = {
+    ...sampleData,
+    showImage: true,
+    showOverline: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const imageAndDescription = () => {
+  const customFields = {
+    ...sampleData,
+    showImage: true,
+    showDescription: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const imageHeadlineAndOverline = () => {
+  const customFields = {
+    ...sampleData,
+    showImage: true,
+    showHeadline: true,
+    showOverline: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const imageHeadlineAndDescription = () => {
+  const customFields = {
+    ...sampleData,
+    showImage: true,
+    showHeadline: true,
+    showDescription: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const onlyOverline = () => {
+  const customFields = {
+    ...sampleData,
+    showOverline: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const onlyHeadline = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const headlineAndDescription = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showDescription: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const headlineDescriptionAndOverline = () => {
+  const customFields = {
+    ...sampleData,
+    showOverline: true,
+    showHeadline: true,
+    showDescription: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};
+
+export const onlyDescription = () => {
+  const customFields = {
+    ...sampleData,
+    showDescription: true,
+  };
+
+  return (
+    <LargeManualPromo customFields={customFields} />
+  );
+};

--- a/blocks/large-manual-promo-block/package.json
+++ b/blocks/large-manual-promo-block/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",
     "@wpmedia/resizer-image-block": "*",

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
 import { useEditableContent, useContent } from 'fusion:content';
 import { useFusionContext } from 'fusion:context';
 

--- a/blocks/large-promo-block/index.story.jsx
+++ b/blocks/large-promo-block/index.story.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import Promo from './features/large-promo/default';
+
+export default {
+  title: 'Blocks/Large Promo',
+};
+
+const allCustomFields = {
+  itemContentConfig: {
+    contentService: 'content-api',
+    contentConfigValues: {
+      _id: '',
+      website_url: '/2019/12/02/baby-panda-born-at-the-zoo/',
+    },
+  },
+  showOverline: false,
+  showHeadline: false,
+  showImage: false,
+  showDescription: false,
+  showByline: false,
+  showDate: false,
+  imageRatio: '4:3',
+};
+
+export const allFields = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showOverline: true,
+    showHeadline: true,
+    showImage: true,
+    showDescription: true,
+    showByline: true,
+    showDate: true,
+  };
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const onlyImage = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showImage: true,
+  };
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const showOverline = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showOverline: true,
+  };
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const showHeadline = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showHeadline: true,
+  };
+
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const showDescription = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showDescription: true,
+  };
+
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const imageAndHeadline = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};
+
+export const imageAndDescription = () => {
+  const updatedCustomFields = {
+    ...allCustomFields,
+    showDescription: true,
+    showImage: true,
+  };
+
+  return (
+    <Promo customFields={updatedCustomFields} />
+  );
+};

--- a/blocks/large-promo-block/index.story.jsx
+++ b/blocks/large-promo-block/index.story.jsx
@@ -3,6 +3,10 @@ import Promo from './features/large-promo/default';
 
 export default {
   title: 'Blocks/Large Promo',
+  parameters: {
+    // Set the viewports in Chromatic at a component level.
+    chromatic: { viewports: [320, 1200] },
+  },
 };
 
 const allCustomFields = {

--- a/blocks/large-promo-block/package.json
+++ b/blocks/large-promo-block/package.json
@@ -10,8 +10,7 @@
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "features",
-    "intl.json"
+    "features"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
@@ -27,6 +26,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/byline-block": "*",
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
 import { useEditableContent, useContent } from 'fusion:content';
 import { useFusionContext } from 'fusion:context';
 

--- a/blocks/medium-promo-block/index.story.jsx
+++ b/blocks/medium-promo-block/index.story.jsx
@@ -5,6 +5,10 @@ import MediumPromo from './features/medium-promo/default';
 export default {
   title: 'Blocks/Medium Promo',
   decorators: [withKnobs],
+  parameters: {
+    // Set the viewports in Chromatic at a component level.
+    chromatic: { viewports: [320, 1200] },
+  },
 };
 
 const sampleData = {

--- a/blocks/medium-promo-block/index.story.jsx
+++ b/blocks/medium-promo-block/index.story.jsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import Medium from './features/medium-promo/default';
+
+export default {
+  title: 'Blocks/Medium Promo',
+  decorators: [withKnobs],
+};
+
+const sampleData = {
+  showHeadline: false,
+  showImage: false,
+  showDescription: false,
+  showByline: false,
+  showDate: false,
+  imageOverrideURL: '',
+  imageRatio: '16:9',
+  itemContentConfig: {
+    contentService: 'abc',
+    contentConfigValues: 'xyz',
+  },
+};
+
+export const allFields = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showImage: true,
+    showDescription: true,
+    showByline: true,
+    showDate: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const image4x3 = () => {
+  const customFields = {
+    ...sampleData,
+    imageRatio: '4:3',
+    showHeadline: true,
+    showImage: true,
+    showDescription: true,
+    showByline: true,
+    showDate: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const image3x2 = () => {
+  const customFields = {
+    ...sampleData,
+    imageRatio: '3:2',
+    showHeadline: true,
+    showImage: true,
+    showDescription: true,
+    showByline: true,
+    showDate: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const headlineOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const imageOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showImage: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const descriptionOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showDescription: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const byLineOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showByline: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const dateOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showDate: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const headingImageDescriptionByline = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showImage: true,
+    showDescription: true,
+    showByline: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const headingImageDescriptionDate = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showImage: true,
+    showDescription: true,
+    showDate: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const headingImageByLineDate = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showImage: true,
+    showByline: true,
+    showDate: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const noImage = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showDescription: true,
+    showByline: true,
+    showDate: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const headingAndDescription = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showDescription: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const headingBylineAndDate = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showByline: true,
+    showDate: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const headingAndByLine = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showByline: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};
+
+export const headingAndDate = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showDate: true,
+  };
+
+  return (
+    <Medium customFields={customFields} />
+  );
+};

--- a/blocks/medium-promo-block/index.story.jsx
+++ b/blocks/medium-promo-block/index.story.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
-import Medium from './features/medium-promo/default';
+import MediumPromo from './features/medium-promo/default';
 
 export default {
   title: 'Blocks/Medium Promo',
@@ -32,7 +32,7 @@ export const allFields = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -48,7 +48,7 @@ export const image4x3 = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -64,7 +64,7 @@ export const image3x2 = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -75,7 +75,7 @@ export const headlineOnly = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -86,7 +86,7 @@ export const imageOnly = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -97,7 +97,7 @@ export const descriptionOnly = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -108,7 +108,7 @@ export const byLineOnly = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -119,7 +119,7 @@ export const dateOnly = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -133,7 +133,7 @@ export const headingImageDescriptionByline = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -147,7 +147,7 @@ export const headingImageDescriptionDate = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -161,7 +161,7 @@ export const headingImageByLineDate = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -175,7 +175,7 @@ export const noImage = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -187,7 +187,7 @@ export const headingAndDescription = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -200,7 +200,7 @@ export const headingBylineAndDate = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -212,7 +212,7 @@ export const headingAndByLine = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };
 
@@ -224,6 +224,6 @@ export const headingAndDate = () => {
   };
 
   return (
-    <Medium customFields={customFields} />
+    <MediumPromo customFields={customFields} />
   );
 };

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -7,10 +7,7 @@
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "features",
-    "chains",
-    "layouts",
-    "intl.json"
+    "features"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -26,6 +26,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/byline-block": "*",
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",

--- a/blocks/resizer-image-block/imageRatioCustomField.js
+++ b/blocks/resizer-image-block/imageRatioCustomField.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
 
 const imageRatioLabels = {
   '16:9': '16:9',

--- a/blocks/resizer-image-block/package.json
+++ b/blocks/resizer-image-block/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
   "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/engine-theme-sdk": "*",
     "thumbor-lite": "^0.1.8"
   },

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
 import { useContent, useEditableContent } from 'fusion:content';
 import { useFusionContext } from 'fusion:context';
 import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';

--- a/blocks/small-promo-block/index.story.jsx
+++ b/blocks/small-promo-block/index.story.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import SmallPromo from './features/small-promo/default';
+
+export default {
+  title: 'Blocks/Small Promo',
+  decorators: [withKnobs],
+};
+
+const sampleData = {
+  showHeadline: false,
+  showImage: false,
+  imagePosition: 'right',
+  itemContentConfig: {
+    contentService: 'abc',
+    contentConfigValues: 'xyz',
+  },
+};
+
+export const allFields = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <SmallPromo customFields={customFields} />
+  );
+};
+
+export const headlineOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+  };
+
+  return (
+    <SmallPromo customFields={customFields} />
+  );
+};
+
+export const imageOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showImage: true,
+  };
+
+  return (
+    <SmallPromo customFields={customFields} />
+  );
+};
+
+export const imageLeft = () => {
+  const customFields = {
+    ...sampleData,
+    imagePosition: 'left',
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <SmallPromo customFields={customFields} />
+  );
+};
+
+export const imageAbove = () => {
+  const customFields = {
+    ...sampleData,
+    imagePosition: 'above',
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <SmallPromo customFields={customFields} />
+  );
+};
+
+export const imageBelow = () => {
+  const customFields = {
+    ...sampleData,
+    imagePosition: 'below',
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <SmallPromo customFields={customFields} />
+  );
+};

--- a/blocks/small-promo-block/index.story.jsx
+++ b/blocks/small-promo-block/index.story.jsx
@@ -11,6 +11,7 @@ const sampleData = {
   showHeadline: false,
   showImage: false,
   imagePosition: 'right',
+  imageRatio: '3:2',
   itemContentConfig: {
     contentService: 'abc',
     contentConfigValues: 'xyz',
@@ -20,6 +21,32 @@ const sampleData = {
 export const allFields = () => {
   const customFields = {
     ...sampleData,
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <SmallPromo customFields={customFields} />
+  );
+};
+
+export const image16x9 = () => {
+  const customFields = {
+    ...sampleData,
+    imageRatio: '16:9',
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <SmallPromo customFields={customFields} />
+  );
+};
+
+export const image4x3 = () => {
+  const customFields = {
+    ...sampleData,
+    imageRatio: '4:3',
     showHeadline: true,
     showImage: true,
   };

--- a/blocks/small-promo-block/package.json
+++ b/blocks/small-promo-block/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",
     "@wpmedia/shared-styles": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8757,7 +8757,8 @@
     "@wpmedia/ads-block": {
       "version": "file:blocks/ads-block",
       "requires": {
-        "arcads": "^4.0.0"
+        "arcads": "^4.0.0",
+        "lazy-child": "^0.2.0"
       }
     },
     "@wpmedia/alert-bar-block": {
@@ -22542,7 +22543,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/lazy-child/-/lazy-child-0.2.0.tgz",
       "integrity": "sha512-QOlhECVjMLIS2FNujfZqPXnWBYpd54sv0k4YDgwuPb16CZMMPC5QxNfN/rH0SpfSe3sktK0l6qrOgtScV7eqWQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "react-peekaboo": "^0.3.0"
@@ -23039,8 +23039,7 @@
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
-      "dev": true
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.toarray": {
       "version": "4.4.0",
@@ -26723,7 +26722,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/react-peekaboo/-/react-peekaboo-0.3.0.tgz",
       "integrity": "sha512-Vae3BZ6aBCqAD4F7nWwX0Q8GWHb15p8hgfLiKtp3XF8/iyWhx+9na4Kz15lvoOR12+V7sdYv3BCNv3rG5gK2uA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "lodash.throttle": "^4.1.1"


### PR DESCRIPTION
## Description
Start setup for promos with showing and hiding various custom fields 

## Jira Ticket
- [TMEDIA-221](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-221&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
Add the following promo blocks to the Blocks storybook, and set them up for visual regression testing with Chromatic: 

Extra Large Promo Block

Large Promo Block

Medium Promo Block

Small Promo Block

## Test Steps
- `git checkout TMEDIA-221-promos-mock-regression`
- `npm run storybook`

## Effect Of Changes
### Before
- no visual validation of promos

### After
- some visual validation of promo styles based upon custom fields 

## Dependencies or Side Effects
- none

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
