### PR TITLE
Fix input field

### DIFF
--- a/blocks/identity-block/components/FormInputField/index.jsx
+++ b/blocks/identity-block/components/FormInputField/index.jsx
@@ -25,25 +25,27 @@ const FormInputField = ({
   validationPattern,
 }) => {
   const [valid, setValid] = useState(true);
+  const [value, setValue] = useState(defaultValue);
+  const [initialBlur, setInitialBlur] = useState(showDefaultError);
   const inputElement = useRef();
 
   useEffect(() => {
-    if (validationErrorMessage) {
-      inputElement.current.setCustomValidity(validationErrorMessage);
+    if (initialBlur) {
+      inputElement.current.setCustomValidity('');
+      const isValid = inputElement.current?.checkValidity();
+      if (!isValid && validationErrorMessage) {
+        inputElement.current.setCustomValidity(validationErrorMessage);
+      }
+      setValid(isValid);
     }
-    if (inputElement.current && showDefaultError) {
-      setValid(inputElement.current.checkValidity());
-    }
-  }, [inputElement, showDefaultError, validationErrorMessage]);
+  }, [initialBlur, inputElement, validationErrorMessage, validationPattern, value]);
 
-  const handleBlur = (event) => {
-    setValid(event.target.checkValidity());
+  const handleBlur = () => {
+    setInitialBlur(true);
   };
 
   const handleChange = (event) => {
-    if (!valid) {
-      handleBlur(event);
-    }
+    setValue(event.target.value);
     onChange({ value: event.target.value });
   };
 
@@ -51,8 +53,7 @@ const FormInputField = ({
   const inputId = `id_${name}_input`;
 
   const fieldParameters = {
-    ...(defaultValue ? { defaultValue } : {}),
-    ...(name ? { name } : {}),
+    ...(defaultValue !== '' ? { defaultValue } : {}),
     ...(validationPattern ? { pattern: validationPattern } : {}),
     ...(placeholder ? { placeholder, 'aria-placeholder': placeholder } : {}),
     ...(required ? { required } : {}),
@@ -74,6 +75,7 @@ const FormInputField = ({
           ...(!valid ? ['xpmedia-form-field-input--error'] : []),
         ].join(' ')}
         id={inputId}
+        name={name}
         type={type}
         onBlur={handleBlur}
         onChange={handleChange}

--- a/blocks/identity-block/components/FormInputField/index.jsx
+++ b/blocks/identity-block/components/FormInputField/index.jsx
@@ -31,7 +31,9 @@ const FormInputField = ({
 
   useEffect(() => {
     if (initialBlur) {
-      inputElement.current.setCustomValidity('');
+      if (validationErrorMessage) {
+        inputElement.current.setCustomValidity('');
+      }
       const isValid = inputElement.current?.checkValidity();
       if (!isValid && validationErrorMessage) {
         inputElement.current.setCustomValidity(validationErrorMessage);

--- a/blocks/identity-block/components/FormInputField/index.story.jsx
+++ b/blocks/identity-block/components/FormInputField/index.story.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import FormInputField, { FIELD_TYPES } from '.';
 
 export default {
-  title: 'Blocks/Identity/InputField',
+  title: 'Blocks/Identity/Components/InputField',
   parameters: {
     chromatic: { viewports: [320, 1200] },
   },

--- a/blocks/identity-block/components/FormInputField/index.test.jsx
+++ b/blocks/identity-block/components/FormInputField/index.test.jsx
@@ -7,13 +7,13 @@ describe('Form Input Field', () => {
   it('renders with a label', () => {
     const wrapper = mount(<FormInputField name="test" label="label text" />);
 
-    expect(wrapper.find('label text')).not.toBe(null);
+    expect(wrapper.text().includes('label text')).toBe(true);
   });
 
   it('renders with a tip', () => {
     const wrapper = mount(<FormInputField name="test" tip="tip text" />);
 
-    expect(wrapper.find('tip text')).not.toBe(null);
+    expect(wrapper.text().includes('tip text')).toBe(true);
   });
 
   it('renders with an error', () => {
@@ -26,9 +26,20 @@ describe('Form Input Field', () => {
       />,
     );
 
-    wrapper.find('input').simulate('blur');
+    wrapper.find('input').at(0).simulate('blur');
 
-    expect(wrapper.find('error message')).not.toBe(null);
+    expect(wrapper.text().includes('error message')).toBe(true);
+  });
+
+  it('renders with a placeholder', () => {
+    const wrapper = mount(
+      <FormInputField
+        name="test"
+        placeholder="Placeholder"
+      />,
+    );
+
+    expect(wrapper.find('input[placeholder="Placeholder"]').length).toBe(1);
   });
 
   it('renders with an error by default', () => {
@@ -42,28 +53,25 @@ describe('Form Input Field', () => {
       />,
     );
 
-    expect(wrapper.find('error message')).not.toBe(null);
+    expect(wrapper.text().includes('error message')).toBe(true);
   });
 
-  it('renders with an error only after blurring', () => {
+  it('renders with an error after changing', () => {
     const wrapper = mount(
       <FormInputField
         name="test"
         type={FIELD_TYPES.EMAIL}
-        defaultValue="invalid"
+        defaultValue="invali"
         validationErrorMessage="error message"
       />,
     );
 
-    expect(wrapper.find('error message')).not.toExist();
+    expect(wrapper.find('span')).not.toExist();
 
-    wrapper.find('input').simulate('change');
+    wrapper.find('input').at(0).simulate('change', { target: { value: 'invalid' } });
+    wrapper.find('input').at(0).simulate('blur');
 
-    expect(wrapper.find('error message')).not.toExist();
-
-    wrapper.find('input').simulate('blur');
-
-    expect(wrapper.find('error message')).not.toBe(null);
+    expect(wrapper.find('span').length).toBe(1);
   });
 
   it('renders with an error overriding tip', () => {
@@ -72,16 +80,46 @@ describe('Form Input Field', () => {
         name="test"
         type={FIELD_TYPES.EMAIL}
         defaultValue="invalid"
-        tip="should not be found after change"
+        tip="should be found before/after change"
         validationErrorMessage="error message"
       />,
     );
 
-    expect(wrapper.find('should not be found after change')).not.toBe(null);
+    expect(wrapper.text().includes('should be found before/after change')).toBe(true);
 
-    wrapper.find('input').simulate('blur');
+    wrapper.find('input').at(0).simulate('blur');
 
-    expect(wrapper.find('should not be found after change')).not.toExist();
-    expect(wrapper.find('error message')).not.toBe(null);
+    expect(wrapper.text().includes('should be found before/after change')).toBe(true);
+    expect(wrapper.text().includes('error message')).toBe(true);
+  });
+
+  it('renders with an error on custom patterns', () => {
+    const wrapper = mount(
+      <FormInputField
+        name="test"
+        defaultValue="invalid"
+        validationErrorMessage="error message"
+        validationPattern="^valid$"
+      />,
+    );
+
+    wrapper.find('input').at(0).simulate('blur');
+
+    expect(wrapper.text().includes('error message')).toBe(true);
+  });
+
+  it('renders with an error on blank required', () => {
+    const wrapper = mount(
+      <FormInputField
+        name="test"
+        required
+        validationErrorMessage="error message"
+        validationPattern="^valid$"
+      />,
+    );
+
+    wrapper.find('input').at(0).simulate('blur');
+
+    expect(wrapper.text().includes('error message')).toBe(true);
   });
 });


### PR DESCRIPTION
## Description
Fixing an issue in the form input field and setting up for the confirm password component.

## Test Steps
1. Checkout this branch `git checkout fix-input-field`
2. Run fusion repo with linked blocks `npm run storybook`

## Effect Of Changes
### Before
Setting a custom error would cause the error state to get stuck in error.

### After
Setting a custom error is now properly cleared before checking validity.

## Author Checklist
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
