### PR TITLE
Tooltip for logoutURL prop type

### DIFF
--- a/blocks/identity-block/features/header-account-action/_children/DropDownLinkListItem.jsx
+++ b/blocks/identity-block/features/header-account-action/_children/DropDownLinkListItem.jsx
@@ -8,6 +8,7 @@ import './DropDownLinkListItem.scss';
 const StyledLinkWithHover = styled.a`
   font-family: ${({ font }) => font};
   color: ${({ primaryColor }) => primaryColor};
+  cursor: pointer;
 
   &:hover {
     color: ${({ primaryColor }) => primaryColor};

--- a/blocks/identity-block/features/header-account-action/default.jsx
+++ b/blocks/identity-block/features/header-account-action/default.jsx
@@ -206,6 +206,7 @@ HeaderAccountAction.propTypes = {
     logoutURL: PropTypes.string.tag({
       defaultValue: '/',
       label: 'Log Out URL',
+      description: 'The URL to which a user would be redirected to after clicking Log Out from the navigation.',
     }),
     manageAccountURL: PropTypes.string.tag({
       defaultValue: '/account/',


### PR DESCRIPTION
## Description
Adds tooltip to Log out URL on Identity Header Account block.  Also updated the cursor on account header drop down links to use a pointer cursor instead of a text selection cursor .

## Jira Ticket
https://arcpublishing.atlassian.net/browse/TMEDIA-502

## Acceptance Criteria

- Question-mark tooltip is added to the Log Out URL field that reads: “The URL to which a user would be redirected to after clicking Log Out from the navigation.”
- Ensure the links in the account header drop down use a pointer cursor instead of a text selection cursor .

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout tmedia-502-logout-tooltip`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/subscriptions-block,@wpmedia/identity-block,@wpmedia/header-nav-chain-block`
3. Open PB, go to the homepage and drive into the props for the Identity Header Account – Arc Block.  Ensure that there is a tool tip for the `Log Out URL` custom field:

![image](https://user-images.githubusercontent.com/833461/136461532-f47f50be-9651-4612-a76f-6d74c082f8e3.png)

4. Go to the publish page of the homepage, ensure the links in the header  account drop-down are now displaying a pointer cursor instead of text selection cursor on hover.

## Effect Of Changes
### Before
1. No tool tip present for `Log Out URL` custom field.
2. header  account drop-down links were displaying text selection cursor on hover.

### After
1. Tool tip present for `Log Out URL` custom field.
2. header  account drop-down links are displaying pointer cursor on hover.

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ x] Confirmed all the test steps a reviewer will follow above are working.
- [x ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x ] Confirmed this PR has unit test files
  - [ x] Ran `npm run test`, made sure all tests are passing


## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
