### PR TITLE
TMEDIA-262 - Update promos and top table list to move headingSection to block level

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -5,7 +5,7 @@ import { useEditableContent } from 'fusion:content';
 import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { imageRatioCustomField } from '@wpmedia/resizer-image-block';
 import {
-  Overline, PromoDescription, PromoHeadline, PromoImage,
+  HeadingSection, Overline, PromoDescription, PromoHeadline, PromoImage,
 } from '@wpmedia/shared-styles';
 
 import '@wpmedia/shared-styles/scss/_extra-large-promo.scss';
@@ -15,7 +15,7 @@ const ExtraLargeManualPromoItem = ({ customFields }) => {
   const { searchableField } = useEditableContent();
 
   return (
-    <>
+    <HeadingSection>
       <article className="container-fluid xl-large-promo xl-large-manual-promo">
         <div className="row">
           {(customFields?.showOverline
@@ -68,7 +68,7 @@ const ExtraLargeManualPromoItem = ({ customFields }) => {
         </div>
       </article>
       <hr />
-    </>
+    </HeadingSection>
   );
 };
 

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -4,7 +4,7 @@ import { useEditableContent, useContent } from 'fusion:content';
 
 import { useFusionContext } from 'fusion:context';
 import {
-  Byline, Overline, PromoDate, PromoDescription, PromoHeadline, PromoImage,
+  Byline, HeadingSection, Overline, PromoDate, PromoDescription, PromoHeadline, PromoImage,
 } from '@wpmedia/shared-styles';
 import {
   extractVideoEmbedFromStory,
@@ -125,7 +125,7 @@ const ExtraLargePromoItem = ({ customFields }) => {
   const videoEmbed = (customFields?.playVideoInPlace && extractVideoEmbedFromStory(content));
 
   return (
-    <>
+    <HeadingSection>
       <article className="container-fluid xl-large-promo">
         <div className="row">
           {(customFields.showOverline
@@ -195,7 +195,7 @@ const ExtraLargePromoItem = ({ customFields }) => {
         </div>
       </article>
       <hr />
-    </>
+    </HeadingSection>
   );
 };
 

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -5,7 +5,7 @@ import { useEditableContent } from 'fusion:content';
 import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { imageRatioCustomField } from '@wpmedia/resizer-image-block';
 import {
-  Overline, PromoDescription, PromoHeadline, PromoImage,
+  HeadingSection, Overline, PromoDescription, PromoHeadline, PromoImage,
 } from '@wpmedia/shared-styles';
 
 import '@wpmedia/shared-styles/scss/_large-promo.scss';
@@ -16,7 +16,7 @@ const LargeManualPromoItem = ({ customFields }) => {
   const textClass = customFields?.showImage ? 'col-sm-12 col-md-xl-6 flex-col' : 'col-sm-xl-12 flex-col';
 
   return (
-    <>
+    <HeadingSection>
       <article className="container-fluid large-promo">
         <div className="row lg-promo-padding-bottom" style={{ position: isAdmin ? 'relative' : null }}>
           {(customFields?.showImage)
@@ -72,7 +72,7 @@ const LargeManualPromoItem = ({ customFields }) => {
         </div>
       </article>
       <hr />
-    </>
+    </HeadingSection>
   );
 };
 

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -13,7 +13,7 @@ import {
 } from '@wpmedia/engine-theme-sdk';
 import { imageRatioCustomField } from '@wpmedia/resizer-image-block';
 import {
-  Byline, Overline, PromoDate, PromoDescription, PromoHeadline, PromoImage,
+  Byline, HeadingSection, Overline, PromoDate, PromoDescription, PromoHeadline, PromoImage,
 } from '@wpmedia/shared-styles';
 
 import '@wpmedia/shared-styles/scss/_large-promo.scss';
@@ -120,7 +120,7 @@ const LargePromoItem = ({ customFields }) => {
   const videoEmbed = customFields?.playVideoInPlace && extractVideoEmbedFromStory(content);
 
   return (
-    <>
+    <HeadingSection>
       <article className="container-fluid large-promo">
         <div className="row">
           {(!!videoEmbed
@@ -185,7 +185,7 @@ const LargePromoItem = ({ customFields }) => {
         </div>
       </article>
       <hr />
-    </>
+    </HeadingSection>
   );
 };
 

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -4,7 +4,9 @@ import { useFusionContext } from 'fusion:context';
 import { useEditableContent } from 'fusion:content';
 import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { imageRatioCustomField } from '@wpmedia/resizer-image-block';
-import { PromoDescription, PromoHeadline, PromoImage } from '@wpmedia/shared-styles';
+import {
+  HeadingSection, PromoDescription, PromoHeadline, PromoImage,
+} from '@wpmedia/shared-styles';
 
 import '@wpmedia/shared-styles/scss/_medium-promo.scss';
 
@@ -15,7 +17,7 @@ const MediumManualPromoItem = ({ customFields }) => {
   const hasImage = customFields?.showImage && customFields?.imageURL;
 
   return (
-    <>
+    <HeadingSection>
       <article className="container-fluid medium-promo" style={{ position: isAdmin ? 'relative' : null }}>
         <div
           className={`medium-promo-wrapper ${hasImage ? 'md-promo-image' : ''}`}
@@ -51,7 +53,7 @@ const MediumManualPromoItem = ({ customFields }) => {
         </div>
       </article>
       <hr />
-    </>
+    </HeadingSection>
   );
 };
 

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -6,7 +6,7 @@ import { useFusionContext } from 'fusion:context';
 import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { imageRatioCustomField } from '@wpmedia/resizer-image-block';
 import {
-  Byline, PromoDate, PromoDescription, PromoHeadline, PromoImage,
+  Byline, HeadingSection, PromoDate, PromoDescription, PromoHeadline, PromoImage,
 } from '@wpmedia/shared-styles';
 
 import '@wpmedia/shared-styles/scss/_medium-promo.scss';
@@ -95,7 +95,7 @@ const MediumPromoItem = ({ customFields }) => {
   }
 
   return (
-    <>
+    <HeadingSection>
       <article className="container-fluid medium-promo">
         <div className={`medium-promo-wrapper ${customFields?.showImage ? 'md-promo-image' : ''}`} style={{ position: isAdmin ? 'relative' : null }}>
           {customFields?.showImage
@@ -142,7 +142,7 @@ const MediumPromoItem = ({ customFields }) => {
         </div>
       </article>
       <hr />
-    </>
+    </HeadingSection>
   );
 };
 

--- a/blocks/shared-styles/_children/promo-headline/index.jsx
+++ b/blocks/shared-styles/_children/promo-headline/index.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { useEditableContent } from 'fusion:content';
 import { useComponentContext, useFusionContext } from 'fusion:context';
 import Heading from '../headings/heading';
-import HeadingSection from '../headings/section';
 
 const PromoHeadline = (props) => {
   const {
@@ -27,25 +26,23 @@ const PromoHeadline = (props) => {
   const editableItem = content?.headlines && editable ? editableContent(content, 'headlines.basic') : {};
 
   return linkText ? (
-    <HeadingSection>
-      <div className={`promo-headline ${className}`}>
-        <Heading
-          className={headingClassName}
-          {...editableItem}
-          suppressContentEditableWarning
+    <div className={`promo-headline ${className}`}>
+      <Heading
+        className={headingClassName}
+        {...editableItem}
+        suppressContentEditableWarning
+      >
+        <a
+          href={linkURL}
+          target={newTab ? '_blank' : '_self'}
+          rel={newTab ? 'noreferrer noopener' : ''}
+          className={linkClassName}
+          onClick={registerSuccessEvent}
         >
-          <a
-            href={linkURL}
-            target={newTab ? '_blank' : '_self'}
-            rel={newTab ? 'noreferrer noopener' : ''}
-            className={linkClassName}
-            onClick={registerSuccessEvent}
-          >
-            {linkText}
-          </a>
-        </Heading>
-      </div>
-    </HeadingSection>
+          {linkText}
+        </a>
+      </Heading>
+    </div>
   ) : null;
 };
 

--- a/blocks/shared-styles/_children/promo-helpers/small/__snapshots__/container.test.jsx.snap
+++ b/blocks/shared-styles/_children/promo-helpers/small/__snapshots__/container.test.jsx.snap
@@ -14,30 +14,32 @@ exports[`SmallPromoContainer default to headline first dom structure by default 
     />
   }
 >
-  <article
-    className="container-fluid small-promo"
-  >
-    <div
-      className="row"
+  <HeadingSection>
+    <article
+      className="container-fluid small-promo"
     >
       <div
-        className="col-sm-xl-8"
+        className="row"
       >
-        <h1>
-          mockHeadline
-        </h1>
+        <div
+          className="col-sm-xl-8"
+        >
+          <h1>
+            mockHeadline
+          </h1>
+        </div>
+        <div
+          className="col-sm-xl-4"
+        >
+          <img
+            alt="mock image"
+            href="mocklink.jpg"
+          />
+        </div>
       </div>
-      <div
-        className="col-sm-xl-4"
-      >
-        <img
-          alt="mock image"
-          href="mocklink.jpg"
-        />
-      </div>
-    </div>
-  </article>
-  <hr />
+    </article>
+    <hr />
+  </HeadingSection>
 </SmallPromoContainer>
 `;
 
@@ -56,26 +58,28 @@ exports[`SmallPromoContainer render headline first if image position is below 1`
   }
   imagePosition="below"
 >
-  <article
-    className="container-fluid small-promo"
-  >
-    <div
-      className="col-sm-xl-8"
+  <HeadingSection>
+    <article
+      className="container-fluid small-promo"
     >
-      <h1>
-        mockHeadline
-      </h1>
-    </div>
-    <div
-      className="col-sm-xl-4"
-    >
-      <img
-        alt="mock image"
-        href="mocklink.jpg"
-      />
-    </div>
-  </article>
-  <hr />
+      <div
+        className="col-sm-xl-8"
+      >
+        <h1>
+          mockHeadline
+        </h1>
+      </div>
+      <div
+        className="col-sm-xl-4"
+      >
+        <img
+          alt="mock image"
+          href="mocklink.jpg"
+        />
+      </div>
+    </article>
+    <hr />
+  </HeadingSection>
 </SmallPromoContainer>
 `;
 
@@ -94,26 +98,28 @@ exports[`SmallPromoContainer render image first if image position is above 1`] =
   }
   imagePosition="above"
 >
-  <article
-    className="container-fluid small-promo"
-  >
-    <div
-      className="col-sm-xl-4"
+  <HeadingSection>
+    <article
+      className="container-fluid small-promo"
     >
-      <img
-        alt="mock image"
-        href="mocklink.jpg"
-      />
-    </div>
-    <div
-      className="col-sm-xl-8"
-    >
-      <h1>
-        mockHeadline
-      </h1>
-    </div>
-  </article>
-  <hr />
+      <div
+        className="col-sm-xl-4"
+      >
+        <img
+          alt="mock image"
+          href="mocklink.jpg"
+        />
+      </div>
+      <div
+        className="col-sm-xl-8"
+      >
+        <h1>
+          mockHeadline
+        </h1>
+      </div>
+    </article>
+    <hr />
+  </HeadingSection>
 </SmallPromoContainer>
 `;
 
@@ -132,30 +138,32 @@ exports[`SmallPromoContainer render image first if image position is on left 1`]
   }
   imagePosition="left"
 >
-  <article
-    className="container-fluid small-promo"
-  >
-    <div
-      className="row"
+  <HeadingSection>
+    <article
+      className="container-fluid small-promo"
     >
       <div
-        className="col-sm-xl-4"
+        className="row"
       >
-        <img
-          alt="mock image"
-          href="mocklink.jpg"
-        />
+        <div
+          className="col-sm-xl-4"
+        >
+          <img
+            alt="mock image"
+            href="mocklink.jpg"
+          />
+        </div>
+        <div
+          className="col-sm-xl-8"
+        >
+          <h1>
+            mockHeadline
+          </h1>
+        </div>
       </div>
-      <div
-        className="col-sm-xl-8"
-      >
-        <h1>
-          mockHeadline
-        </h1>
-      </div>
-    </div>
-  </article>
-  <hr />
+    </article>
+    <hr />
+  </HeadingSection>
 </SmallPromoContainer>
 `;
 
@@ -168,20 +176,22 @@ exports[`SmallPromoContainer renders with no image 1`] = `
   }
   imagePosition="above"
 >
-  <article
-    className="container-fluid small-promo"
-  >
-    <div
-      className="col-sm-xl-4"
-    />
-    <div
-      className="col-sm-xl-12"
+  <HeadingSection>
+    <article
+      className="container-fluid small-promo"
     >
-      <h1>
-        mockHeadline
-      </h1>
-    </div>
-  </article>
-  <hr />
+      <div
+        className="col-sm-xl-4"
+      />
+      <div
+        className="col-sm-xl-12"
+      >
+        <h1>
+          mockHeadline
+        </h1>
+      </div>
+    </article>
+    <hr />
+  </HeadingSection>
 </SmallPromoContainer>
 `;

--- a/blocks/shared-styles/_children/promo-helpers/small/container.jsx
+++ b/blocks/shared-styles/_children/promo-helpers/small/container.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import HeadingSection from '../../headings/section';
 
 import '@wpmedia/shared-styles/scss/_small-promo.scss';
 
@@ -41,12 +42,12 @@ function SmallPromoContainer({ headline, image, imagePosition = 'right' }) {
   }
 
   return (
-    <>
+    <HeadingSection>
       <article className="container-fluid small-promo">
         {output}
       </article>
       <hr />
-    </>
+    </HeadingSection>
   );
 }
 export default SmallPromoContainer;

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.jsx
@@ -6,7 +6,7 @@ import {
   videoPlayerCustomFieldTags,
 } from '@wpmedia/engine-theme-sdk';
 import {
-  Byline, Overline, PromoDate, PromoDescription, PromoHeadline, PromoImage,
+  Byline, HeadingSection, Overline, PromoDate, PromoDescription, PromoHeadline, PromoImage,
 } from '@wpmedia/shared-styles';
 
 const HorizontalOverlineImageStoryItem = (props) => {
@@ -26,7 +26,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
     && extractVideoEmbedFromStory(element);
 
   return (
-    <>
+    <HeadingSection>
       <article key={id} className="container-fluid large-promo">
         <div className="promo-item-margins row lg-promo-padding-bottom">
           {(!!videoEmbed || customFields?.showImageLG)
@@ -98,7 +98,7 @@ const HorizontalOverlineImageStoryItem = (props) => {
         </div>
       </article>
       <hr className={!showBottomBorder ? 'hr-borderless' : ''} />
-    </>
+    </HeadingSection>
   );
 };
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/horizontal-overline-image-story-item.test.jsx
@@ -104,7 +104,7 @@ describe('horizontal overline image story item', () => {
     expect(wrapper.find('a.lg-promo-headline').length).toBe(1);
     expect(wrapper.find('a.lg-promo-headline').prop('href')).toBe(websiteURL);
 
-    expect(wrapper.find('HorizontalOverlineImageStoryItem > hr').length).toBe(1);
+    expect(wrapper.find('hr').length).toBe(1);
     expect(wrapper.find('Image')).toHaveLength(1);
     expect(wrapper.find('VideoPlayer')).toHaveLength(0);
   });
@@ -194,7 +194,7 @@ describe('horizontal overline image story item', () => {
     // does not find overline
     expect(wrapper.find('a.overline').length).toBe(0);
 
-    expect(wrapper.find('HorizontalOverlineImageStoryItem > hr').length).toBe(1);
+    expect(wrapper.find('hr').length).toBe(1);
   });
 
   it('renders VideoPlayer when type "story" with video lead art', () => {

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Byline, PromoDate, PromoDescription, PromoHeadline, PromoImage,
+  Byline, HeadingSection, PromoDate, PromoDescription, PromoHeadline, PromoImage,
 } from '@wpmedia/shared-styles';
 
 const MediumListItem = (props) => {
@@ -12,7 +12,7 @@ const MediumListItem = (props) => {
   const showBottomBorder = (typeof customFields.showBottomBorderMD === 'undefined') ? true : customFields.showBottomBorderMD;
 
   return (
-    <>
+    <HeadingSection>
       <article className="container-fluid medium-promo" key={id}>
         <div className={`promo-item-margins medium-promo-wrapper ${customFields.showImageMD ? 'md-promo-image' : ''}`}>
           {customFields.showImageMD
@@ -61,7 +61,7 @@ const MediumListItem = (props) => {
         </div>
       </article>
       <hr className={!showBottomBorder ? 'hr-borderless' : ''} />
-    </>
+    </HeadingSection>
   );
 };
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium-list-item.test.jsx
@@ -140,7 +140,7 @@ describe('medium list item', () => {
     // finds description text
     expect(wrapper.find('PromoDescription').text()).toBe(descriptionText);
 
-    expect(wrapper.find('MediumListItem > hr').length).toBe(1);
+    expect(wrapper.find('hr').length).toBe(1);
   });
 
   // it('headline has class headline-above when headline position is above', () => {
@@ -245,7 +245,7 @@ describe('medium list item', () => {
     // doesn't find a headline
     expect(wrapper.find('a.md-promo-headline').length).toBe(0);
 
-    expect(wrapper.find('MediumListItem > hr').length).toBe(1);
+    expect(wrapper.find('hr').length).toBe(1);
   });
 
   it('renders image placeholder with empty props with bottom border', () => {
@@ -291,7 +291,7 @@ describe('medium list item', () => {
     expect(wrapper.find('hr').length).toBe(1);
     expect(wrapper.find('hr').hasClass('hr-borderless')).toBe(false);
 
-    expect(wrapper.find('MediumListItem > hr').length).toBe(1);
+    expect(wrapper.find('hr').length).toBe(1);
   });
 
   it('renders image placeholder with empty props without bottom border', () => {
@@ -336,6 +336,6 @@ describe('medium list item', () => {
 
     expect(wrapper.find('hr').hasClass('hr-borderless')).toBe(true);
 
-    expect(wrapper.find('MediumListItem > hr').length).toBe(1);
+    expect(wrapper.find('hr').length).toBe(1);
   });
 });

--- a/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PromoHeadline, PromoImage } from '@wpmedia/shared-styles';
+import { HeadingSection, PromoHeadline, PromoImage } from '@wpmedia/shared-styles';
 import {
   LEFT, RIGHT, ABOVE, BELOW,
 } from '../shared/imagePositionConstants';
@@ -46,26 +46,28 @@ const SmallListItem = (props) => {
   ) : null;
 
   return (
-    <article
-      key={id}
-      className={`top-table-list-small-promo small-promo ${colClasses} ${layout}`}
-    >
-      <div className={`promo-container row ${layout} ${imagePosition === BELOW ? 'image-below' : ''} sm-promo-padding-btm`}>
-        {imagePosition === ABOVE || imagePosition === LEFT ? (
-          <>
-            {Image}
-            {Headline}
-          </>
-        )
-          : (
+    <HeadingSection>
+      <article
+        key={id}
+        className={`top-table-list-small-promo small-promo ${colClasses} ${layout}`}
+      >
+        <div className={`promo-container row ${layout} ${imagePosition === BELOW ? 'image-below' : ''} sm-promo-padding-btm`}>
+          {imagePosition === ABOVE || imagePosition === LEFT ? (
             <>
-              {Headline}
               {Image}
+              {Headline}
             </>
-          )}
-      </div>
-      <hr className={!showBottomBorder ? 'hr-borderless' : ''} />
-    </article>
+          )
+            : (
+              <>
+                {Headline}
+                {Image}
+              </>
+            )}
+        </div>
+        <hr className={!showBottomBorder ? 'hr-borderless' : ''} />
+      </article>
+    </HeadingSection>
   );
 };
 export default SmallListItem;

--- a/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.test.jsx
@@ -103,7 +103,7 @@ describe('small image block', () => {
     expect(wrapper.find('PromoImage').length).toBe(1);
     expect(wrapper.find('Image').prop('url')).toBe(imageURL);
 
-    expect(wrapper.find('SmallListItem > article > hr').length).toBe(1);
+    expect(wrapper.find('article > hr').length).toBe(1);
   });
 
   it('must renders neither title nor image with empty props, renders placeholder image', () => {
@@ -137,7 +137,7 @@ describe('small image block', () => {
     expect(wrapper.find('PromoImage').length).toBe(1);
     expect(wrapper.find('PromoImage').prop('url')).toBe(fallbackImage);
 
-    expect(wrapper.find('SmallListItem > article > hr').length).toBe(1);
+    expect(wrapper.find('article > hr').length).toBe(1);
   });
 
   it('must render only title if showImageSM false', () => {
@@ -179,7 +179,7 @@ describe('small image block', () => {
     expect(wrapper.find('h2.sm-promo-headline').length).toBe(1);
     expect(wrapper.find('h2.sm-promo-headline').text()).toBe(itemTitle);
     expect(wrapper.find('PromoImage').length).toBe(0);
-    expect(wrapper.find('SmallListItem > article > hr').length).toBe(1);
+    expect(wrapper.find('article > hr').length).toBe(1);
   });
 
   it('must render only image if showHeadlinesSM false', () => {
@@ -219,7 +219,7 @@ describe('small image block', () => {
 
     expect(wrapper.find('h2.sm-promo-headline').length).toBe(0);
     expect(wrapper.find('PromoImage').length).toBe(1);
-    expect(wrapper.find('SmallListItem > article > hr').length).toBe(1);
+    expect(wrapper.find('article > hr').length).toBe(1);
   });
 
   it('must render with layout horizontal if image position is "left" or "right"', () => {

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.jsx
@@ -6,7 +6,7 @@ import {
   videoPlayerCustomFieldTags,
 } from '@wpmedia/engine-theme-sdk';
 import {
-  Byline, Overline, PromoDate, PromoDescription, PromoHeadline, PromoImage,
+  Byline, HeadingSection, Overline, PromoDate, PromoDescription, PromoHeadline, PromoImage,
 } from '@wpmedia/shared-styles';
 
 const VerticalOverlineImageStoryItem = (props) => {
@@ -23,7 +23,7 @@ const VerticalOverlineImageStoryItem = (props) => {
     && extractVideoEmbedFromStory(element);
 
   return (
-    <>
+    <HeadingSection>
       <article className="container-fluid xl-large-promo" key={id}>
         <div className="promo-item-margins row xl-promo-padding-bottom">
           {(customFields?.showHeadlineXL
@@ -91,7 +91,7 @@ const VerticalOverlineImageStoryItem = (props) => {
         </div>
       </article>
       <hr className={!showBottomBorder ? 'hr-borderless' : ''} />
-    </>
+    </HeadingSection>
   );
 };
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/vertical-overline-image-story-item.test.jsx
@@ -106,7 +106,7 @@ describe('vertical overline image story item', () => {
     expect(wrapper.find('a.xl-promo-headline').length).toBe(1);
     expect(wrapper.find('a.xl-promo-headline').props().href).toBe(websiteURL);
 
-    expect(wrapper.find('VerticalOverlineImageStoryItem > hr').length).toBe(1);
+    expect(wrapper.find('hr').length).toBe(1);
     expect(wrapper.find('Image')).toHaveLength(1);
     expect(wrapper.find('VideoPlayer')).toHaveLength(0);
   });
@@ -220,7 +220,7 @@ describe('vertical overline image story item', () => {
     // finds overline
     expect(wrapper.find('a.overline').length).toBe(0);
 
-    expect(wrapper.find('VerticalOverlineImageStoryItem > hr').length).toBe(1);
+    expect(wrapper.find('hr').length).toBe(1);
   });
 
   it('renders VideoPlayer when type "story" with video lead art', () => {


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Updated Promo blocks to be wrapped in `HeadingSection` to ensure any `Heading` element inside maintain their hierarchy

## Jira Ticket
- [TMEDIA-262](https://arcpublishing.atlassian.net/browse/TMEDIA-262)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-262-promos-to-use-heading-section`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles,@wpmedia/extra-large-promo-block,@wpmedia/large-promo-block,@wpmedia/medium-promo-block,@wpmedia/small-promo-block,@wpmedia/extra-large-manual-promo-block,@wpmedia/large-manual-promo-block,@wpmedia/medium-manual-promo-block,@wpmedia/small-manual-promo-block,@wpmedia/top-table-list-block`
3. Validate heading hierarchy is maintain correctly - http://localhost/all-blocks/?_website=the-gazette

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
