### PR TITLE
TMEDIA 280 replace corecomponents package, error handling story feed tag

### DIFF
--- a/blocks/story-feed-tag-content-source-block/README.md
+++ b/blocks/story-feed-tag-content-source-block/README.md
@@ -21,4 +21,4 @@ Detail the data structure returned from this content source
 - Add the TTL of the content source
 
 ## Additional Considerations
-_See documentation [here](https://github.com/wapopartners/core-components/tree/dev/packages/content-source_story-feed_tag-v4)._
+

--- a/blocks/story-feed-tag-content-source-block/package-lock.json
+++ b/blocks/story-feed-tag-content-source-block/package-lock.json
@@ -1,29 +1,5 @@
 {
   "name": "@wpmedia/story-feed-tag-content-source-block",
   "version": "5.14.1",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@arc-core-components/content-source_story-feed_tag-v4": {
-      "version": "1.0.6-beta.0",
-      "resolved": "https://registry.npmjs.org/@arc-core-components/content-source_story-feed_tag-v4/-/content-source_story-feed_tag-v4-1.0.6-beta.0.tgz",
-      "integrity": "sha512-ts/TDCa00+OQPBwH4dNFvxykYKA8gvE86H9+6DJxyctxZpYRVMrtNsMuPH+MekJ6444nyKlcGpe5FPGmRtn3/A==",
-      "requires": {
-        "@babel/runtime": "^7.4.3"
-      }
-    },
-    "@babel/runtime": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
-      "integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-    }
-  }
+  "lockfileVersion": 1
 }

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -25,8 +25,5 @@
   "peerDependencies": {
     "@wpmedia/resizer-image-block": "*"
   },
