### PR TITLE
fix: Update height to match incoming image

### DIFF
--- a/blocks/card-list-block/features/card-list/card-list.scss
+++ b/blocks/card-list-block/features/card-list/card-list.scss
@@ -88,9 +88,9 @@
 
   .list-anchor-image {
     img {
-      max-height: 71px;
+      max-height: 70px;
       max-width: 105px;
-      min-height: 71px;
+      min-height: 70px;
       min-width: 105px;
     }
   }


### PR DESCRIPTION
before: 

off by 1 px in hard-coded width and height

<img width="1327" alt="Screen Shot 2021-07-07 at 15 57 15" src="https://user-images.githubusercontent.com/5950956/124827830-1d726480-df3c-11eb-9837-cd4c8d62ae93.png">

<img width="502" alt="Screen Shot 2021-07-07 at 15 30 56" src="https://user-images.githubusercontent.com/5950956/124827897-31b66180-df3c-11eb-9a45-7989ee22f6d5.png">

https://corecomponents.arcpublishing.com/pf/card-list-many-elements/?_website=the-sun

after: 


<img width="1400" alt="Screen Shot 2021-07-07 at 15 56 57" src="https://user-images.githubusercontent.com/5950956/124827851-25320900-df3c-11eb-8966-63af87951955.png">
