### PR TITLE
TMEDIA-203: Use taboola value not pagetype value fix typo

### DIFF
--- a/blocks/ad-taboola-block/features/ad-taboola/default.jsx
+++ b/blocks/ad-taboola-block/features/ad-taboola/default.jsx
@@ -4,9 +4,9 @@ import getProperties from 'fusion:properties';
 import Consumer from 'fusion:consumer';
 import PAGE_TYPE_TABOOLA_MAPPING from './constants/pageTypeTaboolaMapping';
 
-const taboolaLoader = (publisherID, pageType) => (
+const taboolaLoader = (publisherID, taboolaValue) => (
   `window._taboola = window._taboola || [];
-    _taboola.push({${pageType}:'auto'});
+    _taboola.push({${taboolaValue}:'auto'});
     !function (e, f, u, i) {
       if (!document.getElementById(i)){
         e.async = 1;
@@ -88,7 +88,7 @@ class AdTaboola extends Component {
 
     // if taboola value empty falsy string, then do not include script
     if (taboolaValue) {
-      this.appendScript('tbl-loader', head, () => taboolaLoader(this.publisherID, pageType));
+      this.appendScript('tbl-loader', head, () => taboolaLoader(this.publisherID, taboolaValue));
     }
   }
 


### PR DESCRIPTION
## Description
use taboola value mapping from page-type 

## Jira Ticket
- [TMEDIA-203](https://arcpublishing.atlassian.net/browse/TMEDIA-203)

## Acceptance Criteria
- See instructions https://github.com/WPMedia/fusion-news-theme-blocks/pull/968 but use a gallery page type where the pagetype and taboola value don't match 

see https://arcpublishing.atlassian.net/browse/TMEDIA-203?focusedCommentId=618872&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-618872

## Test Steps

1. Checkout this branch `git checkout TMEDIA-264-hotfix-taboola-wrong-value`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/ad-taboola-block`
3. clone an existing gallery page 

<img width="1074" alt="Screen Shot 2021-08-12 at 10 46 30" src="https://user-images.githubusercontent.com/5950956/129227765-43205fc4-d6d3-441a-a296-1eeea94c901e.png">


4. add taboola block 
5. set a b and tbl-widget for options 

<img width="1348" alt="Screen Shot 2021-08-12 at 10 47 51" src="https://user-images.githubusercontent.com/5950956/129227678-f67c18a4-6578-4857-8895-4ebd8cd52f15.png">

6. publish page
7. see gallery page type map to photo here after pub

<img width="1159" alt="Screen Shot 2021-08-12 at 10 48 39" src="https://user-images.githubusercontent.com/5950956/129227652-6112f363-49f3-45a9-93ef-87781651987c.png">

## Effect Of Changes
### Before
Showed page type in taboola script

### After
Show taboola value that maps from page type in taboola script 

## Dependencies or Side Effects


## Author Checklist
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
