### PR TITLE
perf: Update the preconnect and preload for the font

### DIFF
--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -114,7 +114,7 @@ describe('renders a page', () => {
     const wrapper = shallow(
       <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} {...mockFuntions} />,
     );
-    expect(wrapper.find('link').length).toBe(5);
+    expect(wrapper.find('link').length).toBe(4);
   });
 
   it('should have a MedataData component', () => {

--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -114,7 +114,7 @@ describe('renders a page', () => {
     const wrapper = shallow(
       <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} {...mockFuntions} />,
     );
-    expect(wrapper.find('link').length).toBe(2);
+    expect(wrapper.find('link').length).toBe(5);
   });
 
   it('should have a MedataData component', () => {
@@ -257,7 +257,9 @@ describe('head content', () => {
     const wrapper = shallow(
       <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} {...mockFuntions} />,
     );
-    expect(wrapper.find('link').at(1).html()).toMatch(/fonts.googleapis/);
+
+    console.log(wrapper.find('link').debug());
+    expect(wrapper.find('link').at(2).html()).toMatch(/fonts.googleapis/);
   });
 
   it('must not render nested scripts', () => {

--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -258,7 +258,6 @@ describe('head content', () => {
       <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} {...mockFuntions} />,
     );
 
-    console.log(wrapper.find('link').debug());
     expect(wrapper.find('link').at(2).html()).toMatch(/fonts.googleapis/);
   });
 

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -52,19 +52,56 @@ const googleTagManagerNoScript = (gtmID) => {
   );
 };
 
+const optimalFontLoading = (fontUrl, index = '') => (
+  <>
+    <link
+      rel="preload"
+      as="style"
+      href={`${fontUrl}&display=swap`}
+    />
+    <link
+      rel="stylesheet"
+      key={fontUrl}
+      data-testid={`font-loading-url-${index}`}
+      href={`${fontUrl}&display=swap`}
+    />
+
+    <noscript>
+      <link
+        rel="stylesheet"
+        href={`${fontUrl}&display=swap`}
+      />
+    </noscript>
+  </>
+);
+
+// preconnect g static assumes google font, only supported in themes settings anyway
 const fontUrlLink = (fontUrl) => {
   // If fontURL is an array, then iterate over the array and build out the links
   if (fontUrl && Array.isArray(fontUrl) && fontUrl.length > 0) {
-    const fontLinks = [...new Set(fontUrl)].map((url, index) => (
-      <link rel="stylesheet" key={url} data-testid={`font-loading-url-${index}`} href={`${url}&display=swap`} />
-    ));
+    const fontLinks = [...new Set(fontUrl)].map((url, index) => optimalFontLoading(url, index));
+
     return (
-      <>{fontLinks}</>
+      <>
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin
+        />
+        <>{fontLinks}</>
+      </>
     );
   }
   // Legacy support where fontUrl is a string
   return fontUrl ? (
-    <link rel="stylesheet" href={`${fontUrl}&display=swap`} />
+    <>
+      <link
+        rel="preconnect"
+        href="https://fonts.gstatic.com"
+        crossOrigin
+      />
+      {optimalFontLoading(fontUrl)}
+    </>
   ) : '';
 };
 

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -65,13 +65,6 @@ const optimalFontLoading = (fontUrl, index = '') => (
       data-testid={`font-loading-url-${index}`}
       href={`${fontUrl}&display=swap`}
     />
-
-    <noscript>
-      <link
-        rel="stylesheet"
-        href={`${fontUrl}&display=swap`}
-      />
-    </noscript>
   </>
 );
 


### PR DESCRIPTION
- Biggest render-blocking asset in my pagespeed insights testing https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fcorecomponents-the-gazette-prod.cdn.arcpublishing.com%2Fall-blocks%2F


<img width="731" alt="Screen Shot 2021-07-07 at 16 45 37" src="https://user-images.githubusercontent.com/5950956/124832708-af7d6b80-df42-11eb-88cc-eb4656bbaa58.png">

before: 

<img width="1427" alt="Screen Shot 2021-07-07 at 16 41 18" src="https://user-images.githubusercontent.com/5950956/124832805-d5a30b80-df42-11eb-9330-84740ab29863.png">


after: 

- no render-blocking js 


<img width="483" alt="after-preconnect" src="https://user-images.githubusercontent.com/5950956/124832756-c459ff00-df42-11eb-9331-cd51635f9c08.png">


side effects: 

- did not hurt or help cls 

before:

<img width="723" alt="Screen Shot 2021-07-07 at 16 41 37" src="https://user-images.githubusercontent.com/5950956/124832915-f79c8e00-df42-11eb-899d-89859fbf6647.png">

after:

<img width="721" alt="after-preconnect-didnt-fix-cls" src="https://user-images.githubusercontent.com/5950956/124832894-f4090700-df42-11eb-813d-f5feefdc6f4e.png">

Based on https://css-tricks.com/how-to-load-fonts-in-a-way-that-fights-fout-and-makes-lighthouse-happy/
