### PR TITLE
TMEDIA-310 - Block Icons

### DIFF
--- a/blocks/ad-taboola-block/features/ad-taboola/default.jsx
+++ b/blocks/ad-taboola-block/features/ad-taboola/default.jsx
@@ -152,6 +152,8 @@ class AdTaboola extends Component {
 
 AdTaboola.label = 'Taboola Ad – Arc Block';
 
+AdTaboola.icon = 'arc-ads';
+
 AdTaboola.propTypes = {
   customFields: PropTypes.shape({
     placement: PropTypes.string.tag({

--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -138,4 +138,7 @@ ArcAd.propTypes = {
 };
 
 ArcAd.label = 'Google Ad – Arc Block';
+
+ArcAd.icon = 'arc-ads';
+
 export default ArcAd;

--- a/blocks/alert-bar-block/features/alert-bar/default.jsx
+++ b/blocks/alert-bar-block/features/alert-bar/default.jsx
@@ -198,6 +198,8 @@ class AlertBar extends Component {
 
 AlertBar.label = 'Alert Bar – Arc Block';
 
+AlertBar.icon = 'alarm-bell-ring';
+
 AlertBar.propTypes = {
   customFields: PropTypes.shape({
     ariaLabel: PropTypes.string.tag({

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -406,4 +406,6 @@ ArticleBodyChain.propTypes = {
 
 ArticleBodyChain.label = 'Article Body – Arc Block';
 
+ArticleBodyChain.icon = 'arc-article';
+
 export default ArticleBodyChain;

--- a/blocks/article-tag-block/features/tag/default.jsx
+++ b/blocks/article-tag-block/features/tag/default.jsx
@@ -64,6 +64,8 @@ const ArticleTags = ({ customFields = {} }) => {
 
 ArticleTags.label = 'Tags Bar – Arc Block';
 
+ArticleTags.icon = 'tags';
+
 ArticleTags.propTypes = {
   customFields: PropTypes.shape({
     lazyLoad: PropTypes.bool.tag({

--- a/blocks/author-bio-block/features/author-bio/default.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.jsx
@@ -273,6 +273,8 @@ const AuthorBio = ({ customFields = {} }) => {
 
 AuthorBio.label = 'Short Author Bio – Arc Block';
 
+AuthorBio.icon = 'paragraph-normal';
+
 AuthorBio.propTypes = {
   customFields: PropTypes.shape({
     lazyLoad: PropTypes.bool.tag({

--- a/blocks/byline-block/features/byline/default.jsx
+++ b/blocks/byline-block/features/byline/default.jsx
@@ -6,4 +6,6 @@ const ArticleByline = () => <Byline font="Primary" />;
 
 ArticleByline.label = 'Byline – Arc Block';
 
+ArticleByline.icon = 'user-question';
+
 export default ArticleByline;

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -274,6 +274,8 @@ const CardList = ({ customFields }) => {
 
 CardList.label = 'Card List – Arc Block';
 
+CardList.icon = 'arc-list';
+
 CardList.propTypes = {
   customFields: PropTypes.shape({
     listContentConfig: PropTypes.contentConfig('ans-feed').tag(

--- a/blocks/date-block/features/date/default.jsx
+++ b/blocks/date-block/features/date/default.jsx
@@ -58,4 +58,6 @@ class ArticleDate extends Component {
 
 ArticleDate.label = 'Date – Arc Block';
 
+ArticleDate.icon = 'calendar';
+
 export default ArticleDate;

--- a/blocks/double-chain-block/chains/double-chain/default.jsx
+++ b/blocks/double-chain-block/chains/double-chain/default.jsx
@@ -46,6 +46,8 @@ const DoubleChain = ({ children, customFields }) => {
 
 DoubleChain.label = 'Double Chain – Arc Block';
 
+DoubleChain.icon = 'arc-double-chain';
+
 DoubleChain.propTypes = {
   children: PropTypes.array,
   customFields: PropTypes.shape({

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -91,4 +91,6 @@ ExtraLargeManualPromo.propTypes = {
 
 ExtraLargeManualPromo.label = 'Extra Large Manual Promo – Arc Block';
 
+ExtraLargeManualPromo.icon = 'paragraph-bullets';
+
 export default ExtraLargeManualPromo;

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -200,4 +200,6 @@ ExtraLargePromo.propTypes = {
 
 ExtraLargePromo.label = 'Extra Large Promo – Arc Block';
 
+ExtraLargePromo.icon = 'paragraph-bullets';
+
 export default ExtraLargePromo;

--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -214,4 +214,6 @@ Footer.propTypes = {
 
 Footer.label = 'Footer – Arc Block';
 
+Footer.icon = 'arc-footer';
+
 export default Footer;

--- a/blocks/full-author-bio-block/features/full-author-bio/default.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.jsx
@@ -160,6 +160,8 @@ const FullAuthorBio = ({ customFields = {} }) => {
 
 FullAuthorBio.label = 'FullAuthorBio – Arc Block';
 
+FullAuthorBio.icon = 'paragraph-image-right';
+
 FullAuthorBio.propTypes = {
   customFields: PropTypes.shape({
     lazyLoad: PropTypes.bool.tag({

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -102,4 +102,6 @@ GalleryFeature.propTypes = {
 
 GalleryFeature.label = 'Gallery – Arc Block';
 
+GalleryFeature.icon = 'picture-polaroid-landscape';
+
 export default GalleryFeature;

--- a/blocks/header-block/features/header/default.jsx
+++ b/blocks/header-block/features/header/default.jsx
@@ -77,4 +77,6 @@ Header.propTypes = {
 
 Header.label = 'Header – Arc Block';
 
+Header.icon = 'arc-headline';
+
 export default Header;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -53,7 +53,7 @@ const StyledNav = styled.nav`
       max-width: 240px;
       width: auto;
       transition: 0.5s;
-      
+
       @media screen and (max-width: ${(props) => props.breakpoint}px) {
         max-height: 40px;
         min-width: 40px;
@@ -366,5 +366,7 @@ Nav.propTypes = {
 };
 
 Nav.label = 'Navigation - Arc Chain';
+
+Nav.icon = 'arc-navigation';
 
 export default Nav;

--- a/blocks/headline-block/features/headline/default.jsx
+++ b/blocks/headline-block/features/headline/default.jsx
@@ -15,5 +15,7 @@ const HeadlineContainer = () => {
 
 HeadlineContainer.label = 'Headline – Arc Block';
 
+HeadlineContainer.icon = 'arc-headline';
+
 // maintain default export of container
 export default HeadlineContainer;

--- a/blocks/htmlbox-block/features/htmlbox/default.jsx
+++ b/blocks/htmlbox-block/features/htmlbox/default.jsx
@@ -18,6 +18,8 @@ const HTMLBox = ({ id }) => {
 
 HTMLBox.label = 'HTML Box – Arc Block';
 
+HTMLBox.icon = 'programming-language-html';
+
 HTMLBox.propTypes = {
   customFields: PropTypes.shape({
     HTML: PropTypes.richtext,

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -82,4 +82,6 @@ LargeManualPromo.propTypes = {
 
 LargeManualPromo.label = 'Large Manual Promo – Arc Block';
 
+LargeManualPromo.icon = 'paragraph-bullets';
+
 export default LargeManualPromo;

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -181,4 +181,6 @@ LargePromo.propTypes = {
 
 LargePromo.label = 'Large Promo – Arc Block';
 
+LargePromo.icon = 'paragraph-bullets';
+
 export default LargePromo;

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -227,6 +227,8 @@ class LeadArt extends Component {
 
 LeadArt.label = 'Lead Art – Arc Block';
 
+LeadArt.icon = 'picture-landscape';
+
 LeadArt.defaultProps = {
   customFields: {
     enableAutoplay: false,

--- a/blocks/links-bar-block/features/links-bar/default.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.jsx
@@ -68,6 +68,8 @@ const LinksBar = ({ customFields: { navigationConfig = {}, ariaLabel } }) => {
 
 LinksBar.label = 'Links Bar – Arc Block';
 
+LinksBar.icon = 'hyperlink-3';
+
 LinksBar.propTypes = {
   customFields: PropTypes.shape({
     navigationConfig: PropTypes.contentConfig('navigation-hierarchy').tag({

--- a/blocks/masthead-block/features/masthead-block/default.jsx
+++ b/blocks/masthead-block/features/masthead-block/default.jsx
@@ -69,6 +69,8 @@ const MastheadContainer = (props) => {
 
 MastheadContainer.label = 'Masthead – Arc Block';
 
+MastheadContainer.icon = 'arc-masthead';
+
 MastheadContainer.propTypes = {
   customFields: PropTypes.shape({
     logoURL: PropTypes.string.tag({

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -70,4 +70,6 @@ MediumManualPromo.propTypes = {
 
 MediumManualPromo.label = 'Medium Manual Promo – Arc Block';
 
+MediumManualPromo.icon = 'paragraph-bullets';
+
 export default MediumManualPromo;

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -150,4 +150,6 @@ MediumPromo.propTypes = {
 
 MediumPromo.label = 'Medium Promo – Arc Block';
 
+MediumPromo.icon = 'paragraph-bullets';
+
 export default MediumPromo;

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -212,4 +212,6 @@ NumberedListWrapper.propTypes = {
 
 NumberedListWrapper.label = 'Numbered List – Arc Block';
 
+NumberedListWrapper.icon = 'arc-list';
+
 export default NumberedListWrapper;

--- a/blocks/overline-block/features/overline/default.jsx
+++ b/blocks/overline-block/features/overline/default.jsx
@@ -6,4 +6,6 @@ const Overline = () => <OverlineOutput />;
 
 Overline.label = 'Overline – Arc Block';
 
+Overline.icon = 'arc-overline';
+
 export default Overline;

--- a/blocks/quad-chain-block/chains/quad-chain/default.jsx
+++ b/blocks/quad-chain-block/chains/quad-chain/default.jsx
@@ -58,6 +58,8 @@ const QuadChain = ({ children, customFields }) => {
 
 QuadChain.label = 'Quad Chain – Arc Block';
 
+QuadChain.icon = 'arc-quad-chain';
+
 QuadChain.propTypes = {
   children: PropTypes.array,
   customFields: PropTypes.shape({

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -90,6 +90,8 @@ const ResultsList = ({ customFields }) => {
 
 ResultsList.label = 'Results List – Arc Block';
 
+ResultsList.icon = 'arc-list';
+
 ResultsList.propTypes = {
   customFields: PropTypes.shape({
     listContentConfig: PropTypes.contentConfig('ans-feed').tag({

--- a/blocks/search-results-list-block/features/search-results-list/default.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/default.jsx
@@ -55,6 +55,8 @@ const SearchResultsListContainer = (
 
 SearchResultsListContainer.label = 'Search Results List – Arc Block';
 
+SearchResultsListContainer.icon = 'arc-list';
+
 SearchResultsListContainer.propTypes = {
   customFields: PropTypes.shape({
     searchContentConfig: PropTypes.contentConfig().tag({

--- a/blocks/section-title-block/features/section-title/default.jsx
+++ b/blocks/section-title-block/features/section-title/default.jsx
@@ -20,6 +20,8 @@ const SectionTitleContainer = (
 
 SectionTitleContainer.label = 'Section Title – Arc Block';
 
+SectionTitleContainer.icon = 'arc-headline';
+
 SectionTitleContainer.propTypes = {
   customFields: PropTypes.shape({
     sectionContentConfig: PropTypes.contentConfig().tag({

--- a/blocks/share-bar-block/features/share-bar/default.jsx
+++ b/blocks/share-bar-block/features/share-bar/default.jsx
@@ -142,6 +142,8 @@ export const ShareBar = ({
 
 ShareBarContainer.label = 'Share Bar – Arc Block';
 
+ShareBarContainer.icon = 'share';
+
 ShareBarContainer.propTypes = {
   customFields: PropTypes.shape({
     email: PropTypes.bool.tag({

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -207,4 +207,6 @@ SimpleListWrapper.propTypes = {
 
 SimpleListWrapper.label = 'Simple List – Arc Block';
 
+SimpleListWrapper.icon = 'arc-list';
+
 export default SimpleListWrapper;

--- a/blocks/single-chain-block/chains/single-chain/default.jsx
+++ b/blocks/single-chain-block/chains/single-chain/default.jsx
@@ -21,6 +21,8 @@ const SingleChain = ({ children, customFields = {} }) => {
 
 SingleChain.label = 'Single Chain – Arc Block';
 
+SingleChain.icon = 'layout-none';
+
 SingleChain.propTypes = {
   children: PropTypes.array,
   customFields: PropTypes.shape({

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -73,4 +73,6 @@ SmallManualPromo.propTypes = {
 
 SmallManualPromo.label = 'Small Manual Promo – Arc Block';
 
+SmallManualPromo.icon = 'paragraph-bullets';
+
 export default SmallManualPromo;

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -133,4 +133,6 @@ SmallPromo.propTypes = {
 
 SmallPromo.label = 'Small Promo – Arc Block';
 
+SmallPromo.icon = 'paragraph-bullets';
+
 export default SmallPromo;

--- a/blocks/subheadline-block/features/subheadline/default.jsx
+++ b/blocks/subheadline-block/features/subheadline/default.jsx
@@ -50,4 +50,6 @@ SubHeadline.propTypes = {
 
 SubHeadline.label = 'Subheadline – Arc Block';
 
+SubHeadline.icon = 'arc-subheadline';
+
 export default SubHeadline;

--- a/blocks/tag-title-block/features/tag-title/default.jsx
+++ b/blocks/tag-title-block/features/tag-title/default.jsx
@@ -32,4 +32,6 @@ const TagTitle = () => {
 
 TagTitle.label = 'Tag Title - Arc Block';
 
+TagTitle.icon = 'arc-title';
+
 export default TagTitle;

--- a/blocks/textfile-block/features/textfile/text.js
+++ b/blocks/textfile-block/features/textfile/text.js
@@ -9,6 +9,8 @@ const Textfile = ({ customFields }) => {
 
 Textfile.label = 'Text File – Arc Block';
 
+Textfile.icon = 'notes-paper-text';
+
 Textfile.propTypes = {
   customFields: PropTypes.shape({
     // eslint-disable-next-line react/no-typos

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -460,4 +460,6 @@ TopTableListWrapper.propTypes = {
 
 TopTableListWrapper.label = 'Top Table List – Arc Block';
 
+TopTableListWrapper.icon = 'arc-list';
+
 export default TopTableListWrapper;

--- a/blocks/triple-chain-block/chains/triple-chain/default.jsx
+++ b/blocks/triple-chain-block/chains/triple-chain/default.jsx
@@ -52,6 +52,8 @@ const TripleChain = ({ children, customFields }) => {
 
 TripleChain.label = 'Triple Chain – Arc Block';
 
+TripleChain.icon = 'arc-triple-chain';
+
 TripleChain.propTypes = {
   children: PropTypes.array,
   customFields: PropTypes.shape({

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -168,4 +168,6 @@ VideoPlayer.propTypes = {
 
 VideoPlayer.label = 'Video Center Player - Arc Block';
 
+VideoPlayer.icon = 'video-player-adjust';
+
 export default VideoPlayer;


### PR DESCRIPTION
## Description

Add new icon property to blocks as per ticket

## Jira Ticket
- [TMEDIA-310](https://arcpublishing.atlassian.net/browse/TMEDIA-310)

## Test Steps

In Fusion News Theme ensure you have the following environment variables set

```
FUSION_RELEASE=3.0.1
PB_EDITOR=rc
```

1. Checkout this branch `git checkout TMEDIA-310-block-icons`
2. Run fusion repo with linked blocks `npx fusion start -f -l`
3. Open up a page in PageBuilder and click "Add Block" and validate all blocks listed in ticket have icons

## Effect Of Changes

Blocks use a specific icon instead of the default icon

<img width="362" alt="TMEDIA-310-block-icons" src="https://user-images.githubusercontent.com/868127/130246852-b323ce6f-6618-484d-9bf5-5862ea211f5b.png">

## Dependencies or Side Effects

In Fusion News Theme ensure you have the following environment variables set

```
FUSION_RELEASE=3.0.1
PB_EDITOR=rc
```


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
