### PR TITLE
Header storybook

### DIFF
--- a/blocks/header-block/features/header/default.jsx
+++ b/blocks/header-block/features/header/default.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from '@arc-fusion/prop-types';
 import Consumer from 'fusion:consumer';
 import './header.scss';
 import { PrimaryFont } from '@wpmedia/shared-styles';

--- a/blocks/header-block/index.story.jsx
+++ b/blocks/header-block/index.story.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Header from './features/header/default';
+
+export default {
+  title: 'Blocks/Header',
+};
+
+export const extralarge = () => {
+  const customFields = {
+    text: 'Baby panda born at the zoo',
+    size: 'Extra Large',
+  };
+
+  return (
+    <Header customFields={customFields} />
+  );
+};
+
+export const large = () => {
+  const customFields = {
+    text: 'Baby panda born at the zoo',
+    size: 'Large',
+  };
+
+  return (
+    <Header customFields={customFields} />
+  );
+};
+
+export const medium = () => {
+  const customFields = {
+    text: 'Baby panda born at the zoo',
+    size: 'Medium',
+  };
+
+  return (
+    <Header customFields={customFields} />
+  );
+};
+
+export const small = () => {
+  const customFields = {
+    text: 'Baby panda born at the zoo',
+    size: 'Small',
+  };
+
+  return (
+    <Header customFields={customFields} />
+  );
+};

--- a/blocks/header-block/index.story.jsx
+++ b/blocks/header-block/index.story.jsx
@@ -5,7 +5,7 @@ export default {
   title: 'Blocks/Header',
 };
 
-export const extralarge = () => {
+export const extraLarge = () => {
   const customFields = {
     text: 'Baby panda born at the zoo',
     size: 'Extra Large',

--- a/blocks/header-block/package.json
+++ b/blocks/header-block/package.json
@@ -25,7 +25,8 @@
   "peerDependencies": {
     "@wpmedia/engine-theme-sdk": "*",
     "@wpmedia/news-theme-css": "*",
-    "@wpmedia/shared-styles": "*"
+    "@wpmedia/shared-styles": "*",
+    "@arc-fusion/prop-types": "^0.1.5"
   },
   "bugs": {
     "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
Includes Header block in storybook

## Jira Ticket
- [TMEDIA-376](https://arcpublishing.atlassian.net/browse/TMEDIA-376)

## Acceptance Criteria
Include Header block in storybook

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-376/header-block_storybook`
2. Run fusion repo with linked blocks `npm run storybook`
3. Observe `Header` section with different sizes.

## Dependencies or Side Effects
Updated block to use `@arc-fusion/prop-types`.

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
