### PR TITLE
Update beta and stable actions to match canary

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -40,11 +40,6 @@ jobs:
       - name: Pull tags to give lerna access to git info
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-      - name: Configure NPM
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          echo '@WPMedia:registry=https://npm.pkg.github.com' >> .npmrc
-
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -54,12 +49,16 @@ jobs:
       - name: Clean install (CI) dependencies if lockfile (above) changed
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Run tests
         run: npm run test
 
       - name: Publish to beta
         run: npm run release:beta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Check beta failure status
         uses: act10ns/slack@v1

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -40,11 +40,6 @@ jobs:
       - name: Pull tags to give lerna access to git info
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-      - name: Configure NPM
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
-          echo '@WPMedia:registry=https://npm.pkg.github.com' >> .npmrc
-
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -63,6 +58,8 @@ jobs:
       # iterates minor version
       - name: Publish to stable
         run: npm run release:stable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Check stable failure status
         uses: act10ns/slack@v1


### PR DESCRIPTION
Appears to be that the `env.NODE_AUTH_TOKEN` needs to be set for each step in the action

Update the canary publish action directly on canary branch and is now working as expected - https://github.com/WPMedia/fusion-news-theme-blocks/runs/3142490829?check_suite_focus=true

This PR updates the beta and stable actions to follow the same logic.