### PR TITLE
Add new login links block to identity package

### DIFF
--- a/.storybook/alias/properties.js
+++ b/.storybook/alias/properties.js
@@ -6,7 +6,7 @@ export default (site) => ({
 	twitterUsername: true,
 	rssUrl: true,
 	copyrightText: true,
-	lightBackgroundLogo: 'https://arcdesignsystem.com/img/arc-logo-black.svg',
+	lightBackgroundLogo: 'https://design.arcxp.com/arc-glyph-light.svg',
 	lightBackgroundLogoAlt: 'light logo alt text',
 	primaryLogo: 'https://www.klartale.no/img/klartale/klartale-logo-new.svg',
 	primaryLogoAlt: 'primary logo alt text',

--- a/blocks/identity-block/features/login-links/default.jsx
+++ b/blocks/identity-block/features/login-links/default.jsx
@@ -40,18 +40,22 @@ LoginLinks.propTypes = {
     showLogin: PropTypes.bool.tag({
       name: 'Show Login link',
       defaultValue: false,
+      group: 'Login',
     }),
     loginURL: PropTypes.string.tag({
       name: 'Login URL',
       defaultValue: defaultLoginURL,
+      group: 'Login',
     }),
     showSignUp: PropTypes.bool.tag({
       name: 'Show Sign up link',
       defaultValue: false,
+      group: 'Sign Up',
     }),
     signUpURL: PropTypes.string.tag({
       name: 'Sign Up URL',
       defaultValue: defaultSignUpURL,
+      group: 'Sign Up',
     }),
   }),
 };

--- a/blocks/identity-block/features/login-links/default.jsx
+++ b/blocks/identity-block/features/login-links/default.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from '@arc-fusion/prop-types';
+import { useFusionContext } from 'fusion:context';
+import getProperties from 'fusion:properties';
+import getTranslatedPhrases from 'fusion:intl';
+import { PrimaryFont } from '@wpmedia/shared-styles';
+
+import './styles.scss';
+
+const defaultLoginURL = '/account/login/';
+const defaultSignUpURL = '/account/signup/';
+
+const LoginLinks = ({ customFields }) => {
+  const {
+    showLogin = false,
+    loginURL = defaultLoginURL,
+    showSignUp = false,
+    signUpURL = defaultSignUpURL,
+  } = customFields;
+  const { arcSite } = useFusionContext();
+  const { locale } = getProperties(arcSite);
+  const phrases = getTranslatedPhrases(locale);
+
+  if (!showLogin && !showSignUp) {
+    return null;
+  }
+
+  return (
+    <PrimaryFont as="div" className="xpmedia-identity-login-links">
+      {showLogin ? <a href={loginURL}>{phrases.t('identity-block.login-links-login')}</a> : null}
+      {showSignUp ? <a href={signUpURL}>{phrases.t('identity-block.login-links-signup')}</a> : null}
+    </PrimaryFont>
+  );
+};
+
+LoginLinks.label = 'Identity Login Links - Arc Block';
+
+LoginLinks.propTypes = {
+  customFields: PropTypes.shape({
+    showLogin: PropTypes.bool.tag({
+      name: 'Show Login link',
+      defaultValue: false,
+    }),
+    loginURL: PropTypes.string.tag({
+      name: 'Login URL',
+      defaultValue: defaultLoginURL,
+    }),
+    showSignUp: PropTypes.bool.tag({
+      name: 'Show Sign up link',
+      defaultValue: false,
+    }),
+    signUpURL: PropTypes.string.tag({
+      name: 'Sign Up URL',
+      defaultValue: defaultSignUpURL,
+    }),
+  }),
+};
+
+export default LoginLinks;

