### PR TITLE
Header Action Nav - Button Updates

### DIFF
--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -75,7 +75,7 @@ const HeaderAccountAction = ({ customFields }) => {
 
   // What do we want to happen if there is an error?
   return (
-    <div className="xpmedia-subs-header--logged-out-header">
+    <>
       <div className="xpmedia-subs-header--desktop-logged-out-header">
         {createAccountURL ? (
           <Button
@@ -136,7 +136,7 @@ const HeaderAccountAction = ({ customFields }) => {
           </ul>
         )}
       </div>
-    </div>
+    </>
   );
 };
 

--- a/blocks/identity-block/features/header-account-action/default.test.jsx
+++ b/blocks/identity-block/features/header-account-action/default.test.jsx
@@ -34,5 +34,5 @@ it('shows sign in url and create account url', () => {
   />);
 
   expect(wrapper.html()).not.toBe(null);
-  expect(wrapper.find('div.xpmedia-subs-header--logged-out-header')).toHaveLength(1);
+  expect(wrapper.find('div.xpmedia-subs-header--desktop-logged-out-header')).toHaveLength(1);
 });

--- a/blocks/identity-block/features/header-account-action/index.story.jsx
+++ b/blocks/identity-block/features/header-account-action/index.story.jsx
@@ -1,0 +1,14 @@
+/* eslint-disable react/no-children-prop */
+import React from 'react';
+import HeaderAccountAction from './default';
+
+export default {
+  title: 'Blocks/Identity/Blocks/Header Account Action',
+  parameters: {
+    chromatic: { viewports: [320, 1200] },
+  },
+};
+
+export const loginAndSignUp = () => (
+  <HeaderAccountAction customFields={{ loginURL: '/', createAccountURL: '/' }} />
+);

--- a/blocks/identity-block/features/header-account-action/styles.scss
+++ b/blocks/identity-block/features/header-account-action/styles.scss
@@ -2,12 +2,9 @@
   display: flex;
 }
 
-.xpmedia-subs-header--logged-out-header {
-  display: flex;
-}
-
 // hide a tag links button for mobile
 .xpmedia-subs-header--desktop-logged-out-header {
+  display: flex;
   // uses a tags
   > a {
     // should be 16px between buttons

--- a/blocks/shared-styles/_children/button/styles.scss
+++ b/blocks/shared-styles/_children/button/styles.scss
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 
   // if a tag, then hide decoration
   text-decoration: none;
@@ -43,4 +44,3 @@
 .xpmedia-button--large {
   padding: calculateRem(16px);
 }
-

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -20,12 +20,12 @@ body.nav-open {
 }
 
 .section-menu--bottom-placeholder {
-  // on desktop, on the left, the bottom link 
+  // on desktop, on the left, the bottom link
   // is not visible on hover over other links
   height: $mouseover-link-preview-safe-area-height;
   background-color: $section-bg;
 
-  // need to hide that hover and active color 
+  // need to hide that hover and active color
   &:hover,
   &:active {
     // keep the same color unlike other list items
@@ -222,6 +222,7 @@ body.nav-open {
 
     &:last-child {
       margin-right: 0;
+      flex-shrink: 0;
     }
   }
 


### PR DESCRIPTION
## Description
* Fix the wrapping issue with Header Action buttons in the navigation
* Added initial storybook file

## Test Steps

1. Checkout this branch `git checkout stop-buttons-wrapping`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/identity-block,@wpmedia/shared-styles`
3. Check a page with the Header Account Action is added to the right part of the nav chain

## Effect Of Changes
### Before

<img width="871" alt="Microsoft Edge-2021-09-08-17-22 15" src="https://user-images.githubusercontent.com/868127/132550776-ac30a1da-b3ab-4531-a377-e47f2068926b.png">


### After

<img width="945" alt="Microsoft Edge-2021-09-08-17-24 27" src="https://user-images.githubusercontent.com/868127/132550788-18d9f53a-582d-4c3f-bccd-550315861a87.png">
