### PR TITLE
TMEDIA-520 bigger images for medium and large promo at mobile and tablet breakpoint 

### DIFF
--- a/blocks/resizer-image-block/ratiosFor.js
+++ b/blocks/resizer-image-block/ratiosFor.js
@@ -9,16 +9,16 @@ const sizes = {
   },
   LG: {
     options: [
-      { kind: 'small', width: 274 },
-      { kind: 'medium', width: 274 },
+      { kind: 'small', width: 600 },
+      { kind: 'medium', width: 800 },
       { kind: 'large', width: 377 },
     ],
     defaultRatio: '4:3',
   },
   MD: {
     options: [
-      { kind: 'small', width: 274 },
-      { kind: 'medium', width: 274 },
+      { kind: 'small', width: 600 },
+      { kind: 'medium', width: 800 },
       { kind: 'large', width: 400 },
     ],
     defaultRatio: '16:9',

--- a/blocks/resizer-image-block/ratiosFor.test.js
+++ b/blocks/resizer-image-block/ratiosFor.test.js
@@ -46,22 +46,22 @@ describe('validates arithmatic for ratios', () => {
 
     it('default values for LG', () => {
       const ratios = ratiosFor('LG');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(206);
-      expect(ratios.mediumWidth).toBe(274);
-      expect(ratios.mediumHeight).toBe(206);
-      expect(ratios.largeWidth).toBe(377);
-      expect(ratios.largeHeight).toBe(283);
+      expect(ratios.smallWidth).toMatchInlineSnapshot('600');
+      expect(ratios.smallHeight).toMatchInlineSnapshot('450');
+      expect(ratios.mediumWidth).toMatchInlineSnapshot('800');
+      expect(ratios.mediumHeight).toMatchInlineSnapshot('600');
+      expect(ratios.largeWidth).toMatchInlineSnapshot('377');
+      expect(ratios.largeHeight).toMatchInlineSnapshot('283');
     });
 
     it('default values for MD', () => {
       const ratios = ratiosFor('MD');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(154);
-      expect(ratios.mediumWidth).toBe(274);
-      expect(ratios.mediumHeight).toBe(154);
-      expect(ratios.largeWidth).toBe(400);
-      expect(ratios.largeHeight).toBe(225);
+      expect(ratios.smallWidth).toMatchInlineSnapshot('600');
+      expect(ratios.smallHeight).toMatchInlineSnapshot('338');
+      expect(ratios.mediumWidth).toMatchInlineSnapshot('800');
+      expect(ratios.mediumHeight).toMatchInlineSnapshot('450');
+      expect(ratios.largeWidth).toMatchInlineSnapshot('400');
+      expect(ratios.largeHeight).toMatchInlineSnapshot('225');
     });
 
     it('default values for SM', () => {
@@ -106,58 +106,58 @@ describe('validates arithmatic for ratios', () => {
 
     it('LG on 16:9', () => {
       const ratios = ratiosFor('LG', '16:9');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(154);
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(154);
-      expect(ratios.largeWidth).toBe(377);
-      expect(ratios.largeHeight).toBe(212);
+      expect(ratios.smallWidth).toMatchInlineSnapshot('600');
+      expect(ratios.smallHeight).toMatchInlineSnapshot('338');
+      expect(ratios.smallWidth).toMatchInlineSnapshot('600');
+      expect(ratios.smallHeight).toMatchInlineSnapshot('338');
+      expect(ratios.largeWidth).toMatchInlineSnapshot('377');
+      expect(ratios.largeHeight).toMatchInlineSnapshot('212');
     });
     it('LG on 4:3', () => {
       const ratios = ratiosFor('LG', '4:3');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(206);
-      expect(ratios.mediumWidth).toBe(274);
-      expect(ratios.mediumHeight).toBe(206);
-      expect(ratios.largeWidth).toBe(377);
-      expect(ratios.largeHeight).toBe(283);
+      expect(ratios.smallWidth).toMatchInlineSnapshot('600');
+      expect(ratios.smallHeight).toMatchInlineSnapshot('450');
+      expect(ratios.mediumWidth).toMatchInlineSnapshot('800');
+      expect(ratios.mediumHeight).toMatchInlineSnapshot('600');
+      expect(ratios.largeWidth).toMatchInlineSnapshot('377');
+      expect(ratios.largeHeight).toMatchInlineSnapshot('283');
     });
     it('LG on 3:2', () => {
       const ratios = ratiosFor('LG', '3:2');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(183);
-      expect(ratios.mediumWidth).toBe(274);
-      expect(ratios.mediumHeight).toBe(183);
-      expect(ratios.largeWidth).toBe(377);
-      expect(ratios.largeHeight).toBe(251);
+      expect(ratios.smallWidth).toMatchInlineSnapshot('600');
+      expect(ratios.smallHeight).toMatchInlineSnapshot('400');
+      expect(ratios.mediumWidth).toMatchInlineSnapshot('800');
+      expect(ratios.mediumHeight).toMatchInlineSnapshot('533');
+      expect(ratios.largeWidth).toMatchInlineSnapshot('377');
+      expect(ratios.largeHeight).toMatchInlineSnapshot('251');
     });
 
     it('MD on 16:9', () => {
       const ratios = ratiosFor('MD', '16:9');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(154);
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(154);
-      expect(ratios.largeWidth).toBe(400);
-      expect(ratios.largeHeight).toBe(225);
+      expect(ratios.smallWidth).toMatchInlineSnapshot('600');
+      expect(ratios.smallHeight).toMatchInlineSnapshot('338');
+      expect(ratios.smallWidth).toMatchInlineSnapshot('600');
+      expect(ratios.smallHeight).toMatchInlineSnapshot('338');
+      expect(ratios.largeWidth).toMatchInlineSnapshot('400');
+      expect(ratios.largeHeight).toMatchInlineSnapshot('225');
     });
     it('MD on 4:3', () => {
       const ratios = ratiosFor('MD', '4:3');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(206);
-      expect(ratios.mediumWidth).toBe(274);
-      expect(ratios.mediumHeight).toBe(206);
-      expect(ratios.largeWidth).toBe(400);
-      expect(ratios.largeHeight).toBe(300);
+      expect(ratios.smallWidth).toMatchInlineSnapshot('600');
+      expect(ratios.smallHeight).toMatchInlineSnapshot('450');
+      expect(ratios.mediumWidth).toMatchInlineSnapshot('800');
+      expect(ratios.mediumHeight).toMatchInlineSnapshot('600');
+      expect(ratios.largeWidth).toMatchInlineSnapshot('400');
+      expect(ratios.largeHeight).toMatchInlineSnapshot('300');
     });
     it('MD on 3:2', () => {
       const ratios = ratiosFor('MD', '3:2');
-      expect(ratios.smallWidth).toBe(274);
-      expect(ratios.smallHeight).toBe(183);
-      expect(ratios.mediumWidth).toBe(274);
-      expect(ratios.mediumHeight).toBe(183);
-      expect(ratios.largeWidth).toBe(400);
-      expect(ratios.largeHeight).toBe(267);
+      expect(ratios.smallWidth).toMatchInlineSnapshot('600');
+      expect(ratios.smallHeight).toMatchInlineSnapshot('400');
+      expect(ratios.mediumWidth).toMatchInlineSnapshot('800');
+      expect(ratios.mediumHeight).toMatchInlineSnapshot('533');
+      expect(ratios.largeWidth).toMatchInlineSnapshot('400');
+      expect(ratios.largeHeight).toMatchInlineSnapshot('267');
     });
 
     it('SM on 16:9', () => {


### PR DESCRIPTION
## Description
Use larger image sizes for medium and large promos

## Jira Ticket
- [TMEDIA-520](https://arcpublishing.atlassian.net/browse/TMEDIA-520)

## Acceptance Criteria
When Medium promo items in the Top Table List, Medium Promo, and Manual Medium Promo, the width of the image we use on mobile viewports is set to 800px for medium breakpoint and 600px for small breakpoint (800px and 600px are guidance-- if another available size works better, we can use those)

When Large promo items in the Top Table List, Large Promo, and Manual Large Promo are configured to use Image Above or Image Below, the width of the image we use on mobile viewports is set to 800px for medium breakpoint and 600px for small breakpoint (800px and 600px are guidance-- if another available size works better, we can use those)

Tests and documentation are updated to cover this new functionality

## Test Steps

1. Checkout this branch `git checkout TMEDIA-520-bigger-mobile-images`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/resizer-image-block`
3. Look at promos medium and large for localhost/pf/all-blocks-jc/?_website=arc-demo-1 to ensure that they are not upsized on mobile and tablet

## Effect Of Changes
### Before

-stretched image

<img width="1218" alt="Screen Shot 2021-10-15 at 12 44 52" src="https://user-images.githubusercontent.com/5950956/137525126-568f8d4f-f74c-4db4-a77f-e9119a46aa3e.png">

### After

larger size that fits viewport 

<img width="1144" alt="Screen Shot 2021-10-15 at 12 52 13" src="https://user-images.githubusercontent.com/5950956/137525060-ea1f7b72-3d7c-44a8-b4c2-aea94426bcbb.png">


## Dependencies or Side Effects


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x]  Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
