### PR TITLE
Tmedia 468 header nav chain buttons (WIP)

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,7 @@ const path = require('path');
 // Export a function. Accept the base config as the only param.
 module.exports = {
   stories: ['../stories/*.stories.@(js|jsx|mdx|tsx)', '../blocks/**/*.story.@(js|jsx|mdx|tsx)' ],
-  addons: ['@storybook/addon-a11y', '@storybook/addon-docs', '@storybook/addon-knobs'],
+  addons: ['@storybook/addon-a11y', '@storybook/addon-docs', '@storybook/addon-knobs', '@storybook/addon-essentials'],
   webpackFinal: async (config, { configType }) => {
     // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
     // You can change the configuration based on that.

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -14,6 +14,10 @@ export const parameters = {
         value: "#ffffff",
       },
       {
+        name: "grey",
+        value: "grey",
+      },
+      {
         name: "primary",
         value: "rgb(255, 105, 180)",
       }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,6 +6,19 @@ export const parameters = {
     options: {},
     manual: false,
   },
+  backgrounds: {
+    default: "white",
+    values: [
+      {
+        name: "white",
+        value: "#ffffff",
+      },
+      {
+        name: "primary",
+        value: "rgb(255, 105, 180)",
+      }
+    ]
+  },
   options: {
     storySort: (a, b) =>
       a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -2,8 +2,12 @@ import React from 'react';
 import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
-import { HamburgerMenuIcon } from '@wpmedia/engine-theme-sdk';
-import { PrimaryFont } from '@wpmedia/shared-styles';
+import {
+  Button,
+  getNavSpecificSecondaryButtonTheme,
+  BUTTON_TYPES,
+  BUTTON_SIZES,
+} from '@wpmedia/shared-styles';
 import SearchBox from './search-box';
 import QuerylySearch from './queryly-search';
 import { WIDGET_CONFIG, PLACEMENT_AREAS } from '../nav-helper';
@@ -17,7 +21,7 @@ const NavWidget = ({
   menuButtonClickAction,
 }) => {
   const { arcSite } = useFusionContext();
-  const { navColor, locale } = getProperties(arcSite);
+  const { navColor = 'dark', navBarBackground, locale } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
   if (!type || type === 'none') return null;
 
@@ -39,20 +43,18 @@ const NavWidget = ({
         label={phrases.t('header-nav-chain-block.search-text')}
       />
     )) || (type === 'menu' && (
-      <button
-        type="button"
-        // passed down from default.jsx
-        onClick={menuButtonClickAction}
+      <Button
+        additionalClassNames="nav-sections-btn"
         aria-label={phrases.t('header-nav-chain-block.sections-button')}
-        className={`nav-btn nav-sections-btn border transparent ${navColor === 'light' ? 'nav-btn-light' : 'nav-btn-dark'}`}
-      >
-        <PrimaryFont as="span">{phrases.t('header-nav-chain-block.sections-button')}</PrimaryFont>
-        <HamburgerMenuIcon
-          fill={null}
-          height={WIDGET_CONFIG[placement]?.iconSize}
-          width={WIDGET_CONFIG[placement]?.iconSize}
-        />
-      </button>
+        buttonSize={BUTTON_SIZES.SMALL}
+        buttonStyle={getNavSpecificSecondaryButtonTheme(navColor, navBarBackground)}
+        buttonType={BUTTON_TYPES.LABEL_AND_RIGHT_ICON}
+        iconType="hamburger-menu"
+        onClick={menuButtonClickAction}
+        text={phrases.t('header-nav-chain-block.sections-button')}
+        type="button"
+
+      />
     ))
   );
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -35,13 +35,7 @@ const NavWidget = ({
         alwaysOpen={WIDGET_CONFIG[placement]?.expandSearch}
       />
     )) || (type === 'queryly' && (
-      <QuerylySearch
-        theme={
-        placement === PLACEMENT_AREAS.SECTION_MENU
-          ? 'dark' : navColor
-        }
-        label={phrases.t('header-nav-chain-block.search-text')}
-      />
+      <QuerylySearch />
     )) || (type === 'menu' && (
       <Button
         additionalClassNames="nav-sections-btn"

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
@@ -1,28 +1,16 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/label-has-associated-control */
 import React from 'react';
 import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
-import { SearchIcon } from '@wpmedia/engine-theme-sdk';
+import {
+  Button, BUTTON_SIZES, BUTTON_TYPES, getNavSpecificSecondaryButtonTheme,
+} from '@wpmedia/shared-styles';
 
 /*
   This querylySearchClick event isn't the ideal solution -
 
   Queryly uses a hidden checkbox in the DOM which they have an
-  onChange event listener attached to. As we are using a label
-  with the htmlFor attribute that is linked to the ID of their
-  checkbox the change event is fired using the mouse.
-
-  The issue is label's are not a focusable element. But a
-  button is. But events do not bubble downwards, and also
-  due to their use of the checkbox we have to manaully
-  check the checkbox and they dispatch a change event so their
-  code picks it up and loads the queryly search UI.
-
-  We also apply a stopPropagation onto the label to account for
-  mouse clicks on the label element from bubbling up to the
-  button and sending addtional events to the queryly_toggle
+  onChange event listener attached to.
 */
 const querylySearchClick = () => {
   const event = new Event('change');
@@ -30,18 +18,25 @@ const querylySearchClick = () => {
   document.getElementById('queryly_toggle').dispatchEvent(event);
 };
 
-const QuerylySearch = ({ theme = 'dark', iconSize = 16, label }) => {
+const QuerylySearch = () => {
   const { arcSite } = useFusionContext();
-  const { locale = 'en' } = getProperties(arcSite);
+  const {
+    locale = 'en',
+    navBarBackground,
+    navColor = 'dark',
+  } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
   return (
-    <div className={`nav-search ${theme} queryly`}>
-      <button className={`nav-btn nav-btn-${theme} transparent border`} type="button" onClick={querylySearchClick} aria-label={label || phrases.t('header-nav-chain-block.querly-search-aria-label')}>
-        <label htmlFor="queryly_toggle" onClick={(e) => e.stopPropagation()}>
-          <SearchIcon height={iconSize} width={iconSize} />
-        </label>
-      </button>
-    </div>
+    <Button
+      aria-label={phrases.t('header-nav-chain-block.search-text')}
+      buttonSize={BUTTON_SIZES.SMALL}
+      buttonStyle={getNavSpecificSecondaryButtonTheme(navColor, navBarBackground)}
+      buttondType={BUTTON_TYPES.ICON_ONLY}
+      iconType="search"
+      onClick={querylySearchClick}
+      text={phrases.t('header-nav-chain-block.search-text')}
+      type="button"
+    />
   );
 };
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.test.jsx
@@ -17,54 +17,20 @@ jest.mock('fusion:intl', () => jest.fn(
 ));
 
 const testQuerylySearch = ({
-  root, theme, iconSize = 16, label = 'test-translation',
+  root, label = 'test-translation',
 }) => {
-  const container = root.find('.nav-search');
+  const container = root.find('.xpmedia-button ');
   expect(container).toHaveLength(1);
-  expect(container).toHaveClassName(theme);
-  expect(container).toHaveClassName('queryly');
-  const navBtn = container.find('button.nav-btn');
-  expect(navBtn).toHaveLength(1);
-  expect(navBtn).toHaveClassName(`nav-btn-${theme}`);
-  expect(navBtn).toHaveClassName('border');
-  expect(navBtn).toHaveClassName('transparent');
-  const querylyLabel = navBtn.find('label');
-  expect(querylyLabel).toHaveLength(1);
-  expect(querylyLabel.prop('htmlFor')).toEqual('queryly_toggle');
-  const searchIcon = querylyLabel.find('SearchIcon');
-  expect(searchIcon).toHaveLength(1);
-  expect(searchIcon.prop('height')).toEqual(iconSize);
-  expect(searchIcon.prop('width')).toEqual(iconSize);
 
   const button = container.find('button');
   expect(button.prop('aria-label')).toBe(label);
 };
 
 describe('<QuerylySearch/>', () => {
-  it('renders with default props', () => {
+  it('renders', () => {
     const wrapper = shallow(<QuerylySearch />);
-    testQuerylySearch({ root: wrapper, theme: 'dark' });
-  });
-
-  it('renders with dark theme and default icon size', () => {
-    const wrapper = shallow(<QuerylySearch theme="dark" />);
-    testQuerylySearch({ root: wrapper, theme: 'dark' });
-  });
-
-  it('renders with light theme and default icon size', () => {
-    const wrapper = shallow(<QuerylySearch theme="light" />);
-    testQuerylySearch({ root: wrapper, theme: 'light' });
-  });
-
-  it('renders with custom icon size', () => {
-    const wrapper = shallow(<QuerylySearch theme="dark" iconSize={24} />);
-    testQuerylySearch({ root: wrapper, theme: 'dark', iconSize: 24 });
-  });
-
-  it('custom label', () => {
-    const wrapper = shallow(<QuerylySearch theme="dark" iconSize={24} label="Suche" />);
     testQuerylySearch({
-      root: wrapper, theme: 'dark', iconSize: 24, label: 'Suche',
+      root: wrapper,
     });
   });
 });

--- a/blocks/identity-block/components/HeadlinedSubmitForm/index.jsx
+++ b/blocks/identity-block/components/HeadlinedSubmitForm/index.jsx
@@ -48,7 +48,7 @@ const HeadlinedSubmitForm = ({
         {children}
         <Button
           buttonSize={BUTTON_SIZES.MEDIUM}
-          buttonStyle={BUTTON_STYLES.FILLED}
+          buttonStyle={BUTTON_STYLES.PRIMARY}
           fullWidth
           text={buttonLabel}
           type="submit"

--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -11,12 +11,12 @@ import DropDownLinkListItem from './_children/DropDownLinkListItem';
 
 import './styles.scss';
 
-function getInvertedButtonTheme(navColor, navBarBackground) {
+function getNavSpecificPrimaryButtonTheme(navColor, navBarBackground) {
   if (navBarBackground === 'primary-color') {
     return BUTTON_STYLES.PRIMARY_REVERSE;
   }
 
-  return navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT : BUTTON_STYLES.PRIMARY;
+  return navColor === 'dark' ? BUTTON_STYLES.DEFAULT : BUTTON_STYLES.PRIMARY;
 }
 
 function getNavSpecificSecondaryButtonTheme(navColor, navBarBackground) {
@@ -112,7 +112,7 @@ const HeaderAccountAction = ({ customFields }) => {
             aria-expanded={isAccountMenuOpen}
             as="button"
             buttonSize={BUTTON_SIZES.SMALL}
-            buttonStyle={getInvertedButtonTheme(navColor, navBarBackground)}
+            buttonStyle={getNavSpecificPrimaryButtonTheme(navColor, navBarBackground)}
             buttonType={BUTTON_TYPES.ICON_ONLY}
             iconType="user"
             onClick={() => setAccountMenu(!isAccountMenuOpen)}
@@ -147,7 +147,7 @@ const HeaderAccountAction = ({ customFields }) => {
             // should be an a tag if it's a link
             as="a"
             buttonSize={BUTTON_SIZES.SMALL}
-            buttonStyle={getInvertedButtonTheme(navColor, navBarBackground)}
+            buttonStyle={getNavSpecificPrimaryButtonTheme(navColor, navBarBackground)}
             buttonType={BUTTON_TYPES.LABEL_ONLY}
             href={createAccountURL}
             text={phrases.t('identity-block.sign-up')}
@@ -172,7 +172,7 @@ const HeaderAccountAction = ({ customFields }) => {
           as="button"
           aria-expanded={isAccountMenuOpen}
           buttonSize={BUTTON_SIZES.SMALL}
-          buttonStyle={getInvertedButtonTheme(navColor, navBarBackground)}
+          buttonStyle={getNavSpecificPrimaryButtonTheme(navColor, navBarBackground)}
           buttonType={BUTTON_TYPES.ICON_ONLY}
           iconType="user"
           onClick={() => setAccountMenu(!isAccountMenuOpen)}

--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -13,7 +13,7 @@ import './styles.scss';
 
 function getInvertedButtonTheme(navColor, navBarBackground) {
   if (navBarBackground === 'primary-color') {
-    return BUTTON_STYLES.WHITE_BACKGROUND_FILLED;
+    return BUTTON_STYLES.PRIMARY_REVERSE;
   }
 
   return navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT : BUTTON_STYLES.PRIMARY;

--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -16,7 +16,7 @@ function getInvertedButtonTheme(navColor, navBarBackground) {
     return BUTTON_STYLES.WHITE_BACKGROUND_FILLED;
   }
 
-  return navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT : BUTTON_STYLES.FILLED;
+  return navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT : BUTTON_STYLES.PRIMARY;
 }
 
 function getOutlineButtonTheme(navColor, navBarBackground) {

--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -19,12 +19,12 @@ function getInvertedButtonTheme(navColor, navBarBackground) {
   return navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT : BUTTON_STYLES.PRIMARY;
 }
 
-function getOutlineButtonTheme(navColor, navBarBackground) {
+function getNavSpecificSecondaryButtonTheme(navColor, navBarBackground) {
   if (navBarBackground === 'primary-color' || navColor === 'dark') {
     return BUTTON_STYLES.SECONDARY_REVERSE;
   }
 
-  return BUTTON_STYLES.SECONDARY_OUTLINE;
+  return BUTTON_STYLES.SECONDARY;
 }
 
 const HeaderAccountAction = ({ customFields }) => {
@@ -98,7 +98,7 @@ const HeaderAccountAction = ({ customFields }) => {
             aria-expanded={isAccountMenuOpen}
             as="button"
             buttonSize={BUTTON_SIZES.SMALL}
-            buttonStyle={getOutlineButtonTheme(navColor, navBarBackground)}
+            buttonStyle={getNavSpecificSecondaryButtonTheme(navColor, navBarBackground)}
             buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
             iconType="user"
             secondaryIconType={isAccountMenuOpen ? 'chevron-up' : 'chevron-down'}
@@ -158,7 +158,7 @@ const HeaderAccountAction = ({ customFields }) => {
             // should be an a tag if it's a link
             as="a"
             buttonSize={BUTTON_SIZES.SMALL}
-            buttonStyle={getOutlineButtonTheme(navColor, navBarBackground)}
+            buttonStyle={getNavSpecificSecondaryButtonTheme(navColor, navBarBackground)}
             buttonType={BUTTON_TYPES.LABEL_AND_ICON}
             href={loginURL}
             iconType="user"

--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -20,11 +20,11 @@ function getInvertedButtonTheme(navColor, navBarBackground) {
 }
 
 function getOutlineButtonTheme(navColor, navBarBackground) {
-  if (navBarBackground === 'primary-color') {
-    return BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE;
+  if (navBarBackground === 'primary-color' || navColor === 'dark') {
+    return BUTTON_STYLES.SECONDARY_REVERSE;
   }
 
-  return navColor === 'dark' ? BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE : BUTTON_STYLES.SECONDARY_OUTLINE;
+  return BUTTON_STYLES.SECONDARY_OUTLINE;
 }
 
 const HeaderAccountAction = ({ customFields }) => {

--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -11,6 +11,22 @@ import DropDownLinkListItem from './_children/DropDownLinkListItem';
 
 import './styles.scss';
 
+function getSignUpButtonTheme(navColor, navBarBackground) {
+  if (navBarBackground === 'primary-color') {
+    return BUTTON_STYLES.WHITE_BACKGROUND_FILLED;
+  }
+
+  return navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT : BUTTON_STYLES.FILLED;
+}
+
+function getLoginButtonTheme(navColor, navBarBackground) {
+  if (navBarBackground === 'primary-color') {
+    return BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE;
+  }
+
+  return navColor === 'dark' ? BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE : BUTTON_STYLES.SECONDARY_OUTLINE;
+}
+
 const HeaderAccountAction = ({ customFields }) => {
   const {
     createAccountURL,
@@ -21,7 +37,7 @@ const HeaderAccountAction = ({ customFields }) => {
   const { arcSite } = useFusionContext();
 
   const { Identity, isInitialized } = useIdentity();
-  const { locale, navColor = 'dark' } = getProperties(arcSite);
+  const { locale, navColor = 'dark', navBarBackground } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
 
   const [loggedIn, setIsLoggedIn] = useState(false);
@@ -133,8 +149,7 @@ const HeaderAccountAction = ({ customFields }) => {
             // should be an a tag if it's a link
             as="a"
             buttonSize={BUTTON_SIZES.SMALL}
-            // Sign Up: Primary Filled Reverse, Primary Filled if Light nav (Label only)
-            buttonStyle={navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_FILLED : BUTTON_STYLES.FILLED}
+            buttonStyle={getSignUpButtonTheme(navColor, navBarBackground)}
             buttonType={BUTTON_TYPES.LABEL_ONLY}
             href={createAccountURL}
             text={phrases.t('identity-block.sign-up')}
@@ -145,8 +160,7 @@ const HeaderAccountAction = ({ customFields }) => {
             // should be an a tag if it's a link
             as="a"
             buttonSize={BUTTON_SIZES.SMALL}
-            // Log In: Secondary Outline Reverse, Secondary Outline if Light nav (Icon & Label)
-            buttonStyle={navColor === 'dark' ? BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE : BUTTON_STYLES.SECONDARY_OUTLINE}
+            buttonStyle={getLoginButtonTheme(navColor, navBarBackground)}
             buttonType={BUTTON_TYPES.LABEL_AND_ICON}
             href={loginURL}
             iconType="user"

--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -21,7 +21,7 @@ const HeaderAccountAction = ({ customFields }) => {
   const { arcSite } = useFusionContext();
 
   const { Identity, isInitialized } = useIdentity();
-  const { locale } = getProperties(arcSite);
+  const { locale, navColor = 'dark' } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
 
   const [loggedIn, setIsLoggedIn] = useState(false);
@@ -82,7 +82,8 @@ const HeaderAccountAction = ({ customFields }) => {
             aria-expanded={isAccountMenuOpen}
             as="button"
             buttonSize={BUTTON_SIZES.SMALL}
-            buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+            // Account: Secondary Outline Reverse, Secondary Outline if Light nav
+            buttonStyle={navColor === 'dark' ? BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE : BUTTON_STYLES.SECONDARY_OUTLINE}
             buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
             iconType="user"
             secondaryIconType={isAccountMenuOpen ? 'chevron-up' : 'chevron-down'}
@@ -96,7 +97,8 @@ const HeaderAccountAction = ({ customFields }) => {
             aria-expanded={isAccountMenuOpen}
             as="button"
             buttonSize={BUTTON_SIZES.SMALL}
-            buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+            // Mobile: Primary Filled Reverse, Primary Filled if Light nav (Icon only)
+            buttonStyle={navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_FILLED : BUTTON_STYLES.FILLED}
             buttonType={BUTTON_TYPES.ICON_ONLY}
             iconType="user"
             onClick={() => setAccountMenu(!isAccountMenuOpen)}
@@ -131,7 +133,8 @@ const HeaderAccountAction = ({ customFields }) => {
             // should be an a tag if it's a link
             as="a"
             buttonSize={BUTTON_SIZES.SMALL}
-            buttonStyle={BUTTON_STYLES.OUTLINED_GREY}
+            // Sign Up: Primary Filled Reverse, Primary Filled if Light nav (Label only)
+            buttonStyle={navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_FILLED : BUTTON_STYLES.FILLED}
             buttonType={BUTTON_TYPES.LABEL_ONLY}
             href={createAccountURL}
             text={phrases.t('identity-block.sign-up')}
@@ -142,7 +145,8 @@ const HeaderAccountAction = ({ customFields }) => {
             // should be an a tag if it's a link
             as="a"
             buttonSize={BUTTON_SIZES.SMALL}
-            buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+            // Log In: Secondary Outline Reverse, Secondary Outline if Light nav (Icon & Label)
+            buttonStyle={navColor === 'dark' ? BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE : BUTTON_STYLES.SECONDARY_OUTLINE}
             buttonType={BUTTON_TYPES.LABEL_AND_ICON}
             href={loginURL}
             iconType="user"
@@ -156,7 +160,8 @@ const HeaderAccountAction = ({ customFields }) => {
           as="button"
           aria-expanded={isAccountMenuOpen}
           buttonSize={BUTTON_SIZES.SMALL}
-          buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+          // Mobile: Primary Filled Reverse, Primary Filled if Light nav (Icon only)
+          buttonStyle={navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_FILLED : BUTTON_STYLES.FILLED}
           buttonType={BUTTON_TYPES.ICON_ONLY}
           iconType="user"
           onClick={() => setAccountMenu(!isAccountMenuOpen)}

--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -4,28 +4,16 @@ import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 import { useFusionContext } from 'fusion:context';
 import {
-  Button, BUTTON_STYLES, BUTTON_SIZES, BUTTON_TYPES,
+  Button,
+  BUTTON_SIZES,
+  BUTTON_TYPES,
+  getNavSpecificSecondaryButtonTheme,
+  getNavSpecificPrimaryButtonTheme,
 } from '@wpmedia/shared-styles';
 import useIdentity from '../../components/Identity';
 import DropDownLinkListItem from './_children/DropDownLinkListItem';
 
 import './styles.scss';
-
-function getNavSpecificPrimaryButtonTheme(navColor, navBarBackground) {
-  if (navBarBackground === 'primary-color') {
-    return BUTTON_STYLES.PRIMARY_REVERSE;
-  }
-
-  return navColor === 'dark' ? BUTTON_STYLES.DEFAULT : BUTTON_STYLES.PRIMARY;
-}
-
-function getNavSpecificSecondaryButtonTheme(navColor, navBarBackground) {
-  if (navBarBackground === 'primary-color' || navColor === 'dark') {
-    return BUTTON_STYLES.SECONDARY_REVERSE;
-  }
-
-  return BUTTON_STYLES.SECONDARY;
-}
 
 const HeaderAccountAction = ({ customFields }) => {
   const {

--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -11,7 +11,7 @@ import DropDownLinkListItem from './_children/DropDownLinkListItem';
 
 import './styles.scss';
 
-function getSignUpButtonTheme(navColor, navBarBackground) {
+function getInvertedButtonTheme(navColor, navBarBackground) {
   if (navBarBackground === 'primary-color') {
     return BUTTON_STYLES.WHITE_BACKGROUND_FILLED;
   }
@@ -19,7 +19,7 @@ function getSignUpButtonTheme(navColor, navBarBackground) {
   return navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT : BUTTON_STYLES.FILLED;
 }
 
-function getLoginButtonTheme(navColor, navBarBackground) {
+function getOutlineButtonTheme(navColor, navBarBackground) {
   if (navBarBackground === 'primary-color') {
     return BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE;
   }
@@ -98,8 +98,7 @@ const HeaderAccountAction = ({ customFields }) => {
             aria-expanded={isAccountMenuOpen}
             as="button"
             buttonSize={BUTTON_SIZES.SMALL}
-            // Account: Secondary Outline Reverse, Secondary Outline if Light nav
-            buttonStyle={navColor === 'dark' ? BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE : BUTTON_STYLES.SECONDARY_OUTLINE}
+            buttonStyle={getOutlineButtonTheme(navColor, navBarBackground)}
             buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
             iconType="user"
             secondaryIconType={isAccountMenuOpen ? 'chevron-up' : 'chevron-down'}
@@ -113,8 +112,7 @@ const HeaderAccountAction = ({ customFields }) => {
             aria-expanded={isAccountMenuOpen}
             as="button"
             buttonSize={BUTTON_SIZES.SMALL}
-            // Mobile: Primary Filled Reverse, Primary Filled if Light nav (Icon only)
-            buttonStyle={navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_FILLED : BUTTON_STYLES.FILLED}
+            buttonStyle={getInvertedButtonTheme(navColor, navBarBackground)}
             buttonType={BUTTON_TYPES.ICON_ONLY}
             iconType="user"
             onClick={() => setAccountMenu(!isAccountMenuOpen)}
@@ -149,7 +147,7 @@ const HeaderAccountAction = ({ customFields }) => {
             // should be an a tag if it's a link
             as="a"
             buttonSize={BUTTON_SIZES.SMALL}
-            buttonStyle={getSignUpButtonTheme(navColor, navBarBackground)}
+            buttonStyle={getInvertedButtonTheme(navColor, navBarBackground)}
             buttonType={BUTTON_TYPES.LABEL_ONLY}
             href={createAccountURL}
             text={phrases.t('identity-block.sign-up')}
@@ -160,7 +158,7 @@ const HeaderAccountAction = ({ customFields }) => {
             // should be an a tag if it's a link
             as="a"
             buttonSize={BUTTON_SIZES.SMALL}
-            buttonStyle={getLoginButtonTheme(navColor, navBarBackground)}
+            buttonStyle={getOutlineButtonTheme(navColor, navBarBackground)}
             buttonType={BUTTON_TYPES.LABEL_AND_ICON}
             href={loginURL}
             iconType="user"
@@ -174,8 +172,7 @@ const HeaderAccountAction = ({ customFields }) => {
           as="button"
           aria-expanded={isAccountMenuOpen}
           buttonSize={BUTTON_SIZES.SMALL}
-          // Mobile: Primary Filled Reverse, Primary Filled if Light nav (Icon only)
-          buttonStyle={navColor === 'dark' ? BUTTON_STYLES.WHITE_BACKGROUND_FILLED : BUTTON_STYLES.FILLED}
+          buttonStyle={getInvertedButtonTheme(navColor, navBarBackground)}
           buttonType={BUTTON_TYPES.ICON_ONLY}
           iconType="user"
           onClick={() => setAccountMenu(!isAccountMenuOpen)}

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -36,7 +36,6 @@ const iconTypeStringToIconTypeComponent = (
 ) => {
   let Icon = null;
 
-  // use white if primary color is being used
   let iconColor = primaryColor;
 
   switch (buttonStyle) {

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -29,8 +29,13 @@ export const BUTTON_TYPES = {
   LABEL_AND_TWO_ICONS: 'LABEL_AND_TWO_ICONS',
 };
 
-const iconTypeStringToIconTypeComponent = (iconTypeString, iconHeightWidth, primaryColor) => {
+const iconTypeStringToIconTypeComponent = (
+  iconTypeString, iconHeightWidth, primaryColor, buttonStyle,
+) => {
   let Icon = null;
+
+  // use white if primary color is being used
+  const iconColor = buttonStyle === BUTTON_STYLES.FILLED ? '#fff' : primaryColor;
 
   if (iconTypeString) {
     switch (iconTypeString) {
@@ -41,7 +46,7 @@ const iconTypeStringToIconTypeComponent = (iconTypeString, iconHeightWidth, prim
           <UserIcon
             height={iconHeightWidth}
             width={iconHeightWidth}
-            fill={primaryColor}
+            fill={iconColor}
           />
         );
         break;
@@ -50,7 +55,7 @@ const iconTypeStringToIconTypeComponent = (iconTypeString, iconHeightWidth, prim
           <ChevronUpIcon
             height={iconHeightWidth}
             width={iconHeightWidth}
-            fill={primaryColor}
+            fill={iconColor}
           />
         );
         break;
@@ -59,7 +64,7 @@ const iconTypeStringToIconTypeComponent = (iconTypeString, iconHeightWidth, prim
           <ChevronDownIcon
             height={iconHeightWidth}
             width={iconHeightWidth}
-            fill={primaryColor}
+            fill={iconColor}
           />
         );
         break;
@@ -219,11 +224,13 @@ function Button(props) {
     iconType,
     iconHeightWidth,
     primaryColor,
+    buttonStyle,
   );
   const SecondaryIcon = iconTypeStringToIconTypeComponent(
     secondaryIconType,
     iconHeightWidth,
     primaryColor,
+    buttonStyle,
   );
 
   return (

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -12,10 +12,10 @@ import './styles.scss';
 export const BUTTON_STYLES = {
   PRIMARY: 'PRIMARY',
   PRIMARY_REVERSE: 'PRIMARY_REVERSE',
+  SECONDARY_OUTLINE: 'SECONDARY_OUTLINE',
+  SECONDARY_REVERSE: 'SECONDARY_REVERSE',
   OUTLINED: 'OUTLINED',
   OUTLINED_GREY: 'OUTLINED_GREY',
-  SECONDARY_OUTLINE: 'SECONDARY_OUTLINE',
-  SECONDARY_OUTLINE_REVERSE: 'SECONDARY_OUTLINE_REVERSE',
   WHITE_BACKGROUND_DARK_TEXT: 'WHITE_BACKGROUND_DARK_TEXT',
 };
 
@@ -41,7 +41,7 @@ const iconTypeStringToIconTypeComponent = (
 
   switch (buttonStyle) {
     case BUTTON_STYLES.PRIMARY:
-    case BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE:
+    case BUTTON_STYLES.SECONDARY_REVERSE:
       iconColor = '#fff';
       break;
     case BUTTON_STYLES.PRIMARY_REVERSE:
@@ -152,7 +152,7 @@ const StyledDynamicButton = styled.button.attrs((props) => ({
             color: #191919;
           }
         `;
-      case BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE:
+      case BUTTON_STYLES.SECONDARY_REVERSE:
         // istanbul ignore next
         return `
           background-color: transparent;

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -14,8 +14,6 @@ export const BUTTON_STYLES = {
   PRIMARY_REVERSE: 'PRIMARY_REVERSE',
   SECONDARY: 'SECONDARY',
   SECONDARY_REVERSE: 'SECONDARY_REVERSE',
-  OUTLINED: 'OUTLINED',
-  OUTLINED_GREY: 'OUTLINED_GREY',
   WHITE_BACKGROUND_DARK_TEXT: 'WHITE_BACKGROUND_DARK_TEXT',
 };
 
@@ -117,28 +115,6 @@ const StyledDynamicButton = styled.button.attrs((props) => ({
 
           &:hover {
             color: ${primaryColor};
-          }
-        `;
-      case BUTTON_STYLES.OUTLINED:
-        // istanbul ignore next
-        return `
-          background-color: transparent;
-          border-color: ${primaryColor};
-          color: ${primaryColor};
-
-          &:hover {
-            color: ${primaryColor};
-          }
-        `;
-      case BUTTON_STYLES.OUTLINED_GREY:
-        // istanbul ignore next
-        return `
-          background-color: transparent;
-          border-color: rgba(255, 255, 255, 0.5);
-          color: #ffffff;
-
-          &:hover {
-            color: #ffffff;
           }
         `;
       case BUTTON_STYLES.SECONDARY:

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -7,6 +7,7 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
   HamburgerMenuIcon,
+  SearchIcon,
   UserIcon,
 } from '@wpmedia/engine-theme-sdk';
 
@@ -91,6 +92,15 @@ const iconTypeStringToIconTypeComponent = (
       case 'hamburger-menu':
         Icon = (
           <HamburgerMenuIcon
+            height={iconHeightWidth}
+            width={iconHeightWidth}
+            fill={iconColor}
+          />
+        );
+        break;
+      case 'search':
+        Icon = (
+          <SearchIcon
             height={iconHeightWidth}
             width={iconHeightWidth}
             fill={iconColor}

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -14,6 +14,8 @@ export const BUTTON_STYLES = {
   OUTLINED: 'OUTLINED',
   WHITE_BACKGROUND_FILLED: 'WHITE_BACKGROUND_FILLED',
   OUTLINED_GREY: 'OUTLINED_GREY',
+  SECONDARY_OUTLINE: 'SECONDARY_OUTLINE',
+  SECONDARY_OUTLINE_REVERSE: 'SECONDARY_OUTLINE_REVERSE',
 };
 
 export const BUTTON_SIZES = {
@@ -35,7 +37,22 @@ const iconTypeStringToIconTypeComponent = (
   let Icon = null;
 
   // use white if primary color is being used
-  const iconColor = buttonStyle === BUTTON_STYLES.FILLED ? '#fff' : primaryColor;
+  let iconColor = primaryColor;
+
+  switch (buttonStyle) {
+    case BUTTON_STYLES.FILLED:
+    case BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE:
+      iconColor = '#fff';
+      break;
+    case BUTTON_STYLES.WHITE_BACKGROUND_FILLED:
+      iconColor = primaryColor;
+      break;
+    case BUTTON_STYLES.SECONDARY_OUTLINE:
+      iconColor = '#191919';
+      break;
+    default:
+      iconColor = primaryColor;
+  }
 
   if (iconTypeString) {
     switch (iconTypeString) {
@@ -121,6 +138,28 @@ const StyledDynamicButton = styled.button.attrs((props) => ({
 
           &:hover {
             color: #ffffff;
+          }
+        `;
+      case BUTTON_STYLES.SECONDARY_OUTLINE:
+        // istanbul ignore next
+        return `
+          background-color: transparent;
+          border-color: #dadada;
+          color: #191919;
+
+          &:hover {
+            color: #191919;
+          }
+        `;
+      case BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE:
+        // istanbul ignore next
+        return `
+          background-color: transparent;
+          border-color: #fff;
+          color: #fff;
+
+          &:hover {
+            color: #fff;
           }
         `;
       case BUTTON_STYLES.FILLED:

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -11,8 +11,8 @@ import './styles.scss';
 // naming comes from zeplin docs for types
 export const BUTTON_STYLES = {
   PRIMARY: 'PRIMARY',
+  PRIMARY_REVERSE: 'PRIMARY_REVERSE',
   OUTLINED: 'OUTLINED',
-  WHITE_BACKGROUND_FILLED: 'WHITE_BACKGROUND_FILLED',
   OUTLINED_GREY: 'OUTLINED_GREY',
   SECONDARY_OUTLINE: 'SECONDARY_OUTLINE',
   SECONDARY_OUTLINE_REVERSE: 'SECONDARY_OUTLINE_REVERSE',
@@ -44,7 +44,7 @@ const iconTypeStringToIconTypeComponent = (
     case BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE:
       iconColor = '#fff';
       break;
-    case BUTTON_STYLES.WHITE_BACKGROUND_FILLED:
+    case BUTTON_STYLES.PRIMARY_REVERSE:
       iconColor = primaryColor;
       break;
     case BUTTON_STYLES.SECONDARY_OUTLINE:
@@ -109,7 +109,7 @@ const StyledDynamicButton = styled.button.attrs((props) => ({
     // istanbul ignore next
     switch (buttonStyle) {
       // istanbul ignore next
-      case BUTTON_STYLES.WHITE_BACKGROUND_FILLED:
+      case BUTTON_STYLES.PRIMARY_REVERSE:
         return `
           background-color: #ffffff;
           border-color: #ffffff;

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -3,7 +3,12 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import getThemeStyle from 'fusion:themes';
 import { useFusionContext } from 'fusion:context';
-import { UserIcon, ChevronDownIcon, ChevronUpIcon } from '@wpmedia/engine-theme-sdk';
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  HamburgerMenuIcon,
+  UserIcon,
+} from '@wpmedia/engine-theme-sdk';
 
 // handle non-dynamic styling not based on theme styles
 import './styles.scss';
@@ -28,6 +33,7 @@ export const BUTTON_TYPES = {
   ICON_ONLY: 'ICON_ONLY',
   LABEL_AND_ICON: 'LABEL_AND_ICON',
   LABEL_AND_TWO_ICONS: 'LABEL_AND_TWO_ICONS',
+  LABEL_AND_RIGHT_ICON: 'LABEL_AND_RIGHT_ICON',
 };
 
 const iconTypeStringToIconTypeComponent = (
@@ -76,6 +82,15 @@ const iconTypeStringToIconTypeComponent = (
       case 'chevron-down':
         Icon = (
           <ChevronDownIcon
+            height={iconHeightWidth}
+            width={iconHeightWidth}
+            fill={iconColor}
+          />
+        );
+        break;
+      case 'hamburger-menu':
+        Icon = (
+          <HamburgerMenuIcon
             height={iconHeightWidth}
             width={iconHeightWidth}
             fill={iconColor}
@@ -200,6 +215,15 @@ function renderButtonContents(matchedButtonType, text, iconComponent, secondaryI
           {text}
         </>
       );
+    case BUTTON_TYPES.LABEL_AND_RIGHT_ICON:
+      return (
+        <>
+          {text}
+          <div className="xpmedia-button--right-icon-container">
+            {iconComponent}
+          </div>
+        </>
+      );
     case BUTTON_TYPES.ICON_ONLY:
       return (iconComponent);
     case BUTTON_TYPES.LABEL_ONLY:
@@ -214,6 +238,7 @@ function Button(props) {
   const {
     ariaLabel,
     as,
+    additionalClassNames,
     buttonSize,
     buttonStyle,
     buttonType,
@@ -264,7 +289,7 @@ function Button(props) {
       aria-label={buttonType === BUTTON_TYPES.ICON_ONLY ? (ariaLabel || text) : null}
       as={as}
       buttonStyle={buttonStyle}
-      className={`xpmedia-button ${matchedButtonSizeClass}${fullWidth ? ' xpmedia-button--full-width' : ''}`}
+      className={`xpmedia-button ${matchedButtonSizeClass}${fullWidth ? ' xpmedia-button--full-width' : ''}${additionalClassNames ? ` ${additionalClassNames}` : ''}`}
       font={primaryFont}
       primaryColor={primaryColor}
       type={elementType}

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -14,7 +14,7 @@ export const BUTTON_STYLES = {
   PRIMARY_REVERSE: 'PRIMARY_REVERSE',
   SECONDARY: 'SECONDARY',
   SECONDARY_REVERSE: 'SECONDARY_REVERSE',
-  WHITE_BACKGROUND_DARK_TEXT: 'WHITE_BACKGROUND_DARK_TEXT',
+  DEFAULT: 'DEFAULT',
 };
 
 export const BUTTON_SIZES = {
@@ -46,11 +46,9 @@ const iconTypeStringToIconTypeComponent = (
       iconColor = primaryColor;
       break;
     case BUTTON_STYLES.SECONDARY:
-    case BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT:
-      iconColor = '#191919';
-      break;
+    case BUTTON_STYLES.DEFAULT:
     default:
-      iconColor = primaryColor;
+      iconColor = '#191919';
   }
 
   if (iconTypeString) {
@@ -139,19 +137,7 @@ const StyledDynamicButton = styled.button.attrs((props) => ({
             color: #fff;
           }
         `;
-      case BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT:
-        // istanbul ignore next
-        return `
-          background-color: #ffffff;
-          border-color: #ffffff;
-          color: #191919;
-
-          &:hover {
-            color: #191919;
-          }
-        `;
       case BUTTON_STYLES.PRIMARY:
-      default:
         // istanbul ignore next
         return `
           background-color: ${primaryColor};
@@ -160,6 +146,18 @@ const StyledDynamicButton = styled.button.attrs((props) => ({
 
           &:hover {
             color: #ffffff;
+          }
+        `;
+      case BUTTON_STYLES.DEFAULT:
+      default:
+        // istanbul ignore next
+        return `
+          background-color: #ffffff;
+          border-color: #ffffff;
+          color: #191919;
+
+          &:hover {
+            color: #191919;
           }
         `;
     }
@@ -294,7 +292,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
   buttonSize: BUTTON_SIZES.MEDIUM,
-  buttonStyle: BUTTON_STYLES.PRIMARY,
+  buttonStyle: BUTTON_STYLES.DEFAULT,
   buttonType: BUTTON_TYPES.LABEL_ONLY,
   iconType: '',
 };

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -12,7 +12,7 @@ import './styles.scss';
 export const BUTTON_STYLES = {
   PRIMARY: 'PRIMARY',
   PRIMARY_REVERSE: 'PRIMARY_REVERSE',
-  SECONDARY_OUTLINE: 'SECONDARY_OUTLINE',
+  SECONDARY: 'SECONDARY',
   SECONDARY_REVERSE: 'SECONDARY_REVERSE',
   OUTLINED: 'OUTLINED',
   OUTLINED_GREY: 'OUTLINED_GREY',
@@ -47,7 +47,7 @@ const iconTypeStringToIconTypeComponent = (
     case BUTTON_STYLES.PRIMARY_REVERSE:
       iconColor = primaryColor;
       break;
-    case BUTTON_STYLES.SECONDARY_OUTLINE:
+    case BUTTON_STYLES.SECONDARY:
     case BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT:
       iconColor = '#191919';
       break;
@@ -141,7 +141,7 @@ const StyledDynamicButton = styled.button.attrs((props) => ({
             color: #ffffff;
           }
         `;
-      case BUTTON_STYLES.SECONDARY_OUTLINE:
+      case BUTTON_STYLES.SECONDARY:
         // istanbul ignore next
         return `
           background-color: transparent;

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -16,6 +16,7 @@ export const BUTTON_STYLES = {
   OUTLINED_GREY: 'OUTLINED_GREY',
   SECONDARY_OUTLINE: 'SECONDARY_OUTLINE',
   SECONDARY_OUTLINE_REVERSE: 'SECONDARY_OUTLINE_REVERSE',
+  WHITE_BACKGROUND_DARK_TEXT: 'WHITE_BACKGROUND_DARK_TEXT',
 };
 
 export const BUTTON_SIZES = {
@@ -47,6 +48,7 @@ const iconTypeStringToIconTypeComponent = (
       iconColor = primaryColor;
       break;
     case BUTTON_STYLES.SECONDARY_OUTLINE:
+    case BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT:
       iconColor = '#191919';
       break;
     default:
@@ -159,6 +161,17 @@ const StyledDynamicButton = styled.button.attrs((props) => ({
 
           &:hover {
             color: #fff;
+          }
+        `;
+      case BUTTON_STYLES.WHITE_BACKGROUND_DARK_TEXT:
+        // istanbul ignore next
+        return `
+          background-color: #ffffff;
+          border-color: #ffffff;
+          color: #191919;
+
+          &:hover {
+            color: #191919;
           }
         `;
       case BUTTON_STYLES.FILLED:

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -10,7 +10,7 @@ import './styles.scss';
 
 // naming comes from zeplin docs for types
 export const BUTTON_STYLES = {
-  FILLED: 'FILLED',
+  PRIMARY: 'PRIMARY',
   OUTLINED: 'OUTLINED',
   WHITE_BACKGROUND_FILLED: 'WHITE_BACKGROUND_FILLED',
   OUTLINED_GREY: 'OUTLINED_GREY',
@@ -40,7 +40,7 @@ const iconTypeStringToIconTypeComponent = (
   let iconColor = primaryColor;
 
   switch (buttonStyle) {
-    case BUTTON_STYLES.FILLED:
+    case BUTTON_STYLES.PRIMARY:
     case BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE:
       iconColor = '#fff';
       break;
@@ -174,7 +174,7 @@ const StyledDynamicButton = styled.button.attrs((props) => ({
             color: #191919;
           }
         `;
-      case BUTTON_STYLES.FILLED:
+      case BUTTON_STYLES.PRIMARY:
       default:
         // istanbul ignore next
         return `
@@ -318,7 +318,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
   buttonSize: BUTTON_SIZES.MEDIUM,
-  buttonStyle: BUTTON_STYLES.FILLED,
+  buttonStyle: BUTTON_STYLES.PRIMARY,
   buttonType: BUTTON_TYPES.LABEL_ONLY,
   iconType: '',
 };

--- a/blocks/shared-styles/_children/button/index.story.jsx
+++ b/blocks/shared-styles/_children/button/index.story.jsx
@@ -9,43 +9,43 @@ export default {
   },
 };
 
-// start primary filled
-export const PrimaryFilledLabel = () => (
+// start primary
+export const PrimaryLabel = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.FILLED}
+    buttonStyle={BUTTON_STYLES.PRIMARY}
     buttonTypes={BUTTON_TYPES.LABEL_ONLY}
     text="Sign up"
   />
 );
 
-export const PrimaryFilledIconAndLabel = () => (
+export const PrimaryIconAndLabel = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.FILLED}
+    buttonStyle={BUTTON_STYLES.PRIMARY}
     buttonType={BUTTON_TYPES.LABEL_AND_ICON}
     iconType="user"
     text="Sign up"
   />
 );
 
-export const PrimaryFilledIcon = () => (
+export const PrimaryIcon = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.FILLED}
+    buttonStyle={BUTTON_STYLES.PRIMARY}
     buttonType={BUTTON_TYPES.ICON_ONLY}
     iconType="user"
     ariaLabel="Sign up"
   />
 );
 
-export const PrimaryFilledDualIcon = () => (
+export const PrimaryDualIcon = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.FILLED}
+    buttonStyle={BUTTON_STYLES.PRIMARY}
     buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
     iconType="user"
     text="Sign up"
     secondaryIconType="chevron-up"
   />
 );
-// end primary filled
+// end primary
 
 // start primary filled reverse
 export const PrimaryFilledReverseLabel = () => (

--- a/blocks/shared-styles/_children/button/index.story.jsx
+++ b/blocks/shared-styles/_children/button/index.story.jsx
@@ -9,6 +9,7 @@ export default {
   },
 };
 
+// start primary filled
 export const PrimaryFilledLabel = () => (
   <Button
     buttonStyle={BUTTON_STYLES.FILLED}
@@ -44,16 +45,127 @@ export const PrimaryFilledDualIcon = () => (
     secondaryIconType="chevron-up"
   />
 );
+// end primary filled
+
+// start primary filled reverse
+export const PrimaryFilledReverseLabel = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+    buttonType={BUTTON_TYPES.LABEL_ONLY}
+    text="Sign up"
+  />
+);
+
+export const PrimaryFilledReverseIconAndLabel = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+    buttonType={BUTTON_TYPES.LABEL_AND_ICON}
+    iconType="user"
+    text="Sign up"
+  />
+);
+
+export const PrimaryFilledReverseIcon = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+    buttonType={BUTTON_TYPES.ICON_ONLY}
+    iconType="user"
+    ariaLabel="Sign up"
+  />
+);
+
+export const PrimaryFilledReverseDualIcon = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+    buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
+    iconType="user"
+    text="Sign up"
+    secondaryIconType="chevron-up"
+  />
+);
+// end primary filled reverse
+
+// start secondary outline
+export const SecondaryOutlineLabel = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
+    buttonType={BUTTON_TYPES.LABEL_ONLY}
+    text="Sign up"
+  />
+);
+
+export const SecondaryOutlineIconAndLabel = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
+    buttonType={BUTTON_TYPES.LABEL_AND_ICON}
+    iconType="user"
+    text="Sign up"
+  />
+);
+
+export const SecondaryOutlineIcon = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
+    buttonType={BUTTON_TYPES.ICON_ONLY}
+    iconType="user"
+    ariaLabel="Sign up"
+  />
+);
+
+export const SecondaryOutlineDualIcon = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
+    buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
+    iconType="user"
+    text="Sign up"
+    secondaryIconType="chevron-up"
+  />
+);
+// end secondary outline
+
+// start secondary outline reverse
+export const SecondaryOutlineReverseLabel = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE}
+    buttonType={BUTTON_TYPES.LABEL_ONLY}
+    text="Sign up"
+  />
+);
+
+export const SecondaryOutlineReverseIconAndLabel = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE}
+    buttonType={BUTTON_TYPES.LABEL_AND_ICON}
+    iconType="user"
+    text="Sign up"
+  />
+);
+
+export const SecondaryOutlineReverseIcon = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE}
+    buttonType={BUTTON_TYPES.ICON_ONLY}
+    iconType="user"
+    ariaLabel="Sign up"
+  />
+);
+
+export const SecondaryOutlineReverseDualIcon = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE}
+    buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
+    iconType="user"
+    text="Sign up"
+    secondaryIconType="chevron-up"
+  />
+);
+// end secondary outline reverse
 
 export const Outlined = () => (
   <Button
     buttonStyle={BUTTON_STYLES.OUTLINED}
     text="Sign up"
   />
-);
-
-export const WhiteBackgroundFilled = () => (
-  <Button buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED} text="Sign up" />
 );
 
 export const OutlineSmall = () => (

--- a/blocks/shared-styles/_children/button/index.story.jsx
+++ b/blocks/shared-styles/_children/button/index.story.jsx
@@ -161,30 +161,17 @@ export const SecondaryReverseDualIcon = () => (
 );
 // end secondary reverse
 
-export const Outlined = () => (
+export const PrimarySmall = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.OUTLINED}
+    buttonStyle={BUTTON_STYLES.PRIMARY}
+    buttonSize={BUTTON_SIZES.SMALL}
     text="Sign up"
   />
 );
 
-export const OutlineSmall = () => (
-  <Button buttonStyle={BUTTON_STYLES.OUTLINED} buttonSize={BUTTON_SIZES.SMALL} text="Sign up" />
-);
-
-// outlined medium button
-export const OutlinedMedium = () => (
+export const PrimaryLarge = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.OUTLINED}
-    buttonSize={BUTTON_SIZES.MEDIUM}
-    text="Sign up"
-  />
-);
-
-// outlined large button
-export const OutlinedLarge = () => (
-  <Button
-    buttonStyle={BUTTON_STYLES.OUTLINED}
+    buttonStyle={BUTTON_STYLES.PRIMARY}
     buttonSize={BUTTON_SIZES.LARGE}
     text="Sign up"
   />
@@ -193,40 +180,6 @@ export const OutlinedLarge = () => (
 export const LongText = () => (
   <Button
     text="Sign up to get the very best experience and this other really long work and such and more and even more text.Sign up to get the very best experience and this other really long work and such and more and even more text."
-  />
-);
-
-export const UserIconWithLabelOutline = () => (
-  <Button
-    buttonStyle={BUTTON_STYLES.OUTLINED}
-    buttonSize={BUTTON_SIZES.LARGE}
-    text="Sign up"
-    iconType="user"
-  />
-);
-
-export const IconOnlyOutlined = () => (
-  <Button
-    buttonType={BUTTON_TYPES.ICON_ONLY}
-    text="Sign up"
-    iconType="user"
-    buttonStyle={BUTTON_STYLES.OUTLINED}
-  />
-);
-
-export const IconWithLabel = () => (
-  <Button
-    buttonType={BUTTON_TYPES.LABEL_AND_ICON}
-    text="Sign up"
-    iconType="user"
-    buttonStyle={BUTTON_STYLES.OUTLINED}
-  />
-);
-
-export const LabelOnly = () => (
-  <Button
-    buttonType={BUTTON_TYPES.LABEL_ONLY}
-    text="Sign up"
   />
 );
 
@@ -256,15 +209,5 @@ export const aLinkButton = () => (
     text="Type Reset"
     as="a"
     href="https://arcxp.com"
-  />
-);
-
-export const dualIconButton = () => (
-  <Button
-    text="Two icons"
-    buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
-    buttonStyle={BUTTON_STYLES.OUTLINED}
-    iconType="user"
-    secondaryIconType="chevron-up"
   />
 );

--- a/blocks/shared-styles/_children/button/index.story.jsx
+++ b/blocks/shared-styles/_children/button/index.story.jsx
@@ -86,7 +86,7 @@ export const PrimaryReverseDualIcon = () => (
 // end primary reverse
 
 // start secondary
-export const SecondaryOutlineLabel = () => (
+export const SecondaryLabel = () => (
   <Button
     buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
     buttonType={BUTTON_TYPES.LABEL_ONLY}
@@ -94,7 +94,7 @@ export const SecondaryOutlineLabel = () => (
   />
 );
 
-export const SecondaryOutlineIconAndLabel = () => (
+export const SecondaryIconAndLabel = () => (
   <Button
     buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
     buttonType={BUTTON_TYPES.LABEL_AND_ICON}
@@ -103,7 +103,7 @@ export const SecondaryOutlineIconAndLabel = () => (
   />
 );
 
-export const SecondaryOutlineIcon = () => (
+export const SecondaryIcon = () => (
   <Button
     buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
     buttonType={BUTTON_TYPES.ICON_ONLY}
@@ -112,7 +112,7 @@ export const SecondaryOutlineIcon = () => (
   />
 );
 
-export const SecondaryOutlineDualIcon = () => (
+export const SecondaryDualIcon = () => (
   <Button
     buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
     buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
@@ -124,35 +124,35 @@ export const SecondaryOutlineDualIcon = () => (
 // end secondary
 
 // start secondary reverse
-export const SecondaryOutlineReverseLabel = () => (
+export const SecondaryReverseLabel = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE}
+    buttonStyle={BUTTON_STYLES.SECONDARY_REVERSE}
     buttonType={BUTTON_TYPES.LABEL_ONLY}
     text="Sign up"
   />
 );
 
-export const SecondaryOutlineReverseIconAndLabel = () => (
+export const SecondaryReverseIconAndLabel = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE}
+    buttonStyle={BUTTON_STYLES.SECONDARY_REVERSE}
     buttonType={BUTTON_TYPES.LABEL_AND_ICON}
     iconType="user"
     text="Sign up"
   />
 );
 
-export const SecondaryOutlineReverseIcon = () => (
+export const SecondaryReverseIcon = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE}
+    buttonStyle={BUTTON_STYLES.SECONDARY_REVERSE}
     buttonType={BUTTON_TYPES.ICON_ONLY}
     iconType="user"
     ariaLabel="Sign up"
   />
 );
 
-export const SecondaryOutlineReverseDualIcon = () => (
+export const SecondaryReverseDualIcon = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE}
+    buttonStyle={BUTTON_STYLES.SECONDARY_REVERSE}
     buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
     iconType="user"
     text="Sign up"

--- a/blocks/shared-styles/_children/button/index.story.jsx
+++ b/blocks/shared-styles/_children/button/index.story.jsx
@@ -88,7 +88,7 @@ export const PrimaryReverseDualIcon = () => (
 // start secondary
 export const SecondaryLabel = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
+    buttonStyle={BUTTON_STYLES.SECONDARY}
     buttonType={BUTTON_TYPES.LABEL_ONLY}
     text="Sign up"
   />
@@ -96,7 +96,7 @@ export const SecondaryLabel = () => (
 
 export const SecondaryIconAndLabel = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
+    buttonStyle={BUTTON_STYLES.SECONDARY}
     buttonType={BUTTON_TYPES.LABEL_AND_ICON}
     iconType="user"
     text="Sign up"
@@ -105,7 +105,7 @@ export const SecondaryIconAndLabel = () => (
 
 export const SecondaryIcon = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
+    buttonStyle={BUTTON_STYLES.SECONDARY}
     buttonType={BUTTON_TYPES.ICON_ONLY}
     iconType="user"
     ariaLabel="Sign up"
@@ -114,7 +114,7 @@ export const SecondaryIcon = () => (
 
 export const SecondaryDualIcon = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
+    buttonStyle={BUTTON_STYLES.SECONDARY}
     buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
     iconType="user"
     text="Sign up"

--- a/blocks/shared-styles/_children/button/index.story.jsx
+++ b/blocks/shared-styles/_children/button/index.story.jsx
@@ -9,12 +9,47 @@ export default {
   },
 };
 
-export const Filled = () => (
-  <Button buttonStyle={BUTTON_STYLES.FILLED} text="Sign up" />
+export const PrimaryFilledLabel = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.FILLED}
+    buttonTypes={BUTTON_TYPES.LABEL_ONLY}
+    text="Sign up"
+  />
+);
+
+export const PrimaryFilledIconAndLabel = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.FILLED}
+    buttonType={BUTTON_TYPES.LABEL_AND_ICON}
+    iconType="user"
+    text="Sign up"
+  />
+);
+
+export const PrimaryFilledIcon = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.FILLED}
+    buttonType={BUTTON_TYPES.ICON_ONLY}
+    iconType="user"
+    ariaLabel="Sign up"
+  />
+);
+
+export const PrimaryFilledDualIcon = () => (
+  <Button
+    buttonStyle={BUTTON_STYLES.FILLED}
+    buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
+    iconType="user"
+    text="Sign up"
+    secondaryIconType="chevron-up"
+  />
 );
 
 export const Outlined = () => (
-  <Button buttonStyle={BUTTON_STYLES.OUTLINED} text="Sign up" />
+  <Button
+    buttonStyle={BUTTON_STYLES.OUTLINED}
+    text="Sign up"
+  />
 );
 
 export const WhiteBackgroundFilled = () => (

--- a/blocks/shared-styles/_children/button/index.story.jsx
+++ b/blocks/shared-styles/_children/button/index.story.jsx
@@ -47,45 +47,45 @@ export const PrimaryDualIcon = () => (
 );
 // end primary
 
-// start primary filled reverse
-export const PrimaryFilledReverseLabel = () => (
+// start primary reverse
+export const PrimaryReverseLabel = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+    buttonStyle={BUTTON_STYLES.PRIMARY_REVERSE}
     buttonType={BUTTON_TYPES.LABEL_ONLY}
     text="Sign up"
   />
 );
 
-export const PrimaryFilledReverseIconAndLabel = () => (
+export const PrimaryReverseIconAndLabel = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+    buttonStyle={BUTTON_STYLES.PRIMARY_REVERSE}
     buttonType={BUTTON_TYPES.LABEL_AND_ICON}
     iconType="user"
     text="Sign up"
   />
 );
 
-export const PrimaryFilledReverseIcon = () => (
+export const PrimaryReverseIcon = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+    buttonStyle={BUTTON_STYLES.PRIMARY_REVERSE}
     buttonType={BUTTON_TYPES.ICON_ONLY}
     iconType="user"
     ariaLabel="Sign up"
   />
 );
 
-export const PrimaryFilledReverseDualIcon = () => (
+export const PrimaryReverseDualIcon = () => (
   <Button
-    buttonStyle={BUTTON_STYLES.WHITE_BACKGROUND_FILLED}
+    buttonStyle={BUTTON_STYLES.PRIMARY_REVERSE}
     buttonType={BUTTON_TYPES.LABEL_AND_TWO_ICONS}
     iconType="user"
     text="Sign up"
     secondaryIconType="chevron-up"
   />
 );
-// end primary filled reverse
+// end primary reverse
 
-// start secondary outline
+// start secondary
 export const SecondaryOutlineLabel = () => (
   <Button
     buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE}
@@ -121,9 +121,9 @@ export const SecondaryOutlineDualIcon = () => (
     secondaryIconType="chevron-up"
   />
 );
-// end secondary outline
+// end secondary
 
-// start secondary outline reverse
+// start secondary reverse
 export const SecondaryOutlineReverseLabel = () => (
   <Button
     buttonStyle={BUTTON_STYLES.SECONDARY_OUTLINE_REVERSE}
@@ -159,7 +159,7 @@ export const SecondaryOutlineReverseDualIcon = () => (
     secondaryIconType="chevron-up"
   />
 );
-// end secondary outline reverse
+// end secondary reverse
 
 export const Outlined = () => (
   <Button

--- a/blocks/shared-styles/_children/button/utils/getButtonStyle.js
+++ b/blocks/shared-styles/_children/button/utils/getButtonStyle.js
@@ -1,0 +1,22 @@
+import { BUTTON_STYLES } from '../index';
+
+function getNavSpecificPrimaryButtonTheme(navColor, navBarBackground) {
+  if (navBarBackground === 'primary-color') {
+    return BUTTON_STYLES.PRIMARY_REVERSE;
+  }
+
+  return navColor === 'dark' ? BUTTON_STYLES.DEFAULT : BUTTON_STYLES.PRIMARY;
+}
+
+function getNavSpecificSecondaryButtonTheme(navColor, navBarBackground) {
+  if (navBarBackground === 'primary-color' || navColor === 'dark') {
+    return BUTTON_STYLES.SECONDARY_REVERSE;
+  }
+
+  return BUTTON_STYLES.SECONDARY;
+}
+
+export {
+  getNavSpecificSecondaryButtonTheme,
+  getNavSpecificPrimaryButtonTheme,
+};

--- a/blocks/shared-styles/index.js
+++ b/blocks/shared-styles/index.js
@@ -16,6 +16,10 @@ import SmallPromoPresentation from './_children/promos/small';
 import SmallPromoStyles from './_children/promo-helpers/small/styles';
 import ExtraLargePromoPresentation from './_children/promos/extra-large';
 import LargePromoPresentation from './_children/promos/large';
+import {
+  getNavSpecificSecondaryButtonTheme,
+  getNavSpecificPrimaryButtonTheme,
+} from './_children/button/utils/getButtonStyle';
 
 export {
   BUTTON_SIZES,
@@ -39,4 +43,6 @@ export {
   SmallPromoContainer,
   SmallPromoPresentation,
   SmallPromoStyles,
+  getNavSpecificSecondaryButtonTheme,
+  getNavSpecificPrimaryButtonTheme,
 };

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -99,29 +99,6 @@ body.nav-open {
   }
 }
 
-.nav-sections-btn {
-  align-items: center;
-  display: flex;
-
-  @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
-    margin: 0;
-
-    span {
-      display: none;
-    }
-  }
-
-  > span,
-  > img {
-    flex: 0;
-  }
-
-  > span {
-    font-size: calculateRem(14px);
-    font-weight: bold;
-    padding-right: 8px;
-  }
-}
 
 .nav-search {
   align-items: center;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1788,6 +1788,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "@discoveryjs/json-ext": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
+      "integrity": "sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==",
+      "dev": true
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -6948,6 +6954,793 @@
         }
       }
     },
+    "@storybook/addon-actions": {
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.3.8.tgz",
+      "integrity": "sha512-Z6nnxD+pFZ9W/WL8A+53OTTGdRHybdomEgsMaETW4AoNjTOpFu1zY66ah7ENXcQkTT+SuY7yediwxwaGuL1H+g==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.3.8",
+        "@storybook/api": "6.3.8",
+        "@storybook/client-api": "6.3.8",
+        "@storybook/components": "6.3.8",
+        "@storybook/core-events": "6.3.8",
+        "@storybook/theming": "6.3.8",
+        "core-js": "^3.8.2",
+        "fast-deep-equal": "^3.1.3",
+        "global": "^4.4.0",
+        "lodash": "^4.17.20",
+        "polished": "^4.0.5",
+        "prop-types": "^15.7.2",
+        "react-inspector": "^5.1.0",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2",
+        "uuid-browser": "^3.1.0"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.3.8.tgz",
+          "integrity": "sha512-TzYk1f/wvfoGDkLxXIx85ii5ED7IfGP/6eu00/i2Hyn4uGqdNi/ltSOJxnxa+DZv8KjYQRVAEo/Fbh95IEXI1Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/router": "6.3.8",
+            "@storybook/theming": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.3.8.tgz",
+          "integrity": "sha512-8b61KnWhN+sA+Gq+AHH3M4qM0L8pNS9DtdfPi5GUGWzOg6IZ1EgYVsk9afEwkNESxyZ+GM2O6mGu05J0HfyqNg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.3.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channel-postmessage": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.8.tgz",
+          "integrity": "sha512-wI08nip2cQBIs1g+i609dDldQsOuSvnGWecWMiE9FwSvWttAyK61Zdph36UhiNzNjCeNdN5nf5qyVFaxZLGXIA==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "qs": "^6.10.0",
+            "telejson": "^5.3.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.3.8.tgz",
+          "integrity": "sha512-+bjIb5rPTglbhLgGywDoKK25x9ClCMV29fd/fiF86rXQlfxq6J+or6ars6p97gS2/J1wgRbh+Yf3WkLNQx7s6A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.8.tgz",
+          "integrity": "sha512-71HT0K1lswyMSkRRgB1+TGu7X6kFazmoXT3t5wkU6NWIflEngiiJ3w+PMpOGzd6E3Gp3ZOvfkfrzaby5VlBORw==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.3.8",
+            "@storybook/channel-postmessage": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@types/qs": "^6.9.5",
+            "@types/webpack-env": "^1.16.0",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "stable": "^0.1.8",
+            "store2": "^2.12.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.3.8.tgz",
+          "integrity": "sha512-d/65629nvnlDpeubcElTypHuSvOqxNTNKnuN0oKDM8BsE0EO5rhTfzrx2vhiSW8At8MuD1eFC19BWdCZV18Edg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.3.8.tgz",
+          "integrity": "sha512-zIvCk7MAL9z17EI58h7WE/TgFTm0njGwFkQrbXOgGkkKYoFt/yrrs8HqylcqBqfTivJNiXJNnmmx0ooJ83PIwA==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.6.0",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.3.8",
+            "@types/color-convert": "^2.0.0",
+            "@types/overlayscrollbars": "^1.12.0",
+            "@types/react-syntax-highlighter": "11.0.5",
+            "color-convert": "^2.0.1",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "markdown-to-jsx": "^7.1.3",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.13.1",
+            "polished": "^4.0.5",
+            "prop-types": "^15.7.2",
+            "react-colorful": "^5.1.2",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.3",
+            "react-textarea-autosize": "^8.3.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.8.tgz",
+          "integrity": "sha512-M3d2iX842YfopqmOHlXzL/Xy4fICzaRnet99GdfOqWjZhC2CVSemVk1b/vgfQv4MFYOQkSLsAjkbDH/kU8n9Aw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.3.8.tgz",
+          "integrity": "sha512-CafRmHtkwa8CQETum0RaspSExt8mrFsoYZSyrVSWqOyGG048MT3ocCPRsSueor17h+Q5neKamrPVN1jAdSilDg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/client-logger": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.3.8.tgz",
+          "integrity": "sha512-Np51rvecnuHNevZ7Em0uElT5UkgASP5K2u8NpHcCxP/Hd73wxS/h//6XnjA9Aich7h/JanG71jAC3qqhZabatA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.3.8",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.17.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
+          "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+          "dev": true
+        },
+        "markdown-to-jsx": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
+          "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        }
+      }
+    },
+    "@storybook/addon-backgrounds": {
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-6.3.8.tgz",
+      "integrity": "sha512-HxyeNfaJi5E0wfCxQhooT6OKEWRU+ukw80nvkuvlM9vuGoxHE4mVCa7oBFk6Ftjwev6njES1c/u8EpuqbRYeZg==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.3.8",
+        "@storybook/api": "6.3.8",
+        "@storybook/client-logger": "6.3.8",
+        "@storybook/components": "6.3.8",
+        "@storybook/core-events": "6.3.8",
+        "@storybook/theming": "6.3.8",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.3.8.tgz",
+          "integrity": "sha512-TzYk1f/wvfoGDkLxXIx85ii5ED7IfGP/6eu00/i2Hyn4uGqdNi/ltSOJxnxa+DZv8KjYQRVAEo/Fbh95IEXI1Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/router": "6.3.8",
+            "@storybook/theming": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.3.8.tgz",
+          "integrity": "sha512-8b61KnWhN+sA+Gq+AHH3M4qM0L8pNS9DtdfPi5GUGWzOg6IZ1EgYVsk9afEwkNESxyZ+GM2O6mGu05J0HfyqNg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.3.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.3.8.tgz",
+          "integrity": "sha512-+bjIb5rPTglbhLgGywDoKK25x9ClCMV29fd/fiF86rXQlfxq6J+or6ars6p97gS2/J1wgRbh+Yf3WkLNQx7s6A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.3.8.tgz",
+          "integrity": "sha512-d/65629nvnlDpeubcElTypHuSvOqxNTNKnuN0oKDM8BsE0EO5rhTfzrx2vhiSW8At8MuD1eFC19BWdCZV18Edg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.3.8.tgz",
+          "integrity": "sha512-zIvCk7MAL9z17EI58h7WE/TgFTm0njGwFkQrbXOgGkkKYoFt/yrrs8HqylcqBqfTivJNiXJNnmmx0ooJ83PIwA==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.6.0",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.3.8",
+            "@types/color-convert": "^2.0.0",
+            "@types/overlayscrollbars": "^1.12.0",
+            "@types/react-syntax-highlighter": "11.0.5",
+            "color-convert": "^2.0.1",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "markdown-to-jsx": "^7.1.3",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.13.1",
+            "polished": "^4.0.5",
+            "prop-types": "^15.7.2",
+            "react-colorful": "^5.1.2",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.3",
+            "react-textarea-autosize": "^8.3.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.8.tgz",
+          "integrity": "sha512-M3d2iX842YfopqmOHlXzL/Xy4fICzaRnet99GdfOqWjZhC2CVSemVk1b/vgfQv4MFYOQkSLsAjkbDH/kU8n9Aw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.3.8.tgz",
+          "integrity": "sha512-CafRmHtkwa8CQETum0RaspSExt8mrFsoYZSyrVSWqOyGG048MT3ocCPRsSueor17h+Q5neKamrPVN1jAdSilDg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/client-logger": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.3.8.tgz",
+          "integrity": "sha512-Np51rvecnuHNevZ7Em0uElT5UkgASP5K2u8NpHcCxP/Hd73wxS/h//6XnjA9Aich7h/JanG71jAC3qqhZabatA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.3.8",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.17.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
+          "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+          "dev": true
+        },
+        "markdown-to-jsx": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
+          "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        }
+      }
+    },
+    "@storybook/addon-controls": {
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-6.3.8.tgz",
+      "integrity": "sha512-fOG+0gvhX7lbJbt0uqy1C2NCraJalE573/zUmSAwa8PQ3woritdpdn+XpV3H84c5+SpCCptZkBkxlfGLuwI1sw==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.3.8",
+        "@storybook/api": "6.3.8",
+        "@storybook/client-api": "6.3.8",
+        "@storybook/components": "6.3.8",
+        "@storybook/node-logger": "6.3.8",
+        "@storybook/theming": "6.3.8",
+        "core-js": "^3.8.2",
+        "ts-dedent": "^2.0.0"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.3.8.tgz",
+          "integrity": "sha512-TzYk1f/wvfoGDkLxXIx85ii5ED7IfGP/6eu00/i2Hyn4uGqdNi/ltSOJxnxa+DZv8KjYQRVAEo/Fbh95IEXI1Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/router": "6.3.8",
+            "@storybook/theming": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.3.8.tgz",
+          "integrity": "sha512-8b61KnWhN+sA+Gq+AHH3M4qM0L8pNS9DtdfPi5GUGWzOg6IZ1EgYVsk9afEwkNESxyZ+GM2O6mGu05J0HfyqNg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.3.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channel-postmessage": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.8.tgz",
+          "integrity": "sha512-wI08nip2cQBIs1g+i609dDldQsOuSvnGWecWMiE9FwSvWttAyK61Zdph36UhiNzNjCeNdN5nf5qyVFaxZLGXIA==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "qs": "^6.10.0",
+            "telejson": "^5.3.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.3.8.tgz",
+          "integrity": "sha512-+bjIb5rPTglbhLgGywDoKK25x9ClCMV29fd/fiF86rXQlfxq6J+or6ars6p97gS2/J1wgRbh+Yf3WkLNQx7s6A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.8.tgz",
+          "integrity": "sha512-71HT0K1lswyMSkRRgB1+TGu7X6kFazmoXT3t5wkU6NWIflEngiiJ3w+PMpOGzd6E3Gp3ZOvfkfrzaby5VlBORw==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.3.8",
+            "@storybook/channel-postmessage": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@types/qs": "^6.9.5",
+            "@types/webpack-env": "^1.16.0",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "stable": "^0.1.8",
+            "store2": "^2.12.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.3.8.tgz",
+          "integrity": "sha512-d/65629nvnlDpeubcElTypHuSvOqxNTNKnuN0oKDM8BsE0EO5rhTfzrx2vhiSW8At8MuD1eFC19BWdCZV18Edg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.3.8.tgz",
+          "integrity": "sha512-zIvCk7MAL9z17EI58h7WE/TgFTm0njGwFkQrbXOgGkkKYoFt/yrrs8HqylcqBqfTivJNiXJNnmmx0ooJ83PIwA==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.6.0",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.3.8",
+            "@types/color-convert": "^2.0.0",
+            "@types/overlayscrollbars": "^1.12.0",
+            "@types/react-syntax-highlighter": "11.0.5",
+            "color-convert": "^2.0.1",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "markdown-to-jsx": "^7.1.3",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.13.1",
+            "polished": "^4.0.5",
+            "prop-types": "^15.7.2",
+            "react-colorful": "^5.1.2",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.3",
+            "react-textarea-autosize": "^8.3.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.8.tgz",
+          "integrity": "sha512-M3d2iX842YfopqmOHlXzL/Xy4fICzaRnet99GdfOqWjZhC2CVSemVk1b/vgfQv4MFYOQkSLsAjkbDH/kU8n9Aw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.3.8.tgz",
+          "integrity": "sha512-NDXLcvEepnsVGnnhNgRa1SuedPrHJpbi3rubJENCwAy1fD3oB8HIkSCVHaml/htaQXVp6CGMWy02l5iGCVN4ZA==",
+          "dev": true,
+          "requires": {
+            "@types/npmlog": "^4.1.2",
+            "chalk": "^4.1.0",
+            "core-js": "^3.8.2",
+            "npmlog": "^4.1.2",
+            "pretty-hrtime": "^1.0.3"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.3.8.tgz",
+          "integrity": "sha512-CafRmHtkwa8CQETum0RaspSExt8mrFsoYZSyrVSWqOyGG048MT3ocCPRsSueor17h+Q5neKamrPVN1jAdSilDg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/client-logger": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.3.8.tgz",
+          "integrity": "sha512-Np51rvecnuHNevZ7Em0uElT5UkgASP5K2u8NpHcCxP/Hd73wxS/h//6XnjA9Aich7h/JanG71jAC3qqhZabatA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.3.8",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.17.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
+          "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "markdown-to-jsx": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
+          "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@storybook/addon-docs": {
       "version": "6.3.6",
       "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.3.6.tgz",
@@ -7281,6 +8074,1091 @@
         }
       }
     },
+    "@storybook/addon-essentials": {
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-6.3.8.tgz",
+      "integrity": "sha512-8PuXH289gjR0MuRKVfSz38i4kYKSZB3p5z1a+IBqqZBXM6Hujlu4zQE0r9u5qOo7KHT5C/SKWCkn9ZBU9+lSUA==",
+      "dev": true,
+      "requires": {
+        "@storybook/addon-actions": "6.3.8",
+        "@storybook/addon-backgrounds": "6.3.8",
+        "@storybook/addon-controls": "6.3.8",
+        "@storybook/addon-docs": "6.3.8",
+        "@storybook/addon-measure": "^2.0.0",
+        "@storybook/addon-toolbars": "6.3.8",
+        "@storybook/addon-viewport": "6.3.8",
+        "@storybook/addons": "6.3.8",
+        "@storybook/api": "6.3.8",
+        "@storybook/node-logger": "6.3.8",
+        "core-js": "^3.8.2",
+        "regenerator-runtime": "^0.13.7",
+        "storybook-addon-outline": "^1.4.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz",
+          "integrity": "sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-compilation-targets": "^7.13.0",
+            "@babel/helper-module-imports": "^7.12.13",
+            "@babel/helper-plugin-utils": "^7.13.0",
+            "@babel/traverse": "^7.13.0",
+            "debug": "^4.1.1",
+            "lodash.debounce": "^4.0.8",
+            "resolve": "^1.14.2",
+            "semver": "^6.1.2"
+          }
+        },
+        "@storybook/addon-docs": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.3.8.tgz",
+          "integrity": "sha512-STm2dkX3Cx5w7GMKImujluqXfQxkXnta7TbOzuf49sd04rWpKWiG6KnDFPa6lPvUT8xus3oZedyX3lN2Q2x8bA==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.10",
+            "@babel/generator": "^7.12.11",
+            "@babel/parser": "^7.12.11",
+            "@babel/plugin-transform-react-jsx": "^7.12.12",
+            "@babel/preset-env": "^7.12.11",
+            "@jest/transform": "^26.6.2",
+            "@mdx-js/loader": "^1.6.22",
+            "@mdx-js/mdx": "^1.6.22",
+            "@mdx-js/react": "^1.6.22",
+            "@storybook/addons": "6.3.8",
+            "@storybook/api": "6.3.8",
+            "@storybook/builder-webpack4": "6.3.8",
+            "@storybook/client-api": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/components": "6.3.8",
+            "@storybook/core": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/csf-tools": "6.3.8",
+            "@storybook/node-logger": "6.3.8",
+            "@storybook/postinstall": "6.3.8",
+            "@storybook/source-loader": "6.3.8",
+            "@storybook/theming": "6.3.8",
+            "acorn": "^7.4.1",
+            "acorn-jsx": "^5.3.1",
+            "acorn-walk": "^7.2.0",
+            "core-js": "^3.8.2",
+            "doctrine": "^3.0.0",
+            "escodegen": "^2.0.0",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "html-tags": "^3.1.0",
+            "js-string-escape": "^1.0.1",
+            "loader-utils": "^2.0.0",
+            "lodash": "^4.17.20",
+            "p-limit": "^3.1.0",
+            "prettier": "~2.2.1",
+            "prop-types": "^15.7.2",
+            "react-element-to-jsx-string": "^14.3.2",
+            "regenerator-runtime": "^0.13.7",
+            "remark-external-links": "^8.0.0",
+            "remark-slug": "^6.0.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/addons": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.3.8.tgz",
+          "integrity": "sha512-TzYk1f/wvfoGDkLxXIx85ii5ED7IfGP/6eu00/i2Hyn4uGqdNi/ltSOJxnxa+DZv8KjYQRVAEo/Fbh95IEXI1Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/router": "6.3.8",
+            "@storybook/theming": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.3.8.tgz",
+          "integrity": "sha512-8b61KnWhN+sA+Gq+AHH3M4qM0L8pNS9DtdfPi5GUGWzOg6IZ1EgYVsk9afEwkNESxyZ+GM2O6mGu05J0HfyqNg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.3.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/builder-webpack4": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/builder-webpack4/-/builder-webpack4-6.3.8.tgz",
+          "integrity": "sha512-Ze/3JRPKwPogKbJJ5Fm4/BJdMbNiqu7DpFQw9s4gBcecBRK0xlfhYaMrPqMS21kEQ2+gr2HPyGRkdoJUAVHXhQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.10",
+            "@babel/plugin-proposal-class-properties": "^7.12.1",
+            "@babel/plugin-proposal-decorators": "^7.12.12",
+            "@babel/plugin-proposal-export-default-from": "^7.12.1",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+            "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+            "@babel/plugin-proposal-optional-chaining": "^7.12.7",
+            "@babel/plugin-proposal-private-methods": "^7.12.1",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-arrow-functions": "^7.12.1",
+            "@babel/plugin-transform-block-scoping": "^7.12.12",
+            "@babel/plugin-transform-classes": "^7.12.1",
+            "@babel/plugin-transform-destructuring": "^7.12.1",
+            "@babel/plugin-transform-for-of": "^7.12.1",
+            "@babel/plugin-transform-parameters": "^7.12.1",
+            "@babel/plugin-transform-shorthand-properties": "^7.12.1",
+            "@babel/plugin-transform-spread": "^7.12.1",
+            "@babel/plugin-transform-template-literals": "^7.12.1",
+            "@babel/preset-env": "^7.12.11",
+            "@babel/preset-react": "^7.12.10",
+            "@babel/preset-typescript": "^7.12.7",
+            "@storybook/addons": "6.3.8",
+            "@storybook/api": "6.3.8",
+            "@storybook/channel-postmessage": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-api": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/components": "6.3.8",
+            "@storybook/core-common": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/node-logger": "6.3.8",
+            "@storybook/router": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.3.8",
+            "@storybook/ui": "6.3.8",
+            "@types/node": "^14.0.10",
+            "@types/webpack": "^4.41.26",
+            "autoprefixer": "^9.8.6",
+            "babel-loader": "^8.2.2",
+            "babel-plugin-macros": "^2.8.0",
+            "babel-plugin-polyfill-corejs3": "^0.1.0",
+            "case-sensitive-paths-webpack-plugin": "^2.3.0",
+            "core-js": "^3.8.2",
+            "css-loader": "^3.6.0",
+            "dotenv-webpack": "^1.8.0",
+            "file-loader": "^6.2.0",
+            "find-up": "^5.0.0",
+            "fork-ts-checker-webpack-plugin": "^4.1.6",
+            "fs-extra": "^9.0.1",
+            "glob": "^7.1.6",
+            "glob-promise": "^3.4.0",
+            "global": "^4.4.0",
+            "html-webpack-plugin": "^4.0.0",
+            "pnp-webpack-plugin": "1.6.4",
+            "postcss": "^7.0.36",
+            "postcss-flexbugs-fixes": "^4.2.1",
+            "postcss-loader": "^4.2.0",
+            "raw-loader": "^4.0.2",
+            "react-dev-utils": "^11.0.3",
+            "stable": "^0.1.8",
+            "style-loader": "^1.3.0",
+            "terser-webpack-plugin": "^4.2.3",
+            "ts-dedent": "^2.0.0",
+            "url-loader": "^4.1.1",
+            "util-deprecate": "^1.0.2",
+            "webpack": "4",
+            "webpack-dev-middleware": "^3.7.3",
+            "webpack-filter-warnings-plugin": "^1.2.1",
+            "webpack-hot-middleware": "^2.25.0",
+            "webpack-virtual-modules": "^0.2.2"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+              "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+              }
+            }
+          }
+        },
+        "@storybook/channel-postmessage": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.8.tgz",
+          "integrity": "sha512-wI08nip2cQBIs1g+i609dDldQsOuSvnGWecWMiE9FwSvWttAyK61Zdph36UhiNzNjCeNdN5nf5qyVFaxZLGXIA==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "qs": "^6.10.0",
+            "telejson": "^5.3.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.3.8.tgz",
+          "integrity": "sha512-+bjIb5rPTglbhLgGywDoKK25x9ClCMV29fd/fiF86rXQlfxq6J+or6ars6p97gS2/J1wgRbh+Yf3WkLNQx7s6A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.8.tgz",
+          "integrity": "sha512-71HT0K1lswyMSkRRgB1+TGu7X6kFazmoXT3t5wkU6NWIflEngiiJ3w+PMpOGzd6E3Gp3ZOvfkfrzaby5VlBORw==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.3.8",
+            "@storybook/channel-postmessage": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@types/qs": "^6.9.5",
+            "@types/webpack-env": "^1.16.0",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "stable": "^0.1.8",
+            "store2": "^2.12.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.3.8.tgz",
+          "integrity": "sha512-d/65629nvnlDpeubcElTypHuSvOqxNTNKnuN0oKDM8BsE0EO5rhTfzrx2vhiSW8At8MuD1eFC19BWdCZV18Edg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.3.8.tgz",
+          "integrity": "sha512-zIvCk7MAL9z17EI58h7WE/TgFTm0njGwFkQrbXOgGkkKYoFt/yrrs8HqylcqBqfTivJNiXJNnmmx0ooJ83PIwA==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.6.0",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.3.8",
+            "@types/color-convert": "^2.0.0",
+            "@types/overlayscrollbars": "^1.12.0",
+            "@types/react-syntax-highlighter": "11.0.5",
+            "color-convert": "^2.0.1",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "markdown-to-jsx": "^7.1.3",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.13.1",
+            "polished": "^4.0.5",
+            "prop-types": "^15.7.2",
+            "react-colorful": "^5.1.2",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.3",
+            "react-textarea-autosize": "^8.3.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.3.8.tgz",
+          "integrity": "sha512-NTPrqX7goy9DnVEqPFvLccjrQ0eHza64ahP75bXo7H5tyVyEDcaI7ynk1l5zkO4+q6Ze9gkRiWIy7Z324kGAMg==",
+          "dev": true,
+          "requires": {
+            "@storybook/core-client": "6.3.8",
+            "@storybook/core-server": "6.3.8"
+          }
+        },
+        "@storybook/core-client": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.3.8.tgz",
+          "integrity": "sha512-ZO1XA8ENnZXpDN+sW0ElQ468QhV1tJuoGyXXeiKNnpOuKe/7e10vXH9B0VsBc1VIpC0S17cWuq1/vUkcb9fm5Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.3.8",
+            "@storybook/channel-postmessage": "6.3.8",
+            "@storybook/client-api": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/ui": "6.3.8",
+            "airbnb-js-shims": "^2.2.1",
+            "ansi-to-html": "^0.6.11",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "unfetch": "^4.2.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-common": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-6.3.8.tgz",
+          "integrity": "sha512-a1buOaYAbs7m8LMeraN9syG9Hp6wePabJoFrcQxwf4EQZcgfwTUkyYarfpsYsy9vFdDzvvANrOYp/fq6Bnx6LA==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.10",
+            "@babel/plugin-proposal-class-properties": "^7.12.1",
+            "@babel/plugin-proposal-decorators": "^7.12.12",
+            "@babel/plugin-proposal-export-default-from": "^7.12.1",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+            "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+            "@babel/plugin-proposal-optional-chaining": "^7.12.7",
+            "@babel/plugin-proposal-private-methods": "^7.12.1",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-arrow-functions": "^7.12.1",
+            "@babel/plugin-transform-block-scoping": "^7.12.12",
+            "@babel/plugin-transform-classes": "^7.12.1",
+            "@babel/plugin-transform-destructuring": "^7.12.1",
+            "@babel/plugin-transform-for-of": "^7.12.1",
+            "@babel/plugin-transform-parameters": "^7.12.1",
+            "@babel/plugin-transform-shorthand-properties": "^7.12.1",
+            "@babel/plugin-transform-spread": "^7.12.1",
+            "@babel/preset-env": "^7.12.11",
+            "@babel/preset-react": "^7.12.10",
+            "@babel/preset-typescript": "^7.12.7",
+            "@babel/register": "^7.12.1",
+            "@storybook/node-logger": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@types/glob-base": "^0.3.0",
+            "@types/micromatch": "^4.0.1",
+            "@types/node": "^14.0.10",
+            "@types/pretty-hrtime": "^1.0.0",
+            "babel-loader": "^8.2.2",
+            "babel-plugin-macros": "^3.0.1",
+            "babel-plugin-polyfill-corejs3": "^0.1.0",
+            "chalk": "^4.1.0",
+            "core-js": "^3.8.2",
+            "express": "^4.17.1",
+            "file-system-cache": "^1.0.5",
+            "find-up": "^5.0.0",
+            "fork-ts-checker-webpack-plugin": "^6.0.4",
+            "glob": "^7.1.6",
+            "glob-base": "^0.3.0",
+            "interpret": "^2.2.0",
+            "json5": "^2.1.3",
+            "lazy-universal-dotenv": "^3.0.1",
+            "micromatch": "^4.0.2",
+            "pkg-dir": "^5.0.0",
+            "pretty-hrtime": "^1.0.3",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2",
+            "webpack": "4"
+          },
+          "dependencies": {
+            "babel-plugin-macros": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+              "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+              }
+            },
+            "find-up": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+              "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "fork-ts-checker-webpack-plugin": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.3.3.tgz",
+              "integrity": "sha512-S3uMSg8IsIvs0H6VAfojtbf6RcnEXxEpDMT2Q41M2l0m20JO8eA1t4cCJybvrasC8SvvPEtK4B8ztxxfLljhNg==",
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.8.3",
+                "@types/json-schema": "^7.0.5",
+                "chalk": "^4.1.0",
+                "chokidar": "^3.4.2",
+                "cosmiconfig": "^6.0.0",
+                "deepmerge": "^4.2.2",
+                "fs-extra": "^9.0.0",
+                "glob": "^7.1.6",
+                "memfs": "^3.1.2",
+                "minimatch": "^3.0.4",
+                "schema-utils": "2.7.0",
+                "semver": "^7.3.2",
+                "tapable": "^1.0.0"
+              },
+              "dependencies": {
+                "cosmiconfig": {
+                  "version": "6.0.0",
+                  "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+                  "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+                  "dev": true,
+                  "requires": {
+                    "@types/parse-json": "^4.0.0",
+                    "import-fresh": "^3.1.0",
+                    "parse-json": "^5.0.0",
+                    "path-type": "^4.0.0",
+                    "yaml": "^1.7.2"
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "7.3.5",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+              "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            }
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.8.tgz",
+          "integrity": "sha512-M3d2iX842YfopqmOHlXzL/Xy4fICzaRnet99GdfOqWjZhC2CVSemVk1b/vgfQv4MFYOQkSLsAjkbDH/kU8n9Aw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/core-server": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-6.3.8.tgz",
+          "integrity": "sha512-9J7cabcGe/h6nH4KnRvnYOwY1EFeNtl1qOVgej1nh70aIhKyRVMRc+d2gsOAmzmePtK6pocJUjm1/t876P9Ekg==",
+          "dev": true,
+          "requires": {
+            "@discoveryjs/json-ext": "^0.5.3",
+            "@storybook/builder-webpack4": "6.3.8",
+            "@storybook/core-client": "6.3.8",
+            "@storybook/core-common": "6.3.8",
+            "@storybook/csf-tools": "6.3.8",
+            "@storybook/manager-webpack4": "6.3.8",
+            "@storybook/node-logger": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@types/node": "^14.0.10",
+            "@types/node-fetch": "^2.5.7",
+            "@types/pretty-hrtime": "^1.0.0",
+            "@types/webpack": "^4.41.26",
+            "better-opn": "^2.1.1",
+            "boxen": "^4.2.0",
+            "chalk": "^4.1.0",
+            "cli-table3": "0.6.0",
+            "commander": "^6.2.1",
+            "compression": "^1.7.4",
+            "core-js": "^3.8.2",
+            "cpy": "^8.1.1",
+            "detect-port": "^1.3.0",
+            "express": "^4.17.1",
+            "file-system-cache": "^1.0.5",
+            "fs-extra": "^9.0.1",
+            "globby": "^11.0.2",
+            "ip": "^1.1.5",
+            "node-fetch": "^2.6.1",
+            "pretty-hrtime": "^1.0.3",
+            "prompts": "^2.4.0",
+            "regenerator-runtime": "^0.13.7",
+            "serve-favicon": "^2.5.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2",
+            "webpack": "4"
+          }
+        },
+        "@storybook/csf-tools": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-6.3.8.tgz",
+          "integrity": "sha512-yY+xN+3TKoUNK0KVAhQNPC3Pf7J0gkmSTOhBwRaPjVKQ3Dy8RE+r/+h9v7rxdmWnl7thdt7tWsjaUdy5DPNLug==",
+          "dev": true,
+          "requires": {
+            "@babel/generator": "^7.12.11",
+            "@babel/parser": "^7.12.11",
+            "@babel/plugin-transform-react-jsx": "^7.12.12",
+            "@babel/preset-env": "^7.12.11",
+            "@babel/traverse": "^7.12.11",
+            "@babel/types": "^7.12.11",
+            "@mdx-js/mdx": "^1.6.22",
+            "@storybook/csf": "^0.0.1",
+            "core-js": "^3.8.2",
+            "fs-extra": "^9.0.1",
+            "js-string-escape": "^1.0.1",
+            "lodash": "^4.17.20",
+            "prettier": "~2.2.1",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/manager-webpack4": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/manager-webpack4/-/manager-webpack4-6.3.8.tgz",
+          "integrity": "sha512-W4t/NIbkNgxbjW/RsjMV4f3gPwY+Rw69GvoIAVurEEyi6dKJa2tQ1XrGOZMhF3PqWDTybOLTopcp9Ici2MJnMA==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.10",
+            "@babel/plugin-transform-template-literals": "^7.12.1",
+            "@babel/preset-react": "^7.12.10",
+            "@storybook/addons": "6.3.8",
+            "@storybook/core-client": "6.3.8",
+            "@storybook/core-common": "6.3.8",
+            "@storybook/node-logger": "6.3.8",
+            "@storybook/theming": "6.3.8",
+            "@storybook/ui": "6.3.8",
+            "@types/node": "^14.0.10",
+            "@types/webpack": "^4.41.26",
+            "babel-loader": "^8.2.2",
+            "case-sensitive-paths-webpack-plugin": "^2.3.0",
+            "chalk": "^4.1.0",
+            "core-js": "^3.8.2",
+            "css-loader": "^3.6.0",
+            "dotenv-webpack": "^1.8.0",
+            "express": "^4.17.1",
+            "file-loader": "^6.2.0",
+            "file-system-cache": "^1.0.5",
+            "find-up": "^5.0.0",
+            "fs-extra": "^9.0.1",
+            "html-webpack-plugin": "^4.0.0",
+            "node-fetch": "^2.6.1",
+            "pnp-webpack-plugin": "1.6.4",
+            "read-pkg-up": "^7.0.1",
+            "regenerator-runtime": "^0.13.7",
+            "resolve-from": "^5.0.0",
+            "style-loader": "^1.3.0",
+            "telejson": "^5.3.2",
+            "terser-webpack-plugin": "^4.2.3",
+            "ts-dedent": "^2.0.0",
+            "url-loader": "^4.1.1",
+            "util-deprecate": "^1.0.2",
+            "webpack": "4",
+            "webpack-dev-middleware": "^3.7.3",
+            "webpack-virtual-modules": "^0.2.2"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+              "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+              }
+            }
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.3.8.tgz",
+          "integrity": "sha512-NDXLcvEepnsVGnnhNgRa1SuedPrHJpbi3rubJENCwAy1fD3oB8HIkSCVHaml/htaQXVp6CGMWy02l5iGCVN4ZA==",
+          "dev": true,
+          "requires": {
+            "@types/npmlog": "^4.1.2",
+            "chalk": "^4.1.0",
+            "core-js": "^3.8.2",
+            "npmlog": "^4.1.2",
+            "pretty-hrtime": "^1.0.3"
+          }
+        },
+        "@storybook/postinstall": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/postinstall/-/postinstall-6.3.8.tgz",
+          "integrity": "sha512-qtU68/G1NGcoJuin84ZAk2VhaXkWbJC622ngTVrYWxVWvvryGk4A7Qscx2R9o5R8zmQVV18HZ5d7bs5g0ibsgA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.3.8.tgz",
+          "integrity": "sha512-CafRmHtkwa8CQETum0RaspSExt8mrFsoYZSyrVSWqOyGG048MT3ocCPRsSueor17h+Q5neKamrPVN1jAdSilDg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/client-logger": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
+          }
+        },
+        "@storybook/source-loader": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.3.8.tgz",
+          "integrity": "sha512-aQ3mrpxpVB2w7sST4jbQUBgHLQZTLD0H1SgohHSuNPz2nrYieuxmOfwjbJr1ZCtuZDCi5xyLjDgUJ3wZ1hPsfQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "core-js": "^3.8.2",
+            "estraverse": "^5.2.0",
+            "global": "^4.4.0",
+            "loader-utils": "^2.0.0",
+            "lodash": "^4.17.20",
+            "prettier": "~2.2.1",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.3.8.tgz",
+          "integrity": "sha512-Np51rvecnuHNevZ7Em0uElT5UkgASP5K2u8NpHcCxP/Hd73wxS/h//6XnjA9Aich7h/JanG71jAC3qqhZabatA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.3.8",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/ui": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-6.3.8.tgz",
+          "integrity": "sha512-R7LlDfRvD/IcARtmGtYAM79ks2HL+nitdfdRpoW8fYZiX3ErfSIScWzzoxRPFqedg64vwOvbIEhXp7N9JDwFZA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@storybook/addons": "6.3.8",
+            "@storybook/api": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/components": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/router": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.3.8",
+            "@types/markdown-to-jsx": "^6.11.3",
+            "copy-to-clipboard": "^3.3.1",
+            "core-js": "^3.8.2",
+            "core-js-pure": "^3.8.2",
+            "downshift": "^6.0.15",
+            "emotion-theming": "^10.0.27",
+            "fuse.js": "^3.6.1",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "markdown-to-jsx": "^6.11.4",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "qs": "^6.10.0",
+            "react-draggable": "^4.4.3",
+            "react-helmet-async": "^1.0.7",
+            "react-sizeme": "^3.0.1",
+            "regenerator-runtime": "^0.13.7",
+            "resolve-from": "^5.0.0",
+            "store2": "^2.12.0"
+          },
+          "dependencies": {
+            "markdown-to-jsx": {
+              "version": "6.11.4",
+              "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
+              "integrity": "sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==",
+              "dev": true,
+              "requires": {
+                "prop-types": "^15.6.2",
+                "unquote": "^1.1.0"
+              }
+            }
+          }
+        },
+        "@types/node": {
+          "version": "14.17.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.17.tgz",
+          "integrity": "sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ==",
+          "dev": true
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "babel-plugin-polyfill-corejs3": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz",
+          "integrity": "sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-define-polyfill-provider": "^0.1.5",
+            "core-js-compat": "^3.8.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.17.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
+          "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "detect-port": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
+          "integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
+          "dev": true,
+          "requires": {
+            "address": "^1.0.1",
+            "debug": "^2.6.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "escodegen": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+          "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+          "dev": true,
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^5.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "globby": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "markdown-to-jsx": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
+          "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "postcss": {
+          "version": "7.0.36",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+              "dev": true
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
     "@storybook/addon-knobs": {
       "version": "6.2.9",
       "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-6.2.9.tgz",
@@ -7327,6 +9205,485 @@
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
           "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
+    "@storybook/addon-measure": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-2.0.0.tgz",
+      "integrity": "sha512-ZhdT++cX+L9LwjhGYggvYUUVQH/MGn2rwbrAwCMzA/f2QTFvkjxzX8nDgMxIhaLCDC+gHIxfJG2wrWN0jkBr3g==",
+      "dev": true
+    },
+    "@storybook/addon-toolbars": {
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-6.3.8.tgz",
+      "integrity": "sha512-jo9w3/TjYSYapSzTluVJzeeATzxf85KpPA/MjuqHl4MvTA1R7ApckZOsfRDcql6xrGEYUfGjUF6MRIicuxojeg==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.3.8",
+        "@storybook/api": "6.3.8",
+        "@storybook/client-api": "6.3.8",
+        "@storybook/components": "6.3.8",
+        "@storybook/theming": "6.3.8",
+        "core-js": "^3.8.2",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.3.8.tgz",
+          "integrity": "sha512-TzYk1f/wvfoGDkLxXIx85ii5ED7IfGP/6eu00/i2Hyn4uGqdNi/ltSOJxnxa+DZv8KjYQRVAEo/Fbh95IEXI1Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/router": "6.3.8",
+            "@storybook/theming": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.3.8.tgz",
+          "integrity": "sha512-8b61KnWhN+sA+Gq+AHH3M4qM0L8pNS9DtdfPi5GUGWzOg6IZ1EgYVsk9afEwkNESxyZ+GM2O6mGu05J0HfyqNg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.3.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channel-postmessage": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.8.tgz",
+          "integrity": "sha512-wI08nip2cQBIs1g+i609dDldQsOuSvnGWecWMiE9FwSvWttAyK61Zdph36UhiNzNjCeNdN5nf5qyVFaxZLGXIA==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "qs": "^6.10.0",
+            "telejson": "^5.3.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.3.8.tgz",
+          "integrity": "sha512-+bjIb5rPTglbhLgGywDoKK25x9ClCMV29fd/fiF86rXQlfxq6J+or6ars6p97gS2/J1wgRbh+Yf3WkLNQx7s6A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.8.tgz",
+          "integrity": "sha512-71HT0K1lswyMSkRRgB1+TGu7X6kFazmoXT3t5wkU6NWIflEngiiJ3w+PMpOGzd6E3Gp3ZOvfkfrzaby5VlBORw==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.3.8",
+            "@storybook/channel-postmessage": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@types/qs": "^6.9.5",
+            "@types/webpack-env": "^1.16.0",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "stable": "^0.1.8",
+            "store2": "^2.12.0",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.3.8.tgz",
+          "integrity": "sha512-d/65629nvnlDpeubcElTypHuSvOqxNTNKnuN0oKDM8BsE0EO5rhTfzrx2vhiSW8At8MuD1eFC19BWdCZV18Edg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.3.8.tgz",
+          "integrity": "sha512-zIvCk7MAL9z17EI58h7WE/TgFTm0njGwFkQrbXOgGkkKYoFt/yrrs8HqylcqBqfTivJNiXJNnmmx0ooJ83PIwA==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.6.0",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.3.8",
+            "@types/color-convert": "^2.0.0",
+            "@types/overlayscrollbars": "^1.12.0",
+            "@types/react-syntax-highlighter": "11.0.5",
+            "color-convert": "^2.0.1",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "markdown-to-jsx": "^7.1.3",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.13.1",
+            "polished": "^4.0.5",
+            "prop-types": "^15.7.2",
+            "react-colorful": "^5.1.2",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.3",
+            "react-textarea-autosize": "^8.3.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.8.tgz",
+          "integrity": "sha512-M3d2iX842YfopqmOHlXzL/Xy4fICzaRnet99GdfOqWjZhC2CVSemVk1b/vgfQv4MFYOQkSLsAjkbDH/kU8n9Aw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.3.8.tgz",
+          "integrity": "sha512-CafRmHtkwa8CQETum0RaspSExt8mrFsoYZSyrVSWqOyGG048MT3ocCPRsSueor17h+Q5neKamrPVN1jAdSilDg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/client-logger": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.3.8.tgz",
+          "integrity": "sha512-Np51rvecnuHNevZ7Em0uElT5UkgASP5K2u8NpHcCxP/Hd73wxS/h//6XnjA9Aich7h/JanG71jAC3qqhZabatA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.3.8",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.17.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
+          "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+          "dev": true
+        },
+        "markdown-to-jsx": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
+          "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        }
+      }
+    },
+    "@storybook/addon-viewport": {
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-6.3.8.tgz",
+      "integrity": "sha512-aHGg1jWqJdncrB7YuAYIk+T2WLlGhcL/mBHYjIYnUWP4jtilW5QLUVr/kOBB0JlLx1v9hrKMsItJQMAP9jN+mw==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.3.8",
+        "@storybook/api": "6.3.8",
+        "@storybook/client-logger": "6.3.8",
+        "@storybook/components": "6.3.8",
+        "@storybook/core-events": "6.3.8",
+        "@storybook/theming": "6.3.8",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "memoizerific": "^1.11.3",
+        "prop-types": "^15.7.2",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.3.8.tgz",
+          "integrity": "sha512-TzYk1f/wvfoGDkLxXIx85ii5ED7IfGP/6eu00/i2Hyn4uGqdNi/ltSOJxnxa+DZv8KjYQRVAEo/Fbh95IEXI1Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/router": "6.3.8",
+            "@storybook/theming": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.3.8.tgz",
+          "integrity": "sha512-8b61KnWhN+sA+Gq+AHH3M4qM0L8pNS9DtdfPi5GUGWzOg6IZ1EgYVsk9afEwkNESxyZ+GM2O6mGu05J0HfyqNg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.3.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.3.8.tgz",
+          "integrity": "sha512-+bjIb5rPTglbhLgGywDoKK25x9ClCMV29fd/fiF86rXQlfxq6J+or6ars6p97gS2/J1wgRbh+Yf3WkLNQx7s6A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.3.8.tgz",
+          "integrity": "sha512-d/65629nvnlDpeubcElTypHuSvOqxNTNKnuN0oKDM8BsE0EO5rhTfzrx2vhiSW8At8MuD1eFC19BWdCZV18Edg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.3.8.tgz",
+          "integrity": "sha512-zIvCk7MAL9z17EI58h7WE/TgFTm0njGwFkQrbXOgGkkKYoFt/yrrs8HqylcqBqfTivJNiXJNnmmx0ooJ83PIwA==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.6.0",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.3.8",
+            "@types/color-convert": "^2.0.0",
+            "@types/overlayscrollbars": "^1.12.0",
+            "@types/react-syntax-highlighter": "11.0.5",
+            "color-convert": "^2.0.1",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "markdown-to-jsx": "^7.1.3",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.13.1",
+            "polished": "^4.0.5",
+            "prop-types": "^15.7.2",
+            "react-colorful": "^5.1.2",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.3",
+            "react-textarea-autosize": "^8.3.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.8.tgz",
+          "integrity": "sha512-M3d2iX842YfopqmOHlXzL/Xy4fICzaRnet99GdfOqWjZhC2CVSemVk1b/vgfQv4MFYOQkSLsAjkbDH/kU8n9Aw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.3.8.tgz",
+          "integrity": "sha512-CafRmHtkwa8CQETum0RaspSExt8mrFsoYZSyrVSWqOyGG048MT3ocCPRsSueor17h+Q5neKamrPVN1jAdSilDg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/client-logger": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.3.8.tgz",
+          "integrity": "sha512-Np51rvecnuHNevZ7Em0uElT5UkgASP5K2u8NpHcCxP/Hd73wxS/h//6XnjA9Aich7h/JanG71jAC3qqhZabatA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.3.8",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.17.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
+          "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+          "dev": true
+        },
+        "markdown-to-jsx": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
+          "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
           "dev": true
         }
       }
@@ -11119,9 +13476,9 @@
       "version": "file:blocks/double-chain-block"
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.9.11-canary.3",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.9.11-canary.3/e9d292b46a2443eec5348ca40419bec6081ed91532b119507b14ca7da080a12a",
-      "integrity": "sha512-4oKhfXAqeb+dQLRmJ/U4QO5pSxMnQuJGOOu+dpgRvpwIvcUWyJzXp4x7uVKcKStn7t23nfbgLuljYmoWOv0hlg==",
+      "version": "2.11.0-canary.9",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.11.0-canary.9/639625cd15c4c6e5cc5032652816db344308d6b02f7629f54704473363815393",
+      "integrity": "sha512-J/6RbkMSYxL0XLcmB0uFKBeOxY/hojFHMReIrD7je6xkimDGXp2n/eix+txJ5Yyj+ggzSJS0KMXAk6B3Q/t/SQ==",
       "dev": true,
       "requires": {
         "@arc-fusion/prop-types": "^0.1.5",
@@ -11233,9 +13590,9 @@
       "version": "file:blocks/medium-promo-block"
     },
     "@wpmedia/news-theme-css": {
-      "version": "4.2.2-stable.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/4.2.2-stable.0/a62d3fa803429e533def133afbc54ea2847d6e38fdfcb8347efa8b0c269060c7",
-      "integrity": "sha512-5kYrObVIzIfGs4Zyelq4CfJtumkC2oeidySbghQ5r3SGGhhVntO8z7w1EV6oiwb8UpmphgcTS+iFd3uUsbxtwg==",
+      "version": "4.3.1-stable.0",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/4.3.1-stable.0/b9bd2b0a246deff98e4d4621b32ac90c2ce3ff72b03aad561dacbf122935b100",
+      "integrity": "sha512-pFdWkoEtXaNLNRQt6MOYuMIR6jgXhAIWEWBebxu0Cm5dElnLX0bDKvv4zyCuyPAeS5olYhSWqvV8Hrr2ZzF4fQ==",
       "dev": true
     },
     "@wpmedia/numbered-list-block": {
@@ -20960,6 +23317,16 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true
     },
+    "is-dom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.1.0.tgz",
+      "integrity": "sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==",
+      "dev": true,
+      "requires": {
+        "is-object": "^1.0.1",
+        "is-window": "^1.0.2"
+      }
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -21047,6 +23414,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true
+    },
+    "is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
     },
     "is-observable": {
@@ -21196,6 +23569,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
       "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
+      "dev": true
+    },
+    "is-window": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
+      "integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0=",
       "dev": true
     },
     "is-windows": {
@@ -28777,6 +31156,17 @@
         "prop-types": "^15.5.8"
       }
     },
+    "react-inspector": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-5.1.1.tgz",
+      "integrity": "sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "is-dom": "^1.0.0",
+        "prop-types": "^15.0.0"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -30945,6 +33335,218 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.12.0.tgz",
       "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==",
       "dev": true
+    },
+    "storybook-addon-outline": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/storybook-addon-outline/-/storybook-addon-outline-1.4.1.tgz",
+      "integrity": "sha512-Qvv9X86CoONbi+kYY78zQcTGmCgFaewYnOVR6WL7aOFJoW7TrLiIc/O4hH5X9PsEPZFqjfXEPUPENWVUQim6yw==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.3.0",
+        "@storybook/api": "^6.3.0",
+        "@storybook/components": "^6.3.0",
+        "@storybook/core-events": "^6.3.0",
+        "ts-dedent": "^2.1.1"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.3.8.tgz",
+          "integrity": "sha512-TzYk1f/wvfoGDkLxXIx85ii5ED7IfGP/6eu00/i2Hyn4uGqdNi/ltSOJxnxa+DZv8KjYQRVAEo/Fbh95IEXI1Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.3.8",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/router": "6.3.8",
+            "@storybook/theming": "6.3.8",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.3.8.tgz",
+          "integrity": "sha512-8b61KnWhN+sA+Gq+AHH3M4qM0L8pNS9DtdfPi5GUGWzOg6IZ1EgYVsk9afEwkNESxyZ+GM2O6mGu05J0HfyqNg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/channels": "6.3.8",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/core-events": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.3.8",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.3.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.3.8.tgz",
+          "integrity": "sha512-+bjIb5rPTglbhLgGywDoKK25x9ClCMV29fd/fiF86rXQlfxq6J+or6ars6p97gS2/J1wgRbh+Yf3WkLNQx7s6A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.3.8.tgz",
+          "integrity": "sha512-d/65629nvnlDpeubcElTypHuSvOqxNTNKnuN0oKDM8BsE0EO5rhTfzrx2vhiSW8At8MuD1eFC19BWdCZV18Edg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.3.8.tgz",
+          "integrity": "sha512-zIvCk7MAL9z17EI58h7WE/TgFTm0njGwFkQrbXOgGkkKYoFt/yrrs8HqylcqBqfTivJNiXJNnmmx0ooJ83PIwA==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.6.0",
+            "@storybook/client-logger": "6.3.8",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.3.8",
+            "@types/color-convert": "^2.0.0",
+            "@types/overlayscrollbars": "^1.12.0",
+            "@types/react-syntax-highlighter": "11.0.5",
+            "color-convert": "^2.0.1",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "markdown-to-jsx": "^7.1.3",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.13.1",
+            "polished": "^4.0.5",
+            "prop-types": "^15.7.2",
+            "react-colorful": "^5.1.2",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.3",
+            "react-textarea-autosize": "^8.3.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.8.tgz",
+          "integrity": "sha512-M3d2iX842YfopqmOHlXzL/Xy4fICzaRnet99GdfOqWjZhC2CVSemVk1b/vgfQv4MFYOQkSLsAjkbDH/kU8n9Aw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.3.8.tgz",
+          "integrity": "sha512-CafRmHtkwa8CQETum0RaspSExt8mrFsoYZSyrVSWqOyGG048MT3ocCPRsSueor17h+Q5neKamrPVN1jAdSilDg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.4",
+            "@storybook/client-logger": "6.3.8",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.20",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.3.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.3.8.tgz",
+          "integrity": "sha512-Np51rvecnuHNevZ7Em0uElT5UkgASP5K2u8NpHcCxP/Hd73wxS/h//6XnjA9Aich7h/JanG71jAC3qqhZabatA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.3.8",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.17.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
+          "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+          "dev": true
+        },
+        "markdown-to-jsx": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
+          "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        }
+      }
     },
     "storybook-readme": {
       "version": "5.0.9",
@@ -33249,6 +35851,12 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "uuid-browser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-browser/-/uuid-browser-3.1.0.tgz",
+      "integrity": "sha1-DwWkCu90+eWVHiDvv0SxGHHlZBA=",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/preset-react": "^7.0.0",
     "@storybook/addon-a11y": "^6.3.6",
     "@storybook/addon-docs": "^6.3.6",
+    "@storybook/addon-essentials": "^6.3.8",
     "@storybook/addon-knobs": "^6.2.9",
     "@storybook/react": "^6.3.6",
     "@testing-library/jest-dom": "^5.14.1",


### PR DESCRIPTION
NOT READY FOR REVIEW, NO TESTS 

for using sb, please npm i to get addon for background to see some styles: 

![Screen Shot 2021-09-17 at 13 48 37](https://user-images.githubusercontent.com/5950956/133839055-2dd81197-712a-4b15-ab91-a2e0cac00c98.png)


questions: 
- Is my storybook look as expected based on the second requirements? when it was said "secondary", it looks like zeplin is using white and a shade of black.  or am I missing something with secondaryColor?

<img width="372" alt="Screen Shot 2021-09-17 at 13 42 37" src="https://user-images.githubusercontent.com/5950956/133838282-df7eecd0-3e27-4ec1-b056-0cd43f624145.png">
-> based on this, is this what the-sun and the-prophet should look like for the signup and login buttons? 

the-sun
primaryColor is that pink
navColor is light 
"navBarBackground": "primary-color",

<img width="199" alt="Screen Shot 2021-09-17 at 13 43 30" src="https://user-images.githubusercontent.com/5950956/133838392-bf187685-b30f-4fbd-a969-543704b7e315.png">

the-prophet 
navColor is the default dark
primaryColor is light blue 


<img width="202" alt="Screen Shot 2021-09-17 at 13 45 34" src="https://user-images.githubusercontent.com/5950956/133838643-8feb5194-135e-4381-8b57-c3e82b61c1fa.png">


**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
_Information about what you changed for this PR_

## Jira Ticket
- [TMEDIA-](https://arcpublishing.atlassian.net/browse/TMEDIA-)

## Acceptance Criteria
_copy from ticket_

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout {branch name}`
2. Run fusion repo with linked blocks `npx fusion start -f -l {blocks to link}`
3. {Next ....}

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
