### PR TITLE
ci: Update arc ads in package-lock (WIP)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14054,15 +14054,13 @@
       "dev": true
     },
     "arcads": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arcads/-/arcads-4.0.0.tgz",
-      "integrity": "sha512-r0bCObCOFxFIOmpE/pH5pTFdIUEdYKkEgPhJGt9pWXdawh8ZNgKZu8JunLKt60lTXHokBCI0qMwpCeJ80c8dmg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/arcads/-/arcads-6.0.0.tgz",
+      "integrity": "sha512-V6tFqpFzfcDBA/2u2EQPZmPbHiTvS7FRsBTTHz3umzH27M/of/2e/pvDqWp+yMwY8bGquoMD+WSQ7yJ+Oiim1g==",
       "requires": {
-        "anylogger": "^1.0.10",
+        "anylogger": "^1.0.11",
         "anylogger-console": "^1.0.0",
-        "esdoc": "^1.0.4",
-        "esdoc-standard-plugin": "^1.0.0",
-        "promise-polyfill": "^8.0.0"
+        "promise-polyfill": "^8.2.0"
       }
     },
     "are-we-there-yet": {


### PR DESCRIPTION
- Pass tests with mock content issue
- Linked block did not initially update its dependencies

debugging: 
- Tried looking at the code differences and release notes for any clues