### PR TITLE
TMEDIA 500 Autocomplete for signup issues

### DIFF
--- a/blocks/identity-block/components/FormInputField/index.jsx
+++ b/blocks/identity-block/components/FormInputField/index.jsx
@@ -12,6 +12,7 @@ export const FIELD_TYPES = {
 };
 
 const FormInputField = ({
+  autoComplete,
   defaultValue = '',
   label,
   name,
@@ -55,6 +56,7 @@ const FormInputField = ({
   const inputId = `id_${name}_input`;
 
   const fieldParameters = {
+    ...(autoComplete ? { autoComplete } : {}),
     ...(defaultValue !== '' ? { defaultValue } : {}),
     ...(validationPattern ? { pattern: validationPattern } : {}),
     ...(placeholder ? { placeholder, 'aria-placeholder': placeholder } : {}),

--- a/blocks/identity-block/components/FormInputField/index.story.jsx
+++ b/blocks/identity-block/components/FormInputField/index.story.jsx
@@ -111,3 +111,23 @@ export const multipleFields = () => (
     />
   </form>
 );
+
+export const autoCompleteOff = () => (
+  <FormInputField
+    defaultValue=""
+    name="email"
+    type={FIELD_TYPES.EMAIL}
+    label="Email Address"
+    autoComplete="off"
+  />
+);
+
+export const autoCompleteNewPassword = () => (
+  <FormInputField
+    defaultValue=""
+    name="password-new-one"
+    type={FIELD_TYPES.PASSWORD}
+    label="Password"
+    autoComplete="new-password"
+  />
+);

--- a/blocks/identity-block/components/FormPasswordConfirm/index.jsx
+++ b/blocks/identity-block/components/FormPasswordConfirm/index.jsx
@@ -19,22 +19,22 @@ const FormPasswordConfirm = ({
   const [password, setPassword] = useState('');
 
   const fieldParameters = {
+    ...(autoComplete ? { autoComplete } : {}),
     ...(placeholder ? { placeholder } : {}),
     ...(showDefaultError ? { showDefaultError } : {}),
     ...(tip ? { tip } : {}),
     ...(validationErrorMessage ? { validationErrorMessage } : {}),
     ...(validationPattern ? { validationPattern } : {}),
-    ...(autoComplete ? { autoComplete } : {}),
   };
 
   const confirmFieldParameters = {
+    ...(autoComplete ? { autoComplete } : {}),
     ...(confirmPlaceholder ? { placeholder: confirmPlaceholder } : {}),
     ...(showDefaultError ? { showDefaultError } : {}),
     ...(confirmTip ? { tip: confirmTip } : {}),
     ...(confirmValidationErrorMessage
       ? { validationErrorMessage: confirmValidationErrorMessage }
       : {}),
-    ...(autoComplete ? { autoComplete } : {}),
   };
 
   return (

--- a/blocks/identity-block/components/FormPasswordConfirm/index.jsx
+++ b/blocks/identity-block/components/FormPasswordConfirm/index.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import FormInputField, { FIELD_TYPES } from '../FormInputField';
 
 const FormPasswordConfirm = ({
+  autoComplete,
   confirmLabel,
   confirmPlaceholder,
   confirmTip,
@@ -23,6 +24,7 @@ const FormPasswordConfirm = ({
     ...(tip ? { tip } : {}),
     ...(validationErrorMessage ? { validationErrorMessage } : {}),
     ...(validationPattern ? { validationPattern } : {}),
+    ...(autoComplete ? { autoComplete } : {}),
   };
 
   const confirmFieldParameters = {
@@ -32,6 +34,7 @@ const FormPasswordConfirm = ({
     ...(confirmValidationErrorMessage
       ? { validationErrorMessage: confirmValidationErrorMessage }
       : {}),
+    ...(autoComplete ? { autoComplete } : {}),
   };
 
   return (

--- a/blocks/identity-block/features/login/default.jsx
+++ b/blocks/identity-block/features/login/default.jsx
@@ -66,7 +66,7 @@ const Login = ({ customFields }) => {
       formErrorText={error}
     >
       <FormInputField
-        autoComplete="email"
+        autoComplete="off"
         label={phrases.t('identity-block.email')}
         name="email"
         required

--- a/blocks/identity-block/features/login/default.jsx
+++ b/blocks/identity-block/features/login/default.jsx
@@ -66,7 +66,7 @@ const Login = ({ customFields }) => {
       formErrorText={error}
     >
       <FormInputField
-        autoComplete="off"
+        autoComplete="email"
         label={phrases.t('identity-block.email')}
         name="email"
         required

--- a/blocks/identity-block/features/login/default.jsx
+++ b/blocks/identity-block/features/login/default.jsx
@@ -66,6 +66,7 @@ const Login = ({ customFields }) => {
       formErrorText={error}
     >
       <FormInputField
+        autoComplete="email"
         label={phrases.t('identity-block.email')}
         name="email"
         required
@@ -74,6 +75,7 @@ const Login = ({ customFields }) => {
         validationErrorMessage={phrases.t('identity-block.email-requirements')}
       />
       <FormInputField
+        autoComplete="current-password"
         label={phrases.t('identity-block.password')}
         name="password"
         required

--- a/blocks/identity-block/features/login/default.test.jsx
+++ b/blocks/identity-block/features/login/default.test.jsx
@@ -59,5 +59,8 @@ describe('Subscriptions Login Feature', () => {
     expect(wrapper.find('form.xpmedia-form-submittable')).toHaveLength(1);
     expect(wrapper.find('input.xpmedia-form-field-input')).toHaveLength(2);
     expect(wrapper.find('form.xpmedia-form-submittable button')).toHaveLength(1);
+
+    expect(wrapper.find('input.xpmedia-form-field-input').at(0).prop('autoComplete')).toBe('email');
+    expect(wrapper.find('input.xpmedia-form-field-input').at(1).prop('autoComplete')).toBe('current-password');
   });
 });

--- a/blocks/identity-block/features/signup/default.jsx
+++ b/blocks/identity-block/features/signup/default.jsx
@@ -112,6 +112,7 @@ const SignUp = ({ customFields, arcSite }) => {
       formErrorText={error}
     >
       <FormInputField
+        autoComplete="off"
         label={phrases.t('identity-block.email')}
         name="email"
         required
@@ -120,6 +121,7 @@ const SignUp = ({ customFields, arcSite }) => {
         validationErrorMessage={phrases.t('identity-block.email-requirements')}
       />
       <FormPasswordConfirm
+        autoComplete="new-password"
         name="password"
         label={phrases.t('identity-block.password')}
         validationErrorMessage={status === 'success' ? passwordErrorMessage : ''}

--- a/blocks/identity-block/features/signup/default.test.jsx
+++ b/blocks/identity-block/features/signup/default.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import Signup from './default';
 import useIdentity from '../../components/Identity';
 
@@ -20,9 +20,13 @@ describe('With initialized identity', () => {
   it('renders something', () => {
     useIdentity.mockImplementation(() => ({ isInitialized: true }));
 
-    const wrapper = shallow(<Signup
+    const wrapper = mount(<Signup
       customFields={{ redirectURL: '/sign-up', redirectToPreviousPage: true }}
     />);
+
+    expect(wrapper.find('input.xpmedia-form-field-input').at(0).prop('autoComplete')).toBe('off');
+    expect(wrapper.find('input.xpmedia-form-field-input').at(1).prop('autoComplete')).toBe('new-password');
+    expect(wrapper.find('input.xpmedia-form-field-input').at(2).prop('autoComplete')).toBe('new-password');
 
     expect(wrapper.html()).toBeTruthy();
   });


### PR DESCRIPTION
## Description
Autocomplete for signup issues

## Jira Ticket
- [TMEDIA-500](https://arcpublishing.atlassian.net/jira/software/c/projects/TMEDIA/boards/875?modal=detail&selectedIssue=TMEDIA-500)

## Acceptance Criteria
ac talked with Jenae Cerovac :

sign up 

email is autocomplete off 

passwords fields = generate password 

login

email = autocomplete on 

password for sign in = current password

## Test Steps

1. Checkout this branch `git checkout TMEDIA-500-autofill-warnings-sign-up`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles,@wpmedia/identity-block `
3. Go to sign-up and login pages. 
4. Look at autocomplete fields for sign up and input as described in ac 
5. See no warnings in chrome with autocomplete warnings 

## Effect Of Changes
### Before
- current email recommended for sign up 
- warnings for chrome for using autocomplete 

![Screen Shot 2021-10-07 at 10 21 33](https://user-images.githubusercontent.com/5950956/136414687-229e4496-e436-4f63-8a6a-5467670453df.png)

### After
- current email not recommended for sign up 
- no warnings on sign-up or login

## Dependencies or Side Effects
- lastpass extension will not respect autocomplete. this won't solve that 

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
