### PR TITLE
POC Setup codespace with npm and storybook 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.202.5/containers/javascript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.202.5/containers/javascript-node
+{
+	"name": "Node.js",
+	"runArgs": ["--init"],
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
+		// Append -bullseye or -buster to pin to an OS version.
+		// Use -bullseye variants on local arm64/Apple Silicon.
+		"args": { "VARIANT": "12" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [60001],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm config set @wpmedia:registry=https://npm.pkg.github.com/ && npm config set registry=https://registry.npmjs.org && npm config set '//npm.pkg.github.com/:_authToken' ${NPM_PAT_THEMES_CODESPACE} && npm ci && npm run storybook",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node",
+	"features": {
+		"github-cli": "latest"
+	},
+	"portsAttributes": {
+		"60001": {
+			"label": "StoryBook"
+		}
+	}
+}


### PR DESCRIPTION
- Watching github universe, I set this up with devcontainer startup using secrets for read-only package token and running storybook on start https://www.githubuniverse.com/2021/v/s-707713?i=BspKY7zE38ZbIP24PJlqSxbxs6nkki06
- To test, open it up in codespace! *You may need to create a codespace from here

<img width="899" alt="Screen Shot 2021-10-29 at 11 01 58" src="https://user-images.githubusercontent.com/5950956/139466811-e27d19e3-a0b0-43d3-80c0-8cacebd76c49.png">

- Look at ports for labelled storybook forwarded port

<img width="430" alt="Screen Shot 2021-10-29 at 11 02 56" src="https://user-images.githubusercontent.com/5950956/139466903-db36eec6-5382-43bf-8091-e20231a16016.png">

- See storybook running and reacts to changes

<img width="890" alt="Screen Shot 2021-10-29 at 11 03 35" src="https://user-images.githubusercontent.com/5950956/139466978-73ecc414-c8c6-47e3-91fc-41e136d8fac4.png">
 
