### PR TITLE
HOTFIX TMEDIA-526: Use legible white for queryly icon on header nav section menu on mobile

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-widget.jsx
@@ -36,7 +36,10 @@ const NavWidget = ({
         alwaysOpen={WIDGET_CONFIG[placement]?.expandSearch}
       />
     )) || (type === 'queryly' && (
-      <QuerylySearch />
+      <QuerylySearch
+        // passing in placement for nav-spcific styling
+        placement={placement}
+      />
     )) || (type === 'menu' && (
       <Button
         additionalClassNames="nav-sections-btn"

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.jsx
@@ -3,7 +3,7 @@ import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 import {
-  Button, BUTTON_SIZES, BUTTON_TYPES, getNavSpecificSecondaryButtonTheme,
+  Button, BUTTON_SIZES, BUTTON_STYLES, BUTTON_TYPES, getNavSpecificSecondaryButtonTheme,
 } from '@wpmedia/shared-styles';
 
 /*
@@ -18,7 +18,7 @@ const querylySearchClick = () => {
   document.getElementById('queryly_toggle').dispatchEvent(event);
 };
 
-const QuerylySearch = () => {
+const QuerylySearch = ({ placement }) => {
   const { arcSite } = useFusionContext();
   const {
     locale,
@@ -26,11 +26,15 @@ const QuerylySearch = () => {
     navColor = 'dark',
   } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
+
+  // if in section-menu, then use white always SECONDARY_REVERSE for the button
+  const placementSpecificButtonStyle = placement === 'section-menu' ? BUTTON_STYLES.SECONDARY_REVERSE : getNavSpecificSecondaryButtonTheme(navColor, navBarBackground);
+
   return (
     <Button
       aria-label={phrases.t('header-nav-chain-block.search-text')}
       buttonSize={BUTTON_SIZES.SMALL}
-      buttonStyle={getNavSpecificSecondaryButtonTheme(navColor, navBarBackground)}
+      buttonStyle={placementSpecificButtonStyle}
       buttonType={BUTTON_TYPES.ICON_ONLY}
       iconType="search"
       onClick={querylySearchClick}

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/queryly-search.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import getProperties from 'fusion:properties';
 import QuerylySearch from './queryly-search';
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({
@@ -21,7 +22,30 @@ jest.mock('fusion:intl', () => jest.fn(
 describe('<QuerylySearch/>', () => {
   it('renders', () => {
     const wrapper = mount(<QuerylySearch />);
+    expect(wrapper.find('Button').length).toBe(1);
+  });
 
+  it('renders secondary reverse white always for placement section-menu', () => {
+    getProperties.mockImplementation(() => ({
+      locale: 'en',
+      navBarBackground: '',
+      navColor: 'light',
+    }));
+    const wrapper = mount(<QuerylySearch placement="section-menu" />);
+    expect(wrapper.find('path').prop('fill')).toBe('#fff');
+    expect(wrapper.find('Button').length).toBe(1);
+  });
+
+  it('renders not white button with nav color background without placement override', () => {
+    getProperties.mockImplementation(() => ({
+      locale: 'en',
+      navBarBackground: '',
+      navColor: 'light',
+    }));
+
+    const wrapper = mount(<QuerylySearch />);
+
+    expect(wrapper.find('path').prop('fill')).toBe('#191919');
     expect(wrapper.find('Button').length).toBe(1);
   });
 


### PR DESCRIPTION
will also merge into canary upon completion of this

## Description
Ensure querylyicon on menu section is white using the correct button style

## Jira Ticket
- [TMEDIA-526](https://arcpublishing.atlassian.net/browse/TMEDIA-526)

## Acceptance Criteria

For light nav:

Magnifying glass icon is black on desktop 

Magnifying glass icon is white on mobile (in the Sections Menu)

Magnifying glass icon remains white on dark/primary nav (no changes needed)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-524-nav-header-search-color`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Go to http://localhost/homepage/?_website=dagen and see nav-header with light on mobile. The querly button should be visible in white rather than the darker colors for border and text. 

## Effect Of Changes
### Before

For only light nav background, the querly search icon would not be legible on a dark background 

<img width="519" alt="Screen Shot 2021-10-12 at 13 41 32" src="https://user-images.githubusercontent.com/5950956/137011322-5cfd4111-6095-4c58-bb14-f769aa190f7c.png">


### After

<img width="593" alt="Screen Shot 2021-10-12 at 12 57 50" src="https://user-images.githubusercontent.com/5950956/137011015-da8bb977-30c7-43c4-ac50-c3cb363a2548.png">
<img width="624" alt="Screen Shot 2021-10-12 at 13 39 55" src="https://user-images.githubusercontent.com/5950956/137011095-25707d17-be42-484a-acdc-4d5c47540d1e.png">

## Dependencies or Side Effects
- for the section-menu placement, all search icons will be the BUTTON_STYLES.SECONDARY_REVERSE regardless of their nav background because the section-menu will always be dark background

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
