### PR TITLE
TMEDIA-254 video player

### DIFF
--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -3,17 +3,12 @@ import { useFusionContext } from 'fusion:context';
 import { useContent } from 'fusion:content';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import getThemeStyle from 'fusion:themes';
 import {
   // presentational component does not do data fetching
   VideoPlayer as VideoPlayerPresentational,
   videoPlayerCustomFields,
 } from '@wpmedia/engine-theme-sdk';
-import { PrimaryFont } from '@wpmedia/shared-styles';
-
-const DescriptionText = styled.p`
-  font-family: ${(props) => props.secondaryFont};
-`;
+import { PrimaryFont, SecondaryFont } from '@wpmedia/shared-styles';
 
 const AlertBadge = styled.span`
   background-color: #db0a07;
@@ -116,12 +111,12 @@ const VideoPlayer = (props) => {
       )}
       {description
         && (
-        <DescriptionText
-          secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
+        <SecondaryFont
+          as="p"
           className="description-text"
         >
           {description}
-        </DescriptionText>
+        </SecondaryFont>
         )}
     </div>
   );

--- a/blocks/video-player-block/features/video-player/default.test.jsx
+++ b/blocks/video-player-block/features/video-player/default.test.jsx
@@ -145,9 +145,10 @@ describe('VideoPlayer', () => {
     const foundStyledComponents = wrapper.find('StyledComponent');
 
     expect(foundStyledComponents.length).toEqual(3);
-    expect(foundStyledComponents.at(0).text()).toEqual(alertBadgeText);
-    expect(foundStyledComponents.at(1).text()).toEqual(titleText);
-    expect(foundStyledComponents.at(2).text()).toEqual(descriptionText);
+
+    expect(foundStyledComponents.find('span').text()).toEqual(alertBadgeText);
+    expect(foundStyledComponents.find('h2').text()).toEqual(titleText);
+    expect(foundStyledComponents.find('p').text()).toEqual(descriptionText);
   });
 
   it('if no video content, show empty space ', () => {

--- a/blocks/video-player-block/features/video-player/default.test.jsx
+++ b/blocks/video-player-block/features/video-player/default.test.jsx
@@ -142,17 +142,15 @@ describe('VideoPlayer', () => {
       enableAutoplay
     />);
 
-    // todo: write snapshot or styled components style checks for this
-    // would be better with checking text via rtl
-    const expectedAlertBadge = '<span class="sc-EHOje btlWID">Test Alert  Badge</span>';
-    const expectedTitle = '<h2 class="sc-bdVaJa nAQSq xl-promo-headline">Test Title</h2>';
-    const expectedDescription = '<p class="sc-ifAKCX hbGdTs description-text">Test Description</p>';
+    const expectedAlertBadge = 'Test Alert  Badge';
+    const expectedTitle = 'Test Title';
+    const expectedDescription = 'Test Description';
     const foundStyledComponents = wrapper.find('StyledComponent');
 
     expect(foundStyledComponents.length).toEqual(3);
-    expect(foundStyledComponents.at(0).html()).toEqual(expectedAlertBadge);
-    expect(foundStyledComponents.at(1).html()).toEqual(expectedTitle);
-    expect(foundStyledComponents.at(2).html()).toEqual(expectedDescription);
+    expect(foundStyledComponents.at(0).text()).toEqual(expectedAlertBadge);
+    expect(foundStyledComponents.at(1).text()).toEqual(expectedTitle);
+    expect(foundStyledComponents.at(2).text()).toEqual(expectedDescription);
   });
 
   it('if no video content, show empty space ', () => {

--- a/blocks/video-player-block/features/video-player/default.test.jsx
+++ b/blocks/video-player-block/features/video-player/default.test.jsx
@@ -126,7 +126,7 @@ describe('VideoPlayer', () => {
 
     const titleText = 'Test Title';
     const descriptionText = 'Test Description';
-    const alertBadgeText = 'Test Alert  Badge';
+    const alertBadgeText = 'Test Alert Badge';
 
     const customFields = {
       inheritGlobalContent: false,
@@ -142,15 +142,12 @@ describe('VideoPlayer', () => {
       enableAutoplay
     />);
 
-    const expectedAlertBadge = 'Test Alert  Badge';
-    const expectedTitle = 'Test Title';
-    const expectedDescription = 'Test Description';
     const foundStyledComponents = wrapper.find('StyledComponent');
 
     expect(foundStyledComponents.length).toEqual(3);
-    expect(foundStyledComponents.at(0).text()).toEqual(expectedAlertBadge);
-    expect(foundStyledComponents.at(1).text()).toEqual(expectedTitle);
-    expect(foundStyledComponents.at(2).text()).toEqual(expectedDescription);
+    expect(foundStyledComponents.at(0).text()).toEqual(alertBadgeText);
+    expect(foundStyledComponents.at(1).text()).toEqual(titleText);
+    expect(foundStyledComponents.at(2).text()).toEqual(descriptionText);
   });
 
   it('if no video content, show empty space ', () => {

--- a/blocks/video-player-block/package.json
+++ b/blocks/video-player-block/package.json
@@ -7,9 +7,7 @@
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "features",
-    "chains",
-    "layouts"
+    "features"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/blocks/video-promo-block/features/video-promo/default.jsx
+++ b/blocks/video-promo-block/features/video-promo/default.jsx
@@ -2,15 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useContent } from 'fusion:content';
 import styled from 'styled-components';
-import getThemeStyle from 'fusion:themes';
 import { videoOrg, videoEnv } from 'fusion:environment';
 import { useFusionContext } from 'fusion:context';
 import { Video, videoPlayerCustomFields } from '@wpmedia/engine-theme-sdk';
-import { PrimaryFont } from '@wpmedia/shared-styles';
-
-const DescriptionText = styled.p`
-  font-family: ${(props) => props.secondaryFont};
-`;
+import { PrimaryFont, SecondaryFont } from '@wpmedia/shared-styles';
 
 const AlertBadge = styled.span`
   background-color: #db0a07;
