### PR TITLE
TMEDIA-459: Shared form component

### DIFF
--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -58,12 +58,12 @@ const StyledDynamicButton = styled.button`
 const matchButtonSizeWithClass = (matchedButtonSize) => {
   switch (matchedButtonSize) {
     case BUTTON_SIZES.SMALL:
-      return 'xpmedia-subs-button--small';
+      return 'xpmedia-button--small';
     case BUTTON_SIZES.LARGE:
-      return 'xpmedia-subs-button--large';
+      return 'xpmedia-button--large';
     case BUTTON_SIZES.MEDIUM:
     default:
-      return 'xpmedia-subs-button--medium';
+      return 'xpmedia-button--medium';
   }
 };
 
@@ -112,7 +112,7 @@ function Button(props) {
     <StyledDynamicButton
       arcSite={arcSite}
       matchedButtonStyle={matchedButtonStyle}
-      className={`xpmedia-subs-button ${matchedButtonSizeClass}`}
+      className={`xpmedia-button ${matchedButtonSizeClass}`}
     >
       {
         matchedButtonType === BUTTON_TYPES.ICON_ONLY ? (

--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -51,7 +51,7 @@ const StyledDynamicButton = styled.button`
           color: #ffffff;
         `;
     }
-  }};
+  }}
 `;
 
 // get the class name for the button based on the button size based on mocks

--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import getThemeStyle from 'fusion:themes';
 import { useFusionContext } from 'fusion:context';
 import { UserIcon } from '@wpmedia/engine-theme-sdk';
@@ -28,12 +29,12 @@ export const BUTTON_TYPES = {
 
 const StyledDynamicButton = styled.button.attrs((props) => ({
   arcSite: props.arcSite,
-  matchedButtonStyle: props.matchedButtonStyle,
+  buttonStyle: props.buttonStyle,
 }))`
   font-family: ${({ arcSite }) => getThemeStyle(arcSite)['primary-font-family']};
 
-  ${({ matchedButtonStyle, arcSite }) => {
-    switch (matchedButtonStyle) {
+  ${({ buttonStyle, arcSite }) => {
+    switch (buttonStyle) {
       case BUTTON_STYLES.WHITE_BACKGROUND_FILLED:
         return `
           background-color: #ffffff;
@@ -104,13 +105,7 @@ function Button(props) {
     type,
   } = props;
 
-  const matchedButtonSize = BUTTON_SIZES[buttonSize] || BUTTON_SIZES.MEDIUM;
-
-  const matchedButtonSizeClass = matchButtonSizeWithClass(matchedButtonSize);
-
-  const matchedButtonStyle = BUTTON_STYLES[buttonStyle] || BUTTON_STYLES.FILLED;
-
-  const matchedButtonType = BUTTON_TYPES[buttonType] || BUTTON_TYPES.LABEL_ONLY;
+  const matchedButtonSizeClass = matchButtonSizeWithClass(buttonSize);
 
   let Icon = null;
 
@@ -136,14 +131,32 @@ function Button(props) {
   return (
     <StyledDynamicButton
       arcSite={arcSite}
-      matchedButtonStyle={matchedButtonStyle}
+      buttonStyle={buttonStyle}
       className={`xpmedia-button ${matchedButtonSizeClass}`}
       aria-label={ariaLabel}
       type={type}
     >
-      {renderButtonContents(matchedButtonType, text, Icon)}
+      {renderButtonContents(buttonType, text, Icon)}
     </StyledDynamicButton>
   );
 }
+
+Button.propTypes = {
+  buttonSize: PropTypes.oneOf(Object.values(BUTTON_SIZES)),
+  buttonStyle: PropTypes.oneOf(Object.values(BUTTON_STYLES)),
+  buttonType: PropTypes.oneOf(Object.values(BUTTON_TYPES)),
+  iconType: PropTypes.oneOf(['user']),
+  text: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string.isRequired,
+  type: PropTypes.string,
+};
+
+Button.defaultProps = {
+  buttonSize: BUTTON_SIZES.MEDIUM,
+  buttonStyle: BUTTON_STYLES.FILLED,
+  buttonType: BUTTON_TYPES.LABEL_ONLY,
+  iconType: '',
+  type: 'button',
+};
 
 export default Button;

--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -70,6 +70,25 @@ const matchButtonSizeWithClass = (matchedButtonSize) => {
   }
 };
 
