### PR TITLE
Tmedia 314 full author new tab

### DIFF
--- a/blocks/full-author-bio-block/features/full-author-bio/default.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.jsx
@@ -115,8 +115,10 @@ export const FullAuthorBioPresentational = (props) => {
               socials.map((item) => (
                 <a
                   className={`social-column ${item}`}
-                  key={item}
                   href={constructSocialURL(item, content.authors[0][item])}
+                  key={item}
+                  rel="noopener noreferrer"
+                  target="_blank"
                   title={phrases.t(`full-author-bio-block.social-${item.toLowerCase()}`)}
                 >
                   {logos[item]}

--- a/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
@@ -208,6 +208,12 @@ describe('the full author bio block', () => {
 
         expect(wrapper.find('.rss')).toHaveLength(1);
       });
+      it('should render noreferrer and new tab with link', () => {
+        const wrapper = mount(<FullAuthorBio />);
+
+        expect(wrapper.find('.rss').props().rel).toEqual('noopener noreferrer');
+        expect(wrapper.find('.rss').props().target).toEqual('_blank');
+      });
     });
 
     describe('when the twitter link is not present', () => {


### PR DESCRIPTION
## Description
Open full author in new tab

## Jira Ticket
- [TMEDIA-314](https://arcpublishing.atlassian.net/browse/TMEDIA-314)

## Acceptance Criteria
Open links in new tab 

## Test Steps

1. Open storybook in pr. 
2. Go to full author stories
3. Click on one of the links. You should navigate to a new tab 

## Effect Of Changes
### Before
- Stay on same page on full author bio link click 

### After
- Go to new tab with link click 

## Dependencies or Side Effects

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
