### PR TITLE
TMEDIA-250 - Card List Block Story

### DIFF
--- a/.storybook/alias/content.js
+++ b/.storybook/alias/content.js
@@ -13,6 +13,7 @@ const featureMocks = {
 	'extra-large-promo': extraLargePromo,
 	'simple-list': simpleListMock,
 	'numbered-list': simpleListMock,
+	'card-list': simpleListMock,
 }
 
 export const useEditableContent = () => {
@@ -24,6 +25,10 @@ export const useEditableContent = () => {
 
 export const useContent = ({ query }) => {
 	if (!query) {
+		return {};
+	}
+
+	if (query.noData) {
 		return {};
 	}
 

--- a/.storybook/mock-content/simpleList.js
+++ b/.storybook/mock-content/simpleList.js
@@ -8,7 +8,9 @@ export const simpleListMock = {
 			promo_items: {
 				basic: {
 					resized_params: {
-						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/'
+						'105x70': "toq6Dkqxl1xDvAHTWaO9c5qw4_o=filters:format(jpg):quality(70)/",
+						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/',
+						'377x283': "fpRHXIzIpdkN2NZ-2GLSF8sl4Pk=filters:format(jpg):quality(70)/",
 					},
 					type: 'image',
 					url: 'https://d22ff27hdsy159.cloudfront.net/12-12-2019/t_42fd2e985d3f4b868b927ca58620a2ca_name_file_1280x720_2000_v3_1_.jpg'
@@ -28,7 +30,9 @@ export const simpleListMock = {
 			promo_items: {
 				basic: {
 					resized_params: {
-						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/'
+						'105x70': "toq6Dkqxl1xDvAHTWaO9c5qw4_o=filters:format(jpg):quality(70)/",
+						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/',
+						'377x283': "fpRHXIzIpdkN2NZ-2GLSF8sl4Pk=filters:format(jpg):quality(70)/",
 					},
 					type: 'image',
 					url: 'https://d22ff27hdsy159.cloudfront.net/12-12-2019/t_42fd2e985d3f4b868b927ca58620a2ca_name_file_1280x720_2000_v3_1_.jpg'
@@ -48,7 +52,9 @@ export const simpleListMock = {
 			promo_items: {
 				basic: {
 					resized_params: {
-						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/'
+						'105x70': "toq6Dkqxl1xDvAHTWaO9c5qw4_o=filters:format(jpg):quality(70)/",
+						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/',
+						'377x283': "fpRHXIzIpdkN2NZ-2GLSF8sl4Pk=filters:format(jpg):quality(70)/",
 					},
 					type: 'image',
 					url: 'https://d22ff27hdsy159.cloudfront.net/12-12-2019/t_42fd2e985d3f4b868b927ca58620a2ca_name_file_1280x720_2000_v3_1_.jpg'
@@ -68,7 +74,9 @@ export const simpleListMock = {
 			promo_items: {
 				basic: {
 					resized_params: {
-						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/'
+						'105x70': "toq6Dkqxl1xDvAHTWaO9c5qw4_o=filters:format(jpg):quality(70)/",
+						'274x183': 'Y9lCrjFoGrJZukqRLRMi5ntzkak=filters:format(jpg):quality(70)/',
+						'377x283': "fpRHXIzIpdkN2NZ-2GLSF8sl4Pk=filters:format(jpg):quality(70)/",
 					},
 					type: 'image',
 					url: 'https://d22ff27hdsy159.cloudfront.net/12-12-2019/t_42fd2e985d3f4b868b927ca58620a2ca_name_file_1280x720_2000_v3_1_.jpg'

--- a/blocks/card-list-block/features/card-list/card-list.scss
+++ b/blocks/card-list-block/features/card-list/card-list.scss
@@ -69,11 +69,10 @@
 }
 
 .card-list-item {
-  @include block-internal-spacing;
   display: flex;
   justify-content: space-between;
   padding: 1rem 0 0;
-  margin: 0 16px;
+  margin: calculateRem(16px) calculateRem(16px) 0 calculateRem(16px);
   border-top: 1px #dadada solid;
 
   .list-item-number {
@@ -108,16 +107,5 @@
       font-weight: normal;
       line-height: 24px;
     }
-  }
-}
-
-.card-list-item-margins {
-  @media screen and (min-width: map-get($grid-breakpoints, 'sm')) {
-    margin-bottom: 1rem;
-    margin-top: 1rem;
-  }
-  @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-    margin-bottom: 1rem;
-    margin-top: 1rem;
   }
 }

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -1,121 +1,79 @@
 /* eslint-disable camelcase */
-import PropTypes from 'prop-types';
-import Consumer from 'fusion:consumer';
 import React from 'react';
-import ArticleDate from '@wpmedia/date-block';
+import PropTypes from '@arc-fusion/prop-types';
+import { useContent } from 'fusion:content';
+import { useFusionContext } from 'fusion:context';
+import getProperties from 'fusion:properties';
 import { Image, LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { extractResizedParams, extractImageFromStory } from '@wpmedia/resizer-image-block';
 import {
-  Byline, Heading, HeadingSection, Overline,
+  Byline, Heading, HeadingSection, Overline, PromoDate,
 } from '@wpmedia/shared-styles';
-import getProperties from 'fusion:properties';
 import './card-list.scss';
 
-@Consumer
-class CardList extends React.Component {
-  constructor(props) {
-    super(props);
-    const { lazyLoad = false } = props.customFields || {};
+const getFallbackImageURL = ({ deployment, contextPath, fallbackImage }) => {
+  let targetFallbackImage = fallbackImage;
 
-    this.arcSite = props.arcSite;
-    this.lazyLoad = lazyLoad;
-    this.isAdmin = props.isAdmin;
-
-    this.siteProperties = getProperties(props.arcSite);
-
-    this.largeImageOptions = {
-      smallWidth: 377,
-      smallHeight: 283,
-      mediumWidth: 377,
-      mediumHeight: 283,
-      largeWidth: 377,
-      largeHeight: 283,
-      breakpoints: this.siteProperties?.breakpoints,
-      resizerURL: this.siteProperties?.resizerURL,
-    };
-
-    this.smallImageOptions = {
-      smallWidth: 105,
-      smallHeight: 70,
-      mediumWidth: 105,
-      mediumHeight: 70,
-      largeWidth: 105,
-      largeHeight: 70,
-      breakpoints: this.siteProperties?.breakpoints,
-      resizerURL: this.siteProperties?.resizerURL,
-    };
-
-    this.state = {
-      cardList: {},
-      placeholderResizedImageOptions: {},
-    };
-
-    this.fetchPlaceholder();
-
-    // Fetch stories if lazyLoad is not enabled, the code is running on the server
-    if (!this.lazyLoad && isServerSide()) {
-      this.fetchStories();
-    }
+  if (!targetFallbackImage.includes('http')) {
+    targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
   }
 
-  componentDidMount() {
-    this.fetchStories();
-  }
+  return targetFallbackImage;
+};
 
-  getFallbackImageURL() {
-    const { deployment, contextPath } = this.props;
-    let targetFallbackImage = this.siteProperties.fallbackImage;
+const CardListItems = (props) => {
+  const {
+    arcSite,
+    customFields: {
+      listContentConfig: {
+        contentService = '',
+        contentConfigValues = {},
+      } = {},
+      title = '',
+    } = {},
+    placeholderResizedImageOptions,
+    targetFallbackImage,
+    largeImageProps,
+    smallImageProps,
+  } = props;
 
-    if (!targetFallbackImage.includes('http')) {
-      targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
-    }
-
-    return targetFallbackImage;
-  }
-
-  fetchPlaceholder() {
-    const targetFallbackImage = this.getFallbackImageURL();
-
-    if (!targetFallbackImage.includes('/resources/')) {
-      this.fetchContent({
-        placeholderResizedImageOptions: {
-          source: 'resize-image-api',
-          query: { raw_image_url: targetFallbackImage, respect_aspect_ratio: true },
-        },
-      });
-    }
-  }
-
-  fetchStories() {
-    const { customFields: { listContentConfig } } = this.props;
-    const { contentService, contentConfigValues } = listContentConfig;
-    this.fetchContent({
-      cardList: {
-        source: contentService,
-        query: { ...contentConfigValues, feature: 'card-list' },
-        filter: `{
-          content_elements {
-            _id,
-            display_date
-            credits {
-              by {
-                _id
-                name
-                url
-                type
-                additional_properties {
-                  original {
-                    byline
-                  }
-                }
+  // need to inject the arc site here into use content
+  const { content_elements: contentElements = [] } = useContent({
+    source: contentService,
+    query: { ...contentConfigValues, feature: 'card-list' },
+    filter: `{
+      content_elements {
+        _id,
+        display_date
+        credits {
+          by {
+            _id
+            name
+            url
+            type
+            additional_properties {
+              original {
+                byline
               }
             }
-            headlines {
-              basic
+          }
+        }
+        headlines {
+          basic
+        }
+        owner {
+          sponsored
+        }
+        promo_items {
+          basic {
+            type
+            url
+            resized_params {
+              377x283
+              105x70
             }
-            owner {
-              sponsored
-            }
+          }
+          lead_art {
             promo_items {
               basic {
                 type
@@ -125,171 +83,194 @@ class CardList extends React.Component {
                   105x70
                 }
               }
-              lead_art {
-                promo_items {
-                  basic {
-                    type
-                    url
-                    resized_params {
-                      377x283
-                      105x70
-                    }
-                  }
-                }
-                type
-              }
             }
-            websites {
-              ${this.arcSite} {
-                website_url
-                website_section {
-                  name
-                }
-              }
+            type
+          }
+        }
+        websites {
+          ${arcSite} {
+            website_url
+            website_section {
+              name
             }
           }
-        }`,
-      },
-    });
-  }
-
-  render() {
-    if (this.lazyLoad && isServerSide() && !this.isAdmin) {
-      return null;
-    }
-
-    const { customFields: { title } = {}, arcSite } = this.props;
-    const {
-      cardList: { content_elements: pageContent = [] } = {},
-      placeholderResizedImageOptions,
-    } = this.state;
-
-    const contentElements = pageContent.reduce((acc, element) => {
-      if (element.websites?.[arcSite]) {
-        return acc.concat(element);
+        }
       }
-      return acc;
-    }, []);
+    }`,
+  }) || {};
 
-    const showSeparator = !!(
-      contentElements[0]
-      && contentElements[0].credits
-      && contentElements[0].credits.by
-      && contentElements[0].credits.by.length !== 0
-    );
-    const targetFallbackImage = this.getFallbackImageURL();
+  const Wrapper = title ? HeadingSection : React.Fragment;
 
-    const Wrapper = title ? HeadingSection : React.Fragment;
+  const showSeparator = !!(
+    contentElements[0]
+    && contentElements[0].credits
+    && contentElements[0].credits.by
+    && contentElements[0].credits.by.length !== 0
+  );
 
-    const CardListItems = () => (
-      (contentElements.length > 0
-        ? (
-          <HeadingSection>
-            <div className="card-list-container">
-              {title
-                ? (
-                  <Heading className="card-list-title">
-                    {title}
-                  </Heading>
-                ) : null}
-              <Wrapper>
-                <article
-                  className="list-item-simple"
-                  key={`card-list-${contentElements[0].websites[arcSite].website_url}`}
+  return (
+    (contentElements.length > 0
+      ? (
+        <HeadingSection>
+          <div className="card-list-container">
+            {title
+              ? (
+                <Heading className="card-list-title">
+                  {title}
+                </Heading>
+              ) : null}
+            <Wrapper>
+              <article
+                className="list-item-simple"
+                key={`card-list-${contentElements[0].websites[arcSite].website_url}`}
+              >
+                <a
+                  href={contentElements[0].websites[arcSite].website_url}
+                  className="list-anchor card-list--link-container vertical-align-image"
+                  aria-hidden="true"
+                  tabIndex="-1"
                 >
+                  {extractImageFromStory(contentElements[0]) ? (
+                    <Image
+                      {...largeImageProps}
+                      url={extractImageFromStory(contentElements[0])}
+                      alt={contentElements[0].headlines.basic}
+                      resizedImageOptions={extractResizedParams(contentElements[0])}
+                    />
+                  ) : (
+                    <Image
+                      {...largeImageProps}
+                      url={targetFallbackImage}
+                      alt={largeImageProps.primaryLogoAlt || ''}
+                      resizedImageOptions={placeholderResizedImageOptions}
+                    />
+                  )}
+                </a>
+                <Overline story={contentElements[0]} className="card-list-overline" />
+                <Heading className="card-list-headline">
                   <a
                     href={contentElements[0].websites[arcSite].website_url}
-                    className="list-anchor card-list--link-container vertical-align-image"
-                    aria-hidden="true"
-                    tabIndex="-1"
+                    className="list-anchor vertical-align-image"
+                    id="card-list--headline-link"
                   >
-                    {extractImageFromStory(contentElements[0]) ? (
-                      <Image
-                        {...this.largeImageOptions}
-                        url={extractImageFromStory(contentElements[0])}
-                        alt={contentElements[0].headlines.basic}
-                        resizedImageOptions={extractResizedParams(contentElements[0])}
-                      />
-                    ) : (
-                      <Image
-                        {...this.largeImageOptions}
-                        url={targetFallbackImage}
-                        alt={this.siteProperties.primaryLogoAlt || ''}
-                        resizedImageOptions={placeholderResizedImageOptions}
-                      />
-                    )}
+                    {contentElements[0].headlines.basic}
                   </a>
-                  <Overline story={contentElements[0]} className="card-list-overline" />
-                  <Heading className="card-list-headline">
-                    <a
-                      href={contentElements[0].websites[arcSite].website_url}
-                      className="list-anchor vertical-align-image"
-                      id="card-list--headline-link"
+                </Heading>
+                <div className="author-date">
+                  <Byline content={contentElements[0]} list separator={showSeparator} font="Primary" />
+                  <PromoDate
+                    className="story-date"
+                    date={contentElements[0].display_date}
+                  />
+                </div>
+              </article>
+              {contentElements.slice(1).map((element) => {
+                const {
+                  headlines: { basic: headlineText } = {},
+                } = element;
+                const imageURL = extractImageFromStory(element);
+                const url = element.websites[arcSite]?.website_url;
+                if (!url) {
+                  return null;
+                }
+                return (
+                  <React.Fragment key={`card-list-${url}`}>
+                    <article
+                      className="card-list-item"
+                      key={`card-list-${url}`}
                     >
-                      {contentElements[0].headlines.basic}
-                    </a>
-                  </Heading>
-                  <div className="author-date">
-                    <Byline content={contentElements[0]} list separator={showSeparator} font="Primary" />
-                    <ArticleDate
-                      classNames="story-date"
-                      date={contentElements[0].display_date}
-                    />
-                  </div>
-                </article>
-                {contentElements.slice(1).map((element) => {
-                  const {
-                    headlines: { basic: headlineText } = {},
-                  } = element;
-                  const imageURL = extractImageFromStory(element);
-                  const url = element.websites[arcSite].website_url;
-                  return (
-                    <React.Fragment key={`card-list-${url}`}>
-                      <article
-                        className="card-list-item card-list-item-margins"
-                        key={`card-list-${url}`}
-                        type="1"
+                      <a
+                        href={url}
+                        className="headline-list-anchor vertical-align-image"
                       >
-                        <a
-                          href={url}
-                          className="headline-list-anchor vertical-align-image"
-                        >
-                          <Heading className="headline-text">
-                            {headlineText}
-                          </Heading>
-                        </a>
-                        <a
-                          href={url}
-                          className="list-anchor-image vertical-align-image"
-                          aria-hidden="true"
-                          tabIndex="-1"
-                        >
-                          <Image
-                            {...this.smallImageOptions}
-                            url={imageURL || targetFallbackImage}
-                            alt={imageURL ? headlineText : this.siteProperties.primaryLogoAlt || ''}
-                            resizedImageOptions={imageURL
-                              ? extractResizedParams(element) : placeholderResizedImageOptions}
-                          />
-                        </a>
-                      </article>
-                    </React.Fragment>
-                  );
-                })}
-              </Wrapper>
-            </div>
-          </HeadingSection>
-        ) : null
-      )
-    );
+                        <Heading className="headline-text">
+                          {headlineText}
+                        </Heading>
+                      </a>
+                      <a
+                        href={url}
+                        className="list-anchor-image vertical-align-image"
+                        aria-hidden="true"
+                        tabIndex="-1"
+                      >
+                        <Image
+                          {...smallImageProps}
+                          url={imageURL || targetFallbackImage}
+                          alt={imageURL ? headlineText : smallImageProps.primaryLogoAlt || ''}
+                          resizedImageOptions={imageURL
+                            ? extractResizedParams(element) : placeholderResizedImageOptions}
+                        />
+                      </a>
+                    </article>
+                  </React.Fragment>
+                );
+              })}
+            </Wrapper>
+          </div>
+        </HeadingSection>
+      ) : null
+    )
+  );
+};
 
-    return (
-      <LazyLoad enabled={this.lazyLoad && !this.isAdmin}>
-        <CardListItems />
-      </LazyLoad>
-    );
+const CardList = ({ customFields }) => {
+  const {
+    id, arcSite, contextPath, deployment, isAdmin,
+  } = useFusionContext();
+  const {
+    websiteDomain, fallbackImage, primaryLogoAlt, breakpoints, resizerURL,
+  } = getProperties(arcSite);
+
+  const targetFallbackImage = getFallbackImageURL({ deployment, contextPath, fallbackImage });
+
+  const largeImageProps = {
+    smallWidth: 377,
+    smallHeight: 283,
+    mediumWidth: 377,
+    mediumHeight: 283,
+    largeWidth: 377,
+    largeHeight: 283,
+    primaryLogoAlt,
+    breakpoints,
+    resizerURL,
+  };
+
+  const smallImageProps = {
+    smallWidth: 105,
+    smallHeight: 70,
+    mediumWidth: 105,
+    mediumHeight: 70,
+    largeWidth: 105,
+    largeHeight: 70,
+    primaryLogoAlt,
+    breakpoints,
+    resizerURL,
+  };
+
+  const placeholderResizedImageOptions = useContent({
+    source: 'resize-image-api',
+    query: { raw_image_url: targetFallbackImage, respect_aspect_ratio: true },
+  });
+
+  if (customFields.lazyLoad && isServerSide() && !isAdmin) { // On Server
+    return null;
   }
-}
+
+  return (
+    <LazyLoad enabled={customFields.lazyLoad && !isAdmin}>
+      <CardListItems
+        id={id}
+        customFields={customFields}
+        placeholderResizedImageOptions={placeholderResizedImageOptions}
+        targetFallbackImage={targetFallbackImage}
+        websiteDomain={websiteDomain}
+        largeImageProps={largeImageProps}
+        smallImageProps={smallImageProps}
+        arcSite={arcSite}
+      />
+    </LazyLoad>
+  );
+};
 
 CardList.label = 'Card List – Arc Block';
 

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -3,12 +3,7 @@ import { mount } from 'enzyme';
 import getThemeStyle from 'fusion:themes';
 import { useContent } from 'fusion:content';
 import { useFusionContext } from 'fusion:context';
-import mockData,
-{
-  oneListItem,
-  withoutByline,
-  oneListItemWithoutSectionName,
-} from './mock-data';
+import mockData, { oneListItem } from './mock-data';
 
 jest.mock('fusion:content', () => ({
   useContent: jest.fn(() => mockData),
@@ -218,26 +213,6 @@ describe('Card list', () => {
       expect(
         wrapper.find('article.card-list-item').find('.headline-list-anchor').at(0).prop('href'),
       ).toEqual('/this/is/the/correct/url');
-    });
-  });
-
-  describe('render one list item correctly when list of authors is missing', () => {
-    const listContentConfig = {
-      contentConfigValues: {
-        offset: '0',
-        query: 'type:story',
-        size: '1',
-      },
-      contentService: 'story-feed-query',
-    };
-    const customFields = { listContentConfig };
-    const { default: CardList } = require('./default');
-
-    // CardList.prototype.fetchContent = jest.fn().mockReturnValue(withoutByline);
-    const wrapper = mount(<CardList customFields={customFields} />);
-
-    it('should render one parent wrapper', () => {
-      expect(wrapper.find('div.card-list-container').length).toEqual(1);
     });
   });
 

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import getThemeStyle from 'fusion:themes';
+import { useContent } from 'fusion:content';
+import { useFusionContext } from 'fusion:context';
 import mockData,
 {
   oneListItem,
@@ -8,7 +10,17 @@ import mockData,
   oneListItemWithoutSectionName,
 } from './mock-data';
 
-const mockReturnData = mockData;
+jest.mock('fusion:content', () => ({
+  useContent: jest.fn(() => mockData),
+}));
+
+jest.mock('fusion:context', () => ({
+  useFusionContext: jest.fn(() => ({
+    id: '',
+    arcSite: 'the-sun',
+    deployment: jest.fn(() => {}),
+  })),
+}));
 
 jest.mock('fusion:themes', () => jest.fn(() => ({})));
 
@@ -22,17 +34,13 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   isServerSide: () => true,
 }));
 
-jest.mock('@wpmedia/date-block', () => ({
-  __esModule: true,
-  default: function ArticleDate() { return <div />; },
-}));
-
 jest.mock('@wpmedia/shared-styles', () => ({
   __esModule: true,
   Byline: () => <div />,
   Overline: () => <div />,
   Heading: ({ children }) => children,
   HeadingSection: ({ children }) => children,
+  PromoDate: () => <div />,
 }));
 
 describe('Card list', () => {
@@ -50,9 +58,14 @@ describe('Card list', () => {
       lazyLoad: true,
     };
 
+    useFusionContext.mockReturnValueOnce({
+      id: '',
+      arcSite: 'the-sun',
+      deployment: jest.fn(() => {}),
+    });
+
     const { default: CardList } = require('./default');
-    CardList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
-    const wrapper = mount(<CardList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+    const wrapper = mount(<CardList customFields={customFields} />);
     expect(wrapper.html()).toBe(null);
   });
 
@@ -68,13 +81,9 @@ describe('Card list', () => {
     const customFields = { listContentConfig };
 
     const { default: CardList } = require('./default');
-    CardList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
-    const wrapper = mount(<CardList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ cardList: mockData }, () => {
-      wrapper.update();
-      expect(wrapper.find('.card-list-container').length).toEqual(1);
-      expect(wrapper.find('article.card-list-item').length).toEqual(27);
-    });
+    const wrapper = mount(<CardList customFields={customFields} />);
+    expect(wrapper.find('.card-list-container').length).toEqual(1);
+    expect(wrapper.find('article.card-list-item').length).toEqual(27);
   });
 
   it('should render a list of stories only for the arcSite', () => {
@@ -89,14 +98,15 @@ describe('Card list', () => {
     const customFields = { listContentConfig };
 
     const { default: CardList } = require('./default');
-    CardList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
-    const wrapper = mount(<CardList customFields={customFields} arcSite="dagen" deployment={jest.fn((path) => path)} />);
-    wrapper.setState({ cardList: mockData }, () => {
-      wrapper.update();
-      expect(wrapper.find('.card-list-container').length).toEqual(1);
-      expect(wrapper.find('article.card-list-item').length).toEqual(0);
-      expect(wrapper.find('article.list-item-simple').length).toEqual(1);
-    });
+    jest.mock('fusion:context', () => ({
+      useFusionContext: jest.fn(() => ({ arcSite: 'dagen', deployment: jest.fn(() => {}) })),
+    }));
+    useContent.mockReturnValueOnce(null);
+    useContent.mockReturnValueOnce(oneListItem);
+    const wrapper = mount(<CardList customFields={customFields} />);
+    expect(wrapper.find('.card-list-container').length).toEqual(1);
+    expect(wrapper.find('article.card-list-item').length).toEqual(0);
+    expect(wrapper.find('article.list-item-simple').length).toEqual(1);
   });
 
   describe('renders the main list item correctly', () => {
@@ -112,68 +122,68 @@ describe('Card list', () => {
     const customFields = { listContentConfig, title };
     const { default: CardList } = require('./default');
     getThemeStyle.mockImplementation(() => ({ 'primary-font-family': 'Papyrus' }));
-    CardList.prototype.fetchContent = jest.fn().mockReturnValue(oneListItem);
-    const wrapper = mount(<CardList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
 
-    wrapper.setState({ cardList: oneListItem }, () => {
-      it('should have one parent wrapper', () => {
-        expect(wrapper.find('.card-list-container').length).toEqual(1);
-      });
+    useContent.mockReturnValueOnce(null);
+    useContent.mockReturnValueOnce(oneListItem);
+    const wrapper = mount(<CardList customFields={customFields} />);
 
-      it('should render a title with the right text', () => {
-        expect(wrapper.find('.card-list-title').first().text()).toEqual('Test Title');
-      });
+    it('should have one parent wrapper', () => {
+      expect(wrapper.find('.card-list-container').length).toEqual(1);
+    });
 
-      it('should render two anchor tags - one around image one for the title', () => {
-        expect(wrapper.find('article.list-item-simple').find('.list-anchor').length).toEqual(2);
-        expect(wrapper.find('.card-list--link-container').find('Image').length).toEqual(1);
-      });
+    it('should render a title with the right text', () => {
+      expect(wrapper.find('.card-list-title').first().text()).toEqual('Test Title');
+    });
 
-      it('should render one image wrapped in an anchor tag', () => {
-        expect(wrapper.find('article.list-item-simple').find('.list-anchor').find('Image').length).toEqual(1);
-      });
+    it('should render two anchor tags - one around image one for the title', () => {
+      expect(wrapper.find('article.list-item-simple').find('.list-anchor').length).toEqual(2);
+      expect(wrapper.find('.card-list--link-container').find('Image').length).toEqual(1);
+    });
 
-      it('should render an anchor ', () => {
-        expect(wrapper.find('article.list-item-simple').find('.list-anchor').at(0).find('a').length).toEqual(1);
-      });
+    it('should render one image wrapped in an anchor tag', () => {
+      expect(wrapper.find('article.list-item-simple').find('.list-anchor').find('Image').length).toEqual(1);
+    });
 
-      it('should render an anchor and an image with the correct url', () => {
-        const anchors = wrapper.find('article.list-item-simple').find('.list-anchor');
-        expect(anchors.at(0).prop('href')).toEqual('/this/is/the/correct/url');
-        expect(anchors.at(1).prop('href')).toEqual('/this/is/the/correct/url');
-      });
+    it('should render an anchor ', () => {
+      expect(wrapper.find('article.list-item-simple').find('.list-anchor').at(0).find('a').length).toEqual(1);
+    });
 
-      it('should render an anchor and an image with alt text', () => {
-        expect(wrapper.find('article.list-item-simple').find('.list-anchor').find('Image').prop('alt')).toEqual('Article with a YouTube embed in it');
-      });
+    it('should render an anchor and an image with the correct url', () => {
+      const anchors = wrapper.find('article.list-item-simple').find('.list-anchor');
+      expect(anchors.at(0).prop('href')).toEqual('/this/is/the/correct/url');
+      expect(anchors.at(1).prop('href')).toEqual('/this/is/the/correct/url');
+    });
 
-      it('should render an overline', () => {
-        expect(wrapper.find('Overline').length).toEqual(1);
-      });
+    it('should render an anchor and an image with alt text', () => {
+      expect(wrapper.find('article.list-item-simple').find('.list-anchor').find('Image').prop('alt')).toEqual('Article with a YouTube embed in it');
+    });
 
-      it('should render a main headline', () => {
-        expect(wrapper.find('.card-list-headline').length).toEqual(1);
-      });
+    it('should render an overline', () => {
+      expect(wrapper.find('Overline').length).toEqual(1);
+    });
 
-      it('should render an author and a publish date section', () => {
-        expect(wrapper.find('article.list-item-simple').find('.author-date').length).toEqual(1);
-      });
+    it('should render a main headline', () => {
+      expect(wrapper.find('.card-list-headline').length).toEqual(1);
+    });
 
-      it('should render a byline', () => {
-        expect(wrapper.find('.author-date').find('Byline').length).toEqual(1);
-      });
+    it('should render an author and a publish date section', () => {
+      expect(wrapper.find('article.list-item-simple').find('.author-date').length).toEqual(1);
+    });
 
-      it('should render a separator', () => {
-        expect(wrapper.find('Byline').prop('separator')).toEqual(true);
-      });
+    it('should render a byline', () => {
+      expect(wrapper.find('.author-date').find('Byline').length).toEqual(1);
+    });
 
-      it('should render a publish date', () => {
-        expect(wrapper.find('.author-date').find('ArticleDate').length).toEqual(1);
-      });
+    it('should render a separator', () => {
+      expect(wrapper.find('Byline').prop('separator')).toEqual(true);
+    });
 
-      it('should not add the line divider', () => {
-        expect(wrapper.find('article.list-item-simple--divider').length).toEqual(0);
-      });
+    it('should render a publish date', () => {
+      expect(wrapper.find('.author-date').length).toEqual(1);
+    });
+
+    it('should not add the line divider', () => {
+      expect(wrapper.find('article.list-item-simple--divider').length).toEqual(0);
     });
   });
 
@@ -190,28 +200,24 @@ describe('Card list', () => {
     const customFields = { listContentConfig, title };
     const { default: CardList } = require('./default');
 
-    CardList.prototype.fetchContent = jest.fn().mockReturnValue(mockReturnData);
-    const wrapper = mount(<CardList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+    const wrapper = mount(<CardList customFields={customFields} />);
 
-    wrapper.setState({ cardList: mockData }, () => {
-      wrapper.update();
-      it('should render one parent wrapper', () => {
-        expect(wrapper.find('.card-list-container').length).toEqual(1);
-      });
+    it('should render one parent wrapper', () => {
+      expect(wrapper.find('.card-list-container').length).toEqual(1);
+    });
 
-      it('should render a parent for headline and a description', () => {
-        expect(wrapper.find('article.card-list-item').length).toEqual(27);
-      });
+    it('should render a parent for headline and a description', () => {
+      expect(wrapper.find('article.card-list-item').length).toEqual(27);
+    });
 
-      it('should render a headline', () => {
-        expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').length).toEqual(27);
-        expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').find('.headline-text').length).toEqual(27);
-        expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').find('.headline-text').first()
-          .text()).toEqual('Jon’s Prod Story');
-        expect(
-          wrapper.find('article.card-list-item').find('.headline-list-anchor').at(0).prop('href'),
-        ).toEqual('/this/is/the/correct/url');
-      });
+    it('should render a headline', () => {
+      expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').length).toEqual(27);
+      expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').find('.headline-text').length).toEqual(27);
+      expect(wrapper.find('article.card-list-item').find('a.headline-list-anchor').find('.headline-text').first()
+        .text()).toEqual('Jon’s Prod Story');
+      expect(
+        wrapper.find('article.card-list-item').find('.headline-list-anchor').at(0).prop('href'),
+      ).toEqual('/this/is/the/correct/url');
     });
   });
 
@@ -227,14 +233,11 @@ describe('Card list', () => {
     const customFields = { listContentConfig };
     const { default: CardList } = require('./default');
 
-    CardList.prototype.fetchContent = jest.fn().mockReturnValue(withoutByline);
-    const wrapper = mount(<CardList customFields={customFields} arcSite="the-sun" deployment={jest.fn((path) => path)} />);
+    // CardList.prototype.fetchContent = jest.fn().mockReturnValue(withoutByline);
+    const wrapper = mount(<CardList customFields={customFields} />);
 
-    wrapper.setState({ cardList: withoutByline }, () => {
-      wrapper.update();
-      it('should render one parent wrapper', () => {
-        expect(wrapper.find('div.card-list-container').length).toEqual(1);
-      });
+    it('should render one parent wrapper', () => {
+      expect(wrapper.find('div.card-list-container').length).toEqual(1);
     });
   });
 
@@ -250,23 +253,19 @@ describe('Card list', () => {
     const customFields = { listContentConfig };
     const { default: CardList } = require('./default');
 
-    CardList.prototype.fetchContent = jest.fn().mockReturnValue(oneListItemWithoutSectionName);
-    const wrapper = mount(<CardList customFields={customFields} arcSite="dagen" deployment={jest.fn((path) => path)} />);
+    const wrapper = mount(<CardList customFields={customFields} />);
 
-    wrapper.setState({ cardList: oneListItemWithoutSectionName }, () => {
-      wrapper.update();
-      it('should not render overline', () => {
-        expect(wrapper.find('.overline').length).toBe(0);
-      });
-      it('should render headline', () => {
-        expect(wrapper.find('.card-list-headline').length).toBe(1);
-      });
-      it('should render author-date', () => {
-        expect(wrapper.find('.author-date').length).toBe(1);
-      });
-      it('should render image', () => {
-        expect(wrapper.find('article.list-item-simple Image').length).toBe(1);
-      });
+    it('should not render overline', () => {
+      expect(wrapper.find('.overline').length).toBe(0);
+    });
+    it('should render headline', () => {
+      expect(wrapper.find('.card-list-headline').length).toBe(1);
+    });
+    it('should render author-date', () => {
+      expect(wrapper.find('.author-date').length).toBe(1);
+    });
+    it('should render image', () => {
+      expect(wrapper.find('article.list-item-simple Image').length).toBe(1);
     });
   });
 });

--- a/blocks/card-list-block/index.story.jsx
+++ b/blocks/card-list-block/index.story.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import CardList from './features/card-list/default';
+
+export default {
+  title: 'Blocks/Card List',
+  decorators: [withKnobs],
+  parameters: {
+    // Set the viewports in Chromatic at a component level.
+    chromatic: { viewports: [320, 1200] },
+  },
+};
+
+const props = {
+  deployment: (x) => x,
+};
+
+const sampleData = {
+  listContentConfig: {
+    contentService: 'content-api',
+    contentConfigValues: {},
+  },
+  title: 'Card List Headline',
+};
+
+export const allFields = () => {
+  const customFields = {
+    ...sampleData,
+  };
+
+  return (
+    <CardList {...props} customFields={customFields} />
+  );
+};
+
+export const noTitle = () => {
+  const customFields = {
+    ...sampleData,
+    title: null,
+  };
+
+  return (
+    <CardList {...props} customFields={customFields} />
+  );
+};
+
+export const noData = () => {
+  const customFields = {
+    listContentConfig: {
+      contentService: 'content-api',
+      contentConfigValues: { noData: true },
+    },
+    title: 'Card List with No Data',
+  };
+
+  return (
+    <CardList customFields={customFields} />
+  );
+};

--- a/blocks/card-list-block/index.story.jsx
+++ b/blocks/card-list-block/index.story.jsx
@@ -44,7 +44,7 @@ export const noTitle = () => {
   );
 };
 
-export const noData = () => {
+export const titleAndNoContent = () => {
   const customFields = {
     listContentConfig: {
       contentService: 'content-api',

--- a/blocks/card-list-block/package.json
+++ b/blocks/card-list-block/package.json
@@ -23,8 +23,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "peerDependencies": {
-    "@wpmedia/byline-block": "*",
-    "@wpmedia/date-block": "*",
+    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",
     "@wpmedia/shared-styles": "*"

--- a/blocks/numbered-list-block/features/numbered-list/default.test.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.test.jsx
@@ -126,7 +126,7 @@ describe('The numbered-list-block', () => {
         .text()).toEqual('Story with video as the Lead Art');
     });
 
-    it.only('should render elements only for arcSite', () => {
+    it('should render elements only for arcSite', () => {
       const { default: NumberedList } = require('./default');
       const listContentConfig = {
         contentConfigValues:

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -458,8 +458,6 @@ TopTableListWrapper.propTypes = {
   }),
 };
 
-TopTableListWrapper.lazy = true;
-
 TopTableListWrapper.label = 'Top Table List – Arc Block';
 
 export default TopTableListWrapper;

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -458,6 +458,8 @@ TopTableListWrapper.propTypes = {
   }),
 };
 
+TopTableListWrapper.lazy = true;
+
 TopTableListWrapper.label = 'Top Table List – Arc Block';
 
 export default TopTableListWrapper;


### PR DESCRIPTION
## Description
Add stories for Card List Block
* Refactored to use functional components to make it easier to mock within storybook

## Jira Ticket
- [TMEDIA-250](https://arcpublishing.atlassian.net/browse/TMEDIA-250)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-250-card-list-story`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/card-list-block`
3. Verify Card List block works as before - no changes in functionality
 
## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
