### PR TITLE
Tmedia 488 password validation two of 

### DIFF
--- a/blocks/identity-block/utils/validate-password-pattern.js
+++ b/blocks/identity-block/utils/validate-password-pattern.js
@@ -4,6 +4,6 @@ const validatePasswordPattern = (
   pwPwNumbers,
   pwSpecialCharacters,
   pwUppercase,
-) => `^(?=.*[a-z]{${pwLowercase},})(?=.*[A-Z]{${pwUppercase},})(?=.*\\d{${pwPwNumbers},})(?=.*[@$!%*?&]{${pwSpecialCharacters},})[A-Za-z\\d@$!%*?&]{${pwMinLength},}`;
+) => `^(?=(?:.*[a-z]){${pwLowercase},})(?=(?:.*[A-Z]){${pwUppercase},})(?=(?:.*\\d){${pwPwNumbers},})(?=(?:.*[@$!%*?&]){${pwSpecialCharacters},})[A-Za-z\\d@$!%*?&]{${pwMinLength},}`;
 
 export default validatePasswordPattern;

--- a/blocks/identity-block/utils/validate-password-pattern.js
+++ b/blocks/identity-block/utils/validate-password-pattern.js
@@ -5,12 +5,14 @@ const SPECIAL_CHARACTERS_ALLOWED = '@$!%*?&';
 // with the matching any previous values .*
 // and targeting the particular class [a-z]
 // a minimum of how many times {${pwLowercase},} up to unlimited
+
+// at the very end, there's a check for any character "." and min character amount {${pwMinLength},}
 const validatePasswordPattern = (
   pwLowercase,
   pwMinLength,
   pwPwNumbers,
   pwSpecialCharacters,
   pwUppercase,
-) => `(?=(?:.*[a-z]){${pwLowercase},})(?=(?:.*[A-Z]){${pwUppercase},})(?=(?:.*\\d){${pwPwNumbers},})(?=(?:.*[${SPECIAL_CHARACTERS_ALLOWED}]){${pwSpecialCharacters},})(?=(?:.*[A-Za-z\\d${SPECIAL_CHARACTERS_ALLOWED}]){${pwMinLength},})`;
+) => `(?=(?:.*[a-z]){${pwLowercase},})(?=(?:.*[A-Z]){${pwUppercase},})(?=(?:.*\\d){${pwPwNumbers},})(?=(?:.*[${SPECIAL_CHARACTERS_ALLOWED}]){${pwSpecialCharacters},}).{${pwMinLength},}`;
 
 export default validatePasswordPattern;

--- a/blocks/identity-block/utils/validate-password-pattern.js
+++ b/blocks/identity-block/utils/validate-password-pattern.js
@@ -1,9 +1,16 @@
+const SPECIAL_CHARACTERS_ALLOWED = '@$!%*?&';
+
+// positive lookahead (?= )
+// with a non-capturing group within (?: )
+// with the matching any previous values .*
+// and targeting the particular class [a-z]
+// a minimum of how many times {${pwLowercase},} up to unlimited
 const validatePasswordPattern = (
   pwLowercase,
   pwMinLength,
   pwPwNumbers,
   pwSpecialCharacters,
   pwUppercase,
-) => `^(?=(?:.*[a-z]){${pwLowercase},})(?=(?:.*[A-Z]){${pwUppercase},})(?=(?:.*\\d){${pwPwNumbers},})(?=(?:.*[@$!%*?&]){${pwSpecialCharacters},})[A-Za-z\\d@$!%*?&]{${pwMinLength},}`;
+) => `(?=(?:.*[a-z]){${pwLowercase},})(?=(?:.*[A-Z]){${pwUppercase},})(?=(?:.*\\d){${pwPwNumbers},})(?=(?:.*[${SPECIAL_CHARACTERS_ALLOWED}]){${pwSpecialCharacters},})(?=(?:.*[A-Za-z\\d${SPECIAL_CHARACTERS_ALLOWED}]){${pwMinLength},})`;
 
 export default validatePasswordPattern;

--- a/blocks/identity-block/utils/validate-password-pattern.test.js
+++ b/blocks/identity-block/utils/validate-password-pattern.test.js
@@ -36,10 +36,46 @@ describe('Validate Password', () => {
     expect(pattern.test('')).toBe(false);
   });
 
