### PR TITLE
TMEDIA-499 - Update small promo images to use larger variants

### DIFF
--- a/.storybook/mock-content/smallPromo.js
+++ b/.storybook/mock-content/smallPromo.js
@@ -10,12 +10,11 @@ export const smallPromoMock = {
 	promo_items: {
 		basic: {
 			resized_params: {
-				'274x154': 'LBTiSxaxr1Eo-tEz9BKFCnZNArw=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
-				'274x183': 'Z3YDeb5U67phnWn-jjZ1D3raqLg=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
-				'274x206': 'bg-hZozUyDasSC82dzGY6h7OzQE=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
-				'400x225': '0h3vL_qyc8pjZN_cnwYgHECxICA=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
-				'400x267': 'SBSiikbg6B9BLxiEqnZhBDbOelY=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
-				'400x300': '4oA14YOFAWISqfWe7GayPCW-l9k=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/'
+				'600x400': 'IYlSHyCyebwHaotJBuhSSiykktg=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+				'600x450': 'pmSxIhr_2yF6wtOJyOkbEaphdok=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+				'800x450': 'VD7LAiaSV3kPnNUuP36bbTT2S0Y=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+				'800x533': '4dhmPhU2HvAd69Kkkj0rcfE41mw=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/',
+				'800x600': '6fqhqLAchOq1gB_xNn2lGb-WHmk=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/'
 			},
 			type: 'image',
 			url: 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG'

--- a/blocks/resizer-image-block/ratiosFor.js
+++ b/blocks/resizer-image-block/ratiosFor.js
@@ -25,9 +25,9 @@ const sizes = {
   },
   SM: {
     options: [
-      { kind: 'small', width: 274 },
-      { kind: 'medium', width: 274 },
-      { kind: 'large', width: 400 },
+      { kind: 'small', width: 600 },
+      { kind: 'medium', width: 800 },
+      { kind: 'large', width: 600 },
     ],
     defaultRatio: '3:2',
   },

--- a/blocks/resizer-image-block/ratiosFor.test.js
+++ b/blocks/resizer-image-block/ratiosFor.test.js
@@ -66,12 +66,12 @@ describe('validates arithmatic for ratios', () => {
 
     it('default values for SM', () => {
       const ratios = ratiosFor('SM');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(183);
-      expect(ratios.mediumWidth).toBe(274);
-      expect(ratios.mediumHeight).toBe(183);
-      expect(ratios.largeWidth).toBe(400);
-      expect(ratios.largeHeight).toBe(267);
+      expect(ratios.smallWidth).toBe(600);
+      expect(ratios.smallHeight).toBe(400);
+      expect(ratios.mediumWidth).toBe(800);
+      expect(ratios.mediumHeight).toBe(533);
+      expect(ratios.largeWidth).toBe(600);
+      expect(ratios.largeHeight).toBe(400);
     });
   });
 
@@ -162,30 +162,30 @@ describe('validates arithmatic for ratios', () => {
 
     it('SM on 16:9', () => {
       const ratios = ratiosFor('SM', '16:9');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(154);
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(154);
-      expect(ratios.largeWidth).toBe(400);
-      expect(ratios.largeHeight).toBe(225);
+      expect(ratios.smallWidth).toBe(600);
+      expect(ratios.smallHeight).toBe(338);
+      expect(ratios.mediumWidth).toBe(800);
+      expect(ratios.mediumHeight).toBe(450);
+      expect(ratios.largeWidth).toBe(600);
+      expect(ratios.largeHeight).toBe(338);
     });
     it('SM on 4:3', () => {
       const ratios = ratiosFor('SM', '4:3');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(206);
-      expect(ratios.mediumWidth).toBe(274);
-      expect(ratios.mediumHeight).toBe(206);
-      expect(ratios.largeWidth).toBe(400);
-      expect(ratios.largeHeight).toBe(300);
+      expect(ratios.smallWidth).toBe(600);
+      expect(ratios.smallHeight).toBe(450);
+      expect(ratios.mediumWidth).toBe(800);
+      expect(ratios.mediumHeight).toBe(600);
+      expect(ratios.largeWidth).toBe(600);
+      expect(ratios.largeHeight).toBe(450);
     });
     it('SM on 3:2', () => {
       const ratios = ratiosFor('SM', '3:2');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(183);
-      expect(ratios.mediumWidth).toBe(274);
-      expect(ratios.mediumHeight).toBe(183);
-      expect(ratios.largeWidth).toBe(400);
-      expect(ratios.largeHeight).toBe(267);
+      expect(ratios.smallWidth).toBe(600);
+      expect(ratios.smallHeight).toBe(400);
+      expect(ratios.mediumWidth).toBe(800);
+      expect(ratios.mediumHeight).toBe(533);
+      expect(ratios.largeWidth).toBe(600);
+      expect(ratios.largeHeight).toBe(400);
     });
   });
 });

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
@@ -50,26 +50,6 @@ describe('the small promo feature', () => {
     expect(wrapper.find('.container-fluid')).toHaveLength(1);
   });
 
-  it('should have two link elements by default with 4:3 default ratio', () => {
-    const wrapper = mount(<SmallManualPromo customFields={config} />);
-    expect(wrapper.find('a')).toHaveLength(2);
-    expect(wrapper.find('Image').prop('largeHeight')).toBe(267);
-  });
-
-  it('should accept a 16:9 image ratio', () => {
-    const myConfig = { ...config, imageRatio: '16:9' };
-    const wrapper = mount(<SmallManualPromo customFields={myConfig} />);
-    expect(wrapper.find('Image')).toHaveLength(1);
-    expect(wrapper.find('Image').prop('largeHeight')).toBe(225);
-  });
-
-  it('should accept a 3:2 image ratio', () => {
-    const myConfig = { ...config, imageRatio: '3:2' };
-    const wrapper = mount(<SmallManualPromo customFields={myConfig} />);
-    expect(wrapper.find('Image')).toHaveLength(1);
-    expect(wrapper.find('Image').prop('largeHeight')).toBe(267);
-  });
-
   it('should have one img when show image is true', () => {
     const wrapper = mount(<SmallManualPromo customFields={config} />);
     expect(wrapper.find('Image')).toHaveLength(1);

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -38,12 +38,12 @@ const SmallPromoItem = ({ customFields, arcSite }) => {
               type
               url
               resized_params {
-                400x300
-                400x267
-                400x225
-                274x206
-                274x183
-                274x154
+                800x600
+                800x533
+                800x450
+                600x450
+                600x400
+                600x338
               }
             }
           }
@@ -52,12 +52,12 @@ const SmallPromoItem = ({ customFields, arcSite }) => {
           type
           url
           resized_params {
-            400x300
-            400x267
-            400x225
-            274x206
-            274x183
-            274x154
+            800x600
+            800x533
+            800x450
+            600x450
+            600x400
+            600x338
           }
         }
       }

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -104,7 +104,6 @@ describe('the small promo feature', () => {
     const noImgConfig = {
       itemContentConfig: { contentService: 'ans-item', contentConfiguration: {} },
       showHeadline: true,
-      // headlinePosition: 'below',
       showImage: false,
     };
     const wrapper = mount(<SmallPromo customFields={noImgConfig} />);
@@ -119,33 +118,6 @@ describe('the small promo feature', () => {
     };
     const wrapper = mount(<SmallPromo customFields={noHeadlineConfig} />);
     expect(wrapper.find('a')).toHaveLength(1);
-  });
-
-  it('should have by default an 3:2 image ratio', () => {
-    const wrapper = mount(<SmallPromo customFields={config} />);
-    const img = wrapper.find('Image');
-    expect(img.prop('largeHeight')).toBe(267);
-  });
-
-  it('should accept a 16:9 ratio', () => {
-    const myConfig = { ...config, imageRatio: '16:9' };
-    const wrapper = mount(<SmallPromo customFields={myConfig} />);
-    const img = wrapper.find('Image');
-    expect(img.prop('largeHeight')).toBe(225);
-  });
-
-  it('should accept a 3:2 ratio', () => {
-    const myConfig = { ...config, imageRatio: '3:2' };
-    const wrapper = mount(<SmallPromo customFields={myConfig} />);
-    const img = wrapper.find('Image');
-    expect(img.prop('largeHeight')).toBe(267);
-  });
-
-  it('should accept a 4:3 ratio', () => {
-    const myConfig = { ...config, imageRatio: '4:3' };
-    const wrapper = mount(<SmallPromo customFields={myConfig} />);
-    const img = wrapper.find('Image');
-    expect(img.prop('largeHeight')).toBe(300);
   });
 
   it('returns null if null content', () => {


### PR DESCRIPTION
## Description

Increase the size of images used in the different Small Promos to have large image variants to account for all the different locations small images are being rendered.

## Jira Ticket
- [TMEDIA-499](https://arcpublishing.atlassian.net/browse/TMEDIA-499)

## Acceptance Criteria
When small promo items in the Top Table List, Small Promo, and Manual Small Promo are configured to use Image Above or Image Below, the width of the image we use on mobile viewports is set to 800px for medium breakpoint and 600px for small breakpoint (800px and 600px are guidance-- if another available size works better, we can use those)

## Test Steps
1. Checkout this branch `git checkout TMEDIA-499-small-image-updates`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/top-table-list-block,@wpmedia/small-promo-block,@wpmedia/small-manual-promo-block,@wpmedia/resizer-image-block`
3. Visit page - http://localhost/test-tmedia-411//?_website=the-gazette (You'll need to either import from CoreComponents, or grab a data dump)
4. Validated images in the small promos are blurry any more on all breakpoints

## Effect Of Changes
### Before
<img width="771" alt="TMEDIA-499-before" src="https://user-images.githubusercontent.com/868127/134978583-dfec1ed3-55e0-4959-bf84-106a6d8d62a0.png">


### After

<img width="791" alt="TMEDIA-499-after" src="https://user-images.githubusercontent.com/868127/134978602-160ea619-5f56-4f0e-87be-e1832c17c0b5.png">

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
