### PR TITLE
TMEDIA-524: Sections button on mobile should be just hamburger menu icon

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -13,12 +13,13 @@ import QuerylySearch from './queryly-search';
 import { WIDGET_CONFIG, PLACEMENT_AREAS } from '../nav-helper';
 
 const NavWidget = ({
-  type,
-  position = 0,
+  breakpoint,
   children = [],
-  placement = PLACEMENT_AREAS.NAV_BAR,
   customSearchAction,
   menuButtonClickAction,
+  placement = PLACEMENT_AREAS.NAV_BAR,
+  position = 0,
+  type,
 }) => {
   const { arcSite } = useFusionContext();
   const { navColor = 'dark', navBarBackground, locale } = getProperties(arcSite);
@@ -42,7 +43,7 @@ const NavWidget = ({
         aria-label={phrases.t('header-nav-chain-block.sections-button')}
         buttonSize={BUTTON_SIZES.SMALL}
         buttonStyle={getNavSpecificSecondaryButtonTheme(navColor, navBarBackground)}
-        buttonType={BUTTON_TYPES.LABEL_AND_RIGHT_ICON}
+        buttonType={breakpoint === 'desktop' ? BUTTON_TYPES.LABEL_AND_RIGHT_ICON : BUTTON_TYPES.ICON_ONLY}
         iconType="hamburger-menu"
         onClick={menuButtonClickAction}
         text={phrases.t('header-nav-chain-block.sections-button')}

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.test.jsx
@@ -105,6 +105,37 @@ describe('<NavWidget/>', () => {
     expect(menuWidget.prop('onClick')).toEqual(menuButtonClick);
   });
 
+  it('renders nav widget - section menu with svg and container text, with desktop breakpoint', () => {
+    const menuButtonClick = jest.fn(() => {});
+    const wrapper = mount(
+      <NavWidget
+        type="menu"
+        menuButtonClickAction={menuButtonClick}
+        breakpoint="desktop"
+      />,
+    );
+
+    const menuWidget = wrapper.find('button.nav-sections-btn');
+    expect(menuWidget.text()).toBe('test-translation');
+    expect(menuWidget.find('.xpmedia-button--right-icon-container').length).toBe(1);
+    expect(menuWidget.find('svg')).toHaveLength(1);
+  });
+
+  it('renders nav widget - section menu with svg icon and without text container, with mobile breakpoint', () => {
+    const menuButtonClick = jest.fn(() => {});
+    const wrapper = mount(
+      <NavWidget
+        type="menu"
+        menuButtonClickAction={menuButtonClick}
+        breakpoint="mobile"
+      />,
+    );
+    const menuWidget = wrapper.find('button.nav-sections-btn');
+    expect(menuWidget.find('.xpmedia-button--right-icon-container').length).toBe(0);
+    expect(menuWidget.find('svg')).toHaveLength(1);
+    expect(menuWidget.text()).toBe('');
+  });
+
   it('renders nav widget - custom with child component', () => {
     const ChildComponent = () => <div>something</div>;
     const wrapper = mount(

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/widget-list.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/widget-list.jsx
@@ -34,6 +34,7 @@ const WidgetList = ({
             placement={placement}
             position={customFields[cFieldIndexKey]}
             type={navWidgetType}
+            breakpoint={breakpoint}
           >
             {children}
           </NavWidget>


### PR DESCRIPTION
## Description
Sections button on mobile should be just hamburger menu icon

## Jira Ticket
- [TMEDIA-524](https://arcpublishing.atlassian.net/browse/TMEDIA-524)

## Acceptance Criteria
- Show section nav icon only on mobile
- Show icon and text on desktop

## Test Steps

1. Checkout this branch `git checkout HOTFIX-sections-button-text`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Go to http://localhost/homepage/?_website=the-gazette or any page with a section in the header nav chain 
4. Modify screen to mobile breakpoint. See only icon. 
5. Modify screen to desktop breakpoint. See icon and section text 

## Effect Of Changes
### Before

![Screen Shot 2021-10-07 at 12 06 13](https://user-images.githubusercontent.com/5950956/136431409-41d284e9-50c4-484b-8d0c-9ddaa75638e8.png)

### After

![Screen Shot 2021-10-07 at 12 05 43](https://user-images.githubusercontent.com/5950956/136431444-545ec709-d82b-4c47-a0e5-590303f31276.png)


## Dependencies or Side Effects

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
