### PR TITLE
TMEDIA-277 - Fix small promo 1 per row output, also border alignment

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -24,6 +24,18 @@
           "none"
         ]
       }
+    ],
+    "value-no-vendor-prefix": [
+      true,
+      {
+        "ignore": ["-webkit-box"]
+      }
+    ],
+    "property-no-vendor-prefix": [
+      true,
+      {
+        "ignoreProperties": ["box-orient"]
+      }
     ]
   }
 }

--- a/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
@@ -50,7 +50,7 @@ const SmallListItem = (props) => {
       key={id}
       className={`top-table-list-small-promo small-promo ${colClasses} ${layout}`}
     >
-      <div className={`promo-container row ${layout} sm-promo-padding-btm`}>
+      <div className={`promo-container row ${layout} ${imagePosition === BELOW ? 'image-below' : ''} sm-promo-padding-btm`}>
         {imagePosition === ABOVE || imagePosition === LEFT ? (
           <>
             {Image}

--- a/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small-list-item.jsx
@@ -19,38 +19,50 @@ const SmallListItem = (props) => {
   } = props;
 
   const storiesPerRow = (typeof storiesPerRowSM === 'undefined') ? 2 : storiesPerRowSM;
-  const showImage = showImageSM;
   const layout = imagePosition === ABOVE || imagePosition === BELOW ? 'vertical' : 'horizontal';
-  const isReverseLayout = (imagePosition === ABOVE || imagePosition === LEFT);
   const showBottomBorder = (typeof showBottomBorderSM === 'undefined') ? true : showBottomBorderSM;
 
   const colClassNum = (!!storiesPerRow && Math.floor(12 / storiesPerRow)) || 1;
   const colClasses = `col-sm-12 col-md-${colClassNum} col-lg-${colClassNum} col-xl-${colClassNum}`;
 
+  const Headline = showHeadlineSM ? (
+    <PromoHeadline
+      content={element}
+      className="headline-wrap"
+      linkClassName="sm-promo-headline"
+      headingClassName="sm-promo-headline"
+      editable={false}
+    />
+  ) : null;
+
+  const Image = showImageSM ? (
+    <PromoImage
+      content={element}
+      showPromoLabel
+      promoSize="SM"
+      imageRatio={imageRatioSM}
+      editable={false}
+    />
+  ) : null;
+
   return (
     <article
       key={id}
-      className={`top-table-list-small-promo small-promo ${colClasses}`}
+      className={`top-table-list-small-promo small-promo ${colClasses} ${layout}`}
     >
-      <div className={`promo-container row ${layout} ${isReverseLayout ? 'reverse' : ''} sm-promo-padding-btm`}>
-        {showHeadlineSM ? (
-          <PromoHeadline
-            content={element}
-            className="headline-wrap"
-            linkClassName="sm-promo-headline"
-            headingClassName="sm-promo-headline"
-            editable={false}
-          />
-        ) : null}
-        { showImage ? (
-          <PromoImage
-            content={element}
-            showPromoLabel
-            promoSize="SM"
-            imageRatio={imageRatioSM}
-            editable={false}
-          />
-        ) : null }
+      <div className={`promo-container row ${layout} sm-promo-padding-btm`}>
+        {imagePosition === ABOVE || imagePosition === LEFT ? (
+          <>
+            {Image}
+            {Headline}
+          </>
+        )
+          : (
+            <>
+              {Headline}
+              {Image}
+            </>
+          )}
       </div>
       <hr className={!showBottomBorder ? 'hr-borderless' : ''} />
     </article>

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -36,36 +36,37 @@
 }
 
 .top-table-list-small-promo {
-  img {
-    width: 100%;
+  &.vertical {
+    display: flex;
+    flex-direction: column;
+
+    hr {
+      margin-top: auto;
+    }
   }
 
   .promo-container {
     display: flex;
-    flex-direction: row;
     column-gap: calculateRem(24px);
 
-    &.horizontal.reverse {
-      flex-direction: row-reverse;
+    &.vertical {
+      flex-direction: column;
+      row-gap: calculateRem(24px);
+      margin-bottom: calculateRem(16px);
 
-      > div {
-        padding-left: 0;
-        padding-right: 0;
+      .promo-image {
+        display: block;
+        width: 100%;
       }
     }
 
-    &.vertical {
-      @media only screen and (min-width: map-get($grid-breakpoints, 'md')) {
-        flex-direction: column;
+    &.horizontal {
+      .promo-headline {
+        flex: 2;
+      }
 
-        &.reverse {
-          flex-direction: column-reverse;
-
-          > div {
-            margin-bottom: 0;
-            padding: 0;
-          }
-        }
+      .promo-image {
+        flex: 1;
       }
     }
 
@@ -76,31 +77,14 @@
     }
   }
 
-  .promo-headline {
-    flex: 2;
-
-    &.headline-wrap {
-      overflow: hidden;
-      display: -webkit-box;
-      -webkit-box-orient: vertical;
-      -webkit-line-clamp: 3;
-      -moz-box-oriented: vertical;
-      /* opera */
-      text-overflow: -o-ellipsis-lastline;
-    }
-  }
-
-  .promo-image {
-    flex: 1;
-
-    a {
-      display: flex;
-      flex-direction: column;
-    }
-
-    &.flex-col {
-      justify-content: center;
-    }
+  .sm-promo-headline {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    -moz-box-oriented: vertical;
+    /* opera */
+    text-overflow: -o-ellipsis-lastline;
   }
 
   &.wrap-bottom {
@@ -120,7 +104,7 @@
   .image-wrapper {
     position: relative;
 
-    > picture > img {
+    img {
       vertical-align: middle;
     }
   }

--- a/blocks/top-table-list-block/features/top-table-list/default.scss
+++ b/blocks/top-table-list-block/features/top-table-list/default.scss
@@ -49,17 +49,6 @@
     display: flex;
     column-gap: calculateRem(24px);
 
-    &.vertical {
-      flex-direction: column;
-      row-gap: calculateRem(24px);
-      margin-bottom: calculateRem(16px);
-
-      .promo-image {
-        display: block;
-        width: 100%;
-      }
-    }
-
     &.horizontal {
       .promo-headline {
         flex: 2;
@@ -67,6 +56,22 @@
 
       .promo-image {
         flex: 1;
+      }
+    }
+
+    &.vertical {
+      flex-direction: column;
+      flex-grow: 1;
+      row-gap: calculateRem(24px);
+      margin-bottom: calculateRem(16px);
+
+      .promo-image {
+        display: block;
+        width: 100%;
+      }
+
+      &.image-below .promo-image {
+        margin-top: auto;
       }
     }
 


### PR DESCRIPTION
## Description

Update code to ensure DOM order is maintained when choosing different image locations

Fixed issue where small promo's within top table list with set up to have 1 per row and image above would cause overlapping of images

Fixed alignment issues with borders for small promo's - now they align with all promos in the row

## Jira Ticket
- [TMEDIA-277](https://arcpublishing.atlassian.net/browse/TMEDIA-277)

## Acceptance Criteria

When the Top Table List is set to show 1 per row with images above, the image should go full width within its container, and images should not overlap each other or headlines, etc. 


## Test Steps

1. Checkout this branch `git checkout TMEDIA-277-top-table-list-small-promo-bug`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/top-table-list-block,@wpmedia/shared-styles`
3. Validate top table list on all blocks page renders correctly now - http://localhost/pf/all-blocks/?_website=the-gazette
4. Set up a page with top table list and small promos in different settings,
    * First start with 1 per row, and image above

## Effect Of Changes

1 per row image above before
<img width="1148" alt="TMEDIA-277-before" src="https://user-images.githubusercontent.com/868127/123445796-296f3580-d5d0-11eb-9803-8795fe21bb4f.png">

1 per row image above after
<img width="1063" alt="TMEDIA-277-after" src="https://user-images.githubusercontent.com/868127/123445857-35f38e00-d5d0-11eb-86dc-71f10475371f.png">


Alignment issues before
<img width="1150" alt="TMEDIA-277-alignment-before" src="https://user-images.githubusercontent.com/868127/123445906-43a91380-d5d0-11eb-8b04-8d14482546ac.png">

Alignment after
<img width="996" alt="TMEDIA-277-alignment-after" src="https://user-images.githubusercontent.com/868127/123445927-49065e00-d5d0-11eb-8361-1fbf923cf26f.png">



## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
