### PR TITLE
Tmedia 359 storybook alert bar

### DIFF
--- a/blocks/alert-bar-block/features/alert-bar/default.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.jsx
@@ -11,6 +11,45 @@ import { readCookie, saveCookie } from './cookies';
 
 import './alert-bar.scss';
 
+export const AlertBarPresentational = (props) => {
+  const {
+    alertRef,
+    barAriaLabel,
+    closeAriaLabel,
+    hideAlertHandler,
+    content,
+    arcSite,
+  } = props;
+
+  const { content_elements: elements = [] } = content;
+  const article = elements[0] || {};
+  const { websites = {}, headlines = {} } = article;
+  const { website_url: websiteURL = '' } = websites[arcSite] || {};
+
+  return (
+    <nav
+      className="alert-bar"
+      ref={alertRef}
+      aria-label={barAriaLabel}
+    >
+      <PrimaryFont
+        href={websiteURL}
+        className="article-link"
+        as="a"
+      >
+        {headlines.basic}
+      </PrimaryFont>
+      <button
+        type="button"
+        onClick={hideAlertHandler}
+        aria-label={closeAriaLabel}
+      >
+        <CloseIcon className="close" fill="white" />
+      </button>
+    </nav>
+  );
+};
+
 @Consumer
 class AlertBar extends Component {
   constructor(props) {
@@ -141,29 +180,17 @@ class AlertBar extends Component {
 
     const { arcSite, customFields = {} } = this.props;
     const { ariaLabel } = customFields;
-    const { content_elements: elements = [] } = content;
-    const article = elements[0] || {};
-    const { websites = {}, headlines = {} } = article;
-    const { website_url: websiteURL = '' } = websites[arcSite] || {};
 
     return (
       !!content?.content_elements?.length && visible && (
-        <nav
-          className="alert-bar"
-          ref={this.alertRef}
-          aria-label={ariaLabel || this.phrases.t('alert-bar-block.element-aria-label')}
-        >
-          <PrimaryFont
-            href={websiteURL}
-            className="article-link"
-            as="a"
-          >
-            {headlines.basic}
-          </PrimaryFont>
-          <button type="button" onClick={this.hideAlert} aria-label={this.phrases.t('alert-bar-block.close-button')}>
-            <CloseIcon className="close" fill="white" />
-          </button>
-        </nav>
+        <AlertBarPresentational
+          alertRef={this.alertRef}
+          barAriaLabel={ariaLabel || this.phrases.t('alert-bar-block.element-aria-label')}
+          closeAriaLabel={this.phrases.t('alert-bar-block.close-button')}
+          hideAlertHandler={this.hideAlert}
+          content={content}
+          arcSite={arcSite}
+        />
       )
     );
   }

--- a/blocks/alert-bar-block/features/alert-bar/default.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import Consumer from 'fusion:consumer';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
 
 import { CloseIcon } from '@wpmedia/engine-theme-sdk';
 import { PrimaryFont } from '@wpmedia/shared-styles';

--- a/blocks/alert-bar-block/features/alert-bar/default.test.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.test.jsx
@@ -7,7 +7,7 @@ jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
 
 jest.mock('fusion:intl', () => ({
   __esModule: true,
-  // where default aria label is defined live 
+  // where default aria label is defined live
   default: jest.fn((locale) => ({ t: jest.fn((phrase) => require('../../intl.json')[phrase][locale]) })),
 }));
 

--- a/blocks/alert-bar-block/features/alert-bar/default.test.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.test.jsx
@@ -7,6 +7,7 @@ jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
 
 jest.mock('fusion:intl', () => ({
   __esModule: true,
+  // where default aria label is defined live 
   default: jest.fn((locale) => ({ t: jest.fn((phrase) => require('../../intl.json')[phrase][locale]) })),
 }));
 
@@ -109,7 +110,7 @@ describe('the alert can handle user interaction', () => {
       cached: content,
       fetched: new Promise((r) => r(content)),
     });
-    const wrapper = shallow(<AlertBar arcSite="the-sun" />);
+    const wrapper = mount(<AlertBar arcSite="the-sun" />);
     jest.advanceTimersByTime(1000);
     wrapper.update();
     expect(wrapper.find('.alert-bar')).toHaveLength(1);
@@ -142,7 +143,7 @@ describe('the alert can handle user interaction', () => {
       cached: content,
       fetched: new Promise((r) => r(content)),
     });
-    const wrapper = shallow(<AlertBar arcSite="the-sun" />);
+    const wrapper = mount(<AlertBar arcSite="the-sun" />);
     jest.advanceTimersByTime(1000);
     wrapper.update();
     expect(wrapper.find('.alert-bar')).toHaveLength(1);
@@ -330,10 +331,11 @@ describe('when add the alert to main section', () => {
       cached: content,
       fetched: new Promise((r) => r(content)),
     });
-    const wrapper = shallow(<AlertBar arcSite="the-sun" />);
+    const wrapper = mount(<AlertBar arcSite="the-sun" />);
     jest.advanceTimersByTime(1000);
     wrapper.update();
-    expect(wrapper.find('nav').props()).toHaveProperty('aria-label', 'Breaking News Alert');
+    // default aria-label is Breaking News Alert
+    expect(wrapper.find('nav').props()['aria-label']).toBe('Breaking News Alert');
   });
 
   it('should render the block with the default aria-label if blank', () => {
@@ -359,10 +361,15 @@ describe('when add the alert to main section', () => {
       cached: content,
       fetched: new Promise((r) => r(content)),
     });
-    const wrapper = shallow(<AlertBar arcSite="the-sun" customFields={{ ariaLabel: '' }} />);
+
+    // custom field passed in to the component is an empty falsy string
+    const wrapper = mount(<AlertBar arcSite="the-sun" customFields={{ ariaLabel: '' }} />);
+
     jest.advanceTimersByTime(1000);
     wrapper.update();
-    expect(wrapper.find('nav').props()).toHaveProperty('aria-label', 'Breaking News Alert');
+
+    // this is from intl.json aria-label
+    expect(wrapper.find('nav').props()['aria-label']).toBe('Breaking News Alert');
   });
 
   it('should render the block with the custom aria-label', () => {
@@ -388,9 +395,12 @@ describe('when add the alert to main section', () => {
       cached: content,
       fetched: new Promise((r) => r(content)),
     });
-    const wrapper = shallow(<AlertBar arcSite="the-sun" customFields={{ ariaLabel: 'Breaking News' }} />);
+
+    // custom field passed in to the component is an empty falsy string
+    const wrapper = mount(<AlertBar arcSite="the-sun" customFields={{ ariaLabel: 'Breaking News from custom field' }} />);
+
     jest.advanceTimersByTime(1000);
     wrapper.update();
-    expect(wrapper.find('nav').props()).toHaveProperty('aria-label', 'Breaking News');
+    expect(wrapper.find('nav').props()['aria-label']).toBe('Breaking News from custom field');
   });
 });

