### PR TITLE
Tmedia 254 primary font pt2

### DIFF
--- a/blocks/alert-bar-block/features/alert-bar/alert-bar.scss
+++ b/blocks/alert-bar-block/features/alert-bar/alert-bar.scss
@@ -16,7 +16,6 @@ $alert-bar-height: 56px;
     align-items: center;
     color: #fff;
     display: flex;
-    font-family: $theme-primary-font-family;
     font-size: calculateRem(16px);
     font-weight: bold;
     height: 100%;

--- a/blocks/alert-bar-block/features/alert-bar/default.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.jsx
@@ -1,23 +1,16 @@
-/* eslint-disable camelcase */
 import React, { Component } from 'react';
-import styled from 'styled-components';
 import Consumer from 'fusion:consumer';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
-import getThemeStyle from 'fusion:themes';
 import PropTypes from 'prop-types';
 
 import { CloseIcon } from '@wpmedia/engine-theme-sdk';
+import { PrimaryFont } from '@wpmedia/shared-styles';
 
 import { readCookie, saveCookie } from './cookies';
 
 import './alert-bar.scss';
 
-const AlertBarLink = styled.a`
-  &&& {
-    font-family: ${(props) => props.primaryFont};
-  }
-`;
 @Consumer
 class AlertBar extends Component {
   constructor(props) {
@@ -160,13 +153,13 @@ class AlertBar extends Component {
           ref={this.alertRef}
           aria-label={ariaLabel || this.phrases.t('alert-bar-block.element-aria-label')}
         >
-          <AlertBarLink
+          <PrimaryFont
             href={websiteURL}
             className="article-link"
-            primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+            as="a"
           >
             {headlines.basic}
-          </AlertBarLink>
+          </PrimaryFont>
           <button type="button" onClick={this.hideAlert} aria-label={this.phrases.t('alert-bar-block.close-button')}>
             <CloseIcon className="close" fill="white" />
           </button>

--- a/blocks/alert-bar-block/package.json
+++ b/blocks/alert-bar-block/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "*",
-    "styled-components": "^4.4.0"
+    "@wpmedia/shared-styles": "*"
   },
   "dependencies": {
     "cookie": "^0.4.1"

--- a/blocks/article-tag-block/features/tag/default.jsx
+++ b/blocks/article-tag-block/features/tag/default.jsx
@@ -5,29 +5,41 @@ import { useFusionContext } from 'fusion:context';
 import getThemeStyle from 'fusion:themes';
 import { LazyLoad, isServerSide } from '@wpmedia/engine-theme-sdk';
 import { LinkBackgroundHover } from '@wpmedia/news-theme-css/js/styled/linkHovers';
+import { PrimaryFont } from '@wpmedia/shared-styles';
 import './tags.scss';
 
 const Tags = styled(LinkBackgroundHover)`
   background-color: ${(props) => props.primaryColor};
-  font-family: ${(props) => props.primaryFont};
 `;
 
 const ArticleTagItems = () => {
   const { arcSite, globalContent: content } = useFusionContext();
-  const { 'primary-color': primaryColor, 'primary-font-family': primaryFont } = getThemeStyle(arcSite);
+  const { 'primary-color': primaryColor } = getThemeStyle(arcSite);
   const defaultBackgroundColor = '#14689A';
   const { taxonomy: { tags = [] } = {} } = content;
 
   return tags.length ? (
-    <div className="tags-holder">
+    <PrimaryFont
+      as="div"
+      className="tags-holder"
+    >
       {
         tags.map((tag) => {
           const slug = tag.slug || '#';
           const href = slug !== '#' ? encodeURI(`/tags/${slug}/`) : '#';
-          return <Tags key={tag.text} className="tags" href={href} primaryColor={primaryColor || defaultBackgroundColor} primaryFont={primaryFont}>{tag.text}</Tags>;
+          return (
+            <Tags
+              key={tag.text}
+              className="tags"
+              href={href}
+              primaryColor={primaryColor || defaultBackgroundColor}
+            >
+              {tag.text}
+            </Tags>
+          );
         })
       }
-    </div>
+    </PrimaryFont>
   ) : null;
 };
 

--- a/blocks/article-tag-block/features/tag/default.test.jsx
+++ b/blocks/article-tag-block/features/tag/default.test.jsx
@@ -4,6 +4,10 @@ import { mount } from 'enzyme';
 describe('the article tag block', () => {
   jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
   jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+  jest.mock('@wpmedia/shared-styles', () => ({
+    __esModule: true,
+    PrimaryFont: (props) => <div {...props} />,
+  }));
 
   jest.mock('@wpmedia/engine-theme-sdk', () => ({
     LazyLoad: ({ children }) => <>{ children }</>,
@@ -52,7 +56,7 @@ describe('the article tag block', () => {
     it('should render a parent container for the tags', () => {
       const { default: ArticleTags } = require('./default');
       const wrapper = mount(<ArticleTags />);
-      expect(wrapper.children().find('.tags-holder').length).toEqual(1);
+      expect(wrapper.children().find('div.tags-holder').length).toEqual(1);
     });
 
     it('should render a tag element for each tag in the array', () => {

--- a/blocks/article-tag-block/package.json
+++ b/blocks/article-tag-block/package.json
@@ -2,14 +2,12 @@
   "name": "@wpmedia/article-tag-block",
   "version": "5.13.2",
   "description": "Fusion Article Tag block",
-  "author": "Rohit Gande <rohit.gande@washpost.com>",
+  "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "features",
-    "chains",
-    "layouts"
+    "features"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
@@ -27,7 +25,8 @@
   "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",
-    "styled-components": "^4.4.0"
+    "styled-components": "^4.4.0",
+    "@wpmedia/shared-styles": "*"
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }


### PR DESCRIPTION
- updated a few of the blocks so far: 

`npx fusion start -f -l @wpmedia/alert-bar-block,@wpmedia/article-tag-block`
- go to all-blocks page locally to compare the styled-components used based on the screenshots http://localhost/pf/all-blocks/?_website=the-sun vs https://corecomponents.arcpublishing.com/pf/all-blocks/?_website=the-sun

## alert bar block

before (dueling variables)

<img width="1170" alt="Screen Shot 2021-07-12 at 13 52 00" src="https://user-images.githubusercontent.com/5950956/125365117-4a0dee00-e339-11eb-933e-72f5c916368a.png">

after (reusing primary font)

<img width="1191" alt="Screen Shot 2021-07-12 at 14 01 40" src="https://user-images.githubusercontent.com/5950956/125365176-60b44500-e339-11eb-861d-e6c00d0f51e8.png">



## article tag 

before (custom styled component for primary font, duplicated): 

<img width="1153" alt="Screen Shot 2021-07-12 at 17 51 51" src="https://user-images.githubusercontent.com/5950956/125365405-cef90780-e339-11eb-8c52-defcb21cd8c0.png">


after: 

<img width="1199" alt="Screen Shot 2021-07-12 at 14 17 16" src="https://user-images.githubusercontent.com/5950956/125365195-6dd13400-e339-11eb-814a-a6168c96e49c.png">



deferred: @wpmedia/article-body-block