### PR TITLE
TMEDIA-263 - Update all chains to be able to have a heading

### DIFF
--- a/blocks/double-chain-block/chains/double-chain/default.jsx
+++ b/blocks/double-chain-block/chains/double-chain/default.jsx
@@ -1,15 +1,21 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
+import { Heading, HeadingSection } from '@wpmedia/shared-styles';
+
+import '@wpmedia/shared-styles/scss/_chains.scss';
 
 const DoubleChain = ({ children, customFields }) => {
   if (children && children.length && children.length > 0) {
     // if no columnOne length set, then use the length of the children
     // if no length set, then all children will be put in column one
-    const { columnOne: columnOneLength = children.length } = customFields;
+    const {
+      columnOne: columnOneLength = children.length,
+      heading = null,
+    } = customFields;
 
     // check column one length not negative
     if (columnOneLength > 0) {
-      return (
+      const childrenOutput = (
         <div className="container-fluid double-chain chain-container">
           <div className="row wrap-bottom">
             <div className="col-sm-12 col-md-xl-6 ie-flex-100-percent-sm column-1 reduce-internal-row-col-gap chain-col">
@@ -20,6 +26,17 @@ const DoubleChain = ({ children, customFields }) => {
             </div>
           </div>
         </div>
+      );
+
+      if (!heading) {
+        return childrenOutput;
+      }
+
+      return (
+        <HeadingSection>
+          <Heading className="chain-heading">{heading}</Heading>
+          {childrenOutput}
+        </HeadingSection>
       );
     }
   }
@@ -32,6 +49,9 @@ DoubleChain.label = 'Double Chain – Arc Block';
 DoubleChain.propTypes = {
   children: PropTypes.array,
   customFields: PropTypes.shape({
+    heading: PropTypes.string.tag({
+      label: 'Heading',
+    }),
     columnOne: PropTypes.number.isRequired.tag({
       label: 'Column one size',
       description: 'The number of features which will appear in the first column. The rest will go into the second column.',

--- a/blocks/double-chain-block/chains/double-chain/default.test.jsx
+++ b/blocks/double-chain-block/chains/double-chain/default.test.jsx
@@ -76,4 +76,32 @@ describe('the double chain block', () => {
 
     expect(component).toBeEmptyRender();
   });
+
+  it('should render heading from custom field and children', () => {
+    const customFields = { columnOne: 1, heading: 'Double Chain Heading' };
+    const component = mount(
+      <DoubleChain customFields={customFields}>
+        <Comp1 />
+        <Comp2 />
+      </DoubleChain>,
+    );
+
+    expect(component.find('Heading').text()).toBe('Double Chain Heading');
+    expect(component.find('HeadingSection').exists()).toBe(true);
+    expect(component.find('.column-1').text()).toBe('1');
+  });
+
+  it('should not render heading from custom field and children', () => {
+    const customFields = { columnOne: 1 };
+    const component = mount(
+      <DoubleChain customFields={customFields}>
+        <Comp1 />
+        <Comp2 />
+      </DoubleChain>,
+    );
+
+    expect(component.find('Heading').exists()).toBe(false);
+    expect(component.find('HeadingSection').exists()).toBe(false);
+    expect(component.find('.column-1').text()).toBe('1');
+  });
 });

--- a/blocks/double-chain-block/index.story.jsx
+++ b/blocks/double-chain-block/index.story.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import DoubleChain from './chains/double-chain/default';
+
+export default {
+  title: 'Chains/Double',
+  decorators: [withKnobs],
+  parameters: {
+    // Set the viewports in Chromatic at a component level.
+    chromatic: { viewports: [320, 740, 1200] },
+  },
+};
+
+const styles = {
+  backgroundColor: 'rgb(240 240 240)',
+};
+
+const Comp1 = () => <div style={styles}>1</div>;
+const Comp2 = () => <div style={styles}>2</div>;
+
+export const allColumns = () => {
+  const customFields = {
+    columnOne: 1,
+    heading: 'Double Chain Heading',
+  };
+
+  return (
+    <DoubleChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+    </DoubleChain>
+  );
+};
+
+export const allColumnsNoTitle = () => {
+  const customFields = {
+    columnOne: 1,
+  };
+
+  return (
+    <DoubleChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+    </DoubleChain>
+  );
+};
+
+export const zeroColumns = () => {
+  const customFields = {
+    heading: 'Double Chain Heading',
+  };
+
+  return (
+    <DoubleChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+    </DoubleChain>
+  );
+};

--- a/blocks/double-chain-block/package.json
+++ b/blocks/double-chain-block/package.json
@@ -22,8 +22,9 @@
     "directory": "blocks/double-chain-block"
   },
   "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/engine-theme-sdk": "*",
-    "@wpmedia/news-theme-css": "*"
+    "@wpmedia/shared-styles": "*"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/blocks/quad-chain-block/chains/quad-chain/default.jsx
+++ b/blocks/quad-chain-block/chains/quad-chain/default.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
+import { Heading, HeadingSection } from '@wpmedia/shared-styles';
+
+import '@wpmedia/shared-styles/scss/_chains.scss';
 
 const QuadChain = ({ children, customFields }) => {
   if (children && children.length && children.length > 0) {
@@ -9,6 +12,7 @@ const QuadChain = ({ children, customFields }) => {
       columnOne: columnOneLength = children.length,
       columnTwo: columnTwoLength = 0,
       columnThree: columnThreeLength = 0,
+      heading = null,
     } = customFields;
 
     // check column length not negative
@@ -17,7 +21,7 @@ const QuadChain = ({ children, customFields }) => {
 
       const endOfColumnThreeIndex = endOfColumnTwoIndex + columnThreeLength;
 
-      return (
+      const childrenOutput = (
         <div className="container-fluid chain-container">
           <div className="row wrap-bottom">
             <div className="col-sm-12 col-md-xl-3 ie-flex-100-percent-sm reduce-internal-row-col-gap chain-col">
@@ -35,6 +39,17 @@ const QuadChain = ({ children, customFields }) => {
           </div>
         </div>
       );
+
+      if (!heading) {
+        return childrenOutput;
+      }
+
+      return (
+        <HeadingSection>
+          <Heading className="chain-heading">{heading}</Heading>
+          {childrenOutput}
+        </HeadingSection>
+      );
     }
   }
 
@@ -46,6 +61,9 @@ QuadChain.label = 'Quad Chain – Arc Block';
 QuadChain.propTypes = {
   children: PropTypes.array,
   customFields: PropTypes.shape({
+    heading: PropTypes.string.tag({
+      label: 'Heading',
+    }),
     columnOne: PropTypes.number.isRequired.tag({
       label: 'Number of blocks in Column 1:',
       description: 'The number of features which will appear in the first column',

--- a/blocks/quad-chain-block/chains/quad-chain/default.test.jsx
+++ b/blocks/quad-chain-block/chains/quad-chain/default.test.jsx
@@ -7,12 +7,14 @@ describe('the quad chain block', () => {
   const Comp2 = () => <div>2</div>;
   const Comp3 = () => <div>3</div>;
   const Comp4 = () => <div>4</div>;
+
   it('should only render if there are children', () => {
     const component = shallow(
       <Chain />,
     );
     expect(component).toBeEmptyRender();
   });
+
   it('should put all features into the first column by default', () => {
     const customFields = {};
     const component = shallow(
@@ -30,6 +32,7 @@ describe('the quad chain block', () => {
     expect(columnOne.children().length).toBe(4);
     expect(columnTwo.children().length).toBe(0);
   });
+
   it('should be able to accept a number in the custom field, and that number of features within the chain should appear in the first column. ', () => {
     const customFields = { columnOne: 2, columnTwo: 2, columnThree: 0 };
     const component = mount(
@@ -47,6 +50,7 @@ describe('the quad chain block', () => {
     expect(columnOne.text()).toEqual('12');
     expect(columnTwo.text()).toEqual('34');
   });
+
   it('should be able to accept numbers in the custom field, any additional features in the chain should be placed in the fourth column. ', () => {
     const customFields = { columnOne: 1, columnTwo: 1, columnThree: 1 };
     const component = mount(
@@ -68,6 +72,7 @@ describe('the quad chain block', () => {
     expect(columnThree.text()).toEqual('3');
     expect(columnFour.text()).toEqual('4');
   });
+
   it('should render nothing if negative column 1 amount', () => {
     const customFields = { columnOne: -10 };
     const component = mount(
@@ -80,5 +85,42 @@ describe('the quad chain block', () => {
     );
 
     expect(component).toBeEmptyRender();
+  });
+
+  it('should render heading from custom field and children', () => {
+    const customFields = { columnOne: 1, columnTwo: 1, heading: 'Quad Chain Heading' };
+    const component = mount(
+      <Chain customFields={customFields}>
+        <Comp1 />
+        <Comp2 />
+      </Chain>,
+    );
+
+    expect(component.find('Heading').text()).toBe('Quad Chain Heading');
+    expect(component.find('HeadingSection').exists()).toBe(true);
+
+    const columnOne = component.find('.row').children().at(0);
+    const columnTwo = component.find('.row').children().at(1);
+
+    expect(columnOne.text()).toEqual('1');
+    expect(columnTwo.text()).toEqual('2');
+  });
+
+  it('should not render heading from custom field and children', () => {
+    const customFields = { columnOne: 1, columnTwo: 1 };
+    const component = mount(
+      <Chain customFields={customFields}>
+        <Comp1 />
+        <Comp2 />
+      </Chain>,
+    );
+
+    expect(component.find('Heading').exists()).toBe(false);
+    expect(component.find('HeadingSection').exists()).toBe(false);
+    const columnOne = component.find('.row').children().at(0);
+    const columnTwo = component.find('.row').children().at(1);
+
+    expect(columnOne.text()).toEqual('1');
+    expect(columnTwo.text()).toEqual('2');
   });
 });

--- a/blocks/quad-chain-block/index.story.jsx
+++ b/blocks/quad-chain-block/index.story.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import QuadChain from './chains/quad-chain/default';
+
+export default {
+  title: 'Chains/Quad',
+  decorators: [withKnobs],
+  parameters: {
+    // Set the viewports in Chromatic at a component level.
+    chromatic: { viewports: [320, 740, 1200] },
+  },
+};
+
+const styles = {
+  backgroundColor: 'rgb(240 240 240)',
+};
+
+const Comp1 = () => <div style={styles}>1</div>;
+const Comp2 = () => <div style={styles}>2</div>;
+const Comp3 = () => <div style={styles}>3</div>;
+const Comp4 = () => <div style={styles}>4</div>;
+
+export const allColumns = () => {
+  const customFields = {
+    columnOne: 1,
+    columnTwo: 1,
+    columnThree: 1,
+    heading: 'Quad Chain Heading',
+  };
+
+  return (
+    <QuadChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+      <Comp3 />
+      <Comp4 />
+    </QuadChain>
+  );
+};
+
+export const allColumnsNoTitle = () => {
+  const customFields = {
+    columnOne: 1,
+    columnTwo: 1,
+    columnThree: 1,
+  };
+
+  return (
+    <QuadChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+      <Comp3 />
+      <Comp4 />
+    </QuadChain>
+  );
+};
+
+export const zeroColumns = () => {
+  const customFields = {
+    columnOne: 0,
+    columnTwo: 0,
+    columnThree: 0,
+    heading: 'Quad Chain Heading',
+  };
+
+  return (
+    <QuadChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+      <Comp3 />
+      <Comp4 />
+    </QuadChain>
+  );
+};
+
+export const columnOneOnly = () => {
+  const customFields = {
+    columnOne: 1,
+    columnTwo: 0,
+    columnThree: 0,
+    heading: 'Quad Chain Heading',
+  };
+
+  return (
+    <QuadChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+      <Comp3 />
+      <Comp4 />
+    </QuadChain>
+  );
+};
+
+export const columnOneAndTwo = () => {
+  const customFields = {
+    columnOne: 1,
+    columnTwo: 1,
+    columnThree: 0,
+    heading: 'Quad Chain Heading',
+  };
+
+  return (
+    <QuadChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+      <Comp3 />
+      <Comp4 />
+    </QuadChain>
+  );
+};

--- a/blocks/quad-chain-block/package.json
+++ b/blocks/quad-chain-block/package.json
@@ -28,6 +28,8 @@
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95",
   "peerDependencies": {
-    "@wpmedia/engine-theme-sdk": "*"
+    "@arc-fusion/prop-types": "^0.1.5",
+    "@wpmedia/engine-theme-sdk": "*",
+    "@wpmedia/shared-styles": "*"
   }
 }

--- a/blocks/shared-styles/scss/_chains.scss
+++ b/blocks/shared-styles/scss/_chains.scss
@@ -1,0 +1,4 @@
+.chain-heading {
+  font-size: calculateRem(26px);
+  line-height: calculateRem(32px);
+}

--- a/blocks/single-chain-block/chains/single-chain/default.jsx
+++ b/blocks/single-chain-block/chains/single-chain/default.jsx
@@ -1,7 +1,33 @@
 import React from 'react';
+import PropTypes from '@arc-fusion/prop-types';
+import { Heading, HeadingSection } from '@wpmedia/shared-styles';
 
-const SingleChain = ({ children }) => <>{children}</>;
+import '@wpmedia/shared-styles/scss/_chains.scss';
+
+const SingleChain = ({ children, customFields = {} }) => {
+  const { heading = null } = customFields;
+
+  if (!heading) {
+    return <>{children}</>;
+  }
+
+  return (
+    <HeadingSection>
+      <Heading className="chain-heading">{heading}</Heading>
+      {children}
+    </HeadingSection>
+  );
+};
 
 SingleChain.label = 'Single Chain – Arc Block';
+
+SingleChain.propTypes = {
+  children: PropTypes.array,
+  customFields: PropTypes.shape({
+    heading: PropTypes.string.tag({
+      label: 'Heading',
+    }),
+  }),
+};
 
 export default SingleChain;

--- a/blocks/single-chain-block/chains/single-chain/default.test.jsx
+++ b/blocks/single-chain-block/chains/single-chain/default.test.jsx
@@ -15,19 +15,52 @@ describe('single chain', () => {
       );
 
       expect(wrapper.text()).toBe(testText);
+      expect(wrapper.find('HeadingSection').exists()).toBe(false);
       expect(wrapper.html()).toBe(`<p>${testText}</p>`);
     });
+
     it('should render null when null is the child', () => {
       const wrapper = mount(<SingleChain>{null}</SingleChain>);
 
       expect(wrapper.text()).toBe('');
       expect(wrapper.html()).toBe(null);
     });
+
     it('should render null when no child', () => {
       const wrapper = mount(<SingleChain />);
 
       expect(wrapper.text()).toBe('');
       expect(wrapper.html()).toBe(null);
+    });
+
+    it('should render heading from custom field', () => {
+      const wrapper = mount(<SingleChain customFields={{ heading: 'Single Chain Heading' }} />);
+
+      expect(wrapper.find('Heading').text()).toBe('Single Chain Heading');
+    });
+
+    it('should render heading from custom field and children', () => {
+      const wrapper = mount(
+        <SingleChain customFields={{ heading: 'Single Chain Heading' }}>
+          <p>Test</p>
+        </SingleChain>,
+      );
+
+      expect(wrapper.find('Heading').text()).toBe('Single Chain Heading');
+      expect(wrapper.find('HeadingSection').exists()).toBe(true);
+      expect(wrapper.find('p').text()).toBe('Test');
+    });
+
+    it('should not render heading from custom field and children', () => {
+      const wrapper = mount(
+        <SingleChain customFields={{ heading: '' }}>
+          <p>Test</p>
+        </SingleChain>,
+      );
+
+      expect(wrapper.find('Heading').exists()).toBe(false);
+      expect(wrapper.find('HeadingSection').exists()).toBe(false);
+      expect(wrapper.find('p').text()).toBe('Test');
     });
   });
 });

--- a/blocks/single-chain-block/index.story.jsx
+++ b/blocks/single-chain-block/index.story.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import SingleChain from './chains/single-chain/default';
+
+export default {
+  title: 'Chains/Single',
+  decorators: [withKnobs],
+  parameters: {
+    // Set the viewports in Chromatic at a component level.
+    chromatic: { viewports: [320, 1600] },
+  },
+};
+
+const styles = {
+  backgroundColor: 'rgb(240 240 240)',
+};
+
+const Comp1 = () => <div style={styles}>1</div>;
+const Comp2 = () => <div style={styles}>2</div>;
+
+export const oneChild = () => {
+  const customFields = {
+    columnOne: 1,
+    heading: 'Single Chain Heading',
+  };
+
+  return (
+    <SingleChain customFields={customFields}>
+      <Comp1 />
+    </SingleChain>
+  );
+};
+
+export const noHeading = () => {
+  const customFields = {
+    columnOne: 1,
+  };
+
+  return (
+    <SingleChain customFields={customFields}>
+      <Comp1 />
+    </SingleChain>
+  );
+};
+
+export const twoChildren = () => {
+  const customFields = {
+    heading: 'Single Chain Heading',
+  };
+
+  return (
+    <SingleChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+    </SingleChain>
+  );
+};

--- a/blocks/single-chain-block/package.json
+++ b/blocks/single-chain-block/package.json
@@ -24,6 +24,8 @@
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95",
   "peerDependencies": {
-    "@wpmedia/engine-theme-sdk": "*"
+    "@arc-fusion/prop-types": "^0.1.5",
+    "@wpmedia/engine-theme-sdk": "*",
+    "@wpmedia/shared-styles": "*"
   }
 }

--- a/blocks/triple-chain-block/chains/triple-chain/default.jsx
+++ b/blocks/triple-chain-block/chains/triple-chain/default.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
+import { Heading, HeadingSection } from '@wpmedia/shared-styles';
+
+import '@wpmedia/shared-styles/scss/_chains.scss';
 
 const TripleChain = ({ children, customFields }) => {
   if (children && children.length && children.length > 0) {
@@ -8,13 +11,14 @@ const TripleChain = ({ children, customFields }) => {
     const {
       columnOne: columnOneLength = children.length,
       columnTwo: columnTwoLength = 0,
+      heading = null,
     } = customFields;
 
     // check column length not negative
     if (columnOneLength >= 0 && columnTwoLength >= 0) {
       const endOfColumnTwoIndex = columnOneLength + columnTwoLength;
 
-      return (
+      const childrenOutput = (
         <div className="container-fluid triple-chain chain-container">
           <div className="row wrap-bottom">
             <div className="col-sm-12 col-md-xl-4 ie-flex-100-percent-sm reduce-internal-row-col-gap chain-col">
@@ -29,6 +33,17 @@ const TripleChain = ({ children, customFields }) => {
           </div>
         </div>
       );
+
+      if (!heading) {
+        return childrenOutput;
+      }
+
+      return (
+        <HeadingSection>
+          <Heading className="chain-heading">{heading}</Heading>
+          {childrenOutput}
+        </HeadingSection>
+      );
     }
   }
 
@@ -40,6 +55,9 @@ TripleChain.label = 'Triple Chain – Arc Block';
 TripleChain.propTypes = {
   children: PropTypes.array,
   customFields: PropTypes.shape({
+    heading: PropTypes.string.tag({
+      label: 'Heading',
+    }),
     columnOne: PropTypes.number.isRequired.tag({
       label: 'Number of blocks in Column 1:',
       description: 'The number of features which will appear in the first column',

--- a/blocks/triple-chain-block/chains/triple-chain/default.test.jsx
+++ b/blocks/triple-chain-block/chains/triple-chain/default.test.jsx
@@ -7,12 +7,14 @@ describe('the triple chain block', () => {
   const Comp2 = () => <div>2</div>;
   const Comp3 = () => <div>3</div>;
   const Comp4 = () => <div>4</div>;
+
   it('should only render if there are children', () => {
     const component = shallow(
       <TripleChain />,
     );
     expect(component).toBeEmptyRender();
   });
+
   it('should put all features into the first column by default', () => {
     const customFields = {};
     const component = shallow(
@@ -30,6 +32,7 @@ describe('the triple chain block', () => {
     expect(columnOne.children().length).toBe(4);
     expect(columnTwo.children().length).toBe(0);
   });
+
   it('should be able to accept a number in the custom field, and that number of features within the chain should appear in the first column. ', () => {
     const customFields = { columnOne: 2, columnTwo: 2 };
     const component = mount(
@@ -47,6 +50,7 @@ describe('the triple chain block', () => {
     expect(columnOne.text()).toEqual('12');
     expect(columnTwo.text()).toEqual('34');
   });
+
   it('should be able to accept numbers in the custom field, any additional features in the chain should be placed in the third column. ', () => {
     const customFields = { columnOne: 1, columnTwo: 1 };
     const component = mount(
@@ -67,6 +71,7 @@ describe('the triple chain block', () => {
 
     expect(columnThree.text()).toEqual('34');
   });
+
   it('should render nothing if negative column 1 amount', () => {
     const customFields = { columnOne: -10 };
     const component = mount(
@@ -79,5 +84,42 @@ describe('the triple chain block', () => {
     );
 
     expect(component).toBeEmptyRender();
+  });
+
+  it('should render heading from custom field and children', () => {
+    const customFields = { columnOne: 1, columnTwo: 1, heading: 'Triple Chain Heading' };
+    const component = mount(
+      <TripleChain customFields={customFields}>
+        <Comp1 />
+        <Comp2 />
+      </TripleChain>,
+    );
+
+    expect(component.find('Heading').text()).toBe('Triple Chain Heading');
+    expect(component.find('HeadingSection').exists()).toBe(true);
+
+    const columnOne = component.find('.row').children().at(0);
+    const columnTwo = component.find('.row').children().at(1);
+
+    expect(columnOne.text()).toEqual('1');
+    expect(columnTwo.text()).toEqual('2');
+  });
+
+  it('should not render heading from custom field and children', () => {
+    const customFields = { columnOne: 1, columnTwo: 1 };
+    const component = mount(
+      <TripleChain customFields={customFields}>
+        <Comp1 />
+        <Comp2 />
+      </TripleChain>,
+    );
+
+    expect(component.find('Heading').exists()).toBe(false);
+    expect(component.find('HeadingSection').exists()).toBe(false);
+    const columnOne = component.find('.row').children().at(0);
+    const columnTwo = component.find('.row').children().at(1);
+
+    expect(columnOne.text()).toEqual('1');
+    expect(columnTwo.text()).toEqual('2');
   });
 });

--- a/blocks/triple-chain-block/index.story.jsx
+++ b/blocks/triple-chain-block/index.story.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import TripleChain from './chains/triple-chain/default';
+
+export default {
+  title: 'Chains/Triple',
+  decorators: [withKnobs],
+  parameters: {
+    // Set the viewports in Chromatic at a component level.
+    chromatic: { viewports: [320, 740, 1200] },
+  },
+};
+
+const styles = {
+  backgroundColor: 'rgb(240 240 240)',
+};
+
+const Comp1 = () => <div style={styles}>1</div>;
+const Comp2 = () => <div style={styles}>2</div>;
+const Comp3 = () => <div style={styles}>3</div>;
+
+export const allColumns = () => {
+  const customFields = {
+    columnOne: 1,
+    columnTwo: 1,
+    heading: 'Triple Chain Heading',
+  };
+
+  return (
+    <TripleChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+      <Comp3 />
+    </TripleChain>
+  );
+};
+
+export const allColumnsNoTitle = () => {
+  const customFields = {
+    columnOne: 1,
+    columnTwo: 1,
+  };
+
+  return (
+    <TripleChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+      <Comp3 />
+    </TripleChain>
+  );
+};
+
+export const zeroColumns = () => {
+  const customFields = {
+    columnOne: 0,
+    columnTwo: 0,
+    heading: 'Triple Chain Heading',
+  };
+
+  return (
+    <TripleChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+      <Comp3 />
+    </TripleChain>
+  );
+};
+
+export const columnOneOnly = () => {
+  const customFields = {
+    columnOne: 1,
+    columnTwo: 0,
+    heading: 'Triple Chain Heading',
+  };
+
+  return (
+    <TripleChain customFields={customFields}>
+      <Comp1 />
+      <Comp2 />
+      <Comp3 />
+    </TripleChain>
+  );
+};

--- a/blocks/triple-chain-block/package.json
+++ b/blocks/triple-chain-block/package.json
@@ -24,6 +24,8 @@
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95",
   "peerDependencies": {
-    "@wpmedia/engine-theme-sdk": "*"
+    "@arc-fusion/prop-types": "^0.1.5",
+    "@wpmedia/engine-theme-sdk": "*",
+    "@wpmedia/shared-styles": "*"
   }
 }

--- a/jest/mocks/context.js
+++ b/jest/mocks/context.js
@@ -1,3 +1,3 @@
-export const useComponentContext = jest.fn();
-export const useAppContext = jest.fn();
-export const useFusionContext = jest.fn();
+export const useComponentContext = jest.fn(() => ({}));
+export const useAppContext = jest.fn(() => ({}));
+export const useFusionContext = jest.fn(() => ({}));

--- a/jest/mocks/themes.js
+++ b/jest/mocks/themes.js
@@ -1,1 +1,1 @@
-export default jest.fn();
+export default jest.fn(() => ({}));


### PR DESCRIPTION
## Description

Add the ability for chains to have a heading and up to use Heading and HeadingSection component to maintain hierarchy for child features

* Updated chains to have the logic for using Heading and HeadingSection
* Added stories for all chains for visual testing

## Jira Ticket
- [TMEDIA-263](https://arcpublishing.atlassian.net/browse/TMEDIA-263)

## Acceptance Criteria
1. A new string custom field is added to each chain called Title
    * Defaults to empty
    * Defaults to not displayed or output within markup
2 If a Title is present:
    * Title should display above the chain, as shown in the example mockup (where it says “Sports”) using the Medium styling (that we already use in the Header Block) 
    * Chain will be wrapped within a <HeadingSection> and the title (using the <Heading> component) will be placed above the chain children
3. If no Title is specified:
   * Chain does not use any of the new sectioning components as works as currently does

## Test Steps

1. Checkout this branch `git checkout TMEDIA-263-chain-updates`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/single-chain-block,@wpmedia/double-chain-block,@wpmedia/triple-chain-block,@wpmedia/quad-chain-block,@wpmedia/shared-styles`
3. Add each chain to a page and validate
    * They work as currently do - with no heading
    * Chains have the ability to have a heading and if supplied will use Heading and HeadingSection component to ensure child component Headings are incremented.
    * Use small manual promo for testing with children

## Effect Of Changes


![TMEDIA-263-after](https://user-images.githubusercontent.com/868127/125092624-6c013980-e0c9-11eb-9c1b-a72dc90f4c35.png)

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
