### PR TITLE
TMEDIA-447: Add default paging options for the results list block

### DIFF
--- a/blocks/results-list-block/features/results-list/results/index.jsx
+++ b/blocks/results-list-block/features/results-list/results/index.jsx
@@ -56,9 +56,6 @@ const Results = ({
       ? configuredOffset
       : requestedOffset + configuredSize;
     switch (contentService) {
-      case 'story-feed-query': {
-        return { offset, size };
-      }
       case 'story-feed-author':
       case 'story-feed-sections':
       case 'story-feed-tag': {
@@ -69,7 +66,7 @@ const Results = ({
       }
       default: { break; }
     }
-    return {};
+    return { offset, size };
   }, [configuredOffset, configuredSize, contentService]);
 
   const requestedResultList = useContent({
@@ -191,8 +188,11 @@ const Results = ({
   const viewableElements = resultList?.content_elements
     .slice(0, queryOffset + configuredSize - configuredOffset);
 
-  const isThereMore = requestedResultList?.next
-    || viewableElements?.length < resultList?.count - configuredOffset;
+  const fullListLength = resultList?.count
+    ? resultList?.count - configuredOffset
+    : resultList?.content_elements.length;
+
+  const isThereMore = requestedResultList?.next || viewableElements?.length < fullListLength;
 
   const onReadMoreClick = useCallback(() => {
     setQueryOffset((oldOffset) => oldOffset + configuredSize);

--- a/blocks/results-list-block/features/results-list/results/index.test.jsx
+++ b/blocks/results-list-block/features/results-list/results/index.test.jsx
@@ -557,6 +557,8 @@ describe('unknown service', () => {
           feature: 'results-list',
           defaultOffset: 0,
           defaultSize: 1,
+          offset: 0,
+          size: 2,
         },
       }),
     );


### PR DESCRIPTION
## Description
Add default offset and size parameters to results list requests and account for lists that do not have the appropriate properties.

## Jira Ticket
- [TMEDIA-447](https://arcpublishing.atlassian.net/browse/TMEDIA-447)

## Acceptance Criteria
“See More” button of the Results List with custom content source generates new results

## Test Steps
1. Checkout this branch `git checkout TMEDIA-447-result-list-default-paging`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/results-list-block`
3. Add the Results List block to a page and configure it to use the related-content source which has no paging with the _id: ```CMVOSB2VCRDIBPC356BF2AXBFI```
![image](https://user-images.githubusercontent.com/2287238/133690212-82a323f0-4ed5-4164-a3b0-208abac687e3.png)
4. Modify Line 64 of the default.jsx template to mimic a short page value of something like 2:
![image](https://user-images.githubusercontent.com/2287238/133690524-6c2ae6bc-c73b-486e-afe9-e497dc34bccd.png)
Change to:
![image](https://user-images.githubusercontent.com/2287238/133690555-7b427e98-ceb5-4e03-a47a-f90e6ca31f6b.png)
5.  Validate custom parameters are passed for calls to the service:
![image](https://user-images.githubusercontent.com/2287238/133691022-e5829b47-2c8b-4b6d-a4ce-813ca6a6afca.png)

## Effect Of Changes
### Before
The paging component would not show a paging button for sources over the default value.
The paging would not send the default paging parameters for the custom data sources.

### After
The paging component now shows a paging button for sources over the default value and shows more content when clicked.
The paging now sends the default paging parameters for the custom data sources.

## Dependencies or Side Effects
- This will call the service multiple times for services that do not support paging directly and request the full list each time unless they implement `offset` and `size` parameters.

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
