### PR TITLE
TMEDIA-471 - Queryly Search Fix

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import React from 'react';
 import { useFusionContext } from 'fusion:context';
@@ -18,6 +19,10 @@ import { SearchIcon } from '@wpmedia/engine-theme-sdk';
   due to their use of the checkbox we have to manaully
   check the checkbox and they dispatch a change event so their
   code picks it up and loads the queryly search UI.
+
+  We also apply a stopPropagation onto the label to account for
+  mouse clicks on the label element from bubbling up to the
+  button and sending addtional events to the queryly_toggle
 */
 const querylySearchClick = () => {
   const event = new Event('change');
@@ -32,7 +37,7 @@ const QuerylySearch = ({ theme = 'dark', iconSize = 16, label }) => {
   return (
     <div className={`nav-search ${theme} queryly`}>
       <button className={`nav-btn nav-btn-${theme} transparent border`} type="button" onClick={querylySearchClick} aria-label={label || phrases.t('header-nav-chain-block.querly-search-aria-label')}>
-        <label htmlFor="queryly_toggle">
+        <label htmlFor="queryly_toggle" onClick={(e) => e.stopPropagation()}>
           <SearchIcon height={iconSize} width={iconSize} />
         </label>
       </button>


### PR DESCRIPTION
## Description
Fix issue where using mouse click on the label bubbles the event and does not allow queryly to open the second time

## Jira Ticket
- [TMEDIA-471](https://arcpublishing.atlassian.net/browse/TMEDIA-471)

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-471-queryly-click-issue`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Visit http://localhost/homepage/?_website=the-gazette
4. Validate the queryly search button is useable with both keyboard and mouse, and you can open and close the queryly search multiple times


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
