### PR TITLE
TMEDIA-424 - Add HeadingSection as wrapper to simple list block

### DIFF
--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -141,15 +141,16 @@ const SimpleList = (props) => {
   const Wrapper = title ? HeadingSection : React.Fragment;
 
   return (
-    <div key={id} className="list-container layout-section">
-      { title
-        ? (
-          <Heading className="list-title">
-            {title}
-          </Heading>
-        ) : null}
-      <Wrapper>
-        {
+    <HeadingSection>
+      <div key={id} className="list-container layout-section">
+        { title
+          ? (
+            <Heading className="list-title">
+              {title}
+            </Heading>
+          ) : null}
+        <Wrapper>
+          {
         contentElements.reduce(unserializeStory(arcSite), []).map(({
           id: listItemId, itemTitle, imageURL, websiteURL, resizedImageOptions,
         }) => (
@@ -173,8 +174,9 @@ const SimpleList = (props) => {
           </React.Fragment>
         ))
       }
-      </Wrapper>
-    </div>
+        </Wrapper>
+      </div>
+    </HeadingSection>
   );
 };
 


### PR DESCRIPTION
## Description
Add `HeadingSection` component as a wrapper to simple list block to ensure heading hierarchy is correct

## Jira Ticket
- [TMEDIA-424](https://arcpublishing.atlassian.net/browse/TMEDIA-424)


## Test Steps

1. Checkout this branch `git checkout TMEDIA-424-simple-list-heading-section-wrapper`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/simple-list-block`
3. Visit the homepage (http://localhost/homepage/?_website=the-gazette)
4. Verify the simple list block in the right rail heading is a `h2` element and all article titles are a `h3`

## Effect Of Changes
### Before

<img width="1467" alt="TMEDIA-424-before" src="https://user-images.githubusercontent.com/868127/130206660-fe13a6f9-21b6-4504-ad1a-6665a5506249.png">


### After

<img width="1359" alt="TMEDIA-424-after" src="https://user-images.githubusercontent.com/868127/130206679-db1abed1-900c-4860-b68e-11a059719370.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