--- a/blocks/identity-block/features/login-links/default.jsx
+++ b/blocks/identity-block/features/login-links/default.jsx
@@ -35,6 +35,8 @@ const LoginLinks = ({ customFields }) => {
 
 LoginLinks.label = 'Identity Login Links - Arc Block';
 
+LoginLinks.icon = 'laptop-help-message';
+
 LoginLinks.propTypes = {
   customFields: PropTypes.shape({
     showLogin: PropTypes.bool.tag({

--- a/blocks/identity-block/features/login-links/default.test.jsx
+++ b/blocks/identity-block/features/login-links/default.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import LoginLinks from './default';
+
+jest.mock('fusion:properties', () => (jest.fn(() => ({}))));
+
+describe('LoginLinks', () => {
+  it('renders nothing by default', () => {
+    const wrapper = mount(<LoginLinks customFields={{}} />);
+    expect(wrapper.html()).toBe(null);
+  });
+
+  it('renders login and sign up links', () => {
+    const wrapper = mount(<LoginLinks customFields={{ showLogin: true, showSignUp: true }} />);
+    expect(wrapper.find('a').length).toBe(2);
+  });
+
+  it('renders only login link', () => {
+    const wrapper = mount(<LoginLinks customFields={{ showLogin: true }} />);
+    expect(wrapper.find('a').length).toBe(1);
+    expect(wrapper.find('a').prop('href')).toBe('/account/login/');
+  });
+
+  it('renders only sign up link', () => {
+    const wrapper = mount(<LoginLinks customFields={{ showSignUp: true }} />);
+    expect(wrapper.find('a').length).toBe(1);
+    expect(wrapper.find('a').prop('href')).toBe('/account/signup/');
+  });
+});

--- a/blocks/identity-block/features/login-links/index.story.jsx
+++ b/blocks/identity-block/features/login-links/index.story.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import LoginLinks from './default';
+
+export default {
+  title: 'Blocks/Identity/Blocks/Login Links',
+  parameters: {
+    chromatic: { viewports: [320, 1200] },
+  },
+};
+
+export const LoginLink = () => (
+  <LoginLinks customFields={{ showLogin: true }} />
+);
+
+export const SignUpLink = () => (
+  <LoginLinks customFields={{ showSignUp: true }} />
+);
+
+export const loginAndSignUpLink = () => (
+  <LoginLinks customFields={{ showLogin: true, showSignUp: true }} />
+);

--- a/blocks/identity-block/features/login-links/styles.scss
+++ b/blocks/identity-block/features/login-links/styles.scss
@@ -1,0 +1,9 @@
+.xpmedia-identity-login-links {
+  font-size: 1rem;
+  text-align: center;
+
+  a {
+    color: $ui-medium-gray;
+    display: block;
+  }
+}

--- a/blocks/identity-block/intl.json
+++ b/blocks/identity-block/intl.json
@@ -218,5 +218,27 @@
 		"no": "There's been an error logging you in",
 		"pt": "There's been an error logging you in",
 		"sv": "There's been an error logging you in"
+	},
+	"identity-block.login-links-login": {
+		"de": "Already have an account? Log in.",
+		"en": "Already have an account? Log in.",
+		"es": "Already have an account? Log in.",
+		"fr": "Already have an account? Log in.",
+		"ja": "Already have an account? Log in.",
+		"ko": "Already have an account? Log in.",
+		"no": "Already have an account? Log in.",
+		"pt": "Already have an account? Log in.",
+		"sv": "Already have an account? Log in."
+	},
+	"identity-block.login-links-signup": {
+		"de": "Sign up for an account.",
+		"en": "Sign up for an account.",
+		"es": "Sign up for an account.",
+		"fr": "Sign up for an account.",
+		"ja": "Sign up for an account.",
+		"ko": "Sign up for an account.",
+		"no": "Sign up for an account.",
+		"pt": "Sign up for an account.",
+		"sv": "Sign up for an account."
 	}
 }

--- a/locale/de.json
+++ b/locale/de.json
@@ -123,6 +123,8 @@
     "identity-block.password-requirements-uppercase": "Must have at least %{requirementCount} uppercase character(s).",
     "identity-block.email-requirements": "Please enter a valid email address",
     "identity-block.sign-up-form-error": "There's been an error creating your account",
-    "identity-block.login-form-error": "There's been an error logging you in"
+    "identity-block.login-form-error": "There's been an error logging you in",
+    "identity-block.login-links-login": "Already have an account? Log in.",
+    "identity-block.login-links-signup": "Sign up for an account."
   }
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -123,6 +123,8 @@
     "identity-block.password-requirements-uppercase": "Must have at least %{requirementCount} uppercase character(s).",
     "identity-block.email-requirements": "Please enter a valid email address",
     "identity-block.sign-up-form-error": "There's been an error creating your account",
-    "identity-block.login-form-error": "There's been an error logging you in"
+    "identity-block.login-form-error": "There's been an error logging you in",
+    "identity-block.login-links-login": "Already have an account? Log in.",
+    "identity-block.login-links-signup": "Sign up for an account."
   }
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -123,6 +123,8 @@
     "identity-block.password-requirements-uppercase": "Must have at least %{requirementCount} uppercase character(s).",
     "identity-block.email-requirements": "Please enter a valid email address",
     "identity-block.sign-up-form-error": "There's been an error creating your account",
-    "identity-block.login-form-error": "There's been an error logging you in"
+    "identity-block.login-form-error": "There's been an error logging you in",
+    "identity-block.login-links-login": "Already have an account? Log in.",
+    "identity-block.login-links-signup": "Sign up for an account."
   }
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -123,6 +123,8 @@
     "identity-block.password-requirements-uppercase": "Must have at least %{requirementCount} uppercase character(s).",
     "identity-block.email-requirements": "Please enter a valid email address",
     "identity-block.sign-up-form-error": "There's been an error creating your account",
-    "identity-block.login-form-error": "There's been an error logging you in"
+    "identity-block.login-form-error": "There's been an error logging you in",
+    "identity-block.login-links-login": "Already have an account? Log in.",
+    "identity-block.login-links-signup": "Sign up for an account."
   }
 }

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -123,6 +123,8 @@
     "identity-block.password-requirements-uppercase": "Must have at least %{requirementCount} uppercase character(s).",
     "identity-block.email-requirements": "Please enter a valid email address",
     "identity-block.sign-up-form-error": "There's been an error creating your account",
