### PR TITLE
HOTFIX - Updates to output type to work with updated meta data canonical link

### DIFF
--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -19,7 +19,6 @@ describe('the default output type', () => {
   beforeAll(() => {
     jest.mock('fusion:context', () => ({
       useFusionContext: jest.fn(() => ({
-        globalContent: {},
         arcSite: 'the-sun',
       })),
     }));

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -88,6 +88,16 @@ const fontUrlLink = (fontUrl) => {
   ) : '';
 };
 
+const getCanonicalDomain = (globalContent) => {
+  if (!globalContent) {
+    return null;
+  }
+
+  const canonicalSiteProperties = getProperties(globalContent?.canonical_website);
+
+  return canonicalSiteProperties?.websiteDomain || null;
+};
+
 const SampleOutputType = ({
   children,
   contextPath,
@@ -179,6 +189,7 @@ const SampleOutputType = ({
           globalContent={globalContent}
           websiteName={websiteName}
           websiteDomain={websiteDomain}
+          canonicalDomain={getCanonicalDomain(globalContent)}
           twitterUsername={twitterUsername}
           resizerURL={resizerURL}
           arcSite={arcSite}


### PR DESCRIPTION
## Description
Updates to the default output type to work with the update MetaData component that now has a `canonicalDomain` prop that takes the canonical domain name to be used in canonical links for article, video and gallery page types.

## Jira Ticket
- [TMEDIA-530](https://arcpublishing.atlassian.net/browse/TMEDIA-530)


## Test Steps

1. Checkout this branch `git checkout TMEDIA-530-canonical-hotfix`
2. Checkout out the SDK branch `TMEDIA-530-canonical-hotfix`
3. Ensure the SDK is linked via your .env file `ENGINE_SDK_REPO=`
4. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/default-output-block`
5. Visit an article page on the primary site and a second site and very the canonical link type uses the same domain for both
    * Article canonical site is the-gazette and should use the gazette's website domain
    * http://localhost/local/2020/01/14/tampa-reinvents-itself-to-show-off-its-shores/?_website=the-gazette
    * http://localhost/local/2020/01/14/tampa-reinvents-itself-to-show-off-its-shores/?_website=the-sun

## Dependencies or Side Effects

Require SDK updates - https://github.com/WPMedia/engine-theme-sdk/pull/503


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
