### PR TITLE
Tmedia 341 valid machine readable datetime

### DIFF
--- a/blocks/date-block/features/date/default.jsx
+++ b/blocks/date-block/features/date/default.jsx
@@ -33,9 +33,23 @@ class ArticleDate extends Component {
 
   render() {
     const { displayDate } = this.state;
-    const { classNames } = this.props;
+    const {
+      classNames,
+      globalContent: {
+        display_date: globalDateString,
+      } = {},
+      date,
+    } = this.props;
+
+    const dateString = date || globalDateString;
+
     return (
-      <PrimaryFont as="time" key={displayDate} className={`date ${classNames}`} dateTime={displayDate}>
+      <PrimaryFont
+        as="time"
+        key={displayDate}
+        className={`date ${classNames}`}
+        dateTime={dateString}
+      >
         {displayDate}
       </PrimaryFont>
     );

--- a/blocks/shared-styles/_children/promo-date/index.jsx
+++ b/blocks/shared-styles/_children/promo-date/index.jsx
@@ -24,7 +24,7 @@ const PromoDate = (props) => {
     <PrimaryFont
       as="time"
       className={`promo-date ${className}`}
-      dateTime={formattedDate}
+      dateTime={displayDate}
     >
       {formattedDate}
     </PrimaryFont>

--- a/blocks/shared-styles/_children/promo-date/index.test.jsx
+++ b/blocks/shared-styles/_children/promo-date/index.test.jsx
@@ -42,7 +42,7 @@ describe('PromoDate', () => {
     const wrapper = mount(<PromoDate {...props} />);
 
     expect(wrapper.find('time').text()).toBe('Sun Aug 11 2019');
-    expect(wrapper.find('time').prop('dateTime')).toBe('Sun Aug 11 2019');
+    expect(wrapper.find('time').prop('dateTime')).toBe('2019-08-11T16:45:33.209Z');
   });
 
   it('renders description from ANS Story object', () => {
@@ -55,6 +55,6 @@ describe('PromoDate', () => {
     const wrapper = mount(<PromoDate {...props} />);
 
     expect(wrapper.find('time').text()).toBe('Sun Aug 11 2019');
-    expect(wrapper.find('time').prop('dateTime')).toBe('Sun Aug 11 2019');
+    expect(wrapper.find('time').prop('dateTime')).toBe('2019-08-11T16:45:33.209Z');
   });
 });


### PR DESCRIPTION
## Description
Use valid datetime value 

## Jira Ticket
- [TMEDIA-341](https://arcpublishing.atlassian.net/browse/TMEDIA-341)

## Acceptance Criteria
- When you inspect the time elements, you should see the datetime field to be a valid value based on:

a valid global date and time string
2011-11-18T14:54:39.929Z
2011-11-18T14:54:39.929-0400
2011-11-18T14:54:39.929-04:00
2011-11-18 14:54:39.929Z
2011-11-18 14:54:39.929-0400
2011-11-18 14:54:39.929-04:00

see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time

## Test Steps

1. Checkout this branch `git checkout TMEDIA-341-valid-machine-readable-datetime`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/date-block,@wpmedia/shared-styles`
3. Go to an article page. Inspect the date byline 
4. Go to all-blocks page and inspect the promo elements date. They will fit the criteria for https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time. Depending on your browser and platform, you may able to click them or hover over and get that time 

## Effect Of Changes
### Before
- Invalid date string in datetime field. May have skewed google cralwer

### After
- Valid date string. May improve published at dates 

## Dependencies or Side Effects


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
