### PR TITLE
tmedia-422: fix: Do not render if null or empty string for value

### DIFF
--- a/blocks/full-author-bio-block/features/full-author-bio/default.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.jsx
@@ -28,6 +28,25 @@ import { PrimaryFont, SecondaryFont } from '@wpmedia/shared-styles';
 import './full-author-bio.scss';
 import '@wpmedia/shared-styles/scss/_author-bio.scss';
 
+// update constants if update available icons
+const SUPPORTED_SOCIALS_KEYS = [
+  'email',
+  'twitter',
+  'facebook',
+  'instagram',
+  'rss',
+  'linkedin',
+  'reddit',
+  'youtube',
+  'medium',
+  'tumblr',
+  'pinterest',
+  'snapchat',
+  'whatsapp',
+  'soundcloud',
+];
+
+// update constants above if update new components
 const logos = {
   email: <EnvelopeIcon />,
   twitter: <TwitterIcon />,
@@ -52,10 +71,22 @@ export const FullAuthorBioPresentational = (props) => {
 
   const socials = [];
   if (content.authors) {
-    Object.keys(content.authors[0]).forEach((item) => {
-      // todo: check that the value found here is not an empty string
-      if (Object.keys(logos).includes(item)) {
-        socials.push(item);
+    // get keys and values author object
+    /*
+      // don't render non social key and value
+      longBio: 'Jane Doe is a senior product manager for Arc Publishing. This is a Long bio. ',
+
+      // render social key with a truthy value
+      instagram: 'janedoe',
+      rss: 'someusername',
+
+      // don't render social key with a falsy value
+      linkedin: '',
+      twitter: null,
+    */
+    Object.entries(content.authors[0]).forEach(([socialMediaNameKey, socialMediaValue]) => {
+      if (SUPPORTED_SOCIALS_KEYS.includes(socialMediaNameKey) && socialMediaValue) {
+        socials.push(socialMediaNameKey);
       }
     });
   }

--- a/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
@@ -56,7 +56,6 @@ jest.mock('fusion:context', () => ({
           longBio: 'Jane Doe is a senior product manager for Arc Publishing. \nShe works on Arc Themes',
           slug: 'jane-doe',
           instagram: 'janedoe',
-          linkedin: '',
           native_app_rendering: false,
           fuzzy_match: false,
           contributor: false,

--- a/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
@@ -56,6 +56,7 @@ jest.mock('fusion:context', () => ({
           longBio: 'Jane Doe is a senior product manager for Arc Publishing. \nShe works on Arc Themes',
           slug: 'jane-doe',
           instagram: 'janedoe',
+          linkedin: '',
           native_app_rendering: false,
           fuzzy_match: false,
           contributor: false,
@@ -271,5 +272,58 @@ describe('the full author bio block', () => {
 
       expect(wrapper).toBeEmptyRender();
     });
+  });
+});
+
+describe('when there are falsy values as social media links', () => {
+  it('should not render null value', () => {
+    useFusionContext.mockImplementation(() => ({
+      arcSite: 'no-site',
+      globalContent: {
+        authors: [
+          {
+            twitter: null,
+            instagram: 'yay',
+            _id: 'janedoe',
+          },
+        ],
+      },
+    }));
+    const wrapper = mount(<FullAuthorBio />);
+    expect(wrapper.find('.twitter')).toHaveLength(0);
+    expect(wrapper.find('.instagram')).toHaveLength(1);
+  });
+  it('should not render empty string value', () => {
+    useFusionContext.mockImplementation(() => ({
+      arcSite: 'no-site',
+      globalContent: {
+        authors: [
+          {
+            twitter: '',
+            instagram: 'yay',
+            _id: 'janedoe',
+          },
+        ],
+      },
+    }));
+    const wrapper = mount(<FullAuthorBio />);
+    expect(wrapper.find('.twitter')).toHaveLength(0);
+    expect(wrapper.find('.instagram')).toHaveLength(1);
+  });
+  it('should not render if no key social value', () => {
+    useFusionContext.mockImplementation(() => ({
+      arcSite: 'no-site',
+      globalContent: {
+        authors: [
+          {
+            instagram: 'yay',
+            _id: 'janedoe',
+          },
+        ],
+      },
+    }));
+    const wrapper = mount(<FullAuthorBio />);
+    expect(wrapper.find('.twitter')).toHaveLength(0);
+    expect(wrapper.find('.instagram')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Description

Expected: When an author does not have an email, I would expect the author's contact info to not show the email icon. 

Actual: 

When an author does not have an email, the author's contact info displays an email icon. 

## Jira Ticket
- [TMEDIA-422](https://arcpublishing.atlassian.net/browse/TMEDIA-422)

## Acceptance Criteria
Author bio fields that are populated display on Full Author Bio block and Short Author Bio block

Author bio fields that are null or contain an empty string are not displayed

## Test Steps

- Look at storybook fpr pr 
- Open up page that says no social accounts with empty string values 
![Screen Shot 2021-09-14 at 17 11 14](https://user-images.githubusercontent.com/5950956/133340736-adbf074b-3151-4c32-ad8b-d183d68f583d.png)
 - see that the links are not rendered (this is how the bug was discovered)

## Effect Of Changes
### Before

social links rendered even when the values were empty strings 

![Screen Shot 2021-09-14 at 16 35 11](https://user-images.githubusercontent.com/5950956/133340983-7791a9bd-87ce-4ba1-be2c-8329ef040bf6.png)

### After
If links are empty strings or undefined then does not render 

![Screen Shot 2021-09-14 at 16 49 18](https://user-images.githubusercontent.com/5950956/133340789-569dfc57-6879-447a-a614-8dcb5526d126.png)

## Dependencies or Side Effects
- Used constants list rather than generating the list of acceptable social media accounts each iteration

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
