### PR TITLE
Tmedia 254 header nav chain

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -34,7 +34,16 @@
     "property-no-vendor-prefix": [
       true,
       {
-        "ignoreProperties": ["box-orient"]
+        "ignoreProperties": [
+          "box-orient"
+        ]
+      }
+    ],
+    "media-feature-name-no-unknown": [
+      {
+        "ignoreMediaFeatureNames": [
+          "max-width"
+        ]
       }
     ]
   }

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/_children/link.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/_children/link.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 
 function getLocation(uri) {
   let url;
@@ -32,32 +31,25 @@ function fixTrailingSlash(item) {
   return item;
 }
 
-/* Styled Components */
-const StyledLink = styled.a`
-    color: ${(props) => (props.navBarColor === 'light' ? '#000' : '#fff')};
-    font-family: ${(props) => props.font};
-`;
-
 const Link = ({
-  href, name, navBarColor,
+  href, name,
 }) => {
   const externalUrl = /(http(s?)):\/\//i.test(href);
 
   return (
     externalUrl ? (
-      <StyledLink
+      <a
         href={fixTrailingSlash(href)}
         target="_blank"
         rel="noopener noreferrer"
-        navBarColor={navBarColor}
       >
-        {`${name}`}
+        {name}
         <span className="sr-only">(Opens in new window)</span>
-      </StyledLink>
+      </a>
     ) : (
-      <StyledLink href={fixTrailingSlash(href)} navBarColor={navBarColor}>
-        {`${name}`}
-      </StyledLink>
+      <a href={fixTrailingSlash(href)}>
+        {name}
+      </a>
     )
   );
 };
@@ -65,7 +57,6 @@ const Link = ({
 Link.propTypes = {
   href: PropTypes.string,
   name: PropTypes.string,
-  navBarColor: PropTypes.string,
 };
 
 export default Link;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
@@ -14,7 +14,6 @@ const LinkBarSpan = styled.span`
 
   a {
     font-family: ${(props) => props.primaryFont};
-    white-space: nowrap;
   }
 `;
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.jsx
@@ -4,16 +4,16 @@ import { useContent } from 'fusion:content';
 import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
-import getThemeStyle from 'fusion:themes';
+import { PrimaryFont } from '@wpmedia/shared-styles';
 import Link from './_children/link';
 
 import './links-bar.scss';
 
-const LinkBarSpan = styled.span`
-  color: ${(props) => (props.navBarColor === 'light' ? '#000' : '#fff')};
+const ReadableTextNavigationBar = styled.nav`
+  color: ${(props) => (props.color)};
 
   a {
-    font-family: ${(props) => props.primaryFont};
+    color: ${(props) => (props.color)};
   }
 `;
 
@@ -49,44 +49,41 @@ const HorizontalLinksBar = ({
     && showHorizontalSeperatorDots
   );
 
-  const font = getThemeStyle(arcSite)['primary-font-family'];
+  // the interior links and spans need to contrast with nav color scheme
+  const readableContrastingColor = navBarColor === 'light' ? '#000' : '#fff';
 
   return (
-    <>
-      <nav
-        key={id}
-        className="horizontal-links-bar"
-        aria-label={ariaLabel || phrases.t('header-nav-chain-block.links-element-aria-label')}
-      >
-        {menuItems && menuItems.map((item, index) => (
-          <LinkBarSpan
-            className="horizontal-links-menu"
-            key={item._id}
-            primaryFont={font}
-            navBarColor={navBarColor}
-          >
-            {(index > 0 && showSeparator) ? '\u00a0 • \u00a0' : '\u00A0  \u00A0'}
-            {
+    <ReadableTextNavigationBar
+      key={id}
+      color={readableContrastingColor}
+      className="horizontal-links-bar"
+      aria-label={ariaLabel || phrases.t('header-nav-chain-block.links-element-aria-label')}
+    >
+      {menuItems && menuItems.map((item, index) => (
+        <PrimaryFont
+          as="span"
+          className="horizontal-links-menu"
+          key={item._id}
+        >
+          {(index > 0 && showSeparator) ? '\u00a0 • \u00a0' : '\u00A0  \u00A0'}
+          {
               item.node_type === 'link'
                 ? (
                   <Link
                     href={item.url}
                     name={item.display_name}
-                    navBarColor={navBarColor}
                   />
                 )
                 : (
                   <Link
                     href={item._id}
                     name={item.name}
-                    navBarColor={navBarColor}
                   />
                 )
             }
-          </LinkBarSpan>
-        ))}
-      </nav>
-    </>
+        </PrimaryFont>
+      ))}
+    </ReadableTextNavigationBar>
   );
 };
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/default.test.jsx
@@ -6,6 +6,11 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
   formatURL: jest.fn((input) => input.toString()),
 }));
 
+jest.mock('@wpmedia/shared-styles', () => ({
+  __esModule: true,
+  PrimaryFont: (props) => <span {...props} />,
+}));
+
 jest.mock('fusion:properties', () => (jest.fn(() => ({
   locale: 'en',
 }))));
@@ -34,29 +39,6 @@ describe('the links bar feature for the default output type', () => {
     }));
   });
 
-  it('should be a nav element', () => {
-    const { default: LinksBar } = require('./default');
-    jest.mock('fusion:content', () => ({
-      useContent: jest.fn(() => ({
-        children: [
-          {
-            _id: 'id_1',
-            name: 'test link 1',
-          },
-          {
-            _id: 'id_2',
-            name: 'test link 2',
-          },
-        ],
-      })),
-    }));
-    const wrapper = shallow(
-      <LinksBar customFields={{ navigationConfig: 'links' }} />,
-    );
-
-    expect(wrapper.children().at(0).type()).toBe('nav');
-  });
-
   it('should not have separator only one link', () => {
     const { default: LinksBar } = require('./default');
     jest.mock('fusion:content', () => ({
@@ -77,7 +59,7 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\" aria-label=\\"Top Links\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">    <a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a></span></nav>"',
+      '"<nav color=\\"#fff\\" class=\\"sc-bdVaJa hPRxrT horizontal-links-bar\\" aria-label=\\"Top Links\\"><span as=\\"span\\" class=\\"horizontal-links-menu\\">    <a href=\\"id_1/\\">test link 1</a></span></nav>"',
     );
   });
 
@@ -109,7 +91,7 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\" aria-label=\\"Top Links\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">    <a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a></span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">  •  <a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a></span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">  •  <a href=\\"id_3/\\" class=\\"sc-bdVaJa jLoscj\\">test link 3</a></span></nav>"',
+      '"<nav color=\\"#fff\\" class=\\"sc-bdVaJa hPRxrT horizontal-links-bar\\" aria-label=\\"Top Links\\"><span as=\\"span\\" class=\\"horizontal-links-menu\\">    <a href=\\"id_1/\\">test link 1</a></span><span as=\\"span\\" class=\\"horizontal-links-menu\\">  •  <a href=\\"id_2/\\">test link 2</a></span><span as=\\"span\\" class=\\"horizontal-links-menu\\">  •  <a href=\\"id_3/\\">test link 3</a></span></nav>"',
     );
   });
 
@@ -137,7 +119,7 @@ describe('the links bar feature for the default output type', () => {
     );
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      '"<nav class=\\"horizontal-links-bar\\" aria-label=\\"Top Links\\"><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">    <a href=\\"id_1/\\" class=\\"sc-bdVaJa jLoscj\\">test link 1</a></span><span class=\\"sc-bwzfXH dtelAW horizontal-links-menu\\">    <a href=\\"id_2/\\" class=\\"sc-bdVaJa jLoscj\\">test link 2</a></span></nav>"',
+      '"<nav color=\\"#fff\\" class=\\"sc-bdVaJa hPRxrT horizontal-links-bar\\" aria-label=\\"Top Links\\"><span as=\\"span\\" class=\\"horizontal-links-menu\\">    <a href=\\"id_1/\\">test link 1</a></span><span as=\\"span\\" class=\\"horizontal-links-menu\\">    <a href=\\"id_2/\\">test link 2</a></span></nav>"',
     );
   });
 
@@ -203,11 +185,12 @@ describe('the links bar feature for the default output type', () => {
       })),
     }));
     const { default: LinksBar } = require('./default');
-    const wrapper = shallow(
-      <LinksBar />,
-    );
+    const wrapper = shallow(<LinksBar />);
 
-    expect(wrapper.find('nav').props()).toHaveProperty('aria-label', 'Top Links');
+    expect(wrapper.find('.horizontal-links-bar').props()).toHaveProperty(
+      'aria-label',
+      'Top Links',
+    );
   });
 
   it('should render the block with the custom aria-label', () => {
@@ -219,6 +202,9 @@ describe('the links bar feature for the default output type', () => {
     const { default: LinksBar } = require('./default');
     const wrapper = shallow(<LinksBar ariaLabel="Links" />);
 
-    expect(wrapper.find('nav').props()).toHaveProperty('aria-label', 'Links');
+    expect(wrapper.find('.horizontal-links-bar').props()).toHaveProperty(
+      'aria-label',
+      'Links',
+    );
   });
 });

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
@@ -23,7 +23,6 @@
 
   a {
     @include link-color-active-hover($ui-primary-font-color);
-    font-family: $theme-primary-font-family;
     line-height: 14px;
     margin: 8px 0;
     text-align: center;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -3,6 +3,7 @@ import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 import { HamburgerMenuIcon } from '@wpmedia/engine-theme-sdk';
+import { PrimaryFont } from '@wpmedia/shared-styles';
 import SearchBox from './search-box';
 import QuerylySearch from './queryly-search';
 import { WIDGET_CONFIG, PLACEMENT_AREAS } from '../nav-helper';
@@ -43,7 +44,7 @@ const NavWidget = ({
         onClick={menuButtonClickAction}
         className={`nav-btn nav-sections-btn border transparent ${navColor === 'light' ? 'nav-btn-light' : 'nav-btn-dark'}`}
       >
-        <span>{phrases.t('header-nav-chain-block.sections-button')}</span>
+        <PrimaryFont as="span">{phrases.t('header-nav-chain-block.sections-button')}</PrimaryFont>
         <HamburgerMenuIcon
           fill={null}
           height={WIDGET_CONFIG[placement]?.iconSize}

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-plusplus */
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -70,15 +69,9 @@ const StyledNav = styled.nav`
       }
     }
   }
