### PR TITLE
TMEDIA-532 - Only use resizer when image contains http

### DIFF
--- a/blocks/placeholder-image-block/features/placeholder-image/default.jsx
+++ b/blocks/placeholder-image-block/features/placeholder-image/default.jsx
@@ -24,6 +24,7 @@ const PlaceholderImage = ({ client = false }) => {
   } = getProperties(arcSite);
 
   const targetFallbackImage = getFallbackImageURL({ deployment, contextPath, fallbackImage });
+  const absoluteImageURL = targetFallbackImage.includes('http');
   const imageProps = {
     url: targetFallbackImage,
     smallWidth: 800,
@@ -37,12 +38,12 @@ const PlaceholderImage = ({ client = false }) => {
     resizerURL,
   };
 
-  const placeholderResizedImageOptions = useContent({
+  const placeholderResizedImageOptions = useContent(absoluteImageURL ? {
     source: client ? 'resize-image-api-client' : 'resize-image-api',
     query: { raw_image_url: targetFallbackImage, respect_aspect_ratio: true },
-  });
+  } : {});
 
-  if (!placeholderResizedImageOptions) {
+  if (!placeholderResizedImageOptions && absoluteImageURL) {
     return null;
   }
 

--- a/blocks/placeholder-image-block/features/placeholder-image/default.test.jsx
+++ b/blocks/placeholder-image-block/features/placeholder-image/default.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useContent } from 'fusion:content';
+import getProperties from 'fusion:properties';
 import { mount } from 'enzyme';
 import PlaceholderImage from './default';
 
@@ -18,34 +19,46 @@ jest.mock('fusion:context', () => ({
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({
   websiteDomain: '',
-  fallbackImage: 'resources/placeholder.jpg',
+  fallbackImage: 'http://resources/placeholder.jpg',
   resizerURL: 'resizer',
 }))));
 
 describe('placeholder-block', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
+  describe('absolute URL', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('renders nothing if no resizer image options for placeholder image', () => {
+      useContent.mockReturnValueOnce(null);
+      const wrapper = mount(<PlaceholderImage />);
+
+      expect(wrapper.html()).toBe(null);
+    });
+
+    it('renders Image', () => {
+      useContent.mockReturnValueOnce({ abc: 123 });
+      const wrapper = mount(<PlaceholderImage />);
+
+      expect(wrapper.find('Image').length).toBe(1);
+    });
+
+    it('used client side content source with client prop defined', () => {
+      useContent.mockReturnValueOnce({ abc: 123 });
+      const wrapper = mount(<PlaceholderImage client />);
+
+      expect(useContent).toBeCalledWith({ query: { raw_image_url: 'http://resources/placeholder.jpg', respect_aspect_ratio: true }, source: 'resize-image-api-client' });
+      expect(wrapper.find('Image').length).toBe(1);
+    });
   });
 
-  it('renders nothing if no resizer image options for placeholder image', () => {
-    useContent.mockReturnValueOnce(null);
-    const wrapper = mount(<PlaceholderImage />);
+  describe('relative URL', () => {
+    it('uses no content source', () => {
+      getProperties.mockReturnValueOnce({ fallbackImage: '/resources/test.jpg' });
+      const wrapper = mount(<PlaceholderImage client />);
 
-    expect(wrapper.html()).toBe(null);
-  });
-
-  it('renders Image', () => {
-    useContent.mockReturnValueOnce({ abc: 123 });
-    const wrapper = mount(<PlaceholderImage />);
-
-    expect(wrapper.find('Image').length).toBe(1);
-  });
-
-  it('used client side content source with client prop defined', () => {
-    useContent.mockReturnValueOnce({ abc: 123 });
-    const wrapper = mount(<PlaceholderImage client />);
-
-    expect(useContent).toBeCalledWith({ query: { raw_image_url: '/pf/resources/placeholder.jpg', respect_aspect_ratio: true }, source: 'resize-image-api-client' });
-    expect(wrapper.find('Image').length).toBe(1);
+      expect(useContent).toHaveBeenCalledWith({});
+      expect(wrapper.find('Image').length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Description
Update the placeholder block to not call the resizer content source for local images

## Jira Ticket
- [TMEDIA-532](https://arcpublishing.atlassian.net/browse/TMEDIA-532)

## Acceptance Criteria
The placeholder image block should be updated to not fetch resized image options for relative image URLs, and display image

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-532-placeholder-relative-images`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/placeholder-image-block`
3. Grab a copy of the CoreComponent Pagebuilder data
4. Validate this page shows placeholder image - http://localhost/pf/top-table-list-placeholders/?_website=the-gazette
5. Validate this page shows placeholder image - This site is using local fallback image - http://localhost/pf/top-table-list-placeholders/?_website=the-sun

## Effect Of Changes
### Before

<img width="1077" alt="TMEDIA-532-before" src="https://user-images.githubusercontent.com/868127/139327000-b93263c8-cf95-4a01-914a-a1dee5016775.png">


### After

<img width="1082" alt="TMEDIA-532-after" src="https://user-images.githubusercontent.com/868127/139327020-27c7d36d-5622-4969-9943-a7b2ec0294b8.png">


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
