### PR TITLE
fix: Google font url optimization breaking preexisting fonts

### DIFF
--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -56,7 +56,7 @@ const fontUrlLink = (fontUrl) => {
   // If fontURL is an array, then iterate over the array and build out the links
   if (fontUrl && Array.isArray(fontUrl) && fontUrl.length > 0) {
     const fontLinks = [...new Set(fontUrl)].map((url, index) => (
-      <link rel="stylesheet" key={url} data-testid={`font-loading-url-${index}`} href={`${url}&display=swap`} />
+      <link rel="stylesheet" key={url} data-testid={`font-loading-url-${index}`} href={url} />
     ));
     return (
       <>{fontLinks}</>
@@ -64,7 +64,7 @@ const fontUrlLink = (fontUrl) => {
   }
   // Legacy support where fontUrl is a string
   return fontUrl ? (
-    <link rel="stylesheet" href={`${fontUrl}&display=swap`} />
+    <link rel="stylesheet" href={fontUrl} />
   ) : '';
 };
 


### PR DESCRIPTION
- Reverting change made in tmedia-85 
- font url displayed as before (not necessarily always google font url)

https://redirector.arcpublishing.com/alc/arc-products/themes/user-docs/theme-settings/#Integration-Settings
fontURL (either an array of strings or string) 
> URL to a CSS stylesheet which contains font definitions for primary/secondary fonts used on the site (if they are not system fonts). This is commonly a Google Fonts URL.

- `git checkout REVERT-TMEDIA-85-google-font-url-swap`
`npx fusion start -f -l @wpmedia/default-output-block`
- use the https://github.com/WPMedia/Fusion-News-Theme/pull/182 branch with the raw font url (non google)

before

![Screen Shot 2021-07-14 at 09 20 31](https://user-images.githubusercontent.com/5950956/125638144-f51f9680-0b82-4b4c-8357-249d181300a3.png)


after

![Screen Shot 2021-07-14 at 09 19 43](https://user-images.githubusercontent.com/5950956/125638164-a92eadb3-d68f-4e8e-8f9a-bb7668450e53.png)

