### PR TITLE
Tmedia 325 spa per site default output

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     'no-underscore-dangle': ['error', { allow: ['_website', '_id'] }],
     'import/no-extraneous-dependencies': 'off', // This might be fine. It's worth looking into at the very least.
     'import/no-unresolved': [2, {
-      ignore: ['react', '^fusion:.+$', '^@arc-test-org/.+$', '^@arc-core-components/.+$', '^@wpmedia/.+$']
+      ignore: ['react', '^fusion:.+$', '^@arc-test-org/.+$', '^@arc-core-components/.+$', '^@wpmedia/.+$', '~/blocks.json']
     }],
     'react/forbid-prop-types': 'off',
     'react/prop-types': 'off', // We will want to be more granular with this I assume.

--- a/babel.config.js
+++ b/babel.config.js
@@ -29,6 +29,7 @@ module.exports = {
             'fusion:properties': './jest/mocks/properties.js',
             'fusion:static': './jest/mocks/static.js',
             'fusion:intl': './jest/mocks/intl.js',
+            '~/blocks.json': './jest/mocks/blocks.json',
           },
         }],
       ],

--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -531,6 +531,7 @@ describe('queryly render conditions', () => {
 });
 
 describe('The spa property', () => {
+  // we're only expecting spaSites to be an array
   it('should be set as true if spaSites is undefined', () => {
     expect(configureSinglePageApp(undefined)).toStrictEqual(true);
   });

--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
+import { configureSinglePageApp } from '../default';
 
 const dummyComp = () => <meta content="dummy" />;
 const mockFuntions = {
@@ -526,5 +527,24 @@ describe('queryly render conditions', () => {
       <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('queryly-search')} {...mockFuntions} />,
     );
     expect(wrapper.find('script').find({ 'data-integration': 'queryly' }).length).toBe(2);
+  });
+});
+
+describe('The spa property', () => {
+  it('should be set as true if spaSites is undefined', () => {
+    expect(configureSinglePageApp(undefined)).toStrictEqual(true);
+  });
+  it('should be set to empty array if spaSites is an empty array', () => {
+    expect(configureSinglePageApp([])).toStrictEqual([]);
+  });
+  it('should be set to true if spaSites is false', () => {
+    expect(configureSinglePageApp(false)).toStrictEqual(true);
+  });
+  it('should be set to true if spaSites is true', () => {
+    expect(configureSinglePageApp(true)).toStrictEqual(true);
+  });
+  it('should be set to a one-item array if one site id is passed in to spaSites', () => {
+    const spaSites = ['the-sun'];
+    expect(configureSinglePageApp(spaSites)).toStrictEqual(spaSites);
   });
 });

