### PR TITLE
Tmedia 44 blank author link

### DIFF
--- a/blocks/shared-styles/_children/byline/index.jsx
+++ b/blocks/shared-styles/_children/byline/index.jsx
@@ -27,7 +27,7 @@ const Byline = (props) => {
     if (author.type === 'author') {
       /* eslint-disable-next-line camelcase */
       const authorName = author?.additional_properties?.original?.byline || author?.name;
-      const hasURL = Object.prototype.hasOwnProperty.call(author, 'url');
+      const hasURL = author?.url;
 
       // If the author has a url to their bio page, return an anchor tag to the bio.
       // If not, just return the string.

--- a/blocks/shared-styles/_children/byline/index.story.jsx
+++ b/blocks/shared-styles/_children/byline/index.story.jsx
@@ -81,3 +81,28 @@ export const noAuthors = () => {
     <Byline {...props} />
   );
 };
+
+export const noBylineURL = () => {
+  const props = {
+    separator: boolean('separator', true),
+    list: boolean('list', true),
+    content: {
+      credits: {
+        by: [{
+          type: 'author',
+          name: 'No Name Url',
+          url: '',
+          additional_properties: {
+            original: {
+              byline: 'SangHee Kim Byline',
+            },
+          },
+        }],
+      },
+    },
+  };
+
+  return (
+    <Byline {...props} />
+  );
+};


### PR DESCRIPTION
## Description
Test for empty string on byline url

## Jira Ticket
- [TMEDIA-44](https://arcpublishing.atlassian.net/browse/TMEDIA-44)

## Acceptance Criteria
Do not show a tag if no link 

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-44-blank-author-link`
2. Run sb `npm run storybook`
3.  Go to byline and see story for no url at the bottom 

## Effect Of Changes
### Before
![Screen Shot 2021-07-22 at 12 41 25](https://user-images.githubusercontent.com/5950956/126685332-d9bc2af8-c619-4efd-9a74-0c323c869121.png)

### After

![Screen Shot 2021-07-22 at 12 50 25](https://user-images.githubusercontent.com/5950956/126685401-d3667b98-fddc-4211-828a-a8f583906960.png)


## Dependencies or Side Effects
- Previously hasOwnProperty would test true for 

hasOwnProperty returns true even if the value of the property is null or undefined.

o = new Object();
o.propOne = null;
o.hasOwnProperty('propOne');   // returns true
o.propTwo = undefined;
o.hasOwnProperty('propTwo');   // returns true

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
