### PR TITLE
TMEDIA-490 - Add GridList component

### DIFF
--- a/blocks/subscriptions-block/components/GridList/index.jsx
+++ b/blocks/subscriptions-block/components/GridList/index.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from '@arc-fusion/prop-types';
+
+import './styles.scss';
+
+const GridList = ({ children }) => {
+  const additionalClass = children.length > 3 ? `xpmedia-subscription-grid-list--${children.length}` : '';
+  return (
+    <div className={`xpmedia-subscription-grid-list ${additionalClass}`}>
+      {children}
+    </div>
+  );
+};
+
+GridList.propTypes = {
+  children: PropTypes.any,
+};
+
+export default GridList;

--- a/blocks/subscriptions-block/components/GridList/index.story.jsx
+++ b/blocks/subscriptions-block/components/GridList/index.story.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import GridList from '.';
+
+export default {
+  title: 'Blocks/Subscriptions/Components/Grid List',
+  parameters: {
+    chromatic: { viewports: [320, 1200] },
+  },
+};
+
+export const threeItems = () => (
+  <GridList>
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+  </GridList>
+);
+
+export const fourItems = () => (
+  <GridList>
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+  </GridList>
+);
+
+export const fiveItems = () => (
+  <GridList>
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+  </GridList>
+);

--- a/blocks/subscriptions-block/components/GridList/index.test.jsx
+++ b/blocks/subscriptions-block/components/GridList/index.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import GridList from '.';
+
+describe('GridList', () => {
+  it('renders three children', () => {
+    const wrapper = mount(
+      <GridList>
+        <div />
+        <div />
+        <div />
+      </GridList>,
+    );
+
+    expect(wrapper.find('.xpmedia-subscription-grid-list').exists()).toBe(true);
+    expect(wrapper.find('.xpmedia-subscription-grid-list--4').exists()).toBe(false);
+  });
+
+  it('renders four children', () => {
+    const wrapper = mount(
+      <GridList>
+        <div />
+        <div />
+        <div />
+        <div />
+      </GridList>,
+    );
+
+    expect(wrapper.find('.xpmedia-subscription-grid-list').exists()).toBe(true);
+    expect(wrapper.find('.xpmedia-subscription-grid-list--4').exists()).toBe(true);
+  });
+
+  it('renders five children', () => {
+    const wrapper = mount(
+      <GridList>
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+      </GridList>,
+    );
+
+    expect(wrapper.find('.xpmedia-subscription-grid-list').exists()).toBe(true);
+    expect(wrapper.find('.xpmedia-subscription-grid-list--5').exists()).toBe(true);
+  });
+});

--- a/blocks/subscriptions-block/components/GridList/styles.scss
+++ b/blocks/subscriptions-block/components/GridList/styles.scss
@@ -1,0 +1,25 @@
+.xpmedia-subscription-grid-list {
+  display: grid;
+  grid-gap: map-get($spacers, 'lg');
+
+  @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
+    grid-template-columns: repeat(3, 1fr);
+
+    &--4 {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    &--5 {
+      grid-template-columns: repeat(6, 1fr);
+
+      > * {
+        grid-column: span 2;
+      }
+
+      :first-child,
+      :nth-child(2) {
+        grid-column: span 3;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
Add GridList component for rendering 
* 3 Cards,
* 2 x 2 Cards
* 5 Cards in 2 x 3

## Jira Ticket
- [TMEDIA-490](https://arcpublishing.atlassian.net/browse/TMEDIA-490)

## Acceptance Criteria
1. Display-only dumb component renders a max of 5 children according to grid logic
2. Grid behavior:
    * 1 - 3 cards: 1 - 3 in a single row
    * 4 cards: 2 x 2 grid
    * 5 cards: 2 on the first row, 3 on the second row
    * On mobile view, cards are displayed in a single column


## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-490-grid-list`
2. Run storybook locally `npm run storybook`
3. Check the stories under `Blocks/Subscriptions/Components/Grid List`

Check chromatic and accept changes - https://www.chromatic.com/build?appId=5f91e4721ccaba0022a10782&number=1208

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
