### PR TITLE
Tmedia 270 remove sass variables colors

### DIFF
--- a/blocks/ads-block/features/ads/_children/ArcAdminAd/index.scss
+++ b/blocks/ads-block/features/ads/_children/ArcAdminAd/index.scss
@@ -1,5 +1,5 @@
 .pb-ad-admin {
-  background-color: $ui-medium-gray;
+  background-color: #575757;
   border-radius: 6px;
   color: #fff;
 }

--- a/blocks/ads-block/features/ads/ads.scss
+++ b/blocks/ads-block/features/ads/ads.scss
@@ -4,7 +4,7 @@
   .arcad-container {
     margin-left: auto;
     margin-right: auto;
-    color: $ui-medium-gray;
+    color: #575757;
     font-size: calculateRem(12px);
     line-height: calculateRem(16px);
 

--- a/blocks/alert-bar-block/features/alert-bar/alert-bar.scss
+++ b/blocks/alert-bar-block/features/alert-bar/alert-bar.scss
@@ -1,11 +1,9 @@
-$alert-bar-height: 56px;
-
 .alert-bar {
   align-items: center;
-  background-color: $danger-color;
+  background-color: #db0a07;
   display: flex;
   flex-wrap: nowrap;
-  height: $alert-bar-height;
+  height: 56px;
   justify-content: space-between;
   overflow: hidden;
   padding-left: calculateRem(20px);

--- a/blocks/article-body-block/chains/article-body/_articlebody.scss
+++ b/blocks/article-body-block/chains/article-body/_articlebody.scss
@@ -260,7 +260,7 @@
     padding: map-get($spacers, 'sm') 0;
 
     p {
-      color: $ui-medium-gray;
+      color: #575757;
       display: inline;
       font-size: calculateRem(18px);
       font-style: italic;

--- a/blocks/article-body-block/chains/article-body/_articlebody.scss
+++ b/blocks/article-body-block/chains/article-body/_articlebody.scss
@@ -48,7 +48,6 @@
 
   .gallery {
     .image-metadata {
-      color: $image-caption-rule-color;
       font-size: calculateRem(14px);
       line-height: calculateRem(24px);
       margin: 8px 0;
@@ -66,7 +65,6 @@
     margin-top: 0;
 
     p {
-      color: $image-caption-rule-color;
       font-size: calculateRem(14px);
       line-height: 1rem;
       margin: 8px 0;

--- a/blocks/article-body-block/chains/article-body/_articlebody.scss
+++ b/blocks/article-body-block/chains/article-body/_articlebody.scss
@@ -3,12 +3,12 @@
 }
 
 .article-body-wrapper {
-  color: $ui-primary-font-color;
+  color: #191919;
   margin-top: map-get($spacers, 'lg');
 
   a,
   a * {
-    @include link-color-active-hover($ui-primary-font-color);
+    @include link-color-active-hover(#191919);
   }
 
   & > h1,
@@ -126,7 +126,7 @@
     table {
       border: 1px solid $border-rule-color;
       border-collapse: collapse;
-      color: $ui-primary-font-color;
+      color: #191919;
       width: 100%;
 
       thead {
@@ -179,7 +179,7 @@
     }
 
     .citation-text {
-      color: $ui-primary-font-color;
+      color: #191919;
       display: block;
       font-size: calculateRem(16px);
       font-style: normal;
@@ -235,7 +235,7 @@
     margin: 0 0 map-get($spacers, 'md');
 
     a {
-      @include link-color-active-hover($ui-primary-font-color);
+      @include link-color-active-hover(#191919);
       text-decoration: none;
 
       &:active,

--- a/blocks/article-body-block/chains/article-body/_articlebody.scss
+++ b/blocks/article-body-block/chains/article-body/_articlebody.scss
@@ -122,19 +122,19 @@
     overflow-x: auto;
 
     table {
-      border: 1px solid $border-rule-color;
+      border: 1px solid #dadada;
       border-collapse: collapse;
       color: #191919;
       width: 100%;
 
       thead {
         background-color: #eee;
-        border: 2px solid $border-rule-color;
+        border: 2px solid #dadada;
       }
 
       th,
       td {
-        border: 1px solid $border-rule-color;
+        border: 1px solid #dadada;
         padding: map-get($spacers, 'xxs') map-get($spacers, 'xs');
         text-align: center;
       }

--- a/blocks/article-body-block/chains/article-body/_articlebody.scss
+++ b/blocks/article-body-block/chains/article-body/_articlebody.scss
@@ -193,7 +193,7 @@
   }
 
   .pullquote {
-    box-shadow: inset 0 -5px 0 0 $ui-light-gray, inset 0 5px 0 0 $ui-light-gray;
+    box-shadow: inset 0 -5px 0 0 #dadada, inset 0 5px 0 0 #dadada;
     font-size: calculateRem(19px);
     font-weight: bold;
     line-height: calculateRem(24px);
@@ -250,7 +250,7 @@
 
   .correction {
     @include block-margin-bottom;
-    box-shadow: inset 0 -1px 0 0 $ui-light-gray;
+    box-shadow: inset 0 -1px 0 0 #dadada;
     margin-left: 0;
     margin-right: 0;
     margin-top: 0;

--- a/blocks/card-list-block/features/card-list/card-list.scss
+++ b/blocks/card-list-block/features/card-list/card-list.scss
@@ -27,7 +27,7 @@
 }
 
 .card-list-overline {
-  color: $ui-primary-font-color;
+  color: #191919;
   font-size: 16px;
   font-weight: bold;
   line-height: 24px;
@@ -41,7 +41,7 @@
   padding: 10px 18px 0 16px;
 
   a {
-    color: $ui-primary-font-color;
+    color: #191919;
   }
 }
 
@@ -50,7 +50,7 @@
   padding: 16px 16px 0;
 
   .story-date {
-    color: $ui-primary-font-color;
+    color: #191919;
     display: inline;
     font-size: calculateRem(14px);
     line-height: calculateRem(16px);
@@ -77,7 +77,7 @@
   border-top: 1px #dadada solid;
 
   .list-item-number {
-    color: $ui-primary-font-color;
+    color: #191919;
     font-size: 20px;
     font-weight: bold;
     line-height: 24px;
@@ -102,8 +102,8 @@
     text-decoration: none;
 
     .headline-text {
-      @include link-color-active-hover($ui-primary-font-color);
-      color: $ui-primary-font-color;
+      @include link-color-active-hover(#191919);
+      color: #191919;
       font-size: 16px;
       font-weight: normal;
       line-height: 24px;

--- a/blocks/card-list-block/features/card-list/card-list.scss
+++ b/blocks/card-list-block/features/card-list/card-list.scss
@@ -61,7 +61,7 @@
   @include block-internal-spacing;
 
   &--divider {
-    box-shadow: inset 0 -1px 0 0 $ui-light-gray;
+    box-shadow: inset 0 -1px 0 0 #dadada;
   }
 
   .list-anchor {

--- a/blocks/date-block/features/date/date.scss
+++ b/blocks/date-block/features/date/date.scss
@@ -1,5 +1,5 @@
 .date {
-  color: $ui-medium-gray;
+  color: #575757;
 
   font-size: calculateRem(18px);
   line-height: calculateRem(32px);

--- a/blocks/footer-block/features/footer/footer.scss
+++ b/blocks/footer-block/features/footer/footer.scss
@@ -103,16 +103,6 @@ footer {
         margin: 0 auto;
         width: 24px;
       }
-
-      // svg path {
-      //   fill: $primary-color;
-      // }
-
-      // &:hover {
-      //   svg path {
-      //     fill: $primary-color;
-      //   }
-      // }
     }
   }
 

--- a/blocks/footer-block/features/footer/footer.scss
+++ b/blocks/footer-block/features/footer/footer.scss
@@ -147,7 +147,7 @@ footer {
       margin: map-get($spacers, 'xs') 0;
 
       > a {
-        color: $ui-medium-gray;
+        color: #575757;
         text-decoration: none;
       }
     }

--- a/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
+++ b/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
@@ -83,14 +83,14 @@
   width: 24px;
 
   path {
-    fill: rgba($ui-medium-gray, 1);
+    fill: rgba(#575757, 1);
     transition: all 0.2s ease-in-out;
   }
 }
 
 .social-column:hover > svg {
   path {
-    fill: rgba($ui-medium-gray, 0.8);
+    fill: rgba(#575757, 0.8);
   }
 }
 

--- a/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
+++ b/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
@@ -42,8 +42,8 @@
     padding: map-get($spacers, 'sm') 0 map-get($spacers, 'sm') 0;
     text-align: center;
   }
-  border-bottom: 1px solid $border-rule-color;
-  border-top: 1px solid $border-rule-color;
+  border-bottom: 1px solid #dadada;
+  border-top: 1px solid #dadada;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;

--- a/blocks/header-block/features/header/header.scss
+++ b/blocks/header-block/features/header/header.scss
@@ -1,5 +1,5 @@
 .header-block {
-  color: $ui-primary-font-color;
+  color: #191919;
   font-weight: bold;
 
   h2 {

--- a/blocks/header-nav-block/features/navigation/header-nav.scss
+++ b/blocks/header-nav-block/features/navigation/header-nav.scss
@@ -7,7 +7,6 @@ $nav-search-border-color: #dadada;
 $overlay-z-index: 2;
 $section-bg: #575757;
 $section-width: 315px;
-$submenu-link-color: $ui-dark-gray;
 
 .nav-block-search {
   display: flex;
@@ -201,11 +200,11 @@ $submenu-link-color: $ui-dark-gray;
 
     > li {
       > a {
-        color: $submenu-link-color;
+        color: #191919;
         padding: 8px 0;
 
         &:hover {
-          color: darken($submenu-link-color, 20%);
+          color: darken(#191919, 20%);
         }
       }
 

--- a/blocks/header-nav-block/features/navigation/header-nav.scss
+++ b/blocks/header-nav-block/features/navigation/header-nav.scss
@@ -3,7 +3,7 @@ $border-color-dull: rgba(255, 255, 255, 0.5);
 $border-color-bright: rgba(255, 255, 255, 1);
 $border-width: 1px;
 $btn-size: calculateRem(32px);
-$nav-search-border-color: $ui-light-gray;
+$nav-search-border-color: #dadada;
 $overlay-z-index: 2;
 $section-bg: #575757;
 $section-width: 315px;
@@ -19,7 +19,7 @@ $submenu-link-color: $ui-dark-gray;
   }
 
   &.open.light {
-    border: $border-width solid $ui-light-gray;
+    border: $border-width solid #dadada;
   }
 
   &.open {

--- a/blocks/header-nav-block/features/navigation/header-nav.scss
+++ b/blocks/header-nav-block/features/navigation/header-nav.scss
@@ -1,11 +1,7 @@
 $arrow-size: calculateRem(10px);
-$border-color-dull: rgba(255, 255, 255, 0.5);
-$border-color-bright: rgba(255, 255, 255, 1);
 $border-width: 1px;
 $btn-size: calculateRem(32px);
-$nav-search-border-color: #dadada;
 $overlay-z-index: 2;
-$section-bg: #575757;
 $section-width: 315px;
 
 .nav-block-search {
@@ -110,14 +106,14 @@ $section-width: 315px;
   }
 
   .inner-drawer-nav {
-    background-color: $section-bg;
+    background-color: #292929;
     display: flex;
     flex-direction: column;
     width: $section-width;
   }
 
   .nav-block-search {
-    border-bottom: $border-width solid $nav-search-border-color;
+    border-bottom: $border-width solid #dadada;
     margin: 16px 20px 0;
     padding-bottom: 16px;
 
@@ -156,7 +152,7 @@ $section-width: 315px;
       }
 
       &:hover {
-        background: darken($section-bg, 20%);
+        background: darken(#292929, 20%);
 
         .subsection-container {
           opacity: 1;

--- a/blocks/header-nav-block/features/navigation/header-nav.scss
+++ b/blocks/header-nav-block/features/navigation/header-nav.scss
@@ -5,7 +5,7 @@ $border-width: 1px;
 $btn-size: calculateRem(32px);
 $nav-search-border-color: $ui-light-gray;
 $overlay-z-index: 2;
-$section-bg: $ui-medium-gray;
+$section-bg: #575757;
 $section-width: 315px;
 $submenu-link-color: $ui-dark-gray;
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/horizontal-links/links-bar.scss
@@ -22,7 +22,7 @@
   justify-content: center;
 
   a {
-    @include link-color-active-hover($ui-primary-font-color);
+    @include link-color-active-hover(#191919);
     line-height: 14px;
     margin: 8px 0;
     text-align: center;

--- a/blocks/lead-art-block/features/leadart/leadart.scss
+++ b/blocks/lead-art-block/features/leadart/leadart.scss
@@ -35,7 +35,7 @@
     padding-left: 0;
 
     svg {
-      fill: $ui-medium-gray;
+      fill: #575757;
       height: 1rem;
       margin-right: 4px;
       width: 1rem;

--- a/blocks/lead-art-block/features/leadart/leadart.scss
+++ b/blocks/lead-art-block/features/leadart/leadart.scss
@@ -12,7 +12,6 @@
     margin-top: map-get($spacers, 'xs');
 
     p.image-metadata {
-      color: $image-caption-rule-color;
       font-size: calculateRem(14px);
       line-height: calculateRem(24px);
       margin: 8px 0;

--- a/blocks/links-bar-block/features/links-bar/links-bar.scss
+++ b/blocks/links-bar-block/features/links-bar/links-bar.scss
@@ -11,8 +11,8 @@
     padding: 8px 0;
 
     a {
-      @include link-color-active-hover($ui-primary-font-color);
-      color: $ui-primary-font-color;
+      @include link-color-active-hover(#191919);
+      color: #191919;
       font-size: 14px;
       height: 100%;
       line-height: 14px;

--- a/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
+++ b/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
@@ -26,7 +26,7 @@
   justify-content: space-between;
 
   .list-item-number {
-    color: $ui-dark-secondary-color;
+    color: #191919;
     flex: 0 0 calculateRem(40px);
     font-size: calculateRem(20px);
     font-weight: bold;

--- a/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
+++ b/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
@@ -3,7 +3,7 @@
   @include block-internal-spacing;
 
   .list-title {
-    color: $ui-primary-font-color;
+    color: #191919;
     font-size: calculateRem(20px);
     font-weight: bold;
     line-height: calculateRem(24px);
@@ -45,8 +45,8 @@
   }
 
   .headline-list-anchor {
-    @include link-color-active-hover($ui-primary-font-color);
-    color: $ui-primary-font-color;
+    @include link-color-active-hover(#191919);
+    color: #191919;
     display: flex;
     padding-right: calculateRem(16px);
     text-decoration: none;

--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.scss
@@ -34,7 +34,7 @@ body {
 .advanced-grid-desktop-main-area {
   padding: 0;
   @media screen and (min-width: map-get($grid-breakpoints, 'lg')) {
-    border-right: 1px solid $border-rule-color;
+    border-right: 1px solid #dadada;
     padding: 0 map-get($spacers, 'lg') 0 0;
   }
 }

--- a/blocks/right-rail-block/layouts/right-rail/default.scss
+++ b/blocks/right-rail-block/layouts/right-rail/default.scss
@@ -33,7 +33,7 @@ body {
   .left-article-section {
     padding: 0;
     @media screen and (min-width: map-get($grid-breakpoints, 'lg')) {
-      border-right: 1px solid $border-rule-color;
+      border-right: 1px solid #dadada;
       padding: 0 map-get($spacers, 'lg') 0 0;
     }
   }

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-results-list.scss
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-results-list.scss
@@ -38,7 +38,7 @@
 }
 
 .search-results-text {
-  color: $ui-primary-font-color;
+  color: #191919;
   font-size: 14px;
   margin-top: 20px;
   text-align: left;

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-results-list.scss
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-results-list.scss
@@ -11,7 +11,7 @@
 
 .search-bar {
   background-color: #fff;
-  border: 1px solid $ui-medium-gray;
+  border: 1px solid #575757;
   border-radius: 2px;
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
@@ -31,7 +31,7 @@
 }
 
 .btn {
-  border: 1px solid $ui-medium-gray;
+  border: 1px solid #575757;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.2);
   height: 48px;
   margin-left: -0.2%;

--- a/blocks/section-title-block/features/section-title/_children/section-title.scss
+++ b/blocks/section-title-block/features/section-title/_children/section-title.scss
@@ -1,5 +1,5 @@
 .section-title {
-  color: $ui-primary-font-color;
+  color: #191919;
   display: block;
   font-weight: bold;
 }
@@ -10,7 +10,7 @@
 
 .section-title--styled-link {
   font-size: calculateRem(14px);
-  color: $ui-primary-font-color;
+  color: #191919;
   text-decoration: none;
 }
 

--- a/blocks/shared-styles/_children/byline/index.scss
+++ b/blocks/shared-styles/_children/byline/index.scss
@@ -24,7 +24,7 @@
   }
 
   a {
-    color: $ui-primary-font-color;
+    color: #191919;
     text-decoration: none;
   }
 

--- a/blocks/shared-styles/_children/overline/overline.scss
+++ b/blocks/shared-styles/_children/overline/overline.scss
@@ -1,5 +1,5 @@
 .overline {
-  color: $ui-primary-font-color;
+  color: #191919;
   display: inline-block;
   font-size: calculateRem(20px);
   font-weight: bold;
@@ -8,6 +8,6 @@
   text-decoration: none;
 
   &--link {
-    @include link-color-active-hover($ui-primary-font-color);
+    @include link-color-active-hover(#191919);
   }
 }

--- a/blocks/shared-styles/_children/promo-date/index.scss
+++ b/blocks/shared-styles/_children/promo-date/index.scss
@@ -1,5 +1,5 @@
 .promo-date {
-  color: $ui-medium-gray;
+  color: #575757;
 
   font-size: calculateRem(14px);
   line-height: calculateRem(14px);

--- a/blocks/shared-styles/scss/_extra-large-promo.scss
+++ b/blocks/shared-styles/scss/_extra-large-promo.scss
@@ -1,8 +1,8 @@
 .xl-large-promo {
-  color: $ui-primary-font-color;
+  color: #191919;
 
   a {
-    color: $ui-primary-font-color;
+    color: #191919;
     position: relative;
   }
 
@@ -20,7 +20,7 @@
   }
 
   .xl-promo-headline {
-    @include link-color-active-hover($ui-primary-font-color);
+    @include link-color-active-hover(#191919);
     display: block;
     font-size: calculateRem(32px);
     font-weight: bold;

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -32,7 +32,7 @@ body.nav-open {
 
   &-dark {
     span {
-      color: #fff
+      color: #fff;
     }
 
     svg > path {

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -172,7 +172,7 @@ body.nav-open {
   flex-shrink: 0;
 
   &.light {
-    border-bottom: $border-width solid $border-rule-color;
+    border-bottom: $border-width solid #dadada;
   }
 
   * {

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -55,18 +55,18 @@ body.nav-open {
 
   &-light {
     span {
-      color: $ui-medium-gray;
+      color: #575757;
     }
 
     svg > path {
-      fill: $ui-medium-gray;
+      fill: #575757;
     }
 
     &.border {
       border: $border-width solid $ui-light-gray;
 
       &:hover {
-        border: $border-width solid $ui-medium-gray;
+        border: $border-width solid #575757;
       }
     }
   }
@@ -402,7 +402,7 @@ body.nav-open {
 
       &:hover,
       &:active {
-        background: $ui-medium-gray;
+        background: #575757;
       }
     }
   }
@@ -453,7 +453,7 @@ body.nav-open {
 
     > li {
       > a {
-        color: $ui-medium-gray;
+        color: #575757;
         display: block;
         font-size: 16px;
         font-weight: bold;
@@ -506,7 +506,7 @@ body.nav-open {
     display: flex;
 
     path {
-      fill: $ui-medium-gray;
+      fill: #575757;
     }
   }
 }

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -1,12 +1,8 @@
 $arrow-size: calculateRem(10px);
-$border-color-dull: rgba(255, 255, 255, 0.5);
-$border-color-bright: rgba(255, 255, 255, 1);
 $border-width: 1px;
 $btn-size: calculateRem(32px);
 $btn-padding: calculateRem(8px);
-$nav-search-border-color: #dadada;
 $overlay-z-index: 2;
-$section-bg: #292929;
 $section-width: 329px;
 
 body.nav-open {
@@ -44,10 +40,10 @@ body.nav-open {
     }
 
     &.border {
-      border: $border-width solid $border-color-dull;
+      border: $border-width solid rgba(255, 255, 255, 0.5);
 
       &:hover {
-        border: $border-width solid $border-color-bright;
+        border: $border-width solid rgba(255, 255, 255, 1);
       }
     }
 
@@ -125,7 +121,7 @@ body.nav-open {
     }
 
     &.dark input {
-      border: $border-width solid $border-color-bright;
+      border: $border-width solid rgba(255, 255, 255, 1);
     }
 
     &.light input {
@@ -318,7 +314,7 @@ body.nav-open {
   }
 
   .inner-drawer-nav {
-    background-color: $section-bg;
+    background-color: #292929;
     display: flex;
     flex-direction: column;
     transition: transform 300ms ease-in-out;

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -36,11 +36,11 @@ body.nav-open {
 
   &-dark {
     span {
-      color: $ui-btn-white-color;
+      color: #fff
     }
 
     svg > path {
-      fill: $ui-btn-white-color;
+      fill: #fff;
     }
 
     &.border {

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -4,7 +4,7 @@ $border-color-bright: rgba(255, 255, 255, 1);
 $border-width: 1px;
 $btn-size: calculateRem(32px);
 $btn-padding: calculateRem(8px);
-$nav-search-border-color: $ui-light-gray;
+$nav-search-border-color: #dadada;
 $overlay-z-index: 2;
 $section-bg: #292929;
 $section-width: 329px;
@@ -63,7 +63,7 @@ body.nav-open {
     }
 
     &.border {
-      border: $border-width solid $ui-light-gray;
+      border: $border-width solid #dadada;
 
       &:hover {
         border: $border-width solid #575757;
@@ -129,7 +129,7 @@ body.nav-open {
     }
 
     &.light input {
-      border: $border-width solid $ui-light-gray;
+      border: $border-width solid #dadada;
     }
   }
 
@@ -462,7 +462,7 @@ body.nav-open {
         text-decoration: none;
 
         &:hover {
-          background-color: $ui-light-gray;
+          background-color: #dadada;
         }
       }
     }

--- a/blocks/shared-styles/scss/_large-promo.scss
+++ b/blocks/shared-styles/scss/_large-promo.scss
@@ -1,8 +1,8 @@
 .large-promo {
-  color: $ui-primary-font-color;
+  color: #191919;
 
   a {
-    color: $ui-primary-font-color;
+    color: #191919;
     position: relative;
   }
 
@@ -23,7 +23,7 @@
   }
 
   .lg-promo-headline {
-    @include link-color-active-hover($ui-primary-font-color);
+    @include link-color-active-hover(#191919);
     font-size: calculateRem(22px);
     font-weight: bold;
     line-height: calculateRem(24px);

--- a/blocks/shared-styles/scss/_medium-promo.scss
+++ b/blocks/shared-styles/scss/_medium-promo.scss
@@ -1,8 +1,8 @@
 .medium-promo {
-  color: $ui-primary-font-color;
+  color: #191919;
 
   a {
-    color: $ui-primary-font-color;
+    color: #191919;
     position: relative;
     text-decoration: none;
 
@@ -12,7 +12,7 @@
   }
 
   .md-promo-headline {
-    @include link-color-active-hover($ui-primary-font-color);
+    @include link-color-active-hover(#191919);
     display: block;
     margin-bottom: map-get($spacers, 'sm');
     text-decoration: none;

--- a/blocks/shared-styles/scss/_results-list-desktop.scss
+++ b/blocks/shared-styles/scss/_results-list-desktop.scss
@@ -27,7 +27,7 @@
       line-height: calculateRem(16px);
 
       .story-date {
-        color: $ui-primary-font-color;
+        color: #191919;
         display: inline;
         font-size: calculateRem(14px);
         line-height: calculateRem(16px);

--- a/blocks/shared-styles/scss/_results-list-mobile.scss
+++ b/blocks/shared-styles/scss/_results-list-mobile.scss
@@ -27,7 +27,7 @@
       line-height: calculateRem(16px);
 
       .story-date {
-        color: $ui-primary-font-color;
+        color: #191919;
         display: inline;
         font-size: calculateRem(14px);
         line-height: calculateRem(16px);

--- a/blocks/shared-styles/scss/_results-list.scss
+++ b/blocks/shared-styles/scss/_results-list.scss
@@ -15,7 +15,7 @@
 }
 
 .list-item {
-  box-shadow: inset 0 -1px 0 0 $ui-light-gray;
+  box-shadow: inset 0 -1px 0 0 #dadada;
   padding: map-get($spacers, 'sm') 0 map-get($spacers, 'sm') 0;
 
   a {

--- a/blocks/shared-styles/scss/_results-list.scss
+++ b/blocks/shared-styles/scss/_results-list.scss
@@ -19,19 +19,19 @@
   padding: map-get($spacers, 'sm') 0 map-get($spacers, 'sm') 0;
 
   a {
-    @include link-color-active-hover($ui-primary-font-color);
-    color: $ui-primary-font-color;
+    @include link-color-active-hover(#191919);
+    color: #191919;
     text-decoration: none;
 
     & * {
-      @include link-color-active-hover($ui-primary-font-color);
+      @include link-color-active-hover(#191919);
     }
   }
 
   a,
   h2,
   p {
-    color: $ui-primary-font-color;
+    color: #191919;
   }
 
   img {

--- a/blocks/shared-styles/scss/_small-promo.scss
+++ b/blocks/shared-styles/scss/_small-promo.scss
@@ -1,5 +1,5 @@
 .small-promo {
-  color: $ui-primary-font-color;
+  color: #191919;
   margin-top: 0;
 
   @media screen and (min-width: map-get($grid-breakpoints, 'sm')) {
@@ -13,7 +13,7 @@
   }
 
   a {
-    color: $ui-primary-font-color;
+    color: #191919;
     position: relative;
 
     h2 {
@@ -27,7 +27,7 @@
   }
 
   .sm-promo-headline {
-    @include link-color-active-hover($ui-primary-font-color);
+    @include link-color-active-hover(#191919);
     font-size: calculateRem(16px);
     font-weight: normal;
     line-height: calculateRem(24px);

--- a/blocks/simple-list-block/features/simple-list/simple-list.scss
+++ b/blocks/simple-list-block/features/simple-list/simple-list.scss
@@ -6,7 +6,7 @@
   padding-top: 0;
 
   .list-title {
-    color: $ui-primary-font-color;
+    color: #191919;
     font-size: calculateRem(20px);
     font-weight: bold;
     line-height: calculateRem(24px);
@@ -39,8 +39,8 @@
     }
 
     .simple-list-headline-anchor {
-      @include link-color-active-hover($ui-primary-font-color);
-      color: $ui-primary-font-color;
+      @include link-color-active-hover(#191919);
+      color: #191919;
       display: flex;
       padding-left: calculateRem(16px);
       text-decoration: none;

--- a/blocks/subheadline-block/features/subheadline/subheadline.scss
+++ b/blocks/subheadline-block/features/subheadline/subheadline.scss
@@ -1,5 +1,5 @@
 .h4-primary.sub-headline {
-  color: $ui-primary-font-color;
+  color: #191919;
 
   font-size: calculateRem(19px);
   font-weight: normal;

--- a/blocks/tag-title-block/features/tag-title/tag-title.scss
+++ b/blocks/tag-title-block/features/tag-title/tag-title.scss
@@ -1,5 +1,5 @@
 h1.tag-name {
-  color: $ui-primary-font-color;
+  color: #191919;
   margin-bottom: map-get($spacers, 'xs');
 }
 

--- a/blocks/tag-title-block/features/tag-title/tag-title.scss
+++ b/blocks/tag-title-block/features/tag-title/tag-title.scss
@@ -4,7 +4,7 @@ h1.tag-name {
 }
 
 p.tag-description {
-  color: $ui-dark-gray;
+  color: #191919;
   font-size: calculateRem(16px);
   margin-bottom: map-get($spacers, 'xs');
 }


### PR DESCRIPTION
## Description
I found some instances where the sass variable's selector prevented the correct styled component text from displaying

## Jira Ticket
- [TMEDIA-270](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-270&assignee=5e387d6a1b1d910e5dfd7a9b)

subtask https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-343&assignee=5e387d6a1b1d910e5dfd7a9b

## Acceptance Criteria
- No instances of $ui ... or other sass colors $

## Test Steps

1. Checkout this branch `git checkout TMEDIA-270-remove-sass-variables-colors`
2. Checkout this feature pack https://github.com/WPMedia/Fusion-News-Theme/pull/184 `git checkout TMEDIA-342-remove-sass-variable-override-global` in Fusion-News-Theme
3. Run fusion repo with linked blocks `npx fusion start -f -l`
4. Go to http://localhost/pf/entertainment/2021/06/28/jenaes-global-kitchen-sink-article/?_website=the-gazette and ensure font has the correct color below images that's accessible and derived from the engine theme sdk
5. Spot check colors based on news-theme-css and all-blocks in corecomponents

## Effect Of Changes
### Before

<img width="438" alt="Screen Shot 2021-07-16 at 13 01 53" src="https://user-images.githubusercontent.com/5950956/126002876-90c5f723-2b0e-4023-be79-57d99c13e624.png">


### After

<img width="497" alt="Screen Shot 2021-07-16 at 13 06 59" src="https://user-images.githubusercontent.com/5950956/126002848-cfc592f3-f13a-4218-b876-1acc1787a4a1.png">

## Dependencies or Side Effects
- Fusion-News-Theme pr https://github.com/WPMedia/Fusion-News-Theme/pull/184

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added. -> todo for news theme css docs

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
