### PR TITLE
TMEDIA-490 - Add logic for single and two cards

### DIFF
--- a/blocks/subscriptions-block/components/GridList/index.jsx
+++ b/blocks/subscriptions-block/components/GridList/index.jsx
@@ -1,10 +1,10 @@
-import React, { Children } from 'react';
+import React from 'react';
 import PropTypes from '@arc-fusion/prop-types';
 
 import './styles.scss';
 
 const GridList = ({ children }) => {
-  const childCount = Children.toArray(children).length;
+  const childCount = React.Children.count(children);
   const additionalClass = childCount ? `xpmedia-subscription-grid-list--${childCount}` : '';
 
   if (!children) {

--- a/blocks/subscriptions-block/components/GridList/index.jsx
+++ b/blocks/subscriptions-block/components/GridList/index.jsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { Children } from 'react';
 import PropTypes from '@arc-fusion/prop-types';
 
 import './styles.scss';
 
 const GridList = ({ children }) => {
-  const additionalClass = children.length > 3 ? `xpmedia-subscription-grid-list--${children.length}` : '';
+  const childCount = Children.toArray(children).length;
+  const additionalClass = childCount ? `xpmedia-subscription-grid-list--${childCount}` : '';
+
+  if (!children) {
+    return null;
+  }
+
   return (
     <div className={`xpmedia-subscription-grid-list ${additionalClass}`}>
       {children}

--- a/blocks/subscriptions-block/components/GridList/index.story.jsx
+++ b/blocks/subscriptions-block/components/GridList/index.story.jsx
@@ -9,6 +9,19 @@ export default {
   },
 };
 
+export const singleItem = () => (
+  <GridList>
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+  </GridList>
+);
+
+export const twoItems = () => (
+  <GridList>
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+    <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />
+  </GridList>
+);
+
 export const threeItems = () => (
   <GridList>
     <div style={{ background: 'rgb(200 200 200)', height: '5vh' }} />

--- a/blocks/subscriptions-block/components/GridList/index.test.jsx
+++ b/blocks/subscriptions-block/components/GridList/index.test.jsx
@@ -3,6 +3,25 @@ import { mount } from 'enzyme';
 import GridList from '.';
 
 describe('GridList', () => {
+  it('renders nothing when no children', () => {
+    const wrapper = mount(
+      <GridList />,
+    );
+
+    expect(wrapper.html()).toBe(null);
+  });
+
+  it('renders one child', () => {
+    const wrapper = mount(
+      <GridList>
+        <div />
+      </GridList>,
+    );
+
+    expect(wrapper.find('.xpmedia-subscription-grid-list').exists()).toBe(true);
+    expect(wrapper.find('.xpmedia-subscription-grid-list--1').exists()).toBe(true);
+  });
+
   it('renders three children', () => {
     const wrapper = mount(
       <GridList>

--- a/blocks/subscriptions-block/components/GridList/styles.scss
+++ b/blocks/subscriptions-block/components/GridList/styles.scss
@@ -1,9 +1,22 @@
 .xpmedia-subscription-grid-list {
   display: grid;
   grid-gap: map-get($spacers, 'lg');
+  grid-template-columns: 1fr;
+  justify-content: center;
 
   @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-    grid-template-columns: repeat(3, 1fr);
+
+    &--1 {
+      grid-template-columns: minmax(auto, 600px);
+    }
+
+    &--2 {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    &--3 {
+      grid-template-columns: repeat(3, 1fr);
+    }
 
     &--4 {
       grid-template-columns: 1fr 1fr;

--- a/blocks/subscriptions-block/components/GridList/styles.scss
+++ b/blocks/subscriptions-block/components/GridList/styles.scss
@@ -5,7 +5,6 @@
   justify-content: center;
 
   @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-
     &--1 {
       grid-template-columns: minmax(auto, 600px);
     }


### PR DESCRIPTION
## Description
Missed logic for single and two cards

## Jira Ticket
- [TMEDIA-490](https://arcpublishing.atlassian.net/browse/TMEDIA-490)

## Test Steps

1. Checkout this branch `git checkout grid-list-1-and-2-items`
2. Run storybook locally `npm run storybook`
3. Check the stories under Blocks/Subscriptions/Components/Grid List

Check chromatic and accept changes - https://www.chromatic.com/build?appId=5f91e4721ccaba0022a10782&number=1246

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
