### PR TITLE
TMEDIA-254 lead-art-primary-font 

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -19,12 +19,6 @@ import {
 import { PrimaryFont } from '@wpmedia/shared-styles';
 import './leadart.scss';
 
-const LeadArtWrapperDiv = styled.div`
-  figcaption {
-    font-family: ${(props) => props.primaryFont};
-  }
-`;
-
 /**
  * @file LeadArt is a React Class Component
  * @summary React component for displaying an image along with a control to present the image in a
@@ -115,13 +109,13 @@ class LeadArt extends Component {
         }
 
         return (
-          <LeadArtWrapperDiv className="lead-art-wrapper" primaryFont={getThemeStyle(arcSite)['primary-font-family']}>
+          <div className="lead-art-wrapper">
             <div
               className="inner-content"
               dangerouslySetInnerHTML={{ __html: lead_art.content }}
             />
             {lightbox}
-          </LeadArtWrapperDiv>
+          </div>
         );
       }
 

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -5,7 +5,6 @@ import Consumer from 'fusion:consumer';
 import getThemeStyle from 'fusion:themes';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
-import styled from 'styled-components';
 import {
   Gallery,
   ImageMetadata,

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -1,4 +1,4 @@
-/* eslint-disable camelcase, max-len */
+/* eslint-disable camelcase */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Consumer from 'fusion:consumer';
@@ -16,16 +16,10 @@ import {
   videoPlayerCustomFields,
   FullscreenIcon,
 } from '@wpmedia/engine-theme-sdk';
-
+import { PrimaryFont } from '@wpmedia/shared-styles';
 import './leadart.scss';
 
 const LeadArtWrapperDiv = styled.div`
-  figcaption {
-    font-family: ${(props) => props.primaryFont};
-  }
-`;
-
-const LeadArtWrapperFigure = styled.figure`
   figcaption {
     font-family: ${(props) => props.primaryFont};
   }
@@ -168,9 +162,8 @@ class LeadArt extends Component {
         );
 
         return (
-          <LeadArtWrapperFigure
+          <figure
             className="lead-art-wrapper"
-            primaryFont={getThemeStyle(arcSite)['primary-font-family']}
           >
             <button
               type="button"
@@ -178,7 +171,9 @@ class LeadArt extends Component {
               onClick={this.setIsOpenToTrue}
             >
               <FullscreenIcon width="100%" height="100%" fill="#6B6B6B" />
-              {buttonLabel}
+              <PrimaryFont as="span">
+                {buttonLabel}
+              </PrimaryFont>
             </button>
             <div ref={this.imgRef}>
               <Image
@@ -204,7 +199,7 @@ class LeadArt extends Component {
               </figcaption>
             )}
 
-          </LeadArtWrapperFigure>
+          </figure>
         );
       } if (lead_art.type === 'gallery') {
         const galleryCubeClicks = getProperties(arcSite)?.galleryCubeClicks;

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -291,40 +291,6 @@ describe('LeadArt', () => {
     expect(result).toEqual('');
   });
 
-  it('raw html type returns styled component  LeadArtWrapperDiv', () => {
-    const globalContent = {
-      promo_items: {
-        basic: {
-          type: 'raw_html',
-        },
-      },
-    };
-
-    const wrapper = mount(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
-    expect(wrapper.find('StyledComponent').at(0).prop('className')).toEqual('lead-art-wrapper');
-    wrapper.unmount();
-  });
-
-  it('image type returns styled component  LeadArtWrapperFigure', () => {
-    const globalContent = {
-      promo_items: {
-        lead_art: {
-          type: 'image',
-        },
-      },
-    };
-
-    useAppContext.mockImplementation(() => (
-      {
-        arcSite: {},
-      }));
-
-    LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
-    const wrapper = mount(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
-    expect(wrapper.find('ImageMetadata').length).toEqual(1);
-    wrapper.unmount();
-  });
-
   it('setIsOpenToFalse sets isOpen to false', () => {
     const globalContent = {
       promo_items: {

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -1,11 +1,10 @@
 import getProperties from 'fusion:properties';
 import getThemeStyle from 'fusion:themes';
 import getTranslatedPhrases from 'fusion:intl';
-import { useAppContext } from 'fusion:context';
 import LeadArt from './default';
 
 const React = require('react');
-const { mount, shallow } = require('enzyme');
+const { shallow } = require('enzyme');
 
 describe('LeadArt', () => {
   afterEach(() => {

--- a/blocks/lead-art-block/package.json
+++ b/blocks/lead-art-block/package.json
@@ -2,14 +2,12 @@
   "name": "@wpmedia/lead-art-block",
   "version": "5.13.2",
   "description": "Fusion News Theme lead art block",
-  "author": "Brent Miller <brent.miller@washport.com>",
+  "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "features",
-    "chains",
-    "layouts"
+    "features"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
@@ -24,7 +22,7 @@
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",
     "@wpmedia/video-player-block": "*",
-    "styled-components": "^4.4.0"
+    "@wpmedia/shared-styles": "*"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",


### PR DESCRIPTION
- `npx fusion start -f -l @wpmedia/lead-art-block`
- Go to http://localhost/pf/test-article-page/?_website=the-gazette
- Ensure that the expand text above the image is now using primary font 
- Also still ensure that the caption below the image is still using primary font

before: 

using default arial in expand text

<img width="430" alt="Screen Shot 2021-07-14 at 14 47 00" src="https://user-images.githubusercontent.com/5950956/125687500-646127f5-79b0-4de2-8f80-411e35063bec.png">

<img width="1420" alt="Screen Shot 2021-07-14 at 14 45 12" src="https://user-images.githubusercontent.com/5950956/125687567-539e0bfa-07e8-4171-bafe-5503410b9e1b.png">



after: 


image metadata below still using primary font 

<img width="830" alt="Screen Shot 2021-07-14 at 15 22 23" src="https://user-images.githubusercontent.com/5950956/125687716-b5f8a33f-cd1e-4b67-9366-2fd147d2844f.png">

expand text using primary font
<img width="238" alt="Screen Shot 2021-07-14 at 15 23 04" src="https://user-images.githubusercontent.com/5950956/125687790-796c46ac-e12b-40f5-bafa-2039081d3088.png">
