### PR TITLE
feat: Toggle arc static enabling, simplify render logic

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -93,6 +93,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
             largeHeight={0}
             breakpoints={getProperties(arcSite)?.breakpoints}
             resizerURL={getProperties(arcSite)?.resizerURL}
+            disableArcStatic={customFields.lazyLoad}
           />
           <figcaption>
             <ImageMetadata

--- a/blocks/author-bio-block/features/author-bio/default.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.jsx
@@ -32,7 +32,7 @@ import './author-bio.scss';
 
 const MediaLinksStyled = styled(LinkSVGHover)``;
 
-const renderAuthorInfo = (author, arcSite) => {
+const renderAuthorInfo = (author, arcSite, lazyLoad) => {
   const {
     image: { url = '', alt_text: altText = '' },
     image,
@@ -55,12 +55,14 @@ const renderAuthorInfo = (author, arcSite) => {
           breakpoints={getProperties(arcSite)?.breakpoints}
           resizerURL={getProperties(arcSite)?.resizerURL}
           resizedImageOptions={resizedImageOptions}
+          disableArcStatic={lazyLoad}
         />
       ) : null
   );
 };
 
-const AuthorBioItems = () => {
+const AuthorBioItems = (props) => {
+  const { customFields: { lazyLoad } } = props;
   const { globalContent: content, arcSite } = useFusionContext();
   const {
     locale = 'en',
@@ -220,7 +222,7 @@ const AuthorBioItems = () => {
       authorList.push((
         <section key={(author.name) ? author.name : ''} className="authors">
           <section className="author">
-            {renderAuthorInfo(author, arcSite)}
+            {renderAuthorInfo(author, arcSite, lazyLoad)}
             <section className="descriptions">
               {authorNameWithHyperlink || authorName}
               {/* there will always be a description via conditional on 52 */}

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -30,6 +30,7 @@ const CardListItems = (props) => {
         contentConfigValues = {},
       } = {},
       title = '',
+      lazyLoad,
     } = {},
     placeholderResizedImageOptions,
     targetFallbackImage,
@@ -136,6 +137,8 @@ const CardListItems = (props) => {
                       url={extractImageFromStory(contentElements[0])}
                       alt={contentElements[0].headlines.basic}
                       resizedImageOptions={extractResizedParams(contentElements[0])}
+                      // if user elects lazy load, then disable arc static
+                      disableArcStatic={lazyLoad}
                     />
                   ) : (
                     <Image
@@ -143,6 +146,8 @@ const CardListItems = (props) => {
                       url={targetFallbackImage}
                       alt={largeImageProps.primaryLogoAlt || ''}
                       resizedImageOptions={placeholderResizedImageOptions}
+                      // if user elects lazy load, then disable arc static
+                      disableArcStatic={lazyLoad}
                     />
                   )}
                 </a>
@@ -199,6 +204,8 @@ const CardListItems = (props) => {
                           alt={imageURL ? headlineText : smallImageProps.primaryLogoAlt || ''}
                           resizedImageOptions={imageURL
                             ? extractResizedParams(element) : placeholderResizedImageOptions}
+                          // if user elects lazy load, then disable arc static
+                          disableArcStatic={lazyLoad}
                         />
                       </a>
                     </article>

--- a/blocks/full-author-bio-block/features/full-author-bio/default.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.jsx
@@ -44,7 +44,8 @@ const logos = {
   soundcloud: <SoundCloudIcon />,
 };
 
-const FullAuthorBioItem = () => {
+const FullAuthorBioItem = (props) => {
+  const { customFields: { lazyLoad } } = props;
   const { globalContent: content, arcSite } = useFusionContext();
   const { locale = 'en' } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
@@ -80,6 +81,7 @@ const FullAuthorBioItem = () => {
                 resizedImageOptions={content.authors[0].resized_params}
                 resizerURL={getProperties(arcSite)?.resizerURL}
                 breakpoints={getProperties(arcSite)?.breakpoints}
+                disableArcStatic={lazyLoad}
               />
             )
           }

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -195,6 +195,7 @@ class LeadArt extends Component {
                 breakpoints={getProperties(arcSite)?.breakpoints}
                 resizerURL={getProperties(arcSite)?.resizerURL}
                 resizedImageOptions={lead_art.resized_params}
+                // static by default, no lazy load needed
               />
             </div>
             {lightbox}

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -157,6 +157,7 @@ const NumberedListWrapper = ({ customFields }) => {
     primaryLogoAlt,
     breakpoints,
     resizerURL,
+    disableArcStatic: customFields.lazyLoad,
   };
 
   const placeholderResizedImageOptions = useContent({

--- a/blocks/placeholder-image-block/features/placeholder-image/default.jsx
+++ b/blocks/placeholder-image-block/features/placeholder-image/default.jsx
@@ -49,6 +49,7 @@ class PlaceholderImage extends React.Component {
       mediumHeight = 105,
       largeWidth = 105,
       largeHeight = 105,
+      lazyLoad,
     } = this.props;
     const { resizedImageOptions } = this.state;
 
@@ -69,6 +70,7 @@ class PlaceholderImage extends React.Component {
           largeHeight={largeHeight}
           resizedImageOptions={resizedImageOptions}
           resizerURL={getProperties(arcSite)?.resizerURL}
+          disableArcStatic={lazyLoad}
         />
       </>
     );

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -66,6 +66,7 @@ class ResultsList extends Component {
       primaryLogoAlt,
       breakpoints,
       resizerURL,
+      disableArcStatic: lazyLoad,
     };
 
     this.fetchPlaceholder();

--- a/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
@@ -49,6 +49,8 @@ class CustomSearchResultsList extends React.Component {
       primaryLogoAlt,
       breakpoints,
       resizerURL,
+      // lazy ?
+      disableArcStatic: props?.customFields.lazyLoad,
     };
 
     this.fetchPlaceholder();


### PR DESCRIPTION
- use with https://github.com/WPMedia/engine-theme-sdk/pull/379 
- Continue rendering logic for arc-static and loading="lazy" and user-enabled lazyLoad
- npx fusion start -f -l @wpmedia/card-list-block

## lazy load off 

create block with many stories. lazyLoad off
- should all render with static without js enabled

- images only loading once 
![Screen Shot 2021-07-01 at 14 26 23](https://user-images.githubusercontent.com/5950956/124179315-4f855180-da78-11eb-9724-1a3fb94b97b7.png)

## lazy load on 

create block with many stories. lazyLoad on

- add many brs to an html box to lazy load the whole block
- see the requests only begin as you scroll the block into viewport 
![Screen Shot 2021-07-01 at 14 47 02](https://user-images.githubusercontent.com/5950956/124181501-2e723000-da7b-11eb-9532-4aab78fc04ce.png)
![Screen Shot 2021-07-01 at 14 46 23](https://user-images.githubusercontent.com/5950956/124181503-2f0ac680-da7b-11eb-810a-537ad012331f.png)
![Screen Shot 2021-07-01 at 14 45 25](https://user-images.githubusercontent.com/5950956/124181504-2f0ac680-da7b-11eb-889b-ab1e317c6419.png)

- when js is disabled, images should not be called nor render when the content is not in view 
- when you scroll down, with js disabled, and with lazy load on, the images should be displayed as normal
