### PR TITLE
TMEDIA-465 - Numbered List - Allow for headline to take up all remaining space

### DIFF
--- a/.storybook/mock-content/simpleList.js
+++ b/.storybook/mock-content/simpleList.js
@@ -25,7 +25,7 @@ export const simpleListMock = {
 		{
 			_id: '2',
 			headlines: {
-				basic: 'Castle church tower'
+				basic: 'Castle church tower Castle church tower Castle church tower Castle church tower Castle church tower Castle church tower Castle church tower'
 			},
 			promo_items: {
 				basic: {

--- a/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
+++ b/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
@@ -13,7 +13,7 @@
     margin-bottom: 0;
     margin-top: 0;
   }
-  
+
 }
 
 .vertical-align-image > picture > img {
@@ -36,6 +36,7 @@
 
   .list-anchor-image {
     flex: 0 0 25%;
+    padding-left: calculateRem(16px);
     text-decoration: none;
 
     img {
@@ -48,9 +49,8 @@
     @include link-color-active-hover($ui-primary-font-color);
     color: $ui-primary-font-color;
     display: flex;
-    padding-right: calculateRem(16px);
     text-decoration: none;
-    flex: 0 0 75%;
+    flex-grow: 1;
 
     .headline-text {
       font-size: calculateRem(16px);
@@ -62,10 +62,6 @@
 
 .numbered-item-margins {
   @media screen and (min-width: map-get($grid-breakpoints, 'sm')) {
-    margin-bottom: 1rem;
-    margin-top: 1rem;
-  }
-  @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
     margin-bottom: 1rem;
     margin-top: 1rem;
   }

--- a/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
+++ b/blocks/numbered-list-block/features/numbered-list/numbered-list.scss
@@ -35,7 +35,7 @@
   }
 
   .list-anchor-image {
-    flex: 0 0 25%;
+    flex: 0 0 calc(25% + 16px);
     padding-left: calculateRem(16px);
     text-decoration: none;
 


### PR DESCRIPTION
## Description
Allow for headline to take up all remaining space
Remove additional CSS not needed

## Jira Ticket
- [TMEDIA-465](https://arcpublishing.atlassian.net/browse/TMEDIA-465)

## Acceptance Criteria
- Headlines wrap at full width and there is no white space reserved for images

## Test Steps

1. Checkout this branch `git checkout TMEDIA-465-numbered-list-title-only`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/numbered-list-block`
3. On a page with a numbered list block - homepage
4. Validate in Editor when you turn off the Show image promo element custom field the headlines take up the remaining space and wrap as needed

## Effect Of Changes
### Before

<img width="502" alt="TMEDIA-465-before" src="https://user-images.githubusercontent.com/868127/137320409-df542c3d-6cfa-4914-af72-ed46270b195d.png">


### After

<img width="381" alt="TMEDIA-465-after" src="https://user-images.githubusercontent.com/868127/137320425-af298560-1723-4fd0-88a9-aaee6e75ec96.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
