### PR TITLE
fix: Use string cross origin true

### DIFF
--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -79,7 +79,7 @@ const fontUrlLink = (fontUrl) => {
         <link
           rel="preconnect"
           href="https://fonts.gstatic.com"
-          crossOrigin
+          crossOrigin="true"
         />
         <>{fontLinks}</>
       </>
@@ -91,7 +91,7 @@ const fontUrlLink = (fontUrl) => {
       <link
         rel="preconnect"
         href="https://fonts.gstatic.com"
-        crossOrigin
+        crossOrigin="true"
       />
       {optimalFontLoading(fontUrl)}
     </>


### PR DESCRIPTION
before: 

![Screen Shot 2021-07-08 at 11 58 35](https://user-images.githubusercontent.com/5950956/124962162-ebb4d880-dfe3-11eb-9b9b-a186bc385a0f.png)

after: 

![Screen Shot 2021-07-08 at 11 58 59](https://user-images.githubusercontent.com/5950956/124962152-e8215180-dfe3-11eb-8157-f6c34502be09.png)

