### PR TITLE
Add components folder to Jest coverage collection

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
     },
   },
   collectCoverageFrom: [
-    '**/(features|chains|layouts|sources|output-types|_children)/**/*.{js,jsx}',
+    '**/(features|chains|layouts|sources|output-types|_children|components)/**/*.{js,jsx}',
     // for resizer image block
     '**/extractImageFromStory.js',
     '**/imageRatioCustomField.js',


### PR DESCRIPTION
The identity block has a sub folder name `components`, to ensure Jest collects coverage from files in here I had added the folder name to the `collectCoverageFrom` options