### PR TITLE
Tmedia 339 revert swap remove preconnect

### DIFF
--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -115,7 +115,7 @@ describe('renders a page', () => {
     const wrapper = shallow(
       <DefaultOutputType deployment={jest.fn()} metaValue={jest.fn().mockReturnValue('article')} {...mockFuntions} />,
     );
-    expect(wrapper.find('link').length).toBe(4);
+    expect(wrapper.find('link').length).toBe(3);
   });
 
   it('should have a MedataData component', () => {

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -58,17 +58,18 @@ const optimalFontLoading = (fontUrl, index = '') => (
     <link
       rel="preload"
       as="style"
-      href={`${fontUrl}&display=swap`}
+      href={fontUrl}
     />
     <link
       rel="stylesheet"
       key={fontUrl}
       data-testid={`font-loading-url-${index}`}
-      href={`${fontUrl}&display=swap`}
+      href={fontUrl}
     />
   </>
 );
 
+// todo: this was not an ok assumption vv
 // preconnect g static assumes google font, only supported in themes settings anyway
 const fontUrlLink = (fontUrl) => {
   // If fontURL is an array, then iterate over the array and build out the links
@@ -77,6 +78,7 @@ const fontUrlLink = (fontUrl) => {
 
     return (
       <>
+        {/* if regex matches google font */}
         <link
           rel="preconnect"
           href="https://fonts.gstatic.com"
@@ -87,6 +89,7 @@ const fontUrlLink = (fontUrl) => {
     );
   }
   // Legacy support where fontUrl is a string
+  /* if regex matches google font */
   return fontUrl ? (
     <>
       <link

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -69,8 +69,6 @@ const optimalFontLoading = (fontUrl, index = '') => (
   </>
 );
 
-// todo: this was not an ok assumption vv
-// preconnect g static assumes google font, only supported in themes settings anyway
 const fontUrlLink = (fontUrl) => {
   // If fontURL is an array, then iterate over the array and build out the links
   if (fontUrl && Array.isArray(fontUrl) && fontUrl.length > 0) {
@@ -78,25 +76,13 @@ const fontUrlLink = (fontUrl) => {
 
     return (
       <>
-        {/* if regex matches google font */}
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="true"
-        />
         <>{fontLinks}</>
       </>
     );
   }
   // Legacy support where fontUrl is a string
-  /* if regex matches google font */
   return fontUrl ? (
     <>
-      <link
-        rel="preconnect"
-        href="https://fonts.gstatic.com"
-        crossOrigin="true"
-      />
       {optimalFontLoading(fontUrl)}
     </>
   ) : '';


### PR DESCRIPTION
## Description
Remove swap interpolation based on hotfix #973 

## Jira Ticket
- [TMEDIA-339](https://arcpublishing.atlassian.net/browse/TMEDIA-339)

## Acceptance Criteria
Fonts still load as expected if using a non-google font, eg https://github.com/WPMedia/Fusion-News-Theme/pull/182/files and https://github.com/WPMedia/fusion-news-theme-blocks/pull/973

## Test Steps
Same test instructions as https://github.com/WPMedia/fusion-news-theme-blocks/pull/973

## Effect Of Changes
### Before
- Non google fonts didn't load 

### After
-non google fonts do load 

## Dependencies or Side Effects
- I removed preconnect assuming google fonts 
- I kept preload as that may still ensure that fonts are not render-blocking per pr https://github.com/WPMedia/fusion-news-theme-blocks/pull/962

Fonts are still not listed as render-blocking

![Screen Shot 2021-07-14 at 11 05 43](https://user-images.githubusercontent.com/5950956/125654906-2b433fa4-ee24-4959-adac-f39933a08fe7.png)

- opportunity for clients to use swap or optional 
![Screen Shot 2021-07-14 at 11 25 49](https://user-images.githubusercontent.com/5950956/125657952-42cc8148-b484-45f2-a0a0-cd6f05173c0c.png)



## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