--- a/blocks/alert-bar-block/index.story.jsx
+++ b/blocks/alert-bar-block/index.story.jsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { AlertBarPresentational } from './features/alert-bar/default';
+
+export default {
+  title: 'Blocks/Alert Bar',
+  decorators: [withKnobs],
+  parameters: {
+    // Set the viewports in Chromatic at a component level.
+    chromatic: { viewports: [320, 1200] },
+  },
+};
+
+const mockHeadlineObject = {
+  headlines: {
+    basic: '7 questions about traveling to Australia during catastrophic fires, answered',
+  },
+  websites: {
+    'story-book': {
+      website_url: 'https://storybook.js.org',
+    },
+  },
+};
+
+export const headlineAndLink = () => {
+  const contentPaylod = {
+    content_elements: [
+      mockHeadlineObject,
+    ],
+  };
+
+  return (
+    <AlertBarPresentational
+      alertRef={null}
+      barAriaLabel="Alert bar"
+      closeAriaLabel="Close"
+      hideAlertHandler={null}
+      arcSite="story-book"
+      content={contentPaylod}
+    />
+  );
+};
+
+export const noHeadlineAndWithLink = () => {
+  const noHeadlineObject = {
+    ...mockHeadlineObject,
+    headlines: {
+      basic: '',
+    },
+  };
+  const contentPaylod = {
+    content_elements: [
+      noHeadlineObject,
+    ],
+  };
+
+  return (
+    <AlertBarPresentational
+      alertRef={null}
+      barAriaLabel="Alert bar"
+      closeAriaLabel="Close"
+      hideAlertHandler={null}
+      arcSite="story-book"
+      content={contentPaylod}
+    />
+  );
+};
+
+export const headlineAndNoLink = () => {
+  const noLinkObject = {
+    ...mockHeadlineObject,
+    websites: {
+      'story-book': {
+        website_url: '',
+      },
+    },
+  };
+  const contentPaylod = {
+    content_elements: [
+      noLinkObject,
+    ],
+  };
+
+  return (
+    <AlertBarPresentational
+      alertRef={null}
+      barAriaLabel="Alert bar"
+      closeAriaLabel="Close"
+      hideAlertHandler={null}
+      arcSite="story-book"
+      content={contentPaylod}
+    />
+  );
+};
+
+export const headlineWithReallyLongText = () => {
+  const longHeadlineObject = {
+    ...mockHeadlineObject,
+    headlines: {
+      basic: 'This is a really long headline, especially with the longest word pneumonoultramicroscopicsilicovolcanoconiosis pneumonoultramicroscopicsilicovolcanoconiosis pneumonoultramicroscopicsilicovolcanoconiosis pneumonoultramicroscopicsilicovolcanoconiosis pneumonoultramicroscopicsilicovolcanoconiosis pneumonoultramicroscopicsilicovolcanoconiosis pneumonoultramicroscopicsilicovolcanoconiosis',
+    },
+  };
+  const contentPaylod = {
+    content_elements: [
+      longHeadlineObject,
+    ],
+  };
+
+  return (
+    <AlertBarPresentational
+      alertRef={null}
+      barAriaLabel="Alert bar"
+      closeAriaLabel="Close"
+      hideAlertHandler={null}
+      arcSite="story-book"
+      content={contentPaylod}
+    />
+  );
+};

--- a/blocks/alert-bar-block/package.json
+++ b/blocks/alert-bar-block/package.json
@@ -25,7 +25,8 @@
   },
   "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "*",
-    "@wpmedia/shared-styles": "*"
+    "@wpmedia/shared-styles": "*",
+    "@arc-fusion/prop-types": "^0.1.5"
   },
   "dependencies": {
     "cookie": "^0.4.1"


### PR DESCRIPTION
## Description
Alert bar storybook

## Jira Ticket
- [TMEDIA-333](https://arcpublishing.atlassian.net/browse/TMEDIA-333?focusedCommentId=613358&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-613358)

## Acceptance Criteria
- Cover different data options for alert bar 

## Test Steps
- see alert bar in chromatic renders

## Effect Of Changes
### Before

-less knowledge of alert bar 

### After
- more knowledge about alert bar via sb

## Dependencies or Side Effects


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