--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -531,18 +531,12 @@ describe('queryly render conditions', () => {
 });
 
 describe('The spa property', () => {
-  // we're only expecting spaSites to be an array
+  // we're only expecting spaSites to be an array or undefined
   it('should be set as true if spaSites is undefined', () => {
     expect(configureSinglePageApp(undefined)).toStrictEqual(true);
   });
   it('should be set to empty array if spaSites is an empty array', () => {
     expect(configureSinglePageApp([])).toStrictEqual([]);
-  });
-  it('should be set to true if spaSites is false', () => {
-    expect(configureSinglePageApp(false)).toStrictEqual(true);
-  });
-  it('should be set to true if spaSites is true', () => {
-    expect(configureSinglePageApp(true)).toStrictEqual(true);
   });
   it('should be set to a one-item array if one site id is passed in to spaSites', () => {
     const spaSites = ['the-sun'];

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -4,6 +4,7 @@ import getTranslatedPhrases from 'fusion:intl';
 import { useFusionContext } from 'fusion:context';
 import { MetaData } from '@wpmedia/engine-theme-sdk';
 
+import blocks from '~/blocks.json';
 // this is blank import but used to inject scss
 import './default.scss';
 
@@ -194,5 +195,14 @@ const SampleOutputType = ({
     </html>
   );
 };
+
+console.log(blocks);
+
+// include arr if true
+// false if
+// potential options
+// ["the-sun"]
+// false
+SampleOutputType.spa = blocks.spaSites ? blocks.spaSites : !!blocks.spaSites;
 
 export default SampleOutputType;

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -210,6 +210,10 @@ const SampleOutputType = ({
 //    spaSites will be a truthy array and set itself
 
 // fallback to true to ensure all site ids don't have to copy-pasted to blocks.json
-SampleOutputType.spa = blocks.spaSites ? blocks.spaSites : true;
+export function configureSinglePageApp(spaSites) {
+  return spaSites || true;
+}
+
+SampleOutputType.spa = configureSinglePageApp(blocks.spaSites);
 
 export default SampleOutputType;

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -196,13 +196,20 @@ const SampleOutputType = ({
   );
 };
 
-console.log(blocks);
+// if publisher wants no sites to be spa
+// then they do nothing. spaSites will be falsy undefined and fallsback to spa true,
+//  which won't do anything in isolation
 
-// include arr if true
-// false if
-// potential options
-// ["the-sun"]
-// false
-SampleOutputType.spa = blocks.spaSites ? blocks.spaSites : !!blocks.spaSites;
+// if publisher wants all sites to be spa
+// then they set environment "FUSION_SERVICE_WORKER": true and use 2.8
+//  spaSites will be falsy undefined and fallback to spa true
+
+// if publisher wants to select which sites are spa
+// then set environment "FUSION_SERVICE_WORKER": true and use 2.8
+//    and set in blocks.json spaSites: ["target-site-id"].
+//    spaSites will be a truthy array and set itself
+
+// fallback to true to ensure all site ids don't have to copy-pasted to blocks.json
+SampleOutputType.spa = blocks.spaSites ? blocks.spaSites : true;
 
 export default SampleOutputType;

--- a/jest/mocks/blocks.json
+++ b/jest/mocks/blocks.json
@@ -1,0 +1,3 @@
+{
+  "spaSites": ["the-sun"]
+}


### PR DESCRIPTION
## Description
Set spa per site

## Jira Ticket
- [TMEDIA-325](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-325&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria

- use and enable functionality of a player on a site with spa enabled in the blocks.json
- disable and functionality of a player on a site without spa enabled in the blocks.json

## Test Steps

1. Checkout this blocks branch `git checkout TMEDIA-325-spa-per-site-default-output`
2. Checkout this fusion news theme branch `git checkout TMEDIA-325-spa-per-site-default-output`  (pr https://github.com/WPMedia/Fusion-News-Theme/pull/180)
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/default-output-block`
4. Set in .env FUSION_SERVICE_WORKER=true and use FUSION_RELEASE=2.8.1
5. Set the following in spa-test-1 and spa-test-2


test with the-sun working spa
```html
<a href="http://localhost/pf/spa-test-2/?_website=the-sun">Click here for spa test 2 the sun</a>
```

test with the spa per site not working 
```html
<a href="http://localhost/pf/spa-test-2/?_website=the-gazette">Click here for spa test 2 the gazette</a>
```

Set persistent audio player to this url:
https://dl.dropbox.com/s/p624ah6kwyt6425/Eiffel%2065%20-%20Blue%20%28Flume%20Remix%29%20-%20Official%20Visualiser.mp3 

id: song

<img width="361" alt="Screen Shot 2021-07-06 at 14 24 04" src="https://user-images.githubusercontent.com/5950956/124655647-bc785d00-de65-11eb-860f-93f4425faa54.png">

spa test 2 

set same id and url as above 

<img width="730" alt="Screen Shot 2021-07-06 at 14 25 17" src="https://user-images.githubusercontent.com/5950956/124655765-e92c7480-de65-11eb-83ae-4de68fac3260.png">

---

1. Go to spa test 1 with opted-in site the-sun via spaSites 
2. Play persistent audio player 

<img width="334" alt="Screen Shot 2021-07-06 at 14 27 43" src="https://user-images.githubusercontent.com/5950956/124656000-3f99b300-de66-11eb-8e98-5003b3d1e1d0.png">

3. Click the-sun spa test 2 
4. See the-sun one work and continue playing
<img width="565" alt="Screen Shot 2021-07-06 at 14 28 29" src="https://user-images.githubusercontent.com/5950956/124656090-5b04be00-de66-11eb-8161-12ba69449b80.png">
5. Enter in the url bar to the gazette spa test 1 http://localhost/pf/spa-test-1/?_website=the-gazette. Click play again
<img width="267" alt="Screen Shot 2021-07-06 at 14 29 11" src="https://user-images.githubusercontent.com/5950956/124656164-7374d880-de66-11eb-89cf-de4f7679e41b.png">

6. Go to spa test 2 the gazette
7. The player should not continue playing

<img width="660" alt="Screen Shot 2021-07-06 at 14 29 51" src="https://user-images.githubusercontent.com/5950956/124656245-8daeb680-de66-11eb-9af2-b9e329ae3b45.png">


----

## Spa Opt out 

Set   `"FUSION_SERVICE_WORKER": false` and no persistent audio features should work for any site 
- Can do this live, watching the index.json

## Spa opt in completely 
- Stop the cli watcher
- Remove   `"spaSites": ["the-sun"],` from blocks.json
- Make sure all sites spa works 


https://user-images.githubusercontent.com/5950956/124657078-a66b9c00-de67-11eb-89bc-eaaecdc438fb.mov

## Effect Of Changes
### Before
- setting spa on custom output type. opt in or opt out completely, unless you made your own output type

### After
- Can set spa per site 
- If you opt in to spa via environment.json and fusion engine, you get all of your sites on spa

## Dependencies or Side Effects

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