-
-  * {
-    font-family: ${(props) => props.font};
-  }
-
 `;
 
 const StyledSectionDrawer = styled.div`
-  font-family: ${(props) => props.font};
   z-index: ${sectionZIdx};
 
   @media screen and (max-width: ${(props) => props.breakpoint}px) {
@@ -114,7 +107,6 @@ const Nav = (props) => {
 
   const {
     'primary-color': primaryColor = '#000',
-    'primary-font-family': primaryFont,
   } = getThemeStyle(arcSite);
 
   let backgroundColor = '#000';
@@ -298,7 +290,7 @@ const Nav = (props) => {
     } = WIDGET_CONFIG[PLACEMENT_AREAS.NAV_BAR];
     navBarSections.forEach((side) => {
       NAV_BREAKPOINTS.forEach((bpoint) => {
-        for (let i = 1; i <= slotCounts[bpoint]; i++) {
+        for (let i = 1; i <= slotCounts[bpoint]; i += 1) {
           const cFieldKey = getNavComponentPropTypeKey(side, bpoint, i);
           const navWidgetType = getNavWidgetType(cFieldKey);
           const matchesDefault = navWidgetType !== getNavComponentDefaultSelection(cFieldKey);
@@ -314,7 +306,7 @@ const Nav = (props) => {
     if (!id || !breakpoint) return null;
     const { slotCounts } = WIDGET_CONFIG[placement];
     const widgetList = [];
-    for (let i = 1; i <= slotCounts[breakpoint]; i++) {
+    for (let i = 1; i <= slotCounts[breakpoint]; i += 1) {
       const cFieldKey = getNavComponentPropTypeKey(id, breakpoint, i);
       const cFieldIndexKey = getNavComponentIndexPropTypeKey(id, breakpoint, i);
       const navWidgetType = getNavWidgetType(cFieldKey);
@@ -384,75 +376,71 @@ const Nav = (props) => {
   };
 
   return (
-    <>
-      <StyledNav
-        id="main-nav"
-        className={`${navColor === 'light' ? 'light' : 'dark'}`}
-        font={primaryFont}
-        navBarBackground={backgroundColor}
+    <StyledNav
+      id="main-nav"
+      className={`${navColor === 'light' ? 'light' : 'dark'}`}
+      navBarBackground={backgroundColor}
+      navHeight={navHeight}
+      scrolled={scrolled}
+      breakpoint={breakpoints.medium}
+      aria-label={ariaLabel || phrases.t('header-nav-chain-block.sections-element-aria-label')}
+    >
+      <div className={`news-theme-navigation-container news-theme-navigation-bar logo-${logoAlignment} ${displayLinks ? 'horizontal-links' : ''}`}>
+        <NavSection side="left" />
+        <NavLogo isVisible={isLogoVisible} alignment={logoAlignment} />
+        {displayLinks && (
+        <HorizontalLinksBar
+          hierarchy={horizontalLinksHierarchy}
+          navBarColor={navColor}
+          showHorizontalSeperatorDots={showDotSeparators}
+          ariaLabel={ariaLabelLink}
+        />
+        )}
+        <NavSection side="right" />
+      </div>
+
+      <StyledSectionDrawer
+        id="nav-sections"
+        className={`nav-sections ${isSectionDrawerOpen ? 'open' : 'closed'}`}
         navHeight={navHeight}
         scrolled={scrolled}
         breakpoint={breakpoints.medium}
-        aria-label={ariaLabel || phrases.t('header-nav-chain-block.sections-element-aria-label')}
+        onClick={closeDrawer}
       >
-        <div className={`news-theme-navigation-container news-theme-navigation-bar logo-${logoAlignment} ${displayLinks ? 'horizontal-links' : ''}`}>
-          <NavSection side="left" />
-          <NavLogo isVisible={isLogoVisible} alignment={logoAlignment} />
-          {displayLinks && (
-            <HorizontalLinksBar
-              hierarchy={horizontalLinksHierarchy}
-              navBarColor={navColor}
-              showHorizontalSeperatorDots={showDotSeparators}
-              ariaLabel={ariaLabelLink}
-            />
-          )}
-          <NavSection side="right" />
-        </div>
-
-        <StyledSectionDrawer
-          id="nav-sections"
-          className={`nav-sections ${isSectionDrawerOpen ? 'open' : 'closed'}`}
-          font={primaryFont}
-          navHeight={navHeight}
-          scrolled={scrolled}
-          breakpoint={breakpoints.medium}
-          onClick={closeDrawer}
-        >
-          <FocusTrap
-            active={isSectionDrawerOpen}
-            focusTrapOptions={{
-              allowOutsideClick: true,
-              returnFocusOnDeactivate: true,
-              onDeactivate: () => {
-                // Focus the next focusable element in the navbar
-                // Workaround for issue where 'nav-sections-btn' won't programatically focus
-                const focusElement = document.querySelector(`
+        <FocusTrap
+          active={isSectionDrawerOpen}
+          focusTrapOptions={{
+            allowOutsideClick: true,
+            returnFocusOnDeactivate: true,
+            onDeactivate: () => {
+              // Focus the next focusable element in the navbar
+              // Workaround for issue where 'nav-sections-btn' wont programatically focus
+              const focusElement = document.querySelector(`
                   #main-nav a:not(.nav-sections-btn),
                   #main-nav button:not(.nav-sections-btn)
                 `);
                 // istanbul ignore next
-                if (focusElement) {
-                  focusElement.focus();
-                  focusElement.blur();
-                }
-              },
-            }}
-          >
-            <div className="inner-drawer-nav" style={{ zIndex: 10 }}>
-              <SectionNav sections={sections} isHidden={!isSectionDrawerOpen}>
-                <MenuWidgets />
-              </SectionNav>
-            </div>
-          </FocusTrap>
-        </StyledSectionDrawer>
+              if (focusElement) {
+                focusElement.focus();
+                focusElement.blur();
+              }
+            },
+          }}
+        >
+          <div className="inner-drawer-nav" style={{ zIndex: 10 }}>
+            <SectionNav sections={sections} isHidden={!isSectionDrawerOpen}>
+              <MenuWidgets />
+            </SectionNav>
+          </div>
+        </FocusTrap>
+      </StyledSectionDrawer>
 
-        {(horizontalLinksHierarchy && logoAlignment !== 'left' && isAdmin) && (
-          <StyledWarning>
-            In order to render horizontal links, the logo must be aligned to the left.
-          </StyledWarning>
-        )}
-      </StyledNav>
-    </>
+      {(horizontalLinksHierarchy && logoAlignment !== 'left' && isAdmin) && (
+      <StyledWarning>
+        In order to render horizontal links, the logo must be aligned to the left.
+      </StyledWarning>
+      )}
+    </StyledNav>
   );
 };
 

--- a/blocks/header-nav-chain-block/package.json
+++ b/blocks/header-nav-chain-block/package.json
@@ -2,14 +2,12 @@
   "name": "@wpmedia/header-nav-chain-block",
   "version": "5.13.2",
   "description": "Fusion News Theme header nav chain block",
-  "author": "Sean Shannon <sean.shannon@washpost.com>",
+  "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "features",
     "chains",
-    "layouts",
     "intl.json"
   ],
   "publishConfig": {


### PR DESCRIPTION
## Description
Focus on header nav chain for primary-font refactor 

## Jira Ticket
- [TMEDIA-254](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-254&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
- Uses primaryfont shared styles not getThemeStyle
- Existing behavior is unchanged

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-254-header-nav-chain`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain`
3. Go to http://localhost/pf/allblockspr/?_website=the-gazette
4. Ensure text and markers are white 

<img width="1083" alt="Screen Shot 2021-07-15 at 09 29 47" src="https://user-images.githubusercontent.com/5950956/125805318-b7a423d6-8572-4230-b639-7902318e78f8.png">


## Effect Of Changes
### Before
- Creating redundant styled components for primary font 

### After
- Less duplication of styles

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
