### PR TITLE
TMEDIA-503 & TMEDIA-506

### DIFF
--- a/blocks/identity-block/features/login/default.jsx
+++ b/blocks/identity-block/features/login/default.jsx
@@ -100,7 +100,7 @@ Login.propTypes = {
     loggedInPageLocation: PropTypes.string.tag({
       name: 'Logged In URL',
       defaultValue: '/account/',
-      description: 'TThe URL to which a user would be redirected to if visiting a login page when already logged in.',
+      description: 'The URL to which a user would be redirected to if visiting a login page when already logged in.',
     }),
   }),
 };

--- a/blocks/identity-block/features/login/default.jsx
+++ b/blocks/identity-block/features/login/default.jsx
@@ -90,7 +90,7 @@ Login.propTypes = {
   customFields: PropTypes.shape({
     redirectURL: PropTypes.string.tag({
       name: 'Redirect URL',
-      defaultValue: '/account/profile/',
+      defaultValue: '/account/',
     }),
     redirectToPreviousPage: PropTypes.bool.tag({
       name: 'Redirect to previous page',
@@ -100,7 +100,7 @@ Login.propTypes = {
     loggedInPageLocation: PropTypes.string.tag({
       name: 'Logged In URL',
       defaultValue: '/account/',
-      description: 'The URL to which a user would be redirected to if logged in an vist a page with the login form on',
+      description: 'TThe URL to which a user would be redirected to if visiting a login page when already logged in.',
     }),
   }),
 };


### PR DESCRIPTION
## Jira Ticket
- [TMEDIA-503](https://arcpublishing.atlassian.net/browse/TMEDIA-503)
- [TMEDIA-506](https://arcpublishing.atlassian.net/browse/TMEDIA-506)

## Acceptance Criteria
TMEDIA-503

Redirect URL in the Identity Log In custom fields defaults to /account/

TMEDIA-506
Update the tooltip for Logged In URL to:

“The URL to which a user would be redirected to if visiting a login page when already logged in.”

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
