### PR TITLE
TMEDIA-250 - Numbered List and Simple List Stories

### DIFF
--- a/.storybook/alias/content.js
+++ b/.storybook/alias/content.js
@@ -12,6 +12,7 @@ const featureMocks = {
 	'large-promo': largePromoMock,
 	'extra-large-promo': extraLargePromo,
 	'simple-list': simpleListMock,
+	'numbered-list': simpleListMock,
 }
 
 export const useEditableContent = () => {

--- a/.storybook/alias/content.js
+++ b/.storybook/alias/content.js
@@ -3,6 +3,16 @@ import { smallPromoMock } from '../mock-content/smallPromo';
 import { mediumPromoMock } from '../mock-content/mediumPromo';
 import { extraLargePromo } from '../mock-content/extraLargePromo';
 import { largePromoMock } from '../mock-content/largePromo';
+import { simpleListMock } from '../mock-content/simpleList';
+
+const featureMocks = {
+	footer: footerContentMock,
+	'small-promo': smallPromoMock,
+	'medium-promo': mediumPromoMock,
+	'large-promo': largePromoMock,
+	'extra-large-promo': extraLargePromo,
+	'simple-list': simpleListMock,
+}
 
 export const useEditableContent = () => {
 	return {
@@ -15,22 +25,9 @@ export const useContent = ({ query }) => {
 	if (!query) {
 		return {};
 	}
-	if ( query.feature === 'footer' ) {
-		return footerContentMock;
-	}
-	if ( query.feature === 'small-promo' ) {
-		return smallPromoMock;
-	}
-	if ( query.feature === 'medium-promo' ) {
-		return mediumPromoMock;
-	}
 
-	if (query.feature === 'large-promo') {
-		return largePromoMock;
-	}
-
-	if (query.feature === 'extra-large-promo') {
-		return extraLargePromo;
+	if (featureMocks[query.feature]) {
+		return featureMocks[query.feature];
 	}
 
 	if (query.raw_image_url === 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG' ) {

--- a/.storybook/alias/properties.js
+++ b/.storybook/alias/properties.js
@@ -10,6 +10,7 @@ export default (site) => ({
 	lightBackgroundLogoAlt: 'light logo alt text',
 	primaryLogo: 'https://www.klartale.no/img/klartale/klartale-logo-new.svg',
 	primaryLogoAlt: 'primary logo alt text',
+	fallbackImage: '',
 	dateLocalization: {
 		language: 'en',
 		timeZone: 'America/New_York',

--- a/.storybook/mock-content/simpleList.js
+++ b/.storybook/mock-content/simpleList.js
@@ -1,0 +1,84 @@
+export const simpleListMock = {
+	content_elements: [
+		{
+			_id: '1',
+			headlines: {
+				basic: 'Castle church tower'
+			},
+			promo_items: {
+				basic: {
+					resized_params: {
+						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/'
+					},
+					type: 'image',
+					url: 'https://d22ff27hdsy159.cloudfront.net/12-12-2019/t_42fd2e985d3f4b868b927ca58620a2ca_name_file_1280x720_2000_v3_1_.jpg'
+				}
+			},
+			websites: {
+				'story-book': {
+					website_url: '/video/2019/12/12/castle-church-tower/'
+				}
+			}
+		},
+		{
+			_id: '2',
+			headlines: {
+				basic: 'Castle church tower'
+			},
+			promo_items: {
+				basic: {
+					resized_params: {
+						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/'
+					},
+					type: 'image',
+					url: 'https://d22ff27hdsy159.cloudfront.net/12-12-2019/t_42fd2e985d3f4b868b927ca58620a2ca_name_file_1280x720_2000_v3_1_.jpg'
+				}
+			},
+			websites: {
+				'story-book': {
+					website_url: '/video/2019/12/12/castle-church-tower/'
+				}
+			}
+		},
+		{
+			_id: '3',
+			headlines: {
+				basic: 'Castle church tower'
+			},
+			promo_items: {
+				basic: {
+					resized_params: {
+						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/'
+					},
+					type: 'image',
+					url: 'https://d22ff27hdsy159.cloudfront.net/12-12-2019/t_42fd2e985d3f4b868b927ca58620a2ca_name_file_1280x720_2000_v3_1_.jpg'
+				}
+			},
+			websites: {
+				'story-book': {
+					website_url: '/video/2019/12/12/castle-church-tower/'
+				}
+			}
+		},
+		{
+			_id: '4',
+			headlines: {
+				basic: 'Castle church tower'
+			},
+			promo_items: {
+				basic: {
+					resized_params: {
+						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/'
+					},
+					type: 'image',
+					url: 'https://d22ff27hdsy159.cloudfront.net/12-12-2019/t_42fd2e985d3f4b868b927ca58620a2ca_name_file_1280x720_2000_v3_1_.jpg'
+				}
+			},
+			websites: {
+				'story-book': {
+					website_url: '/video/2019/12/12/castle-church-tower/'
+				}
+			}
+		}
+	]
+}

--- a/.storybook/mock-content/simpleList.js
+++ b/.storybook/mock-content/simpleList.js
@@ -43,7 +43,7 @@ export const simpleListMock = {
 		{
 			_id: '3',
 			headlines: {
-				basic: 'Castle church tower'
+				basic: '7 questions about traveling to Australia during catastrophic fires, answered'
 			},
 			promo_items: {
 				basic: {

--- a/blocks/numbered-list-block/features/numbered-list/default.test.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { useFusionContext } from 'fusion:context';
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({
   fallbackImage: 'placeholder.jpg',
@@ -11,6 +12,17 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   isServerSide: () => true,
 }));
 const { default: mockData } = require('./mock-data');
+
+jest.mock('fusion:content', () => ({
+  useContent: jest.fn(() => mockData),
+}));
+
+jest.mock('fusion:context', () => ({
+  useFusionContext: jest.fn(() => ({
+    arcSite: 'the-sun',
+    deployment: jest.fn(() => {}),
+  })),
+}));
 
 jest.mock('fusion:themes', () => (
   () => ({
@@ -45,8 +57,7 @@ describe('The numbered-list-block', () => {
       };
 
       const { default: NumberedList } = require('./default');
-      NumberedList.prototype.fetchContent = jest.fn().mockReturnValue({});
-      const wrapper = mount(<NumberedList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+      const wrapper = mount(<NumberedList customFields={customFields} />);
       expect(wrapper.html()).toBe(null);
     });
 
@@ -66,31 +77,24 @@ describe('The numbered-list-block', () => {
         showHeadline: true,
         showImage: true,
       };
-      NumberedList.prototype.fetchContent = jest.fn().mockReturnValue(mockData);
 
-      const wrapper = mount(<NumberedList
-        customFields={customFields}
-        arcSite="the-sun"
-        deployment={jest.fn((path) => path)}
-      />);
-      wrapper.setState({ resultList: mockData }, () => {
-        wrapper.update();
-        expect(wrapper.find('.numbered-list-container').length).toEqual(1);
-        expect(wrapper.find('.numbered-list-container').childAt(0).type()).toEqual('div');
-        expect(wrapper.find('.numbered-list-container').childAt(0).find('.list-item-number').length).toEqual(1);
-        expect(wrapper.find('.numbered-list-container').childAt(0).find('.list-item-number').children()
-          .text()).toEqual('1');
-        expect(wrapper.find('.numbered-list-container').childAt(0).find('.headline-list-anchor').length).toEqual(1);
-        expect(wrapper.find('.numbered-list-container').childAt(0).find('.headline-list-anchor').find('.headline-text')).toHaveLength(1);
-        expect(wrapper.find('.numbered-list-container').childAt(0).find('.list-anchor-image').length).toEqual(1);
-        expect(wrapper.find('.numbered-list-container').childAt(0).find('.list-anchor-image').find('Image').length)
-          .toEqual(1);
-        expect(wrapper.find('.numbered-list-container').childAt(0).find('.list-anchor-image').find('Image'))
-          .toHaveProp('url', 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/K6FTNMOXBBDS5HHTYTAV7LNEF4.jpg');
-        expect(wrapper.find('.numbered-list-container').childAt(0).find('.headline-list-anchor').find('.headline-text')
-          .children()
-          .text()).toEqual('Article with only promo_items.basic');
-      });
+      const wrapper = mount(<NumberedList customFields={customFields} />);
+
+      expect(wrapper.find('.numbered-list-container').length).toEqual(1);
+      expect(wrapper.find('.numbered-list-container').childAt(0).type()).toEqual('div');
+      expect(wrapper.find('.numbered-list-container').childAt(0).find('.list-item-number').length).toEqual(1);
+      expect(wrapper.find('.numbered-list-container').childAt(0).find('.list-item-number').children()
+        .text()).toEqual('1');
+      expect(wrapper.find('.numbered-list-container').childAt(0).find('.headline-list-anchor').length).toEqual(1);
+      expect(wrapper.find('.numbered-list-container').childAt(0).find('.headline-list-anchor').find('.headline-text')).toHaveLength(1);
+      expect(wrapper.find('.numbered-list-container').childAt(0).find('.list-anchor-image').length).toEqual(1);
+      expect(wrapper.find('.numbered-list-container').childAt(0).find('.list-anchor-image').find('Image').length)
+        .toEqual(1);
+      expect(wrapper.find('.numbered-list-container').childAt(0).find('.list-anchor-image').find('Image'))
+        .toHaveProp('url', 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/K6FTNMOXBBDS5HHTYTAV7LNEF4.jpg');
+      expect(wrapper.find('.numbered-list-container').childAt(0).find('.headline-list-anchor').find('.headline-text')
+        .children()
+        .text()).toEqual('Article with only promo_items.basic');
     });
 
     it('should render a place holder image', () => {
@@ -109,28 +113,21 @@ describe('The numbered-list-block', () => {
         showHeadline: true,
         showImage: true,
       };
-      NumberedList.prototype.fetchContent = jest.fn().mockReturnValue(mockData);
 
-      const wrapper = mount(<NumberedList
-        customFields={customFields}
-        arcSite="the-sun"
-        deployment={jest.fn((path) => path)}
-      />);
-      wrapper.setState({ resultList: mockData }, () => {
-        wrapper.update();
-        expect(wrapper.find('.numbered-list-container').length).toEqual(1);
-        expect(wrapper.find('.numbered-list-container').childAt(4).type()).toEqual('div');
-        expect(wrapper.find('.numbered-list-container').childAt(4).find('.list-anchor-image').length).toEqual(1);
-        const placeholderImage = wrapper.find('.numbered-list-container').childAt(4).find('.list-anchor-image').children();
-        // the placeholder component is mocked globally in jest mocks with this alt tag
-        expect(placeholderImage.html()).toEqual('<img alt="test">');
-        expect(wrapper.find('.numbered-list-container').childAt(6).find('.headline-list-anchor').find('.headline-text')
-          .children()
-          .text()).toEqual('Story with video as the Lead Art');
-      });
+      const wrapper = mount(<NumberedList customFields={customFields} />);
+
+      expect(wrapper.find('.numbered-list-container').length).toEqual(1);
+      expect(wrapper.find('.numbered-list-container').childAt(4).type()).toEqual('div');
+      expect(wrapper.find('.numbered-list-container').childAt(4).find('.list-anchor-image').length).toEqual(1);
+      const placeholderImage = wrapper.find('.numbered-list-container').childAt(4).find('.list-anchor-image').children();
+      // the placeholder component is mocked globally in jest mocks with this alt tag
+      expect(placeholderImage.html()).toEqual('<img alt="test">');
+      expect(wrapper.find('.numbered-list-container').childAt(6).find('.headline-list-anchor').find('.headline-text')
+        .children()
+        .text()).toEqual('Story with video as the Lead Art');
     });
 
-    it('should render elements only for arcSite', () => {
+    it.only('should render elements only for arcSite', () => {
       const { default: NumberedList } = require('./default');
       const listContentConfig = {
         contentConfigValues:
@@ -146,18 +143,18 @@ describe('The numbered-list-block', () => {
         showHeadline: true,
         showImage: true,
       };
-      NumberedList.prototype.fetchContent = jest.fn().mockReturnValue(mockData);
 
-      const wrapper = mount(<NumberedList
-        customFields={customFields}
-        arcSite="dagen"
-        deployment={jest.fn((path) => path)}
-      />);
-      wrapper.setState({ resultList: mockData }, () => {
-        wrapper.update();
-        expect(wrapper.find('.numbered-list-container').length).toEqual(1);
-        expect(wrapper.find('.numbered-list-item').length).toEqual(1);
-      });
+      jest.mock('fusion:context', () => ({
+        useFusionContext: jest.fn(() => ({
+          arcSite: 'dagen',
+          deployment: jest.fn(() => {}),
+        })),
+      }));
+
+      const wrapper = mount(<NumberedList customFields={customFields} />);
+
+      expect(wrapper.find('.numbered-list-container').length).toEqual(1);
+      expect(wrapper.find('.numbered-list-item').length).toEqual(1);
     });
   });
 });

--- a/blocks/numbered-list-block/features/numbered-list/default.test.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { useFusionContext } from 'fusion:context';
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({
   fallbackImage: 'placeholder.jpg',

--- a/blocks/numbered-list-block/index.story.jsx
+++ b/blocks/numbered-list-block/index.story.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import NumberedList from './features/numbered-list/default';
+
+export default {
+  title: 'Blocks/Numbered List',
+  decorators: [withKnobs],
+  parameters: {
+    // Set the viewports in Chromatic at a component level.
+    chromatic: { viewports: [320, 1200] },
+  },
+};
+
+const props = {
+  deployment: (x) => x,
+};
+
+const sampleData = {
+  listContentConfig: {
+    contentService: 'content-api',
+    contentConfigValues: {},
+  },
+  title: 'Numbered List Headline',
+  showHeadline: false,
+  showImage: false,
+};
+
+export const allFields = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <NumberedList {...props} customFields={customFields} />
+  );
+};
+
+export const noBlockTitle = () => {
+  const customFields = {
+    ...sampleData,
+    title: '',
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <NumberedList {...props} customFields={customFields} />
+  );
+};
+
+export const headlineOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+  };
+
+  return (
+    <NumberedList {...props} customFields={customFields} />
+  );
+};
+
+export const imageOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showImage: true,
+  };
+
+  return (
+    <NumberedList {...props} customFields={customFields} />
+  );
+};
+
+export const noImageNoHeadline = () => {
+  const customFields = {
+    ...sampleData,
+  };
+
+  return (
+    <NumberedList {...props} customFields={customFields} />
+  );
+};

--- a/blocks/numbered-list-block/package.json
+++ b/blocks/numbered-list-block/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",
     "@wpmedia/shared-styles": "*"

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -38,10 +38,9 @@ const SimpleListWrapper = ({ customFields }) => {
     id, arcSite, contextPath, deployment, isAdmin,
   } = useFusionContext();
   const {
-    websiteDomain, primaryLogoAlt, breakpoints, resizerURL,
+    websiteDomain, fallbackImage, primaryLogoAlt, breakpoints, resizerURL,
   } = getProperties(arcSite);
 
-  const fallbackImage = 'resources/images/default_feed_image.jpg';
   const targetFallbackImage = getFallbackImageURL({ deployment, contextPath, fallbackImage });
   const imageProps = {
     smallWidth: 274,

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -1,12 +1,12 @@
 /* eslint-disable camelcase */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React from 'react';
+import PropTypes from '@arc-fusion/prop-types';
 import { useContent } from 'fusion:content';
+import { useFusionContext } from 'fusion:context';
 import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { extractResizedParams, extractImageFromStory } from '@wpmedia/resizer-image-block';
 import { Heading, HeadingSection } from '@wpmedia/shared-styles';
 import getProperties from 'fusion:properties';
-import Consumer from 'fusion:consumer';
 import StoryItem from './_children/story-item';
 import './simple-list.scss';
 
@@ -23,86 +23,61 @@ const unserializeStory = (arcSite) => (acc, storyObject) => {
   return acc;
 };
 
-@Consumer
-class SimpleListWrapper extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      placeholderResizedImageOptions: {},
-    };
-    const { lazyLoad = false } = props.customFields || {};
-    const {
-      websiteDomain, fallbackImage, primaryLogoAlt, breakpoints, resizerURL,
-    } = getProperties(props.arcSite) || {};
+const getFallbackImageURL = ({ deployment, contextPath, fallbackImage }) => {
+  let targetFallbackImage = fallbackImage;
 
-    this.lazyLoad = lazyLoad;
-    this.isAdmin = props.isAdmin;
-    this.websiteDomain = websiteDomain;
-    this.fallbackImage = fallbackImage;
-    this.imageProps = {
-      smallWidth: 274,
-      smallHeight: 183,
-      mediumWidth: 274,
-      mediumHeight: 183,
-      largeWidth: 274,
-      largeHeight: 183,
-      primaryLogoAlt,
-      breakpoints,
-      resizerURL,
-    };
-
-    this.fetchPlaceholder();
+  if (!targetFallbackImage.includes('http')) {
+    targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
   }
 
-  getFallbackImageURL() {
-    const { deployment, contextPath } = this.props;
-    let targetFallbackImage = this.fallbackImage;
+  return targetFallbackImage;
+};
 
-    if (!targetFallbackImage.includes('http')) {
-      targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
-    }
+const SimpleListWrapper = ({ customFields }) => {
+  const {
+    id, arcSite, contextPath, deployment, isAdmin,
+  } = useFusionContext();
+  const {
+    websiteDomain, primaryLogoAlt, breakpoints, resizerURL,
+  } = getProperties(arcSite);
 
-    return targetFallbackImage;
+  const fallbackImage = 'resources/images/default_feed_image.jpg';
+  const targetFallbackImage = getFallbackImageURL({ deployment, contextPath, fallbackImage });
+  const imageProps = {
+    smallWidth: 274,
+    smallHeight: 183,
+    mediumWidth: 274,
+    mediumHeight: 183,
+    largeWidth: 274,
+    largeHeight: 183,
+    primaryLogoAlt,
+    breakpoints,
+    resizerURL,
+  };
+
+  const placeholderResizedImageOptions = useContent({
+    source: 'resize-image-api',
+    query: { raw_image_url: targetFallbackImage, respect_aspect_ratio: true },
+  });
+
+  if (customFields.lazyLoad && isServerSide() && !isAdmin) { // On Server
+    return null;
   }
 
-  fetchPlaceholder() {
-    const targetFallbackImage = this.getFallbackImageURL();
-
-    // using the fetchContent seems both more reliable
-    // and allows for conditional calls whereas useContent hook does not
-    if (!targetFallbackImage.includes('/resources/')) {
-      this.fetchContent({
-        placeholderResizedImageOptions: {
-          source: 'resize-image-api',
-          query: { raw_image_url: targetFallbackImage, respect_aspect_ratio: true },
-        },
-      });
-    }
-  }
-
-  render() {
-    if (this.lazyLoad && isServerSide() && !this.isAdmin) { // On Server
-      return null;
-    }
-
-    const { placeholderResizedImageOptions } = this.state;
-    const targetFallbackImage = this.getFallbackImageURL();
-
-    return (
-      <LazyLoad enabled={this.lazyLoad && !this.isAdmin}>
-        <HeadingSection>
-          <SimpleList
-            {...this.props}
-            placeholderResizedImageOptions={placeholderResizedImageOptions}
-            targetFallbackImage={targetFallbackImage}
-            websiteDomain={this.websiteDomain}
-            imageProps={this.imageProps}
-          />
-        </HeadingSection>
-      </LazyLoad>
-    );
-  }
-}
+  return (
+    <LazyLoad enabled={customFields.lazyLoad && !isAdmin}>
+      <SimpleList
+        id={id}
+        customFields={customFields}
+        placeholderResizedImageOptions={placeholderResizedImageOptions}
+        targetFallbackImage={targetFallbackImage}
+        websiteDomain={websiteDomain}
+        imageProps={imageProps}
+        arcSite={arcSite}
+      />
+    </LazyLoad>
+  );
+};
 
 const SimpleList = (props) => {
   const {
@@ -117,7 +92,7 @@ const SimpleList = (props) => {
       showHeadline = true,
       showImage = true,
     } = {},
-    id,
+    id = '',
     placeholderResizedImageOptions,
     targetFallbackImage,
     imageProps,
@@ -167,40 +142,40 @@ const SimpleList = (props) => {
   const Wrapper = title ? HeadingSection : React.Fragment;
 
   return (
-    <>
-      <div key={id} className="list-container layout-section">
-        { title
-          ? (
-            <Heading className="list-title">
-              {title}
-            </Heading>
-          ) : null}
-        <Wrapper>
-          {contentElements.reduce(unserializeStory(arcSite), []).map(({
-            id: listItemId, itemTitle, imageURL, websiteURL, resizedImageOptions,
-          }) => (
-            <React.Fragment key={listItemId}>
-              <StoryItem
-                key={listItemId}
-                id={listItemId}
-                itemTitle={itemTitle}
-                imageURL={imageURL}
-                websiteURL={websiteURL}
-                websiteDomain={websiteDomain}
-                showHeadline={showHeadline}
-                showImage={showImage}
-                resizedImageOptions={resizedImageOptions}
-                placeholderResizedImageOptions={placeholderResizedImageOptions}
-                targetFallbackImage={targetFallbackImage}
-                arcSite={arcSite}
-                imageProps={imageProps}
-              />
-              <hr />
-            </React.Fragment>
-          ))}
-        </Wrapper>
-      </div>
-    </>
+    <div key={id} className="list-container layout-section">
+      { title
+        ? (
+          <Heading className="list-title">
+            {title}
+          </Heading>
+        ) : null}
+      <Wrapper>
+        {
+        contentElements.reduce(unserializeStory(arcSite), []).map(({
+          id: listItemId, itemTitle, imageURL, websiteURL, resizedImageOptions,
+        }) => (
+          <React.Fragment key={listItemId}>
+            <StoryItem
+              key={listItemId}
+              id={listItemId}
+              itemTitle={itemTitle}
+              imageURL={imageURL}
+              websiteURL={websiteURL}
+              websiteDomain={websiteDomain}
+              showHeadline={showHeadline}
+              showImage={showImage}
+              resizedImageOptions={resizedImageOptions}
+              placeholderResizedImageOptions={placeholderResizedImageOptions}
+              targetFallbackImage={targetFallbackImage}
+              arcSite={arcSite}
+              imageProps={imageProps}
+            />
+            <hr />
+          </React.Fragment>
+        ))
+      }
+      </Wrapper>
+    </div>
   );
 };
 

--- a/blocks/simple-list-block/features/simple-list/default.test.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.test.jsx
@@ -87,6 +87,7 @@ jest.mock('fusion:context', () => ({
     customFields: {
       elementPlacement: { 1: 2, 2: 1 },
     },
+    deployment: jest.fn(() => {}),
   })),
 }));
 
@@ -113,29 +114,23 @@ describe('Simple list', () => {
 
     const customFields = {
       title: testText,
+      lazyLoad: false,
     };
 
-    const wrapper = mount(<SimpleList
-      customFields={customFields}
-      deployment={jest.fn((path) => path)}
-    />);
+    const wrapper = mount(<SimpleList customFields={customFields} />);
 
     expect(wrapper.find('.list-title').first().text()).toBe(testText);
   });
 
   it('should show no title if there is no title provided', () => {
-    SimpleList.prototype.fetchContent = jest.fn().mockReturnValue({});
-
-    jest.mock('fusion:content', () => ({
-      useContent: jest.fn(() => mockOutput),
-    }));
-    const wrapper = mount(<SimpleList deployment={jest.fn((path) => path)} />);
+    const wrapper = mount(<SimpleList customFields={{ lazyLoad: false }} />);
 
     expect(wrapper.find('.list-title').length).toBe(0);
   });
 
   it('should fetch an array of data when content service is provided', () => {
     const customFields = {
+      lazyLoad: false,
       listContentConfig: {
         contentService: 'something',
         contentConfigValues: {
@@ -144,19 +139,14 @@ describe('Simple list', () => {
       },
     };
 
-    const wrapper = mount(<SimpleList
-      customFields={customFields}
-      arcSite="the-sun"
-      deployment={jest.fn((path) => path)}
-    />);
+    const wrapper = mount(<SimpleList customFields={customFields} arcSite="the-sun" />);
 
     expect(wrapper.find('StoryItem').length).toBe(2);
   });
 
   it('should not render items when no data provided', () => {
-    useContent.mockReturnValueOnce(null);
-
     const customFields = {
+      lazyLoad: false,
       listContentConfig: {
         contentService: 'something',
         contentConfigValues: {
@@ -164,12 +154,11 @@ describe('Simple list', () => {
         },
       },
     };
+    // Once for Placeholder, once for SimpleList data
+    useContent.mockReturnValueOnce(null);
+    useContent.mockReturnValueOnce(null);
 
-    const wrapper = mount(<SimpleList
-      customFields={customFields}
-      arcSite="the-sun"
-      deployment={jest.fn((path) => path)}
-    />);
+    const wrapper = mount(<SimpleList customFields={customFields} arcSite="the-sun" />);
 
     expect(wrapper.find('StoryItem').length).toBe(0);
   });
@@ -177,10 +166,7 @@ describe('Simple list', () => {
 
 describe('Simple list', () => {
   it('should render content only for the arcSite', () => {
-    const wrapper = mount(<SimpleList
-      arcSite="the-sun"
-      deployment={jest.fn((path) => path)}
-    />);
+    const wrapper = mount(<SimpleList arcSite="the-sun" customFields={{ lazyLoad: false }} />);
 
     expect(wrapper.find('StoryItem')).toHaveLength(2);
   });

--- a/blocks/simple-list-block/index.story.jsx
+++ b/blocks/simple-list-block/index.story.jsx
@@ -37,6 +37,19 @@ export const allFields = () => {
   );
 };
 
+export const noBlockTitle = () => {
+  const customFields = {
+    ...sampleData,
+    title: '',
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <SimpleList {...props} customFields={customFields} />
+  );
+};
+
 export const headlineOnly = () => {
   const customFields = {
     ...sampleData,
@@ -52,6 +65,16 @@ export const imageOnly = () => {
   const customFields = {
     ...sampleData,
     showImage: true,
+  };
+
+  return (
+    <SimpleList {...props} customFields={customFields} />
+  );
+};
+
+export const noImageNoHeadline = () => {
+  const customFields = {
+    ...sampleData,
   };
 
   return (

--- a/blocks/simple-list-block/index.story.jsx
+++ b/blocks/simple-list-block/index.story.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import SimpleList from './features/simple-list/default';
+
+export default {
+  title: 'Blocks/Simple List',
+  decorators: [withKnobs],
+  parameters: {
+    // Set the viewports in Chromatic at a component level.
+    chromatic: { viewports: [320, 1200] },
+  },
+};
+
+const props = {
+  deployment: (x) => x,
+};
+
+const sampleData = {
+  listContentConfig: {
+    contentService: 'content-api',
+    contentConfigValues: { _id: 'K2FFSIYSVRC7HIBZBXLQ2CUPTY' },
+  },
+  title: 'Simple List Headline',
+  showHeadline: false,
+  showImage: false,
+};
+
+export const allFields = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+    showImage: true,
+  };
+
+  return (
+    <SimpleList {...props} customFields={customFields} />
+  );
+};
+
+export const headlineOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showHeadline: true,
+  };
+
+  return (
+    <SimpleList {...props} customFields={customFields} />
+  );
+};
+
+export const imageOnly = () => {
+  const customFields = {
+    ...sampleData,
+    showImage: true,
+  };
+
+  return (
+    <SimpleList {...props} customFields={customFields} />
+  );
+};

--- a/blocks/simple-list-block/package.json
+++ b/blocks/simple-list-block/package.json
@@ -22,6 +22,7 @@
     "directory": "blocks/simple-list-block"
   },
   "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",
     "@wpmedia/shared-styles": "*"


### PR DESCRIPTION
## Description
Add stories for Numbered List and Simple List
For ease of storybook integration switching components to be functional components allows for easier storybook mocking

Card List is part of TMEDIA-250, and will coming another PR

## Jira Ticket
- [TMEDIA-250](https://arcpublishing.atlassian.net/browse/TMEDIA-250)

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-250-card-numbered-simple-list-stories`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/simple-list-block,@wpmedia/numbered-list-block`
3. Validate Numbered List and Simple list still work as expected - http://localhost/homepage/?_website=the-gazette
4. Click through to Chromatic from the pull request check lists to see stories


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