-  "dependencies": {
-    "@arc-core-components/content-source_story-feed_tag-v4": "^1.0.6-beta.0"
-  },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
@@ -13,7 +13,7 @@ const params = {
 */
 const pattern = (key = {}) => {
   const website = key['arc-site'] || 'Arc Site is not defined';
-  const { tagSlug, feedOffset, feedSize } = key;
+  const { tagSlug, feedOffset = 0, feedSize = 10 } = key;
 
   if (!tagSlug) {
     throw new Error('tagSlug parameter is required');

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
@@ -1,9 +1,5 @@
 import getResizedImageData from '@wpmedia/resizer-image-block';
 
-// via https://github.com/wapopartners/core-components/blob/dev/packages/content-source_story-feed_tag-v4/src/index.js#L19
-// Default values for the Core Component
-const schemaName = 'ans-feed';
-
 const params = {
   tagSlug: 'text',
   feedSize: 'number',
@@ -19,6 +15,10 @@ const pattern = (key = {}) => {
   const website = key['arc-site'] || 'Arc Site is not defined';
   const { tagSlug, feedOffset, feedSize } = key;
 
+  if (!tagSlug) {
+    throw new Error('tagSlug parameter is required');
+  }
+
   return `/content/v4/search/published?q=taxonomy.tags.slug:${tagSlug}&size=${feedSize}&from=${feedOffset}&sort=display_date:desc&website=${website}`;
 };
 
@@ -29,16 +29,11 @@ const pattern = (key = {}) => {
 */
 const resolve = (key) => pattern(key);
 
-const source = {
-  resolve,
-  schemaName,
-  params,
-};
-
 export default {
-  resolve: source.resolve,
-  schemaName: source.schemaName,
-  params: source.params,
+  resolve,
+  schemaName: 'ans-feed',
+  params,
+
   // other options null use default functionality, such as filter quality
   transform: (data, query) => (
     getResizedImageData(

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
@@ -13,13 +13,15 @@ const params = {
 */
 const pattern = (key = {}) => {
   const website = key['arc-site'] || 'Arc Site is not defined';
-  const { tagSlug, feedOffset = 0, feedSize = 10 } = key;
+  const { tagSlug, feedOffset, feedSize } = key;
 
   if (!tagSlug) {
     throw new Error('tagSlug parameter is required');
   }
 
-  return `/content/v4/search/published?q=taxonomy.tags.slug:${tagSlug}&size=${feedSize}&from=${feedOffset}&sort=display_date:desc&website=${website}`;
+  // have to use inline due to content source
+  // defaults for feedSize 10 and feedOffset 0
+  return `/content/v4/search/published?q=taxonomy.tags.slug:${tagSlug}&size=${feedSize || 10}&from=${feedOffset || 0}&sort=display_date:desc&website=${website}`;
 };
 
 /**

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
@@ -1,6 +1,39 @@
-/* eslint-disable import/no-unresolved */
-import source from '@arc-core-components/content-source_story-feed_tag-v4';
 import getResizedImageData from '@wpmedia/resizer-image-block';
+
+// via https://github.com/wapopartners/core-components/blob/dev/packages/content-source_story-feed_tag-v4/src/index.js#L19
+// Default values for the Core Component
+const schemaName = 'ans-feed';
+
+const params = {
+  tagSlug: 'text',
+  feedSize: 'number',
+  feedOffset: 'number',
+};
+
+/**
+* @func pattern
+* @param {Object} key
+* @return {String} slugified content api search url
+*/
+const pattern = (key = {}) => {
+  const website = key['arc-site'] || 'Arc Site is not defined';
+  const { tagSlug, feedOffset, feedSize } = key;
+
+  return `/content/v4/search/published?q=taxonomy.tags.slug:${tagSlug}&size=${feedSize}&from=${feedOffset}&sort=display_date:desc&website=${website}`;
+};
+
+/**
+* @func resolve
+* @param {Object} key - the object key to return a slugified pattern for
+* @return {String} slugified content api search url
+*/
+const resolve = (key) => pattern(key);
+
+const source = {
+  resolve,
+  schemaName,
+  params,
+};
 
 export default {
   resolve: source.resolve,

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.test.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.test.js
@@ -17,6 +17,27 @@ describe('content source object', () => {
       expect(storyFeedTag.resolve(key)).toBe(endpoint);
     });
 
+    it('Throws error on empty string tag slug', () => {
+      const emptyTagSlug = '';
+
+      const options = {
+        feedOffset: 0,
+        feedSize: 5,
+        tagSlug: emptyTagSlug,
+      };
+
+      expect(() => storyFeedTag.resolve(options)).toThrow('tagSlug parameter is required');
+    });
+
+    it('Throws error on undefined tag slug', () => {
+      const options = {
+        feedOffset: 0,
+        feedSize: 5,
+      };
+
+      expect(() => storyFeedTag.resolve(options)).toThrow('tagSlug parameter is required');
+    });
+
     it('Returns error if no params', () => {
       expect(() => storyFeedTag.resolve()).toThrow('tagSlug parameter is required');
     });

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.test.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.test.js
@@ -1,0 +1,24 @@
+import storyFeedTag from './story-feed-tag';
+
+describe('content source object', () => {
+  describe('source.resolve function', () => {
+    const key = {
+      'arc-site': 'test-site',
+      tagSlug: 'my-slug',
+      feedOffset: 0,
+      feedSize: 5,
+    };
+
+    it('Checks that source.resolve returns the right pattern from the key', () => {
+      const website = key['arc-site'];
+      const { tagSlug, feedOffset, feedSize } = key;
+
+      const endpoint = `/content/v4/search/published?q=taxonomy.tags.slug:${tagSlug}&size=${feedSize}&from=${feedOffset}&sort=display_date:desc&website=${website}`;
+      expect(storyFeedTag.resolve(key)).toBe(endpoint);
+    });
+
+    it('Returns error if no params', () => {
+      expect(() => storyFeedTag.resolve()).toThrow('tagSlug parameter is required');
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,14 +38,6 @@
         "@babel/runtime": "^7.4.3"
       }
     },
-    "@arc-core-components/content-source_story-feed_tag-v4": {
-      "version": "1.0.6-beta.0",
-      "resolved": "https://registry.npmjs.org/@arc-core-components/content-source_story-feed_tag-v4/-/content-source_story-feed_tag-v4-1.0.6-beta.0.tgz",
-      "integrity": "sha512-ts/TDCa00+OQPBwH4dNFvxykYKA8gvE86H9+6DJxyctxZpYRVMrtNsMuPH+MekJ6444nyKlcGpe5FPGmRtn3/A==",
-      "requires": {
-        "@babel/runtime": "^7.4.3"
-      }
-    },
     "@arc-fusion/prop-types": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@arc-fusion/prop-types/-/prop-types-0.1.5.tgz",
@@ -9058,9 +9050,9 @@
       "version": "file:blocks/double-chain-block"
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.9.10-canary.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.9.10-canary.0/538795fe709a0f52de701c667e5fca143f0dd1e36656c1e073fa81e453bab928",
-      "integrity": "sha512-SWEUO5IcTU/MDTwUmKVTfnU/CuBiR00AOkD9TcdJ8avBVp7jFR3DyzFLzIwPPbRNjtdWuZsdYlegNrd3olutNw==",
+      "version": "2.9.10-canary.1",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.9.10-canary.1/1b68edb41153bca12526057bc293e1c638357e1be84b8dcb8f62459341c14f82",
+      "integrity": "sha512-jorF9uOxWFmcp3tZYnc89LkYu7juDPR3Dn5Pf8TXOZJSV7myfz6LsAVyQelVSU2SR6vY9MvATyxpMTEoiSacoQ==",
       "dev": true,
       "requires": {
         "@arc-fusion/prop-types": "^0.1.5",
@@ -9250,10 +9242,7 @@
       "version": "file:blocks/story-feed-sections-content-source-block"
     },
     "@wpmedia/story-feed-tag-content-source-block": {
-      "version": "file:blocks/story-feed-tag-content-source-block",
-      "requires": {
-        "@arc-core-components/content-source_story-feed_tag-v4": "^1.0.6-beta.0"
-      }
+      "version": "file:blocks/story-feed-tag-content-source-block"
     },
     "@wpmedia/subheadline-block": {
       "version": "file:blocks/subheadline-block"


### PR DESCRIPTION
## Description
Copy-paste corecomponents package
Add error handling for falsy tag slug

## Jira Ticket
- [TMEDIA-280](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-280)

## Acceptance Criteria
The Story Feed Tags Content Source block no longer has arc-core-components as a dependency

NOTE: Make sure it’s also removed from the block’s package.json!

If no tag is provided, the content source does not make a request to the content api.
## Test Steps

1. Checkout this branch `git checkout TMEDIA-280-story-feed-tag-perf`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/story-feed-tag-content-source-block `
3. Use content debugger and see preexisting request still working like "sports" tag
<img width="724" alt="Screen Shot 2021-07-26 at 09 46 41" src="https://user-images.githubusercontent.com/5950956/127008976-9dc15684-ae27-4a2b-8009-88292edcce3b.png">
4. Throw error if falsy param for tag slug 

## Dependencies or Side Effects
- removing deps 

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