-    "identity-block.login-form-error": "There's been an error logging you in"
+    "identity-block.login-form-error": "There's been an error logging you in",
+    "identity-block.login-links-login": "Already have an account? Log in.",
+    "identity-block.login-links-signup": "Sign up for an account."
   }
 }

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -123,6 +123,8 @@
     "identity-block.password-requirements-uppercase": "Must have at least %{requirementCount} uppercase character(s).",
     "identity-block.email-requirements": "Please enter a valid email address",
     "identity-block.sign-up-form-error": "There's been an error creating your account",
-    "identity-block.login-form-error": "There's been an error logging you in"
+    "identity-block.login-form-error": "There's been an error logging you in",
+    "identity-block.login-links-login": "Already have an account? Log in.",
+    "identity-block.login-links-signup": "Sign up for an account."
   }
 }

--- a/locale/no.json
+++ b/locale/no.json
@@ -123,6 +123,8 @@
     "identity-block.password-requirements-uppercase": "Must have at least %{requirementCount} uppercase character(s).",
     "identity-block.email-requirements": "Please enter a valid email address",
     "identity-block.sign-up-form-error": "There's been an error creating your account",
-    "identity-block.login-form-error": "There's been an error logging you in"
+    "identity-block.login-form-error": "There's been an error logging you in",
+    "identity-block.login-links-login": "Already have an account? Log in.",
+    "identity-block.login-links-signup": "Sign up for an account."
   }
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -123,6 +123,8 @@
     "identity-block.password-requirements-uppercase": "Must have at least %{requirementCount} uppercase character(s).",
     "identity-block.email-requirements": "Please enter a valid email address",
     "identity-block.sign-up-form-error": "There's been an error creating your account",
-    "identity-block.login-form-error": "There's been an error logging you in"
+    "identity-block.login-form-error": "There's been an error logging you in",
+    "identity-block.login-links-login": "Already have an account? Log in.",
+    "identity-block.login-links-signup": "Sign up for an account."
   }
 }

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -123,6 +123,8 @@
     "identity-block.password-requirements-uppercase": "Must have at least %{requirementCount} uppercase character(s).",
     "identity-block.email-requirements": "Please enter a valid email address",
     "identity-block.sign-up-form-error": "There's been an error creating your account",
-    "identity-block.login-form-error": "There's been an error logging you in"
+    "identity-block.login-form-error": "There's been an error logging you in",
+    "identity-block.login-links-login": "Already have an account? Log in.",
+    "identity-block.login-links-signup": "Sign up for an account."
   }
 }


### PR DESCRIPTION
## Description

Add new block "login links" to the identity package.

## Jira Ticket
- [TMEDIA-484](https://arcpublishing.atlassian.net/browse/TMEDIA-484)

## Acceptance Criteria
* Create a new block “Identity Log In Links” that has 2 sections (Sign Up and Log In)
* Checkbox to enable each section (off by default)
* “Sign up for an account.” is a translated language string
* Custom field for the Sign Up URL defaults to /account/signup/
* “Already have an account? Log in.” is translated as a language string
* Custom field for the Log In URL defaults to /account/login/

## Test Steps

1. Checkout this branch `git checkout TMEDIA-484-log-in-links-block`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/identity-block`
3. Open a page in Editor and add the new block - "Identity Login Links - Arc Block" to the page
4. Validate the block is added to the page and toggling the checkbox in the custom fields to show Login or Sign up links



<img width="1016" alt="Microsoft Edge-2021-10-07-15-15 59" src="https://user-images.githubusercontent.com/868127/136402797-c4b32897-4a42-4d24-94e2-e0428d8c8abf.png">



## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
