### PR TITLE
TMEDIA 496: fix: Remove footer's discernible text violation, reduce dom size, unnecessary column

### DIFF
--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -158,12 +158,20 @@ const FooterItem = ({ customFields: { navigationConfig } }) => {
             </li>
           )) : [];
 
+          if (columnItems.length === 0) {
+            return null;
+          }
+
           return (
             <div
               className="footer-section col-sm-12 col-md-6 col-lg-xl-3"
               key={column._id}
             >
-              <PrimaryFont as="h4" className="footer-header">{(column.name) ? column.name : ''}</PrimaryFont>
+              {
+                (column.name) ? (
+                  <PrimaryFont as="h4" className="footer-header">{column.name}</PrimaryFont>
+                ) : null
+              }
               <PrimaryFont as="ul">{columnItems}</PrimaryFont>
             </div>
           );

--- a/blocks/footer-block/features/footer/default.test.jsx
+++ b/blocks/footer-block/features/footer/default.test.jsx
@@ -83,7 +83,7 @@ const mockPayload = {
     },
     {
       _id: 'get-us',
-      name: '',
+      name: '', // empty name should not render due to accessibility requirement
       children: [
         {
           display_name: 'Why Our Product',
@@ -98,8 +98,9 @@ const mockPayload = {
       ],
     },
     {
-      _id: 'blank-colum',
-      name: '',
+      _id: 'blank-column',
+      name: '', // Empty string header name
+      // no children items
     },
   ],
 };
@@ -151,7 +152,10 @@ describe('the footer feature for the default output type', () => {
   it('should have 5 column headers', () => {
     const wrapper = mount(<Footer customFields={{ navigationConfig: { contentService: 'footer-service', contentConfiguration: {} } }} />);
 
-    expect(wrapper.find('h4.footer-header')).toHaveLength(5);
+    // there are only 4 columns with any non-empty string data
+    // two of the 5 objects have empty string names
+    // therefore those h4 elements should not render if no content is present
+    expect(wrapper.find('h4.footer-header')).toHaveLength(3);
   });
 
   it('should have 12 column items', () => {


### PR DESCRIPTION
## Description
In the footer block when a parent item has not name value the heading element is output, leaving an empty heading element on the page and giving an accessibility violation.

If a section has not name (title) or children elements do not render the HTML elements

## Jira Ticket
- [TMEDIA-496](https://arcpublishing.atlassian.net/browse/TMEDIA-496)

## Acceptance Criteria
_copy from ticket_

## Test Steps

1. Check storybook accessibility tests for footer

## Effect Of Changes
before: 

<img width="1195" alt="Screen Shot 2021-09-16 at 10 49 18" src="https://user-images.githubusercontent.com/5950956/133646465-66747e20-5d7b-4037-a8d5-613bd237190b.png">


after: 

<img width="1104" alt="Screen Shot 2021-09-16 at 10 52 23" src="https://user-images.githubusercontent.com/5950956/133646480-82696465-4aa7-4f2f-8476-a2bbe9f09c60.png">

## Dependencies or Side Effects

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