@@ -64,7 +59,6 @@ const VideoPromo = ({ customFields }) => {
             && (
             <PrimaryFont
               as="h2"
-              primaryFont={getThemeStyle(arcSite)['primary-font-family']}
               className="xl-promo-headline"
             >
               {title}
@@ -81,12 +75,12 @@ const VideoPromo = ({ customFields }) => {
           />
           {description
             && (
-            <DescriptionText
-              secondaryFont={getThemeStyle(arcSite)['secondary-font-family']}
+            <SecondaryFont
+              as="p"
               className="description-text"
             >
               {description}
-            </DescriptionText>
+            </SecondaryFont>
             )}
         </div>
       </div>


### PR DESCRIPTION
## Description
Use primary and secondary rather than getTheme for video and video promo

## Jira Ticket
- [TMEDIA-254](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-254&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
- Uses primaryfont and secondaryfont shared styles rather than getTheme call and duplicate styled components 

## Test Steps

1. Checkout this branch `git checkout TMEDIA-254-video-player-video-promo`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/video-promo-block,@wpmedia/video-player-block`
3. Go to page http://localhost/pf/video-blocks/?_website=the-gazette and validate that styling of fonts is as expected with primary the alert and the top headline and secondary for the text below 
<img width="399" alt="Screen Shot 2021-07-15 at 11 23 30" src="https://user-images.githubusercontent.com/5950956/125822958-40550881-70a1-45ab-a886-b46c99cc623f.png">
<img width="388" alt="Screen Shot 2021-07-15 at 11 23 25" src="https://user-images.githubusercontent.com/5950956/125822959-0df401e3-ba7d-4667-9dcd-4ad372054111.png">


## Effect Of Changes
### Before
- More styled component duplication

### After
- less styled component duplication

## Dependencies or Side Effects


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