-  it('length 12, at least 1 lowercase and 1 uppercase', () => {
-    const pattern = new RegExp(validatePasswordPattern(1, 12, 0, 0, 1));
+  it('length 12, at least non-sequentially 2 lowercase, 1 uppercase', () => {
+    const pattern = new RegExp(validatePasswordPattern(2, 12, 0, 0, 1));
 
-    expect(pattern.test('aBCDEFABCDEF')).toBe(true);
+    expect(pattern.test('aBCDEFABCDEFa')).toBe(true);
+
+    expect(pattern.test('ABCDEFABCDEF')).toBe(false);
+    expect(pattern.test('Abc123!')).toBe(false);
+    expect(pattern.test('abc123')).toBe(false);
+    expect(pattern.test('abc123!')).toBe(false);
+    expect(pattern.test('ABC123!')).toBe(false);
+    expect(pattern.test('')).toBe(false);
+  });
+  it('length 12, at least 1 lowercase, non-sequentially 2 uppercase', () => {
+    const pattern = new RegExp(validatePasswordPattern(1, 12, 0, 0, 2));
+
+    expect(pattern.test('BaaaaaaaaaaaaaaaaaaB')).toBe(true);
+
+    expect(pattern.test('ABCDEFABCDEF')).toBe(false);
+    expect(pattern.test('Abc123!')).toBe(false);
+    expect(pattern.test('abc123')).toBe(false);
+    expect(pattern.test('abc123!')).toBe(false);
+    expect(pattern.test('ABC123!')).toBe(false);
+    expect(pattern.test('')).toBe(false);
+  });
+  it('length 12 at least non-sequentially 2 digits, 1 lowercase', () => {
+    const pattern = new RegExp(validatePasswordPattern(1, 12, 2, 0, 0));
+
+    expect(pattern.test('1aaaaaaaaaaaaaaaaaa1')).toBe(true);
+
+    expect(pattern.test('ABCDEFABCDEF')).toBe(false);
+    expect(pattern.test('Abc123!')).toBe(false);
+    expect(pattern.test('abc123')).toBe(false);
+    expect(pattern.test('abc123!')).toBe(false);
+    expect(pattern.test('ABC123!')).toBe(false);
+    expect(pattern.test('')).toBe(false);
+  });
+  it('length 12 at least non-sequentially 2 special characters, 1 lowercase', () => {
+    const pattern = new RegExp(validatePasswordPattern(1, 12, 0, 2, 0));
+
+    expect(pattern.test('!aaaaaaaaaaaaaaaaa&')).toBe(true);
 
     expect(pattern.test('ABCDEFABCDEF')).toBe(false);
     expect(pattern.test('Abc123!')).toBe(false);

--- a/blocks/identity-block/utils/validate-password-pattern.test.js
+++ b/blocks/identity-block/utils/validate-password-pattern.test.js
@@ -84,4 +84,11 @@ describe('Validate Password', () => {
     expect(pattern.test('ABC123!')).toBe(false);
     expect(pattern.test('')).toBe(false);
   });
+  it('passes non-sequentially 2 character-long amount', () => {
+    const pattern = new RegExp(validatePasswordPattern(0, 2, 0, 0, 0));
+
+    expect(pattern.test('f f')).toBe(true);
+
+    expect(pattern.test('')).toBe(false);
+  });
 });

--- a/blocks/identity-block/utils/validate-password-pattern.test.js
+++ b/blocks/identity-block/utils/validate-password-pattern.test.js
@@ -91,4 +91,10 @@ describe('Validate Password', () => {
 
     expect(pattern.test('')).toBe(false);
   });
+  it('passes on complicated two character-long non-sequential requirements', () => {
+    const pattern = new RegExp(validatePasswordPattern(2, 12, 2, 2, 2));
+
+    expect(pattern.test('Abc123!Abc123!')).toBe(true);
+    expect(pattern.test('ffff')).toBe(false);
+  });
 });

--- a/blocks/identity-block/utils/validate-password-pattern.test.js
+++ b/blocks/identity-block/utils/validate-password-pattern.test.js
@@ -108,4 +108,11 @@ describe('Validate Password', () => {
     expect(pattern.test('Abc123!Abc123!')).toBe(true);
     expect(pattern.test('ffff')).toBe(false);
   });
+  it('Takes matching special characters', () => {
+    const pattern = new RegExp(validatePasswordPattern(0, 1, 0, 7, 0));
+
+    expect(pattern.test('@$!%*?&')).toBe(true);
+    expect(pattern.test('---------')).toBe(false);
+    expect(pattern.test('^^^^^^^^^^^^^^^^^^^^^^^')).toBe(false);
+  });
 });

--- a/blocks/identity-block/utils/validate-password-pattern.test.js
+++ b/blocks/identity-block/utils/validate-password-pattern.test.js
@@ -36,6 +36,17 @@ describe('Validate Password', () => {
     expect(pattern.test('')).toBe(false);
   });
 
+  it('length 12, at least 1 lowercase and 1 uppercase', () => {
+    const pattern = new RegExp(validatePasswordPattern(1, 12, 0, 0, 1));
+
+    expect(pattern.test('aBCDEFABCDEF')).toBe(true);
+
+    expect(pattern.test('ABCDEFABCDEF')).toBe(false);
+    expect(pattern.test('Abc123!')).toBe(false);
+    expect(pattern.test('ABC123!')).toBe(false);
+    expect(pattern.test('')).toBe(false);
+  });
+
   it('length 12, at least non-sequentially 2 lowercase, 1 uppercase', () => {
     const pattern = new RegExp(validatePasswordPattern(2, 12, 0, 0, 1));
 


### PR DESCRIPTION
## Description
Sequential matching of password requirements 

## Jira Ticket
- [TMEDIA-488](https://arcpublishing.atlassian.net/browse/TMEDIA-488)

## Acceptance Criteria
<p data-pm-slice="1 1 []">The Mercury password rules are: </p>

Rules | Value
-- | --
Length | 12
Special Characters | 2
Lowercase | 2
Uppercase | 2
Numerical | 2

<p></p><p>The following passwords meet these rules but the signup form shows as errors:</p>

Password
<img width="711" alt="Screen Shot 2021-09-15 at 13 49 40" src="https://user-images.githubusercontent.com/5950956/133491970-2f719703-b06e-402e-b3fa-bea2dc3008c7.png">

## Test Steps

1. Use the latest version of fusion-news-theme with the-mercury
2. Checkout this branch `git checkout TMEDIA-488-password-validation-two-of`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/identity-block`
3. Go to http://localhost/pf/account/sign-up/?_website=the-mercury
4. Type in a password to fulfill the criteria with two uppercase for example not next to each other. Please see https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-488&assignee=5e387d6a1b1d910e5dfd7a9b and screenshot above for target strings 
5. Other sites with one requirement should still work as well and be able to submit and create new user 

## Effect Of Changes
### Before

- Non-sequential "aAAAAa" would not pass for lowercase check

### After
- non-sequential requirements work as expected 

## Dependencies or Side Effects


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
