### PR TITLE
Tmedia 428 allow list themesettings domains

### DIFF
--- a/blocks/resizer-image-content-source-block/README.md
+++ b/blocks/resizer-image-content-source-block/README.md
@@ -67,3 +67,16 @@ ManualBlock.label = 'Manual Block – Arc Block';
 
 export default ManualBlock;
 ```
+
+The following urls are allowed by default to be resized on the client-side: 
+
+```
+  'images.arcpublishing.com',
+  's3.amazonaws.com/arc-authors/',
+  'static.themebuilder.aws.arc.pub',
+  'themebuilder-api-uploads-ap-northeast-1.s3.amazonaws.com',
+  'themebuilder-api-uploads-eu-central-1.s3.amazonaws.com',
+  'themebuilder-api-uploads-us-east-1.s3.amazonaws.com',
+  'themebuilder-api-uploads.s3.amazonaws.com',
+```
+

--- a/blocks/resizer-image-content-source-block/sources/resize-image-api-client.js
+++ b/blocks/resizer-image-content-source-block/sources/resize-image-api-client.js
@@ -1,7 +1,15 @@
 import { allowedImageDomains as ALLOWED_IMAGE_DOMAINS } from 'fusion:environment';
 import getResizedImageData from '@wpmedia/resizer-image-block';
 
-const ARCDomains = ['images.arcpublishing.com', 's3.amazonaws.com/arc-authors/'];
+const ARCDomains = [
+  'images.arcpublishing.com',
+  's3.amazonaws.com/arc-authors/',
+  'static.themebuilder.aws.arc.pub',
+  'themebuilder-api-uploads-ap-northeast-1.s3.amazonaws.com',
+  'themebuilder-api-uploads-eu-central-1.s3.amazonaws.com',
+  'themebuilder-api-uploads-us-east-1.s3.amazonaws.com',
+  'themebuilder-api-uploads.s3.amazonaws.com',
+];
 
 const params = {
   // has to be an external image

--- a/blocks/resizer-image-content-source-block/sources/resize-image-api-client.test.js
+++ b/blocks/resizer-image-content-source-block/sources/resize-image-api-client.test.js
@@ -32,6 +32,7 @@ describe('the resizer image api client source block', () => {
     contentSource.fetch({ raw_image_url: 'http://images.arcpublishing.com/image.jpg' });
     expect(mockFn.mock.calls.length).toBe(2);
 
+    // 's3.amazonaws.com/arc-authors/', is a default allowed domain
     contentSource.fetch({ raw_image_url: 'https://s3.amazonaws.com/arc-authors/marty-mcfly.jpg' });
     expect(mockFn.mock.calls.length).toBe(3);
 
@@ -58,6 +59,7 @@ describe('the resizer image api client source block', () => {
     contentSource.fetch({ raw_image_url: 'https://example.com/image.jpg' });
     expect(mockFn.mock.calls.length).toBe(3);
 
+    // does not iterate the mock call because 'examples' doesn't match 'example' in mock
     contentSource.fetch({ raw_image_url: 'https://examples.com/image.jpg' });
     expect(mockFn.mock.calls.length).toBe(3);
   });
@@ -83,5 +85,33 @@ describe('the resizer image api client source block', () => {
 
     contentSource.fetch({ raw_image_url: 'https://my-custom-domain.com/image.jpg' });
     expect(mockFn.mock.calls.length).toBe(4);
+  });
+  it('allows default arc domains to be called', () => {
+    const { default: contentSource } = require('./resize-image-api-client');
+
+    // iterates mock call length because defaults in ARCDomains
+    contentSource.fetch({ raw_image_url: 'http://themes.images.arcpublishing.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(1);
+
+    contentSource.fetch({ raw_image_url: 'http://images.arcpublishing.com/image.jpg' });
+    expect(mockFn.mock.calls.length).toBe(2);
+
+    contentSource.fetch({ raw_image_url: 'https://s3.amazonaws.com/arc-authors/marty-mcfly.jpg' });
+    expect(mockFn.mock.calls.length).toBe(3);
+
+    contentSource.fetch({ raw_image_url: 'https://static.themebuilder.aws.arc.pub/marty-mcfly.jpg' });
+    expect(mockFn.mock.calls.length).toBe(4);
+
+    contentSource.fetch({ raw_image_url: 'https://themebuilder-api-uploads-ap-northeast-1.s3.amazonaws.com/marty-mcfly.jpg' });
+    expect(mockFn.mock.calls.length).toBe(5);
+
+    contentSource.fetch({ raw_image_url: 'https://themebuilder-api-uploads-eu-central-1.s3.amazonaws.com/marty-mcfly.jpg' });
+    expect(mockFn.mock.calls.length).toBe(6);
+
+    contentSource.fetch({ raw_image_url: 'https://themebuilder-api-uploads-us-east-1.s3.amazonaws.com/marty-mcfly.jpg' });
+    expect(mockFn.mock.calls.length).toBe(7);
+
+    contentSource.fetch({ raw_image_url: 'https://themebuilder-api-uploads.s3.amazonaws.com/marty-mcfly.jpg' });
+    expect(mockFn.mock.calls.length).toBe(8);
   });
 });


### PR DESCRIPTION
## Description
Add domains for Theme Settings images to safelist 

## Jira Ticket
- [TMEDIA-428](https://arcpublishing.atlassian.net/browse/TMEDIA-428)

## Acceptance Criteria
- 1. Images uploaded via Theme Settings UI are added to the Arc safelist 

## Test Steps

- Tests should pass as arc domain logic is tested there

## Effect Of Changes
### Before
- Theme settings urls specified may not be allowed client-side resizing

### After
- All theme settings urls are allowed client-side resizing 

## Dependencies or Side Effects
- Matthew talked with theme settings team to get the list

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
