### PR TITLE
Remove dependency on core-components

### DIFF
--- a/blocks/story-feed-sections-content-source-block/README.md
+++ b/blocks/story-feed-sections-content-source-block/README.md
@@ -17,6 +17,3 @@ Detail the data structure returned from this content source
 
 ## TTL
 - Add the TTL of the content source
-
-## Additional Considerations
-_See documentation [here](https://github.com/wapopartners/core-components/tree/dev/packages/content-source_story-feed_sections-v4)._

--- a/blocks/story-feed-sections-content-source-block/package.json
+++ b/blocks/story-feed-sections-content-source-block/package.json
@@ -25,8 +25,5 @@
   "peerDependencies": {
     "@wpmedia/resizer-image-block": "*"
   },
-  "dependencies": {
-    "@arc-core-components/content-source_story-feed_sections-v4": "^1.0.6-beta.0"
-  },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
@@ -1,10 +1,102 @@
-import source from '@arc-core-components/content-source_story-feed_sections-v4';
 import getResizedImageData from '@wpmedia/resizer-image-block';
 
+const params = {
+  includeSections: 'text',
+  excludeSections: 'text',
+  feedSize: 'number',
+  feedOffset: 'number',
+};
+
+/**
+* @func itemsToArray
+* @param {String} itemString - a csv list of items to turn into an array
+* @return {String[]} the itemString now in an array
+*/
+export const itemsToArray = (itemString = '') => itemString.split(',').map((item) => item.replace(/"/g, ''));
+
+/**
+* @func pattern
+* @param {Object} key
+* @return {String} elastic search query for the feed sections
+*/
+const pattern = (key = {}) => {
+  const website = key['arc-site'];
+  const {
+    includeSections, excludeSections, feedOffset, feedSize,
+  } = key;
+
+  if (!includeSections) {
+    throw new Error('includeSections parameter is required');
+  }
+
+  const sectionsIncluded = itemsToArray(includeSections);
+  const sectionsExcluded = itemsToArray(excludeSections);
+
+  const body = {
+    query: {
+      bool: {
+        must: [{
+          term: {
+            'revision.published': 'true',
+          },
+        },
+        {
+          nested: {
+            path: 'taxonomy.sections',
+            query: {
+              bool: {
+                must: [
+                  {
+                    terms: {
+                      'taxonomy.sections._id': sectionsIncluded,
+                    },
+                  },
+                  {
+                    term: {
+                      'taxonomy.sections._website': website,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        }],
+        must_not: [{
+          nested: {
+            path: 'taxonomy.sections',
+            query: {
+              bool: {
+                must: [
+                  {
+                    terms: {
+                      'taxonomy.sections._id': sectionsExcluded,
+                    },
+                  },
+                  {
+                    term: {
+                      'taxonomy.sections._website': website,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        }],
+      },
+    },
+  };
+
+  const encodedBody = encodeURI(JSON.stringify(body));
+
+  return `/content/v4/search/published?body=${encodedBody}&website=${website}&size=${feedSize || 10}&from=${feedOffset || 0}&sort=display_date:desc`;
+};
+
+const resolve = (key) => pattern(key);
+
 export default {
-  resolve: source.resolve,
-  schemaName: source.schemaName,
-  params: source.params,
+  resolve,
+  schemaName: 'ans-feed',
+  params,
   // other options null use default functionality, such as filter quality
   transform: (data, query) => (
     getResizedImageData(

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.test.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.test.js
@@ -1,0 +1,121 @@
+import storyFeedSections from './story-feed-sections';
+
+describe('storyFeedSections.resolve function', () => {
+  const key = {
+    'arc-site': 'test-site',
+    includeSections: '/my-sections-to-include,/another-section-to-include',
+    excludeSections: '/my-sections-to-exclude,/another-section-to-exclude',
+    feedSize: 5,
+    feedOffset: 0,
+  };
+
+  const body = {
+    query: {
+      bool: {
+        must: [
+          {
+            term: {
+              'revision.published': 'true',
+            },
+          },
+          {
+            nested: {
+              path: 'taxonomy.sections',
+              query: {
+                bool: {
+                  must: [
+                    {
+                      terms: {
+                        'taxonomy.sections._id': [
+                          '/my-sections-to-include',
+                          '/another-section-to-include',
+                        ],
+                      },
+                    },
+                    {
+                      term: {
+                        'taxonomy.sections._website': 'test-site',
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+        must_not: [
+          {
+            nested: {
+              path: 'taxonomy.sections',
+              query: {
+                bool: {
+                  must: [
+                    {
+                      terms: {
+                        'taxonomy.sections._id': [
+                          '/my-sections-to-exclude',
+                          '/another-section-to-exclude',
+                        ],
+                      },
+                    },
+                    {
+                      term: {
+                        'taxonomy.sections._website': 'test-site',
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  it('Checks that storyFeedSections.resolve returns the right pattern from the key', () => {
+    const { feedOffset, feedSize } = key;
+    const website = key['arc-site'];
+    const encodedBody = encodeURI(JSON.stringify(body));
+    const endpoint = `/content/v4/search/published?body=${encodedBody}&website=${website}&size=${feedSize}&from=${feedOffset}&sort=display_date:desc`;
+    expect(storyFeedSections.resolve(key)).toBe(endpoint);
+  });
+
+  it('Checks that includeSections return correctly', () => {
+    const endcodedSectionsArray = [
+      '/my-sections-to-include',
+      '/another-section-to-include',
+    ];
+    expect(
+      storyFeedSections
+        .resolve(key)
+        .includes(encodeURI(JSON.stringify(endcodedSectionsArray))),
+    ).toBe(true);
+  });
+
+  it('uses the default feedSize and feedOffset', () => {
+    const options = {
+      'arc-site': 'test-site',
+      includeSections: '/my-sections-to-include,/another-section-to-include',
+    };
+
+    expect(storyFeedSections.resolve(options))
+      .toBe('/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22revision.published%22:%22true%22%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/my-sections-to-include%22,%22/another-section-to-include%22%5D%7D%7D,%7B%22term%22:%7B%22taxonomy.sections._website%22:%22test-site%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22%22%5D%7D%7D,%7B%22term%22:%7B%22taxonomy.sections._website%22:%22test-site%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=test-site&size=10&from=0&sort=display_date:desc');
+  });
+
+  it('Allows excludeSection to be not passed', () => {
+    const options = {
+      'arc-site': 'test-site',
+      includeSections: '/my-sections-to-include,/another-section-to-include',
+      feedSize: 5,
+      feedOffset: 0,
+    };
+
+    expect(storyFeedSections.resolve(options))
+      .toBe('/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22revision.published%22:%22true%22%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/my-sections-to-include%22,%22/another-section-to-include%22%5D%7D%7D,%7B%22term%22:%7B%22taxonomy.sections._website%22:%22test-site%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22%22%5D%7D%7D,%7B%22term%22:%7B%22taxonomy.sections._website%22:%22test-site%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=test-site&size=5&from=0&sort=display_date:desc');
+  });
+
+  it('Returns error if no params', () => {
+    expect(() => storyFeedSections.resolve()).toThrow('includeSections parameter is required');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,14 +38,6 @@
         "@babel/runtime": "^7.4.3"
       }
     },
-    "@arc-core-components/content-source_story-feed_sections-v4": {
-      "version": "1.0.6-beta.0",
-      "resolved": "https://registry.npmjs.org/@arc-core-components/content-source_story-feed_sections-v4/-/content-source_story-feed_sections-v4-1.0.6-beta.0.tgz",
-      "integrity": "sha512-Ndj9YJd3NHF/Fhs0CDskGqNJIlu6TAqiAaBW01xXUZR1vU8CnrAWq5cq8/crfQnJE26hivP6q5crG8tGXDQDdQ==",
-      "requires": {
-        "@babel/runtime": "^7.4.3"
-      }
-    },
     "@arc-core-components/content-source_story-feed_tag-v4": {
       "version": "1.0.6-beta.0",
       "resolved": "https://registry.npmjs.org/@arc-core-components/content-source_story-feed_tag-v4/-/content-source_story-feed_tag-v4-1.0.6-beta.0.tgz",
@@ -9255,10 +9247,7 @@
       "version": "file:blocks/story-feed-query-content-source-block"
     },
     "@wpmedia/story-feed-sections-content-source-block": {
-      "version": "file:blocks/story-feed-sections-content-source-block",
-      "requires": {
-        "@arc-core-components/content-source_story-feed_sections-v4": "^1.0.6-beta.0"
-      }
+      "version": "file:blocks/story-feed-sections-content-source-block"
     },
     "@wpmedia/story-feed-tag-content-source-block": {
       "version": "file:blocks/story-feed-tag-content-source-block",


### PR DESCRIPTION
## Description
Update story-feed-sections content source to not rely on core-components for a dependency
Reimplemented what core components was doing
Throw error if no includeSections is passed in
Default feedSize to 10 and feedOffset to 0

## Jira Ticket
- [TMEDIA-279](https://arcpublishing.atlassian.net/browse/TMEDIA-279)

## Acceptance Criteria
1. The Story Feed Sections Content Source block no longer has arc-core-components as a dependency
    * NOTE: Make sure it’s also removed from the block’s package.json!
2. If no section is provided, the content source does not make a request to the content api.

## Test Steps

1. Checkout this branch `git checkout TMEDIA-279-story-feeds-content-source-improvements`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/story-feed-sections-content-source-block`
3. Using content debugger- http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=story-feed-sections
    * Validate the content source works
    * Updates from before, if you do not specify offset or size it will use default values

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
