### PR TITLE
TMEDIA-359 : Add HTML Block to story book

### DIFF
--- a/.storybook/alias/context.js
+++ b/.storybook/alias/context.js
@@ -49,6 +49,7 @@ export const useFusionContext = () => ({
     pinterest: true,
     twitter: true,
     linkedIn: true,
+    HTML: '<h1>Sample HTML</h1><p>This is sentence <strong>one</strong>.</p><p>This is sentence <em>two</em>.</p>'
   },
   globalContent: {
     headlines: {

--- a/blocks/htmlbox-block/index.story.jsx
+++ b/blocks/htmlbox-block/index.story.jsx
@@ -8,4 +8,4 @@ export default {
   },
 };
 
-export const LoremIpsum = () => <HTMLBox />;
+export const SampleHTML = () => <HTMLBox />;

--- a/blocks/htmlbox-block/index.story.jsx
+++ b/blocks/htmlbox-block/index.story.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import HTMLBox from './features/htmlbox/default';
+
+export default {
+  title: 'Blocks/HTML Box',
+  parameters: {
+    chromatic: { viewports: [320, 1200] },
+  },
+};
+
+export const LoremIpsum = () => <HTMLBox />;


### PR DESCRIPTION
## Description
Added storybook story for `HTMLBox` block.

## Jira Ticket
- [TMEDIA-359](https://arcpublishing.atlassian.net/browse/TMEDIA-359)


## Acceptance Criteria
1. Add the following blocks to the Blocks storybook, and set them up for visual regression testing with Chromatic: 
    1. HTML block

## Test Steps
1. Checkout this branch `git checkout TMEDIA-359-add-HTML-block-to-StoryBook`
2. Run Storybox locally with `npm run storybook`
3. Verify `HTML Box` has been added with other blocks.

## Effect Of Changes
### Before
Storybook block visualizations did not include HTML Box.

### After
Storybook block visualizations now include HTML Box.

![image](https://user-images.githubusercontent.com/452134/137814492-84d3b79e-240e-497c-94f7-cfd15f237052.png)

## Dependencies or Side Effects
Due to the way this blocks `HTML` custom feature is imported via `FusionContext()`, I added an `HTML` custom field to the Storybook aliases. Please let me know if there is another preferred approach. Thanks!

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