+function renderButtonContents(matchedButtonType, text, iconComponent) {
+  switch (matchedButtonType) {
+    case BUTTON_TYPES.LABEL_ONLY:
+      return (text);
+    case BUTTON_TYPES.ICON_ONLY:
+      return (iconComponent);
+    case BUTTON_TYPES.LABEL_AND_ICON:
+    default:
+      return (
+        <>
+          <div className="xpmedia-button--left-icon-container">
+            {iconComponent}
+          </div>
+          {text}
+        </>
+      );
+  }
+}
+
 function Button(props) {
   const { arcSite } = useFusionContext();
 
@@ -77,7 +96,8 @@ function Button(props) {
     buttonSize,
     buttonStyle,
     buttonType,
-    children,
+    // todo: take in children and handle
+    // children,
     iconType = '',
     text,
     ariaLabel,
@@ -121,19 +141,7 @@ function Button(props) {
       aria-label={ariaLabel}
       type={type}
     >
-      {
-        matchedButtonType === BUTTON_TYPES.ICON_ONLY ? (
-          <>
-            {Icon}
-          </>
-        ) : (
-          <>
-            {Icon}
-            {text}
-          </>
-        )
-      }
-      {children}
+      {renderButtonContents(matchedButtonType, text, Icon)}
     </StyledDynamicButton>
   );
 }

--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -76,7 +76,7 @@ function Button(props) {
     buttonType,
     children,
     iconType = '',
-    text = '',
+    text,
   } = props;
 
   const matchedButtonSize = BUTTON_SIZES[buttonSize] || BUTTON_SIZES.MEDIUM;

--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -4,8 +4,10 @@ import getThemeStyle from 'fusion:themes';
 import { useFusionContext } from 'fusion:context';
 import { UserIcon } from '@wpmedia/engine-theme-sdk';
 
+// handle non-dynamic styling not based on theme styles
 import './styles.scss';
 
+// naming comes from zeplin docs for types
 export const BUTTON_STYLES = {
   FILLED: 'FILLED',
   OUTLINED: 'OUTLINED',
@@ -52,6 +54,7 @@ const StyledDynamicButton = styled.button`
   }};
 `;
 
+// get the class name for the button based on the button size based on mocks
 const matchButtonSizeWithClass = (matchedButtonSize) => {
   switch (matchedButtonSize) {
     case BUTTON_SIZES.SMALL:

--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -81,6 +81,7 @@ function Button(props) {
     iconType = '',
     text,
     ariaLabel,
+    type,
   } = props;
 
   const matchedButtonSize = BUTTON_SIZES[buttonSize] || BUTTON_SIZES.MEDIUM;
@@ -118,6 +119,7 @@ function Button(props) {
       matchedButtonStyle={matchedButtonStyle}
       className={`xpmedia-button ${matchedButtonSizeClass}`}
       aria-label={ariaLabel}
+      type={type}
     >
       {
         matchedButtonType === BUTTON_TYPES.ICON_ONLY ? (

--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -80,6 +80,7 @@ function Button(props) {
     children,
     iconType = '',
     text,
+    ariaLabel,
   } = props;
 
   const matchedButtonSize = BUTTON_SIZES[buttonSize] || BUTTON_SIZES.MEDIUM;
@@ -116,6 +117,7 @@ function Button(props) {
       arcSite={arcSite}
       matchedButtonStyle={matchedButtonStyle}
       className={`xpmedia-button ${matchedButtonSizeClass}`}
+      aria-label={ariaLabel}
     >
       {
         matchedButtonType === BUTTON_TYPES.ICON_ONLY ? (

--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import styled from 'styled-components';
+import getThemeStyle from 'fusion:themes';
+import { useFusionContext } from 'fusion:context';
+import { UserIcon } from '@wpmedia/engine-theme-sdk';
+
+import './styles.scss';
+
+export const BUTTON_STYLES = {
+  FILLED: 'FILLED',
+  OUTLINED: 'OUTLINED',
+};
+
+export const BUTTON_SIZES = {
+  SMALL: 'SMALL',
+  MEDIUM: 'MEDIUM',
+  LARGE: 'LARGE',
+};
+
+export const BUTTON_TYPES = {
+  LABEL_ONLY: 'LABEL_ONLY',
+  ICON_ONLY: 'ICON_ONLY',
+  LABEL_AND_ICON: 'LABEL_AND_ICON',
+};
+
+const StyledDynamicButton = styled.button`
+  font-family: ${({ arcSite }) => getThemeStyle(arcSite)['primary-font-family']};
+  border: 1px solid ${({ arcSite }) => getThemeStyle(arcSite)['primary-color']};
+
+  ${({ matchedButtonStyle, arcSite }) => {
+    switch (matchedButtonStyle) {
+      case BUTTON_STYLES.OUTLINED:
+        return `
+          background-color: transparent;
+          color: ${getThemeStyle(arcSite)['primary-color']};
+        `;
+      case BUTTON_STYLES.FILLED:
+      default:
+        return `
+          background-color: ${getThemeStyle(arcSite)['primary-color']};
+          color: #ffffff;
+        `;
+    }
+  }};
+`;
+
+const matchButtonSizeWithClass = (matchedButtonSize) => {
+  switch (matchedButtonSize) {
+    case BUTTON_SIZES.SMALL:
+      return 'xpmedia-subs-button--small';
+    case BUTTON_SIZES.LARGE:
+      return 'xpmedia-subs-button--large';
+    case BUTTON_SIZES.MEDIUM:
+    default:
+      return 'xpmedia-subs-button--medium';
+  }
+};
+
+function Button(props) {
+  const { arcSite } = useFusionContext();
+
+  const {
+    buttonSize,
+    buttonStyle,
+    buttonType,
+    children,
+    iconType = '',
+    text = '',
+  } = props;
+
+  const matchedButtonSize = BUTTON_SIZES[buttonSize] || BUTTON_SIZES.MEDIUM;
+
+  const matchedButtonSizeClass = matchButtonSizeWithClass(matchedButtonSize);
+
+  const matchedButtonStyle = BUTTON_STYLES[buttonStyle] || BUTTON_STYLES.FILLED;
+
+  const matchedButtonType = BUTTON_TYPES[buttonType] || BUTTON_TYPES.LABEL_ONLY;
+
+  let Icon = null;
+
+  if (iconType) {
+    switch (iconType) {
+      case 'user':
+        Icon = (
+          // todo: width and height for large and medium icons are different
+          // https://app.zeplin.io/project/603fa53e2626ed1592e7c0e6/screen/60411633bdf9b380a0f087ca
+          <UserIcon />
+        );
+        break;
+      default:
+        Icon = null;
+        break;
+    }
+  }
+
+  return (
+    <StyledDynamicButton
+      arcSite={arcSite}
+      matchedButtonStyle={matchedButtonStyle}
+      className={`xpmedia-subs-button ${matchedButtonSizeClass}`}
+    >
+      {
+        matchedButtonType === BUTTON_TYPES.ICON_ONLY ? (
+          <>
+            {Icon}
+          </>
+        ) : (
+          <>
+            {Icon}
+            {text}
+          </>
+        )
+      }
+      {children}
+    </StyledDynamicButton>
+  );
+}
+
+export default Button;

--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -9,6 +9,7 @@ import './styles.scss';
 export const BUTTON_STYLES = {
   FILLED: 'FILLED',
   OUTLINED: 'OUTLINED',
+  WHITE_BACKGROUND_FILLED: 'WHITE_BACKGROUND_FILLED',
 };
 
 export const BUTTON_SIZES = {
@@ -25,19 +26,26 @@ export const BUTTON_TYPES = {
 
 const StyledDynamicButton = styled.button`
   font-family: ${({ arcSite }) => getThemeStyle(arcSite)['primary-font-family']};
-  border: 1px solid ${({ arcSite }) => getThemeStyle(arcSite)['primary-color']};
 
   ${({ matchedButtonStyle, arcSite }) => {
     switch (matchedButtonStyle) {
+      case BUTTON_STYLES.WHITE_BACKGROUND_FILLED:
+        return `
+          background-color: #ffffff;
+          border-color: #ffffff;
+          color: ${getThemeStyle(arcSite)['primary-color']};
+        `;
       case BUTTON_STYLES.OUTLINED:
         return `
           background-color: transparent;
+          border-color: ${getThemeStyle(arcSite)['primary-color']};
           color: ${getThemeStyle(arcSite)['primary-color']};
         `;
       case BUTTON_STYLES.FILLED:
       default:
         return `
           background-color: ${getThemeStyle(arcSite)['primary-color']};
+          border-color: ${getThemeStyle(arcSite)['primary-color']};
           color: #ffffff;
         `;
     }
@@ -84,7 +92,11 @@ function Button(props) {
         Icon = (
           // todo: width and height for large and medium icons are different
           // https://app.zeplin.io/project/603fa53e2626ed1592e7c0e6/screen/60411633bdf9b380a0f087ca
-          <UserIcon />
+          <UserIcon
+            height={16}
+            width={16}
+            fill={getThemeStyle(arcSite)['primary-color']}
+          />
         );
         break;
       default:

--- a/blocks/identity-block/components/Button/index.jsx
+++ b/blocks/identity-block/components/Button/index.jsx
@@ -26,7 +26,10 @@ export const BUTTON_TYPES = {
   LABEL_AND_ICON: 'LABEL_AND_ICON',
 };
 
-const StyledDynamicButton = styled.button`
+const StyledDynamicButton = styled.button.attrs((props) => ({
+  arcSite: props.arcSite,
+  matchedButtonStyle: props.matchedButtonStyle,
+}))`
   font-family: ${({ arcSite }) => getThemeStyle(arcSite)['primary-font-family']};
 
   ${({ matchedButtonStyle, arcSite }) => {

--- a/blocks/identity-block/components/Button/index.story.jsx
+++ b/blocks/identity-block/components/Button/index.story.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import Button, { BUTTON_STYLES, BUTTON_SIZES } from '.';
+
+export default {
+  title: 'Blocks/Identity/Components/Button',
+  parameters: {
+    chromatic: { viewports: [320, 1200] },
+  },
+};
+
+export const Default = () => (
+  <Button text="" />
+);
+
+export const Filled = () => (
+  <Button buttonStyle={BUTTON_STYLES.FILLED} text="Sign up" />
+);
+
+export const Outlined = () => (
+  <Button buttonStyle={BUTTON_STYLES.OUTLINED} text="Sign up" />
+);
+
+export const OutlineSmall = () => (
+  <Button buttonStyle={BUTTON_STYLES.OUTLINED} buttonSize={BUTTON_SIZES.SMALL} text="Sign up" />
+);
+
+// outlined medium button
+export const OutlinedMedium = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.OUTLINED}
+    buttonSize={BUTTON_SIZES.MEDIUM}
+    text="Sign up"
+  />
+);
+
+// outlined large button
+export const OutlinedLarge = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.OUTLINED}
+    buttonSize={BUTTON_SIZES.LARGE}
+    text="Sign up"
+  />
+);
+
+export const LongText = () => (
+  <Button
+    text="Sign up to get the very best experience and this other really long work and such and more and even more text.Sign up to get the very best experience and this other really long work and such and more and even more text."
+  />
+);
+
+export const UserIconWithLabel = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.OUTLINED}
+    buttonSize={BUTTON_SIZES.LARGE}
+    text="Sign up"
+    iconType="user"
+  />
+);

--- a/blocks/identity-block/components/Button/index.story.jsx
+++ b/blocks/identity-block/components/Button/index.story.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Button, { BUTTON_STYLES, BUTTON_SIZES } from '.';
+import Button, { BUTTON_STYLES, BUTTON_SIZES, BUTTON_TYPES } from '.';
 
 export default {
   title: 'Blocks/Identity/Components/Button',
@@ -55,5 +55,31 @@ export const UserIconWithLabel = () => (
     buttonSize={BUTTON_SIZES.LARGE}
     text="Sign up"
     iconType="user"
+  />
+);
+
+export const IconOnly = () => (
+  <Button
+    buttonType={BUTTON_TYPES.ICON_ONLY}
+    text="Sign up"
+    iconType="user"
+    buttonStyle={BUTTON_STYLES.OUTLINED}
+  />
+);
+
+export const IconWithLabel = () => (
+  <Button
+    buttonType={BUTTON_TYPES.LABEL_AND_ICON}
+    text="Sign up"
+    iconType="user"
+    buttonStyle={BUTTON_STYLES.OUTLINED}
+  />
+);
+
+export const LabelOnly = () => (
+  <Button
+    buttonType={BUTTON_TYPES.LABEL_ONLY}
+    text="Sign up"
+    buttonStyle={BUTTON_STYLES.OUTLINED}
   />
 );

--- a/blocks/identity-block/components/Button/index.story.jsx
+++ b/blocks/identity-block/components/Button/index.story.jsx
@@ -21,6 +21,10 @@ export const Outlined = () => (
   <Button buttonStyle={BUTTON_STYLES.OUTLINED} text="Sign up" />
 );
 
+export const WhiteBackgroundFilled = () => (
+  <Button buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED} text="Sign up" />
+);
+
 export const OutlineSmall = () => (
   <Button buttonStyle={BUTTON_STYLES.OUTLINED} buttonSize={BUTTON_SIZES.SMALL} text="Sign up" />
 );

--- a/blocks/identity-block/components/Button/index.story.jsx
+++ b/blocks/identity-block/components/Button/index.story.jsx
@@ -49,7 +49,7 @@ export const LongText = () => (
   />
 );
 
-export const UserIconWithLabel = () => (
+export const UserIconWithLabelOutline = () => (
   <Button
     buttonStyle={BUTTON_STYLES.OUTLINED}
     buttonSize={BUTTON_SIZES.LARGE}
@@ -58,7 +58,7 @@ export const UserIconWithLabel = () => (
   />
 );
 
-export const IconOnly = () => (
+export const IconOnlyOutlined = () => (
   <Button
     buttonType={BUTTON_TYPES.ICON_ONLY}
     text="Sign up"
@@ -80,7 +80,6 @@ export const LabelOnly = () => (
   <Button
     buttonType={BUTTON_TYPES.LABEL_ONLY}
     text="Sign up"
-    buttonStyle={BUTTON_STYLES.OUTLINED}
   />
 );
 

--- a/blocks/identity-block/components/Button/index.story.jsx
+++ b/blocks/identity-block/components/Button/index.story.jsx
@@ -90,3 +90,24 @@ export const CustomAriaLabel = () => (
     ariaLabel="Opens login window"
   />
 );
+
+export const CustomSubmitType = () => (
+  <Button
+    text="Type Submit"
+    type="submit"
+  />
+);
+
+export const CustomButtonType = () => (
+  <Button
+    text="Type Button"
+    type="button"
+  />
+);
+
+export const ButtonResetType = () => (
+  <Button
+    text="Type Reset"
+    type="reset"
+  />
+);

--- a/blocks/identity-block/components/Button/index.story.jsx
+++ b/blocks/identity-block/components/Button/index.story.jsx
@@ -83,3 +83,10 @@ export const LabelOnly = () => (
     buttonStyle={BUTTON_STYLES.OUTLINED}
   />
 );
+
+export const CustomAriaLabel = () => (
+  <Button
+    text="Login"
+    ariaLabel="Opens login window"
+  />
+);

--- a/blocks/identity-block/components/Button/index.story.jsx
+++ b/blocks/identity-block/components/Button/index.story.jsx
@@ -9,10 +9,6 @@ export default {
   },
 };
 
-export const Default = () => (
-  <Button text="" />
-);
-
 export const Filled = () => (
   <Button buttonStyle={BUTTON_STYLES.FILLED} text="Sign up" />
 );

--- a/blocks/identity-block/components/Button/styles.scss
+++ b/blocks/identity-block/components/Button/styles.scss
@@ -5,6 +5,10 @@
   font-weight: bold;
   line-height: 1.5;
 
+  // border color managed in styled component
+  border-style: solid;
+  border-width: calculateRem(1px);
+
   &:hover {
     filter: brightness(0.85);
   }

--- a/blocks/identity-block/components/Button/styles.scss
+++ b/blocks/identity-block/components/Button/styles.scss
@@ -10,6 +10,8 @@
   border-width: calculateRem(1px);
 
   &:hover {
+    // darkens all nested elements on hover
+    // see css filter docs https://developer.mozilla.org/en-US/docs/Web/CSS/filter
     filter: brightness(0.85);
   }
 }

--- a/blocks/identity-block/components/Button/styles.scss
+++ b/blocks/identity-block/components/Button/styles.scss
@@ -1,0 +1,24 @@
+.xpmedia-subs-button {
+  width: 100%;
+  border-radius: calculateRem(4px);
+  font-size: calculateRem(16px);
+  font-weight: bold;
+  line-height: 1.5;
+
+  &:hover {
+    filter: brightness(0.85);
+  }
+}
+
+.xpmedia-subs-button--small {
+  padding: calculateRem(4px);
+}
+
+.xpmedia-subs-button--medium {
+  padding: calculateRem(12px);
+}
+
+.xpmedia-subs-button--large {
+  padding: calculateRem(16px);
+}
+

--- a/blocks/identity-block/components/Button/styles.scss
+++ b/blocks/identity-block/components/Button/styles.scss
@@ -1,4 +1,4 @@
-.xpmedia-subs-button {
+.xpmedia-button {
   width: 100%;
   border-radius: calculateRem(4px);
   font-size: calculateRem(16px);
@@ -16,15 +16,15 @@
   }
 }
 
-.xpmedia-subs-button--small {
+.xpmedia-button--small {
   padding: calculateRem(4px);
 }
 
-.xpmedia-subs-button--medium {
+.xpmedia-button--medium {
   padding: calculateRem(12px);
 }
 
-.xpmedia-subs-button--large {
+.xpmedia-button--large {
   padding: calculateRem(16px);
 }
 

--- a/blocks/identity-block/components/Button/styles.scss
+++ b/blocks/identity-block/components/Button/styles.scss
@@ -1,5 +1,8 @@
 .xpmedia-button {
   width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: calculateRem(4px);
   font-size: calculateRem(16px);
   font-weight: bold;
@@ -14,6 +17,10 @@
     // see css filter docs https://developer.mozilla.org/en-US/docs/Web/CSS/filter
     filter: brightness(0.85);
   }
+}
+
+.xpmedia-button--left-icon-container {
+  padding-right: calculateRem(8px);
 }
 
 .xpmedia-button--small {

--- a/blocks/identity-block/components/HeadlinedSubmitForm/index.jsx
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/index.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useRef } from 'react';
+import PropTypes from '@arc-fusion/prop-types';
+
+import { PrimaryFont } from '@wpmedia/shared-styles';
+
+import './styles.scss';
+
+const HeadlinedSubmitForm = ({
+  children,
+  headline,
+  buttonLabel,
+  onSubmit = () => {},
+}) => {
+  const formRef = useRef();
+  const [error, setError] = useState(false);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    const valid = formRef.current.checkValidity();
+    if (valid) {
+      const namedFields = Array.from(formRef.current.elements)
+        .filter((element) => element?.name && typeof element?.name !== 'undefined')
+        .reduce((accumulator, element) => ({
+          ...accumulator,
+          [element.name]: element.value,
+        }), {});
+      onSubmit(namedFields);
+    } else {
+      setError('Error');
+    }
+  };
+
+  return (
+    <section>
+      <PrimaryFont
+        as="h2"
+        className="xpmedia-form-headline"
+      >
+        {headline}
+      </PrimaryFont>
+      <form
+        aria-label={headline}
+        className="xpmedia-form-submittable"
+        onSubmit={handleSubmit}
+        ref={formRef}
+      >
+        {children}
+        <PrimaryFont
+          as="button"
+          className="xpmedia-form-filled-button xpmedia-form-medium-button"
+        >
+          {buttonLabel}
+        </PrimaryFont>
+        {error ? (
+          <section>
+            <PrimaryFont as="p">
+              {error}
+            </PrimaryFont>
+          </section>
+        ) : null}
+      </form>
+    </section>
+  );
+};
+
+HeadlinedSubmitForm.propTypes = {
+  headline: PropTypes.string.isRequired,
+  buttonLabel: PropTypes.string.isRequired,
+  onSubmit: PropTypes.func,
+};
+
+export default HeadlinedSubmitForm;

--- a/blocks/identity-block/components/HeadlinedSubmitForm/index.jsx
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/index.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from '@arc-fusion/prop-types';
 
 import { PrimaryFont } from '@wpmedia/shared-styles';
+import Button, { BUTTON_STYLES, BUTTON_SIZES } from '../Button';
 
 import './styles.scss';
 
@@ -9,10 +10,10 @@ const HeadlinedSubmitForm = ({
   children,
   headline,
   buttonLabel,
+  formErrorText,
   onSubmit = () => {},
 }) => {
   const formRef = useRef();
-  const [error, setError] = useState(false);
 
   const handleSubmit = (event) => {
     event.preventDefault();
@@ -26,8 +27,6 @@ const HeadlinedSubmitForm = ({
           [element.name]: element.value,
         }), {});
       onSubmit(namedFields);
-    } else {
-      setError('Error');
     }
   };
 
@@ -46,16 +45,23 @@ const HeadlinedSubmitForm = ({
         ref={formRef}
       >
         {children}
-        <PrimaryFont
-          as="button"
-          className="xpmedia-form-filled-button xpmedia-form-medium-button"
-        >
-          {buttonLabel}
-        </PrimaryFont>
-        {error ? (
-          <section>
+        <Button
+          buttonStyle={BUTTON_STYLES.FILLED}
+          buttonSize={BUTTON_SIZES.MEDIUM}
+          text={buttonLabel}
+        />
+        {formErrorText ? (
+          <section className="xpmedia-form-error">
             <PrimaryFont as="p">
-              {error}
+              <svg fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M8.49.463a8.137 8.137 0 0 0-5.674 2.435A7.866 7.866 0 0 0 .501 8.6a7.852 7.852 0 0 0 7.866 7.861h.143a8.073 8.073 0 0 0 7.99-8.138A7.843 7.843 0 0 0 8.49.463zM7.5 11.49a.984.984 0 0 1 .966-1.02h.018c.547.001.995.434 1.016.98a.983.983 0 0 1-.966 1.02h-.018a1.02 1.02 0 0 1-1.016-.98zm.334-6.694v4a.667.667 0 1 0 1.333 0v-4a.667.667 0 1 0-1.333 0z"
+                  fill="currentColor"
+                />
+              </svg>
+              {formErrorText}
             </PrimaryFont>
           </section>
         ) : null}

--- a/blocks/identity-block/components/HeadlinedSubmitForm/index.story.jsx
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/index.story.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import HeadlinedSubmitForm from '.';
+import FormInputField, { FIELD_TYPES } from '../FormInputField';
+
+export default {
+  title: 'Blocks/Identity/Components/HeadlinedSubmitForm',
+  parameters: {
+    chromatic: { viewports: [320, 1200] },
+  },
+};
+
+export const basicForm = () => (
+  <HeadlinedSubmitForm
+    headline="Sign Up"
+    buttonLabel="Submit"
+  >
+    <FormInputField
+      label="Text Field"
+      name="field1"
+    />
+    <FormInputField
+      label="Text Field2"
+      name="field2"
+    />
+  </HeadlinedSubmitForm>
+);
+
+export const errorForm = () => (
+  <HeadlinedSubmitForm
+    headline="Sign Up"
+    buttonLabel="Submit"
+  >
+    <FormInputField
+      defaultValue="invalid!email.com"
+      label="Email"
+      name="field1"
+      showDefaultError
+      type={FIELD_TYPES.EMAIL}
+    />
+  </HeadlinedSubmitForm>
+);

--- a/blocks/identity-block/components/HeadlinedSubmitForm/index.story.jsx
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/index.story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import HeadlinedSubmitForm from '.';
 import FormInputField, { FIELD_TYPES } from '../FormInputField';
+import FormPasswordConfirm from '../FormPasswordConfirm';
 
 export default {
   title: 'Blocks/Identity/Components/HeadlinedSubmitForm',
@@ -30,6 +31,7 @@ export const errorForm = () => (
   <HeadlinedSubmitForm
     headline="Sign Up"
     buttonLabel="Submit"
+    formErrorText="Unable to submit your request.  Please correct any issues and re-submit."
   >
     <FormInputField
       defaultValue="invalid!email.com"
@@ -37,6 +39,13 @@ export const errorForm = () => (
       name="field1"
       showDefaultError
       type={FIELD_TYPES.EMAIL}
+    />
+    <FormPasswordConfirm
+      confirmLabel="Confirm password"
+      confirmPlaceholder="Confirm your password"
+      label="Password"
+      name="field2"
+      placeholder="Enter a password"
     />
   </HeadlinedSubmitForm>
 );

--- a/blocks/identity-block/components/HeadlinedSubmitForm/index.test.jsx
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/index.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import HeadlinedSubmitForm from '.';
+
+describe('Headlined Submit Form', () => {
+  it('renders with required items', () => {
+    const wrapper = mount(<HeadlinedSubmitForm
+      headline="Sign Up"
+      buttonLabel="Submit"
+    />);
+
+    expect(wrapper.find('form').at(0)).not.toBeNull();
+    expect(wrapper.find('form[aria-label="Sign Up"]').at(0)).not.toBeNull();
+    expect(wrapper.find('button').at(0)).not.toBeNull();
+  });
+
+  it('does not submit if the input is invalid', () => {
+    const callback = jest.fn();
+
+    const wrapper = mount(
+      <HeadlinedSubmitForm
+        headline="Sign Up"
+        buttonLabel="Submit"
+        onSubmit={callback}
+      >
+        <input name="inputField" type="email" defaultValue="invalid" />
+      </HeadlinedSubmitForm>,
+    );
+
+    wrapper.find('form').simulate('submit');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('does submit if the input is valid', () => {
+    const callback = jest.fn();
+
+    const wrapper = mount(
+      <HeadlinedSubmitForm
+        headline="Sign Up"
+        buttonLabel="Submit"
+        onSubmit={callback}
+      >
+        <input name="inputField" type="email" defaultValue="valid@email.com" />
+      </HeadlinedSubmitForm>,
+    );
+
+    wrapper.find('form').simulate('submit');
+
+    expect(callback).toHaveBeenCalledWith({
+      inputField: 'valid@email.com',
+    });
+  });
+});

--- a/blocks/identity-block/components/HeadlinedSubmitForm/index.test.jsx
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/index.test.jsx
@@ -52,4 +52,18 @@ describe('Headlined Submit Form', () => {
       inputField: 'valid@email.com',
     });
   });
+
+  it('shows a form error is text is passed in', () => {
+    const wrapper = mount(
+      <HeadlinedSubmitForm
+        headline="Sign Up"
+        buttonLabel="Submit"
+        formErrorText="This should show up in the error field"
+      >
+        <input name="inputField" type="email" defaultValue="valid@email.com" />
+      </HeadlinedSubmitForm>,
+    );
+
+    expect(wrapper.find('.xpmedia-form-error').at(0).text().includes('This should show up in the error field'));
+  });
 });

--- a/blocks/identity-block/components/HeadlinedSubmitForm/styles.scss
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/styles.scss
@@ -2,6 +2,14 @@
   border-bottom: 1px solid $border-rule-color;
   margin-bottom: map-get($spacers, 'sm');
 
+  .xpmedia-form-headline {
+    border-bottom: 1px solid $border-rule-color;
+    padding-bottom: map-get($spacers, 'sm');
+    margin-bottom: map-get($spacers, 'sm');
+    text-align: center;
+    width: 100%;
+  }
+
   .xpmedia-form-field {
     margin: map-get($spacers, 'md') 0;
 
@@ -13,28 +21,27 @@
       margin-bottom: map-get($spacers, 'sm');
     }
   }
+
+  .xpmedia-button {
+    margin: map-get($spacers, 'md') 0;
+  }
 }
 
-.xpmedia-form-headline {
-  border-bottom: 1px solid $border-rule-color;
-  padding-bottom: map-get($spacers, 'sm');
-  margin-bottom: map-get($spacers, 'sm');
-  text-align: center;
-  width: 100%;
-}
-
-.xpmedia-form-filled-button {
-  margin: map-get($spacers, 'md') 0;
-  // primary color for arc subs
-  background-color: #183bb6;
-  color: $ui-btn-white-color;
-  border: 0;
-}
-
-.xpmedia-form-medium-button {
-  padding: map-get($spacers, 'sm');
-  width: 100%;
-  line-height: 1.5;
+.xpmedia-form-error {
+  color: $danger-color;
   font-size: calculateRem(16px);
-  border-radius: calculateRem(4px);
+  margin: map-get($spacers, 'md') 0;
+
+  p {
+    display: flex;
+    line-height: 1.5;
+
+    svg {
+      display: block;
+      flex: 0 0 1em;
+      height: 1em;
+      margin: 0.125em 0.3125em 0 0;
+      width: 1em;
+    }
+  }
 }

--- a/blocks/identity-block/components/HeadlinedSubmitForm/styles.scss
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/styles.scss
@@ -1,14 +1,14 @@
+.xpmedia-form-headline {
+  border-bottom: 1px solid $border-rule-color;
+  padding-bottom: map-get($spacers, 'sm');
+  margin-bottom: map-get($spacers, 'sm');
+  text-align: center;
+  width: 100%;
+}
+
 .xpmedia-form-submittable {
   border-bottom: 1px solid $border-rule-color;
   margin-bottom: map-get($spacers, 'sm');
-
-  .xpmedia-form-headline {
-    border-bottom: 1px solid $border-rule-color;
-    padding-bottom: map-get($spacers, 'sm');
-    margin-bottom: map-get($spacers, 'sm');
-    text-align: center;
-    width: 100%;
-  }
 
   .xpmedia-form-field {
     margin: map-get($spacers, 'md') 0;

--- a/blocks/identity-block/components/HeadlinedSubmitForm/styles.scss
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/styles.scss
@@ -1,0 +1,40 @@
+.xpmedia-form-submittable {
+  border-bottom: 1px solid $border-rule-color;
+  margin-bottom: map-get($spacers, 'sm');
+
+  .xpmedia-form-field {
+    margin: map-get($spacers, 'md') 0;
+
+    &:first-of-type {
+      margin-top: map-get($spacers, 'sm');
+    }
+
+    &:last-of-type {
+      margin-bottom: map-get($spacers, 'sm');
+    }
+  }
+}
+
+.xpmedia-form-headline {
+  border-bottom: 1px solid $border-rule-color;
+  padding-bottom: map-get($spacers, 'sm');
+  margin-bottom: map-get($spacers, 'sm');
+  text-align: center;
+  width: 100%;
+}
+
+.xpmedia-form-filled-button {
+  margin: map-get($spacers, 'md') 0;
+  // primary color for arc subs
+  background-color: #183bb6;
+  color: $ui-btn-white-color;
+  border: 0;
+}
+
+.xpmedia-form-medium-button {
+  padding: map-get($spacers, 'sm');
+  width: 100%;
+  line-height: 1.5;
+  font-size: calculateRem(16px);
+  border-radius: calculateRem(4px);
+}


### PR DESCRIPTION
## Description
Create a reusable form component that we can use for each of the form pages (sign up, log in, etc)

## Jira Ticket
- [TMEDIA-459](https://arcpublishing.atlassian.net/browse/TMEDIA-459)

## Acceptance Criteria
- Reusable form component is validated in Storybook 
- Utilizes form fields 
- Matches the styles of current design documentation (links above)
- Tests created to validate the form functions properly
- Includes: Form title, divider, form inputs, button, divider
- Fits the width of the container

## Test Steps
1. Checkout this branch `git checkout TMEDIA-459-shared-form-component`
2. Run fusion repo with linked blocks `npm run storybook`
3. Validate http://localhost:60001/?path=/story/blocks-identity-components-headlinedsubmitform--basic-form
![image](https://user-images.githubusercontent.com/2287238/131035931-965c8898-f56e-4dac-932c-a4153278629c.png)
4. And http://localhost:60001/?id=blocks-identity-components-headlinedsubmitform--error-form
TODO: insert image of error state

## Effect Of Changes
### Before
Shared form did not exist

### After
It now exists

## Dependencies or Side Effects
Depends on https://github.com/WPMedia/fusion-news-theme-blocks/pull/1067 Button component.  Could potentially be merged with that when the Button is reviewed.

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
