### PR TITLE
TMEDIA-469: Switch Error Icon to use the SDK Icon

### DIFF
--- a/blocks/identity-block/components/HeadlinedSubmitForm/index.jsx
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/index.jsx
@@ -2,6 +2,8 @@ import React, { useRef } from 'react';
 import PropTypes from '@arc-fusion/prop-types';
 
 import { PrimaryFont } from '@wpmedia/shared-styles';
+import { ErrorIcon } from '@wpmedia/engine-theme-sdk';
+
 import Button, { BUTTON_STYLES, BUTTON_SIZES } from '../Button';
 
 import './styles.scss';
@@ -53,14 +55,7 @@ const HeadlinedSubmitForm = ({
         {formErrorText ? (
           <section className="xpmedia-form-error">
             <PrimaryFont as="p">
-              <svg fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path
-                  fillRule="evenodd"
-                  clipRule="evenodd"
-                  d="M8.49.463a8.137 8.137 0 0 0-5.674 2.435A7.866 7.866 0 0 0 .501 8.6a7.852 7.852 0 0 0 7.866 7.861h.143a8.073 8.073 0 0 0 7.99-8.138A7.843 7.843 0 0 0 8.49.463zM7.5 11.49a.984.984 0 0 1 .966-1.02h.018c.547.001.995.434 1.016.98a.983.983 0 0 1-.966 1.02h-.018a1.02 1.02 0 0 1-1.016-.98zm.334-6.694v4a.667.667 0 1 0 1.333 0v-4a.667.667 0 1 0-1.333 0z"
-                  fill="currentColor"
-                />
-              </svg>
+              <ErrorIcon />
               {formErrorText}
             </PrimaryFont>
           </section>

--- a/blocks/identity-block/components/HeadlinedSubmitForm/styles.scss
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/styles.scss
@@ -39,9 +39,7 @@
     svg {
       display: block;
       flex: 0 0 1em;
-      height: 1em;
       margin: 0.125em 0.3125em 0 0;
-      width: 1em;
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11119,12 +11119,13 @@
       "version": "file:blocks/double-chain-block"
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.9.10-canary.2",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.9.10-canary.2/36bf20cc2dfd98416887dd7907ba830b92239560fb98c7adbe5d9168ea01fa23",
-      "integrity": "sha512-Eb0paGxjriCF3v4FEwUacydFPqxi79OO+fOGH1G3HOjMxf78L2ANaeLn3tlPsLwkpoNpcFXg2TPZ+ZIc6oSD2A==",
+      "version": "2.9.11-canary.3",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.9.11-canary.3/e9d292b46a2443eec5348ca40419bec6081ed91532b119507b14ca7da080a12a",
+      "integrity": "sha512-4oKhfXAqeb+dQLRmJ/U4QO5pSxMnQuJGOOu+dpgRvpwIvcUWyJzXp4x7uVKcKStn7t23nfbgLuljYmoWOv0hlg==",
       "dev": true,
       "requires": {
         "@arc-fusion/prop-types": "^0.1.5",
+        "@wpmedia/timezone": "^1.1.1",
         "dom-parser": "^0.1.6",
         "is-react": "^1.3.3",
         "lazy-child": "^0.3.1",
@@ -11137,8 +11138,7 @@
         "react-swipeable": "^5.5.0",
         "rimraf": "^3.0.2",
         "styled-components": "^4.4.1",
-        "thumbor-lite": "^0.1.6",
-        "timezone": "1.0.23"
+        "thumbor-lite": "^0.1.6"
       },
       "dependencies": {
         "lazy-child": {
@@ -11233,9 +11233,9 @@
       "version": "file:blocks/medium-promo-block"
     },
     "@wpmedia/news-theme-css": {
-      "version": "4.2.1-stable.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/4.2.1-stable.0/056804adbbf5612a4595079c715b7a990997d46c5dec5982712ad9481889aba3",
-      "integrity": "sha512-QJu9kMfgdeRvjlxkFEbmeF8sud0PO5yUReUYpUrPHXQuWo7k82ERIWH0mbrPGGHQt3ugF1wGf5P4JsTSI89xJg==",
+      "version": "4.2.2-stable.0",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/4.2.2-stable.0/a62d3fa803429e533def133afbc54ea2847d6e38fdfcb8347efa8b0c269060c7",
+      "integrity": "sha512-5kYrObVIzIfGs4Zyelq4CfJtumkC2oeidySbghQ5r3SGGhhVntO8z7w1EV6oiwb8UpmphgcTS+iFd3uUsbxtwg==",
       "dev": true
     },
     "@wpmedia/numbered-list-block": {
@@ -11324,6 +11324,12 @@
     },
     "@wpmedia/textfile-block": {
       "version": "file:blocks/textfile-block"
+    },
+    "@wpmedia/timezone": {
+      "version": "1.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/timezone/1.1.1/0ad6c48a887bc2b122d141a1eb5fb9a81b5f2ee7195d0d81f38aab7366919c2b",
+      "integrity": "sha512-nN6M2q8cyJELhihJ65t4CVFWr7QgZSnO+aAEXVFdh/k9RpQJd7EtGVLjZyd8HzAFwhiGv+O4Iz7nclbOnNXEWg==",
+      "dev": true
     },
     "@wpmedia/top-table-list-block": {
       "version": "file:blocks/top-table-list-block"
@@ -32480,12 +32486,6 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
-    },
-    "timezone": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/timezone/-/timezone-1.0.23.tgz",
-      "integrity": "sha512-yhQgk6qmSLB+TF8HGmApZAVI5bfzR1CoKUGr+WMZWmx75ED1uDewAZA8QMGCQ70TEv4GmM8pDB9jrHuxdaQ1PA==",
-      "dev": true
     },
     "tiny-emitter": {
       "version": "2.1.0",


### PR DESCRIPTION
## Description
Use the SDK ErrorIcon instead of the embedded icon in the initial story.

## Jira Ticket
- [TMEDIA-469](https://arcpublishing.atlassian.net/browse/TMEDIA-469)

## Acceptance Criteria
- Icon used in the shared form is changed to use the new shared icon from engine-theme-sdk

## Test Steps
1. Checkout this branch `git checkout TMEDIA-469-switch-to-sdk-error-icon`
2. Run storybook `npm run storybook`
3. Check http://localhost:60001/?id=blocks-identity-components-headlinedsubmitform--error-form&viewMode=story to validate that the icon has been updated: 
![image](https://user-images.githubusercontent.com/2287238/131731510-e035621f-f522-4abf-8927-2efbde2fe4fa.png)


## Effect Of Changes
### Before

Used internal embedded icon

### After

Uses SDK ErrorIcon

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
