### PR TITLE
SPIKE TMEDIA-542: Rename fusion news theme blocks to fusion theme blocks (Foundation work)

### DIFF
--- a/.storybook/arcTheme.js
+++ b/.storybook/arcTheme.js
@@ -41,7 +41,7 @@ export default create({
   inputBorderRadius: 4,
 
   brandTitle: 'Theme Blocks',
-  brandUrl: 'https://github.com/WPMedia/fusion-news-theme-blocks',
+  brandUrl: 'https://github.com/WPMedia/fusion-theme-blocks',
   // todo: change this to a legitimate image url
   // brandImage: 'https://arcdesignsystem.com/img/arc-logo-black.svg',
 });

--- a/News Theme Development.md
+++ b/News Theme Development.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-All of the themes-related packages reside in the GitHub Package Registry. This means that you are now able to manage the packages directly in GitHub (for example, this repo's packages reside [here](https://github.com/WPMedia/fusion-news-theme-blocks/packages)), as well as incorporate GitHub Actions. You also need to make sure that you are setup with enabling SSO if you're pushing to the repo. [Please follow](https://help.github.com/en/github/authenticating-to-github/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on) GitHub docs. If you don't, you'll get errors that the blocks can't be installed when trying to run `npx fusion start` in your local feature blocks repo. See [documentation](https://github.com/WPMedia/Fusion-News-Theme#how-to-do-local-themes-development) for a step-by-step setup.
+All of the themes-related packages reside in the GitHub Package Registry. This means that you are now able to manage the packages directly in GitHub (for example, this repo's packages reside [here](https://github.com/WPMedia/fusion-theme-blocks/packages)), as well as incorporate GitHub Actions. You also need to make sure that you are setup with enabling SSO if you're pushing to the repo. [Please follow](https://help.github.com/en/github/authenticating-to-github/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on) GitHub docs. If you don't, you'll get errors that the blocks can't be installed when trying to run `npx fusion start` in your local feature blocks repo. See [documentation](https://github.com/WPMedia/Fusion-News-Theme#how-to-do-local-themes-development) for a step-by-step setup.
 
 To set up this repo for local development and deployment, you'll have to set up your .npmrc like so:
 
@@ -54,19 +54,19 @@ The engine-theme-sdk is located at: <https://github.com/WPMedia/engine-theme-sdk
 
 For contributing to that repo, please see its contributing guidelines.
 
-### fusion-news-theme-blocks
+### fusion-theme-blocks
 
-The fusion-news-theme-blocks repo is located at: <https://github.com/WPMedia/fusion-news-theme-blocks>. In a typical client setup, you have a feature pack repository and inside you have a components directory where you store your code for feature, chains, etc. In our theme's environment, the majority of these components will be stored in this repo instead. We refer to these external components as "blocks." The components directory in the feature pack will be reserved for custom components that the client might build. This separation from the feature pack will allow the customer to pick and choose the components that they want added in their site. Also, because fusion-news-them-blocks is a multi-repo (using Lerna), any unused components will not be part of the client bundle.
+The fusion-theme-blocks repo is located at: <https://github.com/WPMedia/fusion-theme-blocks>. In a typical client setup, you have a feature pack repository and inside you have a components directory where you store your code for feature, chains, etc. In our theme's environment, the majority of these components will be stored in this repo instead. We refer to these external components as "blocks." The components directory in the feature pack will be reserved for custom components that the client might build. This separation from the feature pack will allow the customer to pick and choose the components that they want added in their site. Also, because fusion-news-them-blocks is a multi-repo (using Lerna), any unused components will not be part of the client bundle.
 
-As indicated from the diagram above, fusion-news-theme-blocks is dependent on the engine-theme-sdk and news-theme-css packages. As you will see in the fusion-news-theme section, we have a way to set theming properties (color, font-family, etc). To set these properties, we are using styled components to inject these values into the component.
+As indicated from the diagram above, fusion-theme-blocks is dependent on the engine-theme-sdk and news-theme-css packages. As you will see in the fusion-news-theme section, we have a way to set theming properties (color, font-family, etc). To set these properties, we are using styled components to inject these values into the component.
 
-The development process is similar engine-theme-sdk, except when it comes time to publish, you need to follow the Lerna publish procedure. For more information, see the repo's read me: <https://github.com/WPMedia/fusion-news-theme-blocks/blob/stable/README.md>
+The development process is similar engine-theme-sdk, except when it comes time to publish, you need to follow the Lerna publish procedure. For more information, see the repo's read me: <https://github.com/WPMedia/fusion-theme-blocks/blob/stable/README.md>
 
-Note: When creating a bundle, you will need a `.npmrc` file in your feature pack that has credentials accessed to the GitHub Package Registry. Please see [guide](https://github.com/WPMedia/Fusion-News-Theme#how-to-do-local-themes-development) for more info on what you need in the `.npmrc` in the feature pack (Fusion-News-Theme) and also in the blocks repo (fusion-news-theme-blocks) for local development. There's also more info on `npx fusion zip` for creating a bundle on the fusion-cli repo [readme](https://github.com/WPMedia/fusion-cli#commands).
+Note: When creating a bundle, you will need a `.npmrc` file in your feature pack that has credentials accessed to the GitHub Package Registry. Please see [guide](https://github.com/WPMedia/Fusion-News-Theme#how-to-do-local-themes-development) for more info on what you need in the `.npmrc` in the feature pack (Fusion-News-Theme) and also in the blocks repo (fusion-theme-blocks) for local development. There's also more info on `npx fusion zip` for creating a bundle on the fusion-cli repo [readme](https://github.com/WPMedia/fusion-cli#commands).
 
-Local development work on  fusion-news-theme-blocks can be set up so that the changes you make on your local fusion-news-theme-blocks  can be manifested within another local client code base, or Fusion-News-Theme.
+Local development work on  fusion-theme-blocks can be set up so that the changes you make on your local fusion-theme-blocks  can be manifested within another local client code base, or Fusion-News-Theme.
 
-As of 10/13/2020, In fusion-news-theme-blocks, Blocks/header-nav-chain-block use-debounce which needs to be installed manually. Navigate to this block, copy .npmrc file to this dir, do npm install, the (re)start fusion. You can also look into setting up a [global npmrc configuration](https://docs.npmjs.com/cli-commands/config.html).
+As of 10/13/2020, In fusion-theme-blocks, Blocks/header-nav-chain-block use-debounce which needs to be installed manually. Navigate to this block, copy .npmrc file to this dir, do npm install, the (re)start fusion. You can also look into setting up a [global npmrc configuration](https://docs.npmjs.com/cli-commands/config.html).
 ```sh
 cd blocks/header-nav-chain-block
 check .npmrc file here exists
@@ -204,9 +204,9 @@ If you need to create a feature pack to set either `BLOCK_DIST_TAG` to a specifi
 
 ### How To Publish
 
-Merge into `canary` branch to publish to canary tag. Please reach out to arc block maintainers to talk about publishing into `beta`, `stable`, `rc`, or other desired tags. The tags and publish GitHub Actions can be tracked by looking at the [Actions tab on the GitHub UI](https://github.com/WPMedia/fusion-news-theme-blocks/actions) and within the .github folder within the repository.
+Merge into `canary` branch to publish to canary tag. Please reach out to arc block maintainers to talk about publishing into `beta`, `stable`, `rc`, or other desired tags. The tags and publish GitHub Actions can be tracked by looking at the [Actions tab on the GitHub UI](https://github.com/WPMedia/fusion-theme-blocks/actions) and within the .github folder within the repository.
 
-WARNING: If you need help rolling back publish, please see the wiki [How A Dev Can Rollback Published Version](https://github.com/WPMedia/fusion-news-theme-blocks/wiki/How-To-%22Rollback%22-From-A-Published-Version)
+WARNING: If you need help rolling back publish, please see the wiki [How A Dev Can Rollback Published Version](https://github.com/WPMedia/fusion-theme-blocks/wiki/How-To-%22Rollback%22-From-A-Published-Version)
 
 ---
 
@@ -217,7 +217,7 @@ RC Release is the contents of the canary branch once signed off - Canary -> RC
 1. Ensure canary is signed off with all RC tickets merged in
 2. `git checkout canary && git remote update --prune origin && git reset --hard origin/canary` - Checkout canary and reset your local to remote canary
 3. `git push origin canary:rc -f`
-4. Check GitHub action used to publish rc tag for success - https://github.com/WPMedia/fusion-news-theme-blocks/actions/workflows/rc-build.yml
+4. Check GitHub action used to publish rc tag for success - https://github.com/WPMedia/fusion-theme-blocks/actions/workflows/rc-build.yml
 
 Any environment with the `BLOCK_DIST_TAG=rc` will get the updated blocks on next deploy
 
@@ -229,7 +229,7 @@ Beta Release is the contents of the RC branch once signed off - RC -> Beta
 1. Enusre RC is ready - All PR's/hotfixes made against RC are merged in
 2. `git checkout rc && git remote update --prune origin && git reset --hard origin/rc` - Checkout rc and reset your local to remote rc
 3. `git push origin rc:beta -f`
-4. Check GitHub action used to publish beta tag for success - https://github.com/WPMedia/fusion-news-theme-blocks/actions/workflows/beta-build.yml
+4. Check GitHub action used to publish beta tag for success - https://github.com/WPMedia/fusion-theme-blocks/actions/workflows/beta-build.yml
 
 Any environment with the `BLOCK_DIST_TAG=beta` will get the updated blocks on next deploy
 
@@ -239,7 +239,7 @@ Any environment with the `BLOCK_DIST_TAG=beta` will get the updated blocks on ne
 Stable Release is the contents of the beta branch once signed off - beta -> stable
 
 1. Create a Pull Request from Beta -> Stable
-    * https://github.com/WPMedia/fusion-news-theme-blocks/compare/stable...beta?expand=1
+    * https://github.com/WPMedia/fusion-theme-blocks/compare/stable...beta?expand=1
     * Resolve any conflicts
 2. Get pull request approved and merged
 3. Get latest stable code locally - `git checkout stable && git remote update --prune origin && git reset --hard origin/stable`
@@ -249,7 +249,7 @@ Stable Release is the contents of the beta branch once signed off - beta -> stab
     * Make sure all blocks have been graduated or promoted.
     * Check that there is a commit in your local for the next version - created by the `npx lerna` command
     * `git push origin stable`
-    * GitHub action is used to make latest and stable parity - https://github.com/WPMedia/fusion-news-theme-blocks/actions/workflows/stable-dist-tag.yml
+    * GitHub action is used to make latest and stable parity - https://github.com/WPMedia/fusion-theme-blocks/actions/workflows/stable-dist-tag.yml
 5. Merge the last commit from `stable` to `canary` - This should only be the commit that bumps the version numbers.
     * `git checkout stable && git remote update --prune origin && git reset --hard origin/stable`
     * `git checkout canary && git remote update --prune origin && git reset --hard origin/canary`
@@ -321,9 +321,9 @@ Below describes the various properties that are in blocks.json and their purpose
 | --- | --- |
 | **org** | The organization name of the NPM repo. Used internally by Fusion i.e. "@wpmedia/" |
 | **useLocal** | true \| false. Used in local development (see the local dev section below). This will soon be replaced by a more conventual npm link process, so this property will eventually be removed. |
-| **blocks** | This array lists all the blocks that are to be made available to the site. Any block that is in the fusion-news-theme-blocks repo, but not listed here will not be available and will also not be included in the client bundle. |
+| **blocks** | This array lists all the blocks that are to be made available to the site. Any block that is in the fusion-theme-blocks repo, but not listed here will not be available and will also not be included in the client bundle. |
 | **cssFramework** | The CSS framework package being used. For News theme, it is the news-theme-css package. |
-| **cssImport** | Specifies the main Sass file entry point into the framework. This is leveraged by fusion to automatically import the framework into each of the block's source file in fusion-news-theme-blocks during build time. So, in other words, you do not have to explicitly import the css framework in your blocks source code. |
+| **cssImport** | Specifies the main Sass file entry point into the framework. This is leveraged by fusion to automatically import the framework into each of the block's source file in fusion-theme-blocks during build time. So, in other words, you do not have to explicitly import the css framework in your blocks source code. |
 | **sassVariableOverrides** | In addition to using styled components to set theme properties, we also want the css framework to pick up on the custom settings and over-ride the appropriate Sass default properties. Fusion handles the override process internally. |
 | **values** | This is where we set the custom theme values for the site. There are two main areas: default and per site. |
 
@@ -333,7 +333,7 @@ Since this is the feature pack there is no publishing process. In fact, when you
 
 For canary we are currently using this environment: <https://corecomponents.arcpublishing.com/pf/admin/app/browse/pages.html>.
 
-Unless you are adding new resources or custom components in this repo, you do not need to follow a PR process. Usually, you will be creating a new block in fusion-news-theme-blocks and once that has gone through the PR process and pushed to stable and published, all you'll need to do here is make sure its listed in the blocks section of `blocks.json`. If it's not listed, cause it new for example, then feel free to add it and commit immediately to stable. Then, create a build and deploy to the environment for design and general testing. If, however, you are doing something more custom then follow these procedures:
+Unless you are adding new resources or custom components in this repo, you do not need to follow a PR process. Usually, you will be creating a new block in fusion-theme-blocks and once that has gone through the PR process and pushed to stable and published, all you'll need to do here is make sure its listed in the blocks section of `blocks.json`. If it's not listed, cause it new for example, then feel free to add it and commit immediately to stable. Then, create a build and deploy to the environment for design and general testing. If, however, you are doing something more custom then follow these procedures:
 
 1.  First create a branch off stable for what you want to work on.
 2.  Once changes are completed, then add, commit, push all changes to your branch on GitHub.
@@ -406,7 +406,7 @@ _Fusion-News-Theme/.env_
 resizerKey=[no brackets, should be decrypted resizer key in the env index]
 ```
 
-fusion-news-theme-blocks/environment/index.json\*
+fusion-theme-blocks/environment/index.json\*
 
 ```json
 
@@ -419,7 +419,7 @@ fusion-news-theme-blocks/environment/index.json\*
 
 2. Ensure you have your corresponding resizer url for the resizer key for your org. This can also be managed on a per site basis.
 
-_fusion-news-theme-blocks/environment/index.json_
+_fusion-theme-blocks/environment/index.json_
 
 ```json
 
@@ -432,7 +432,7 @@ _fusion-news-theme-blocks/environment/index.json_
 
 3. If you are creating a custom block using the engine-theme-sdk Image component, you will need to import and pass in the resizerURL so that the thumbor url can be recreated.
 
-_fusion-news-theme-blocks/blocks/custom-image-block/index.js_
+_fusion-theme-blocks/blocks/custom-image-block/index.js_
 
 ```jsx
 import getProperties from "fusion:properties";
@@ -556,7 +556,7 @@ _Fusion-News-Theme/blocks.json_
   }
 ```
 
-_fusion-news-theme-blocks/blocks/custom-image-block/index.js_
+_fusion-theme-blocks/blocks/custom-image-block/index.js_
 
 ```jsx
 import { Image } from "@wpmedia/engine-theme-sdk";
@@ -637,7 +637,7 @@ _Fusion-News-Theme/blocks.json_
 
 ```
 
-_fusion-news-theme-blocks/blocks/resizer-image-block/index.js_
+_fusion-theme-blocks/blocks/resizer-image-block/index.js_
 
 ```js
 import { resizerURL, resizerKey } from "fusion:environment";
@@ -688,7 +688,7 @@ const getResizerParam = (
 
 #### Check you're in top-level directory
 
-`pwd` -> /Users/user/sites/fusion-news-theme-blocks
+`pwd` -> /Users/user/sites/fusion-theme-blocks
 
 #### Ensure you have latest version
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fusion News Theme blocks
 
->**[Please See Wiki If You Can't Find What You're Looking For](https://github.com/WPMedia/fusion-news-theme-blocks/wiki), Like [Rolling Back If You Have Publish Issues](https://github.com/WPMedia/fusion-news-theme-blocks/wiki/How-To-%22Rollback%22-From-A-Published-Version)**
+>**[Please See Wiki If You Can't Find What You're Looking For](https://github.com/WPMedia/fusion-theme-blocks/wiki), Like [Rolling Back If You Have Publish Issues](https://github.com/WPMedia/fusion-theme-blocks/wiki/How-To-%22Rollback%22-From-A-Published-Version)**
 
 This is the lerna-managed monorepo for the blocks that make up the Fusion News Theme.
 
@@ -15,7 +15,7 @@ This monorepo is a collection of packages for blocks. Blocks are versioned toget
 This package has been published with a number of dist-tags meant for different purposes:
 
 - `stable`: This tag should be equivalent to `latest` and the process for maintaining parity _should_ be automated with a [Github Action workflow found here](/.github/workflows/stable-dist-tag.yml). If that workflow doesn't work or the versions tagged by `latest` and `stable` do not match you can run `npm run latest-stable-parity` to fix that.
-- `beta`: These are prerelease builds published with the `npx lerna publish --preid beta --pre-dist-tag beta` command from the `beta` branch. [More information can be found here.](/News%20Theme%20Development.md#fusion-news-theme-blocks)
+- `beta`: These are prerelease builds published with the `npx lerna publish --preid beta --pre-dist-tag beta` command from the `beta` branch. [More information can be found here.](/News%20Theme%20Development.md#fusion-theme-blocks)
 - `canary`: These builds are generated with [this Github Action](/.github/workflows/canary-build.yml) on every push to the `canary` branch. These builds don't follow the normal versioning scheme, instead they are published as version `0.0.0` appended with the short commit ID for the commit being built from (ex. `0.0.0-canary`).
 - `rc`: This stands for release candidate. This is not client-facing. 
 - `hotfix`: As you may have guessed, these builds are meant for hotfixes. [More information about how these builds are made can be found here.](/News%20Theme%20Development.md#publish-hotfix)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Fusion News Theme blocks
+# Fusion Theme blocks
 
 >**[Please See Wiki If You Can't Find What You're Looking For](https://github.com/WPMedia/fusion-theme-blocks/wiki), Like [Rolling Back If You Have Publish Issues](https://github.com/WPMedia/fusion-theme-blocks/wiki/How-To-%22Rollback%22-From-A-Published-Version)**
 
-This is the lerna-managed monorepo for the blocks that make up the Fusion News Theme.
+This is the lerna-managed monorepo for the blocks that make up the Fusion Theme.
 
 This monorepo is a collection of packages for blocks. Blocks are versioned together.
 

--- a/blocks/a11y-testing-block/package.json
+++ b/blocks/a11y-testing-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/a11y-testing-block",
   "version": "5.14.1",
-  "description": "Fusion News Theme A11y Testing block",
+  "description": "Fusion Theme A11y Testing block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND",

--- a/blocks/a11y-testing-block/package.json
+++ b/blocks/a11y-testing-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.14.1",
   "description": "Fusion News Theme A11y Testing block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/a11y-testing-block"
   },
   "scripts": {

--- a/blocks/ad-taboola-block/package.json
+++ b/blocks/ad-taboola-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/ad-taboola-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme Taboola Widget",
+  "description": "Fusion Theme Taboola Widget",
   "author": "nelson fernandez <nelson.fernandez@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND",

--- a/blocks/ad-taboola-block/package.json
+++ b/blocks/ad-taboola-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme Taboola Widget",
   "author": "nelson fernandez <nelson.fernandez@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/ad-taboola-block"
   },
   "scripts": {

--- a/blocks/ads-block/package.json
+++ b/blocks/ads-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "> TODO: description",
   "author": "nealmalkani <nealm939@gmail.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "ISC",
   "main": "index.js",
   "files": [
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/ads-block"
   },
   "scripts": {

--- a/blocks/alert-bar-block/package.json
+++ b/blocks/alert-bar-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/alert-bar-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme alert bar block",
+  "description": "Fusion Theme alert bar block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/alert-bar-block/package.json
+++ b/blocks/alert-bar-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme alert bar block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/links-bar-block"
   },
   "scripts": {

--- a/blocks/alert-bar-content-source-block/package.json
+++ b/blocks/alert-bar-content-source-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.14.1",
   "description": "Fusion News Theme collections content API content source block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/alert-bar-content-source-block"
   },
   "scripts": {

--- a/blocks/alert-bar-content-source-block/package.json
+++ b/blocks/alert-bar-content-source-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/alert-bar-content-source-block",
   "version": "5.14.1",
-  "description": "Fusion News Theme collections content API content source block",
+  "description": "Fusion Theme collections content API content source block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/article-body-block/README.md
+++ b/blocks/article-body-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/article-body-block`
-_Fusion News Theme article-body block_
+_Fusion Theme article-body block_
 
 // TODO: add badge for passing/failing tests
 

--- a/blocks/article-body-block/package.json
+++ b/blocks/article-body-block/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/article-body-block"
   },
   "scripts": {

--- a/blocks/article-body-block/package.json
+++ b/blocks/article-body-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/article-body-block",
   "version": "5.17.0",
-  "description": "Fusion News Theme article body block",
+  "description": "Fusion Theme article body block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"

--- a/blocks/article-tag-block/package.json
+++ b/blocks/article-tag-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion Article Tag block",
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/article-tag-block"
   },
   "scripts": {

--- a/blocks/author-bio-block/README.md
+++ b/blocks/author-bio-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/author-bio-block`
-_Author Short Biography block for Fusion News Theme_
+_Author Short Biography block for Fusion Theme_
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/author-bio-block/package.json
+++ b/blocks/author-bio-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/author-bio-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme byline block",
+  "description": "Fusion Theme byline block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/author-bio-block/package.json
+++ b/blocks/author-bio-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme byline block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/author-bio-block"
   },
   "scripts": {

--- a/blocks/author-content-source-block/README.md
+++ b/blocks/author-content-source-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/author-content-source-block`
-Fusion News Theme author API content source block
+Fusion Theme author API content source block
 _Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria

--- a/blocks/author-content-source-block/package.json
+++ b/blocks/author-content-source-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.14.1",
   "description": "Fusion News Theme author API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/author-content-source-block"
   },
   "scripts": {

--- a/blocks/author-content-source-block/package.json
+++ b/blocks/author-content-source-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/author-content-source-block",
   "version": "5.14.1",
-  "description": "Fusion News Theme author API content source block",
+  "description": "Fusion Theme author API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/byline-block/README.md
+++ b/blocks/byline-block/README.md
@@ -1,6 +1,6 @@
 # `@wpmedia/byline-block`
 
-Byline block for Fusion News Theme
+Byline block for Fusion Theme
 
 ## Acceptance Criteria
 - If there's one author, it will return `By <author>`

--- a/blocks/byline-block/package.json
+++ b/blocks/byline-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/byline-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme byline block",
+  "description": "Fusion Theme byline block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "contributors": [
     "Jack Howard <jack.howard@washpost.com>"

--- a/blocks/byline-block/package.json
+++ b/blocks/byline-block/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Jack Howard <jack.howard@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/byline-block"
   },
   "scripts": {

--- a/blocks/card-list-block/README.md
+++ b/blocks/card-list-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/card-list-block`
-Fusion News Theme card list block
+Fusion Theme card list block
 _Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria

--- a/blocks/card-list-block/package.json
+++ b/blocks/card-list-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion themes card list block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/card-list-block"
   },
   "scripts": {

--- a/blocks/collections-content-source-block/README.md
+++ b/blocks/collections-content-source-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/collections-content-source-block`
-Fusion News Theme content API collections content source block. _Please provide a 1-2 sentence description of what the block is and what it does._
+Fusion Theme content API collections content source block. _Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/collections-content-source-block/package.json
+++ b/blocks/collections-content-source-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.14.1",
   "description": "Fusion News Theme collections content API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/collections-content-source-block"
   },
   "scripts": {

--- a/blocks/collections-content-source-block/package.json
+++ b/blocks/collections-content-source-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/collections-content-source-block",
   "version": "5.14.1",
-  "description": "Fusion News Theme collections content API content source block",
+  "description": "Fusion Theme collections content API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/content-api-source-block/package.json
+++ b/blocks/content-api-source-block/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/content-api-source-block"
   },
   "scripts": {

--- a/blocks/date-block/README.md
+++ b/blocks/date-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/date-block`
-Fusion News Theme date block. _Please provide a 1-2 sentence description of what the block is and what it does._
+Fusion Theme date block. _Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/date-block/package.json
+++ b/blocks/date-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme date block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/date-block"
   },
   "scripts": {

--- a/blocks/date-block/package.json
+++ b/blocks/date-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/date-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme date block",
+  "description": "Fusion Theme date block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/default-output-block/README.md
+++ b/blocks/default-output-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/default-output-block`
-Fusion News Theme default output type. _Please provide a 1-2 sentence description of what the block is and what it does._
+Fusion Theme default output type. _Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/default-output-block/package.json
+++ b/blocks/default-output-block/package.json
@@ -7,7 +7,7 @@
     "Jack Howard <jack.howard@washpost.com>",
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/default-output-block"
   },
   "scripts": {

--- a/blocks/default-output-block/package.json
+++ b/blocks/default-output-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/default-output-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme default output type",
+  "description": "Fusion Theme default output type",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "contributors": [
     "Jack Howard <jack.howard@washpost.com>",

--- a/blocks/double-chain-block/README.md
+++ b/blocks/double-chain-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/double-chain-block`
-Fusion News Theme double-chain block. Takes in a number of how many items to be put in column one. The rest go in column two. Negative numbers here will yield nothing.
+Fusion Theme double-chain block. Takes in a number of how many items to be put in column one. The rest go in column two. Negative numbers here will yield nothing.
 
 ## Acceptance Criteria
 - Places features within the Double Chain within two columns. 

--- a/blocks/double-chain-block/package.json
+++ b/blocks/double-chain-block/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Jack Howard <jack.howard@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/double-chain-block"
   },
   "peerDependencies": {

--- a/blocks/event-tester-block/README.md
+++ b/blocks/event-tester-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/event-tester-block`
-_Fusion News Theme event tester block. Used for testing the event emitter.  When new events are created, they should be subscribed to in this component in the constructor.  When this component is added to a page, it will not render anything visually. It will console.log a message altering you what event has been consumed and also dump our the event object that can be inspected to ensure the correct data was captured._
+_Fusion Theme event tester block. Used for testing the event emitter.  When new events are created, they should be subscribed to in this component in the constructor.  When this component is added to a page, it will not render anything visually. It will console.log a message altering you what event has been consumed and also dump our the event object that can be inspected to ensure the correct data was captured._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/event-tester-block/package.json
+++ b/blocks/event-tester-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion News Theme event tester-block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/event-tester-block"
   },
   "scripts": {

--- a/blocks/event-tester-block/package.json
+++ b/blocks/event-tester-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/event-tester-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme event tester-block",
+  "description": "Fusion Theme event tester-block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/extra-large-manual-promo-block/package.json
+++ b/blocks/extra-large-manual-promo-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/extra-large-manual-promo-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme Extra Large Manual Promo block",
+  "description": "Fusion Theme Extra Large Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/extra-large-manual-promo-block/package.json
+++ b/blocks/extra-large-manual-promo-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion News Theme Extra Large Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/extra-large-manual-promo-block"
   },
   "scripts": {

--- a/blocks/extra-large-promo-block/package.json
+++ b/blocks/extra-large-promo-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/extra-large-promo-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme Extra Large Promo block",
+  "description": "Fusion Theme Extra Large Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "contributors": [

--- a/blocks/extra-large-promo-block/package.json
+++ b/blocks/extra-large-promo-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme Extra Large Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/extra-large-promo-block"
   },
   "scripts": {

--- a/blocks/footer-block/README.md
+++ b/blocks/footer-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/header-nav-block`
-_Footer block for the Fusion News Theme. This will pull the data from the footer hierarchy from the organization's site service._
+_Footer block for the Fusion Theme. This will pull the data from the footer hierarchy from the organization's site service._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/footer-block/package.json
+++ b/blocks/footer-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme footer block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/footer-block"
   },
   "scripts": {

--- a/blocks/footer-block/package.json
+++ b/blocks/footer-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/footer-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme footer block",
+  "description": "Fusion Theme footer block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/full-author-bio-block/README.md
+++ b/blocks/full-author-bio-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/full-author-bio-block`
-_Fusion News Theme full author bio block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme full author bio block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/full-author-bio-block/package.json
+++ b/blocks/full-author-bio-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/full-author-bio-block",
   "version": "5.17.0",
-  "description": "Fusion News Theme full author bio block",
+  "description": "Fusion Theme full author bio block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/full-author-bio-block/package.json
+++ b/blocks/full-author-bio-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.17.0",
   "description": "Fusion News Theme full author bio block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/full-author-bio-block"
   },
   "scripts": {
@@ -30,7 +30,7 @@
     "@wpmedia/shared-styles": "*"
   },
   "bugs": {
-    "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
+    "url": "https://github.com/WPMedia/fusion-theme-blocks/issues"
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/gallery-block/package.json
+++ b/blocks/gallery-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/gallery-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme gallery block",
+  "description": "Fusion Theme gallery block",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/gallery-block/package.json
+++ b/blocks/gallery-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme gallery block",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/gallery-block"
   },
   "scripts": {

--- a/blocks/global-phrases-block/package.json
+++ b/blocks/global-phrases-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "A package containing a list of translation phrases expected to be global.",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "ISC",
   "main": "index.js",
   "files": [
@@ -15,14 +15,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "git+https://github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/global-phrases-block"
   },
   "scripts": {
     "test": "echo \"Translation block does not contain tests\""
   },
   "bugs": {
-    "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
+    "url": "https://github.com/WPMedia/fusion-theme-blocks/issues"
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95",
   "peerDependencies": {

--- a/blocks/header-block/README.md
+++ b/blocks/header-block/README.md
@@ -1,5 +1,5 @@
 # `@arc-test-org/header-block`
-_Fusion News Theme header block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme header block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/header-block/package.json
+++ b/blocks/header-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion themes header block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/header-block"
   },
   "scripts": {
@@ -28,7 +28,7 @@
     "@wpmedia/shared-styles": "*"
   },
   "bugs": {
-    "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
+    "url": "https://github.com/WPMedia/fusion-theme-blocks/issues"
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/header-nav-block/package.json
+++ b/blocks/header-nav-block/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/header-nav-block"
   },
   "scripts": {

--- a/blocks/header-nav-block/package.json
+++ b/blocks/header-nav-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/header-nav-block",
   "version": "5.17.0",
-  "description": "Fusion News Theme header nav block",
+  "description": "Fusion Theme header nav block",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"

--- a/blocks/header-nav-chain-block/package.json
+++ b/blocks/header-nav-chain-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/header-nav-chain-block",
   "version": "5.19.0",
-  "description": "Fusion News Theme header nav chain block",
+  "description": "Fusion Theme header nav chain block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/header-nav-chain-block/package.json
+++ b/blocks/header-nav-chain-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.19.0",
   "description": "Fusion News Theme header nav chain block",
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/header-nav-chain-block"
   },
   "scripts": {

--- a/blocks/headline-block/README.md
+++ b/blocks/headline-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/headline-block`
-_Fusion News Theme headline block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme headline block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/headline-block/package.json
+++ b/blocks/headline-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/headline-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme headline block",
+  "description": "Fusion Theme headline block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/headline-block/package.json
+++ b/blocks/headline-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion News Theme headline block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/headline-block"
   },
   "scripts": {

--- a/blocks/htmlbox-block/README.md
+++ b/blocks/htmlbox-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/htmlbox-block`
-_HTML Box for block for Fusion News Theme. Please provide a 1-2 sentence description of what the block is and what it does._
+_HTML Box for block for Fusion Theme. Please provide a 1-2 sentence description of what the block is and what it does._
 
 // TODO: add badge for passing/failing tests
 

--- a/blocks/htmlbox-block/package.json
+++ b/blocks/htmlbox-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion News Theme HTMLBox block",
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/htmlbox-block"
   },
   "scripts": {

--- a/blocks/htmlbox-block/package.json
+++ b/blocks/htmlbox-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/htmlbox-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme HTMLBox block",
+  "description": "Fusion Theme HTMLBox block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/identity-block/package.json
+++ b/blocks/identity-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion themes identity block.",
   "author": "ARC XP",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/identity-block"
   },
   "scripts": {
@@ -33,7 +33,7 @@
     "@wpmedia/shared-styles": "*"
   },
   "bugs": {
-    "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
+    "url": "https://github.com/WPMedia/fusion-theme-blocks/issues"
   },
   "dependencies": {
     "@arc-fusion/prop-types": "^0.1.5",

--- a/blocks/large-manual-promo-block/package.json
+++ b/blocks/large-manual-promo-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion News Theme Large Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/large-manual-promo-block"
   },
   "scripts": {

--- a/blocks/large-manual-promo-block/package.json
+++ b/blocks/large-manual-promo-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/large-manual-promo-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme Large Manual Promo block",
+  "description": "Fusion Theme Large Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/large-promo-block/package.json
+++ b/blocks/large-promo-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/large-promo-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme Large Promo block",
+  "description": "Fusion Theme Large Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "contributors": [

--- a/blocks/large-promo-block/package.json
+++ b/blocks/large-promo-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme Large Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/large-promo-block"
   },
   "scripts": {

--- a/blocks/lead-art-block/README.md
+++ b/blocks/lead-art-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/lead-art-block`
-_Fusion News Theme lead art block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme lead art block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/lead-art-block/package.json
+++ b/blocks/lead-art-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme lead art block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/lead-art-block"
   },
   "peerDependencies": {

--- a/blocks/lead-art-block/package.json
+++ b/blocks/lead-art-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/lead-art-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme lead art block",
+  "description": "Fusion Theme lead art block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/links-bar-block/package.json
+++ b/blocks/links-bar-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/links-bar-block",
   "version": "5.17.0",
-  "description": "Fusion News Theme links bar block",
+  "description": "Fusion Theme links bar block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"

--- a/blocks/links-bar-block/package.json
+++ b/blocks/links-bar-block/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/links-bar-block"
   },
   "scripts": {

--- a/blocks/masthead-block/README.md
+++ b/blocks/masthead-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/masthead-block`
-_Fusion News Theme masthead block is a relatively simple feature that is typically only used on newspaper homepages. It displays the logo, the date, a tag line, and an optional link (usually to a Weather page but could be to other pages)._
+_Fusion Theme masthead block is a relatively simple feature that is typically only used on newspaper homepages. It displays the logo, the date, a tag line, and an optional link (usually to a Weather page but could be to other pages)._
 
 ## Acceptance Criteria
 - As a Themes customer, I can put a Masthead Arc Block onto my homepage, because I want this traditional newspaper design element 

--- a/blocks/masthead-block/package.json
+++ b/blocks/masthead-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Masthead – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/masthead-block"
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"

--- a/blocks/medium-manual-promo-block/package.json
+++ b/blocks/medium-manual-promo-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion News Theme Medium Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/medium-manual-promo-block"
   },
   "scripts": {

--- a/blocks/medium-manual-promo-block/package.json
+++ b/blocks/medium-manual-promo-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/medium-manual-promo-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme Medium Manual Promo block",
+  "description": "Fusion Theme Medium Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/medium-promo-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme Medium Promo block",
+  "description": "Fusion Theme Medium Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/medium-promo-block/package.json
+++ b/blocks/medium-promo-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme Medium Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/medium-promo-block"
   },
   "scripts": {

--- a/blocks/numbered-list-block/README.md
+++ b/blocks/numbered-list-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/numbered-list-block`
-_Numbered List block for Fusion News Theme. Displays a numbered list where each list item will have a number, headline and an Image._
+_Numbered List block for Fusion Theme. Displays a numbered list where each list item will have a number, headline and an Image._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/numbered-list-block/package.json
+++ b/blocks/numbered-list-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/numbered-list-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme numbered list block",
+  "description": "Fusion Theme numbered list block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/numbered-list-block/package.json
+++ b/blocks/numbered-list-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme numbered list block",
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "contributors": [
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/numbered-list-block"
   },
   "scripts": {

--- a/blocks/overline-block/README.md
+++ b/blocks/overline-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/overline-block`
-_Fusion News Theme Overline block. Text usually displayed over the headline. By default will use the ANS fields Label or Web Site Section if they exist or optionally a custom text and url can be used._
+_Fusion Theme Overline block. Text usually displayed over the headline. By default will use the ANS fields Label or Web Site Section if they exist or optionally a custom text and url can be used._
 
 ## Props
 | **Prop** | **Required** | **Type** | **Description** |

--- a/blocks/overline-block/package.json
+++ b/blocks/overline-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion themes block containing an overline block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/overline-block"
   },
   "scripts": {
@@ -29,7 +29,7 @@
     "@wpmedia/shared-styles": "*"
   },
   "bugs": {
-    "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
+    "url": "https://github.com/WPMedia/fusion-theme-blocks/issues"
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/placeholder-image-block/README.md
+++ b/blocks/placeholder-image-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/placeholder-image-block`
-_Fusion News Theme placeholder image. The intended use is to take the feature pack fallback image, as an external url or relative path._
+_Fusion Theme placeholder image. The intended use is to take the feature pack fallback image, as an external url or relative path._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/placeholder-image-block/package.json
+++ b/blocks/placeholder-image-block/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/placeholder-image-block"
   },
   "keywords": [

--- a/blocks/quad-chain-block/README.md
+++ b/blocks/quad-chain-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/triple-chain-block`
-_Fusion News Theme quad-chain block. Utilizes bootstrap's three column approach on anything but small size._
+_Fusion Theme quad-chain block. Utilizes bootstrap's three column approach on anything but small size._
 
 ## Acceptance Criteria
 - Takes in a number of how many items to be put in column one, two, and three. The rest go in column four. Negative numbers here will yield nothing.

--- a/blocks/quad-chain-block/package.json
+++ b/blocks/quad-chain-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Quad Chain – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/quad-chain-block"
   },
   "scripts": {

--- a/blocks/related-content-content-source-block/package.json
+++ b/blocks/related-content-content-source-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.14.1",
   "description": "Content source block to get stories related content.",
   "author": "nelson fernandez <nelson.fernandez@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/related-content-content-source--block"
   },
   "scripts": {

--- a/blocks/resizer-image-block/package.json
+++ b/blocks/resizer-image-block/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "git+https://github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/resizer-image-block"
   },
   "publishConfig": {
@@ -25,9 +25,9 @@
   "author": "Jack Howard <jack.howard@washpost.com>",
   "license": "CC-BY-NC-ND-4.0",
   "bugs": {
-    "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
+    "url": "https://github.com/WPMedia/fusion-theme-blocks/issues"
   },
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "peerDependencies": {
     "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/engine-theme-sdk": "*",

--- a/blocks/resizer-image-content-source-block/package.json
+++ b/blocks/resizer-image-content-source-block/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/resizer-image-content-source-block"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
   },
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "files": [
     "sources"
   ],

--- a/blocks/results-list-block/README.md
+++ b/blocks/results-list-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/results-list-block`
-_Results List block for Fusion News Theme. Displays a results list where each result card will have a description, headline, byline block and publish date. ._
+_Results List block for Fusion Theme. Displays a results list where each result card will have a description, headline, byline block and publish date. ._
 
 ## Acceptance Criteria
 - If there's one author, it will return `By <author>`

--- a/blocks/results-list-block/package.json
+++ b/blocks/results-list-block/package.json
@@ -7,7 +7,7 @@
     "Beltran Caliz <beltran.caliz@washpost.com>",
     "Jack Howard <jack.howard@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/results-list-block"
   },
   "scripts": {

--- a/blocks/results-list-block/package.json
+++ b/blocks/results-list-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/results-list-block",
   "version": "5.17.0",
-  "description": "Fusion News Theme results list block",
+  "description": "Fusion Theme results list block",
   "author": "Jack Howard <jack.howard@washpost.com>",
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>",

--- a/blocks/right-rail-advanced-block/package.json
+++ b/blocks/right-rail-advanced-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion themes block containing an advanced right-rail layout.",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/right-rail-advanced-block"
   },
   "scripts": {

--- a/blocks/right-rail-block/package.json
+++ b/blocks/right-rail-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion themes block containing a right-rail layout.",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/right-rail-block"
   },
   "scripts": {

--- a/blocks/search-content-source-block/README.md
+++ b/blocks/search-content-source-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/search-content-source-block`
-_Fusion News Theme unpublished API content source block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme unpublished API content source block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/search-content-source-block/package.json
+++ b/blocks/search-content-source-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.14.1",
   "description": "Fusion News Theme search API content source block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/search-content-source-block"
   },
   "scripts": {

--- a/blocks/search-content-source-block/package.json
+++ b/blocks/search-content-source-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/search-content-source-block",
   "version": "5.14.1",
-  "description": "Fusion News Theme search API content source block",
+  "description": "Fusion Theme search API content source block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/search-results-list-block/README.md
+++ b/blocks/search-results-list-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/search-results-list-block`
-_Search Results List block for Fusion News Theme. This block displays a search bar with a results list where each result card will have a description, headline, byline block and publish date._
+_Search Results List block for Fusion Theme. This block displays a search bar with a results list where each result card will have a description, headline, byline block and publish date._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/search-results-list-block/package.json
+++ b/blocks/search-results-list-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/search-results-list-block",
   "version": "5.17.0",
-  "description": "Fusion News Theme search results list block",
+  "description": "Fusion Theme search results list block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/search-results-list-block/package.json
+++ b/blocks/search-results-list-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.17.0",
   "description": "Fusion News Theme search results list block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/search-results-list-block"
   },
   "scripts": {
@@ -31,7 +31,7 @@
     "styled-components": "^4.4.0"
   },
   "bugs": {
-    "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
+    "url": "https://github.com/WPMedia/fusion-theme-blocks/issues"
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/section-title-block/README.md
+++ b/blocks/section-title-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/section-title-block`
-_Fusion News Theme section title block# Name of Block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme section title block# Name of Block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/section-title-block/package.json
+++ b/blocks/section-title-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/section-title-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme section title block",
+  "description": "Fusion Theme section title block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/section-title-block/package.json
+++ b/blocks/section-title-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion News Theme section title block",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/section-title-block"
   },
   "scripts": {
@@ -29,7 +29,7 @@
     "@wpmedia/shared-styles": "*"
   },
   "bugs": {
-    "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
+    "url": "https://github.com/WPMedia/fusion-theme-blocks/issues"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }

--- a/blocks/share-bar-block/package.json
+++ b/blocks/share-bar-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme share bar block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/share-bar-block"
   },
   "scripts": {

--- a/blocks/share-bar-block/package.json
+++ b/blocks/share-bar-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/share-bar-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme share bar block",
+  "description": "Fusion Theme share bar block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/shared-styles/package.json
+++ b/blocks/shared-styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/shared-styles",
   "version": "5.17.0",
-  "description": "Fusion News Theme Shared Styles",
+  "description": "Fusion Theme Shared Styles",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/shared-styles/package.json
+++ b/blocks/shared-styles/package.json
@@ -3,7 +3,7 @@
   "version": "5.17.0",
   "description": "Fusion News Theme Shared Styles",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/shared-styles"
   },
   "peerDependencies": {

--- a/blocks/simple-list-block/README.md
+++ b/blocks/simple-list-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/simple-list-block`
-_Fusion News Theme Simple List block is a dynamically-sized list with items of a title and image. The list itself also has a title._
+_Fusion Theme Simple List block is a dynamically-sized list with items of a title and image. The list itself also has a title._
 
 ## Acceptance Criteria
 - As a Themes customer, I can place a Simple List Block on my PageBuilder pages and templates, so that I can showcase most read or editor's picks content to my readers.

--- a/blocks/simple-list-block/package.json
+++ b/blocks/simple-list-block/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/simple-list-block"
   },
   "peerDependencies": {

--- a/blocks/single-chain-block/README.md
+++ b/blocks/single-chain-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/single-chain-block`
-_Fusion News Theme single-chain block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme single-chain block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/single-chain-block/package.json
+++ b/blocks/single-chain-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Single Chain – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/single-chain-block"
   },
   "scripts": {

--- a/blocks/site-hierarchy-content-block/package.json
+++ b/blocks/site-hierarchy-content-block/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Jack Howard <jack.howard@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "directories": {
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/site-hierarchy-content-block"
   },
   "scripts": {

--- a/blocks/small-manual-promo-block/package.json
+++ b/blocks/small-manual-promo-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.17.0",
   "description": "Fusion News Theme Small Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/small-manual-promo-block"
   },
   "scripts": {

--- a/blocks/small-manual-promo-block/package.json
+++ b/blocks/small-manual-promo-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/small-manual-promo-block",
   "version": "5.17.0",
-  "description": "Fusion News Theme Small Manual Promo block",
+  "description": "Fusion Theme Small Manual Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/small-promo-block/package.json
+++ b/blocks/small-promo-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/small-promo-block",
   "version": "5.17.0",
-  "description": "Fusion News Theme Small Promo block",
+  "description": "Fusion Theme Small Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/small-promo-block/package.json
+++ b/blocks/small-promo-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.17.0",
   "description": "Fusion News Theme Small Promo block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/small-promo-block"
   },
   "scripts": {

--- a/blocks/story-feed-author-content-source-block/package.json
+++ b/blocks/story-feed-author-content-source-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.14.1",
   "description": "Content source block for story feed queries by author",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/story-feed-author-content-source-block"
   },
   "scripts": {

--- a/blocks/story-feed-query-content-source-block/package.json
+++ b/blocks/story-feed-query-content-source-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.14.1",
   "description": "Content source block for story feed queries by Elasticsearch queries",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/story-feed-query-content-source-block"
   },
   "scripts": {

--- a/blocks/story-feed-sections-content-source-block/package.json
+++ b/blocks/story-feed-sections-content-source-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Content source block for story feed queries by section",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/story-feed-sections-content-source-block"
   },
   "scripts": {

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Content source block for story feed queries by tag",
   "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/story-feed-tag-content-source-block"
   },
   "scripts": {

--- a/blocks/subheadline-block/README.md
+++ b/blocks/subheadline-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/subheadline-block`
-_Fusion News Theme sub-headline block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme sub-headline block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/subheadline-block/package.json
+++ b/blocks/subheadline-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion News Theme sub-headline block",
   "author": "Brent Miller <brent.miller@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/subheadline-block"
   },
   "scripts": {

--- a/blocks/subheadline-block/package.json
+++ b/blocks/subheadline-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/subheadline-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme sub-headline block",
+  "description": "Fusion Theme sub-headline block",
   "author": "Brent Miller <brent.miller@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/subscriptions-block/package.json
+++ b/blocks/subscriptions-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion themes subscriptions block.",
   "author": "ARC XP",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/subscriptions-block"
   },
   "scripts": {
@@ -29,7 +29,7 @@
     "@wpmedia/identity-block": "*"
   },
   "bugs": {
-    "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
+    "url": "https://github.com/WPMedia/fusion-theme-blocks/issues"
   },
   "dependencies": {
     "@arc-fusion/prop-types": "^0.1.5",

--- a/blocks/tag-title-block/README.md
+++ b/blocks/tag-title-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/tag-title-block`
-_Fusion News Theme tag title block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme tag title block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/tag-title-block/package.json
+++ b/blocks/tag-title-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion themes block containing a tag title block.",
   "author": "Beltran Caliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks#readme",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks#readme",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/tag-title-block"
   },
   "scripts": {
@@ -28,7 +28,7 @@
     "@wpmedia/shared-styles": "*"
   },
   "bugs": {
-    "url": "https://github.com/WPMedia/fusion-news-theme-blocks/issues"
+    "url": "https://github.com/WPMedia/fusion-theme-blocks/issues"
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/tags-content-source-block/README.md
+++ b/blocks/tags-content-source-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/tags-content-source-block`
-_Fusion News Theme tags API content source block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme tags API content source block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/tags-content-source-block/package.json
+++ b/blocks/tags-content-source-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/tags-content-source-block",
   "version": "5.14.1",
-  "description": "Fusion News Theme tags API content source block",
+  "description": "Fusion Theme tags API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/tags-content-source-block/package.json
+++ b/blocks/tags-content-source-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.14.1",
   "description": "Fusion News Theme tags API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/tags-content-source-block"
   },
   "scripts": {

--- a/blocks/text-output-block/README.md
+++ b/blocks/text-output-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/text-output-block`
-_Fusion News Theme text output type. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme text output type. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/text-output-block/package.json
+++ b/blocks/text-output-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/text-output-block",
   "version": "5.14.1",
-  "description": "Fusion News Theme text output type",
+  "description": "Fusion Theme text output type",
   "author": "nelson fernandez <nelson.fernandez@washport.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/text-output-block/package.json
+++ b/blocks/text-output-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.14.1",
   "description": "Fusion News Theme text output type",
   "author": "nelson fernandez <nelson.fernandez@washport.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/text-output-block"
   },
   "scripts": {

--- a/blocks/textfile-block/README.md
+++ b/blocks/textfile-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/textfile-block`
-_Text File block for Fusion News Theme. This block offers a convenient way to render text files such as `ads.txt` or `robots.txt`. It must be used with `text` output type only, if other output type is selected, it will render nothing._
+_Text File block for Fusion Theme. This block offers a convenient way to render text files such as `ads.txt` or `robots.txt`. It must be used with `text` output type only, if other output type is selected, it will render nothing._
 
 ## Acceptance Criteria
 - The content of the custom field `Text` is the data to be rendered on the page.

--- a/blocks/textfile-block/package.json
+++ b/blocks/textfile-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/textfile-block",
   "version": "5.15.0",
-  "description": "Fusion News Theme text file block",
+  "description": "Fusion Theme text file block",
   "author": "nelson fernandez <nelson.fernandez@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/textfile-block/package.json
+++ b/blocks/textfile-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.15.0",
   "description": "Fusion News Theme text file block",
   "author": "nelson fernandez <nelson.fernandez@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/textfile-block"
   },
   "scripts": {

--- a/blocks/top-table-list-block/README.md
+++ b/blocks/top-table-list-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/top-table-list-block`
-_Fusion News Theme top table list block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme top table list block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 // TODO: add badge for passing/failing tests
 

--- a/blocks/top-table-list-block/package.json
+++ b/blocks/top-table-list-block/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Beltran Caliz <beltran.caliz@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/top-table-list-block"
   },
   "peerDependencies": {

--- a/blocks/triple-chain-block/README.md
+++ b/blocks/triple-chain-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/triple-chain-block`
-_Fusion News Theme triple-chain block. Utilizes bootstrap's three column approach on anything but small size. Takes in a number of how many items to be put in column one and two. The rest go in column three. Negative numbers here will yield nothing._
+_Fusion Theme triple-chain block. Utilizes bootstrap's three column approach on anything but small size. Takes in a number of how many items to be put in column one and two. The rest go in column three. Negative numbers here will yield nothing._
 
 ## Acceptance Criteria
 - Places features within the Triple Chain within three equal columns. 

--- a/blocks/triple-chain-block/package.json
+++ b/blocks/triple-chain-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Triple Chain – Arc Block",
   "author": "Jack Howard <jack.howard@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/triple-chain-block"
   },
   "scripts": {

--- a/blocks/unpublished-content-source-block/README.md
+++ b/blocks/unpublished-content-source-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/unpublished-content-source-block`
-_Fusion News Theme unpublished API content source block. Please provide a 1-2 sentence description of what the block is and what it does._
+_Fusion Theme unpublished API content source block. Please provide a 1-2 sentence description of what the block is and what it does._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/unpublished-content-source-block/package.json
+++ b/blocks/unpublished-content-source-block/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Jack Howard <jack.howard@washpost.com>"
   ],
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/unpublished-content-source-block"
   },
   "scripts": {

--- a/blocks/unpublished-content-source-block/package.json
+++ b/blocks/unpublished-content-source-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/unpublished-content-source-block",
   "version": "5.14.1",
-  "description": "Fusion News Theme unpublished API content source block",
+  "description": "Fusion Theme unpublished API content source block",
   "author": "beltrancaliz <beltran.caliz@washpost.com>",
   "contributors": [
     "Jack Howard <jack.howard@washpost.com>"

--- a/blocks/video-player-block/README.md
+++ b/blocks/video-player-block/README.md
@@ -1,5 +1,5 @@
 # `@wpmedia/video-player-block`
-_Fusion News Theme video player block. Provides a feature to play videos._
+_Fusion Theme video player block. Provides a feature to play videos._
 
 ## Acceptance Criteria
 - Add AC relevant to the block

--- a/blocks/video-player-block/package.json
+++ b/blocks/video-player-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/video-player-block",
   "version": "5.17.0",
-  "description": "Fusion News Theme video player block",
+  "description": "Fusion Theme video player block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/blocks/video-player-block/package.json
+++ b/blocks/video-player-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.17.0",
   "description": "Fusion News Theme video player block",
   "author": "SangHee Kim <sanghee.kim@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/video-player-block"
   },
   "scripts": {

--- a/blocks/video-promo-block/package.json
+++ b/blocks/video-promo-block/package.json
@@ -3,7 +3,7 @@
   "version": "5.16.0",
   "description": "Fusion News Theme Video Promo block",
   "author": "Cheng-Hsin Weng <cheng-hsin.weng@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com/WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com/WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/video-promo-block"
   },
   "scripts": {

--- a/blocks/video-promo-block/package.json
+++ b/blocks/video-promo-block/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpmedia/video-promo-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme Video Promo block",
+  "description": "Fusion Theme Video Promo block",
   "author": "Cheng-Hsin Weng <cheng-hsin.weng@washpost.com>",
   "homepage": "https://github.com/WPMedia/fusion-theme-blocks",
   "license": "CC-BY-NC-ND-4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "fusion-news-theme-blocks",
+  "name": "fusion-theme-blocks",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "fusion-news-theme-blocks",
+  "name": "fusion-theme-blocks",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com:WPMedia/fusion-news-theme-blocks.git",
+    "url": "ssh://git@github.com:WPMedia/fusion-theme-blocks.git",
     "directory": "blocks/article-body-block"
   },
   "private": true,


### PR DESCRIPTION
## Description

Ensure renaming repo path doesn't affect watching 

## Jira Ticket
- [TMEDIA-542](https://arcpublishing.atlassian.net/browse/TMEDIA-542)

## Acceptance Criteria
- Can run blocks with new local name fusion-news-blocks

## Test Steps

1. Checkout this branch `git checkout canary`
2. cp -r fusion-news-theme-blocks fusion-theme-blocks
3. Change fusion-news-theme's .env file THEMES_BLOCKS_REPO=/{your path}/fusion-news-theme-blocks -> THEMES_BLOCKS_REPO=/{your path}/fusion-theme-blocks
4. Open fusion-theme-blocks repo 
5. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/headline-block`
6. Make change in that block and see rebuild and effect 
![Screen Shot 2021-11-01 at 14 47 16](https://user-images.githubusercontent.com/5950956/139734737-57338b3a-c62d-4722-a530-70428ea99097.png)
![Screen Shot 2021-11-01 at 14 46 18](https://user-images.githubusercontent.com/5950956/139734798-7e633b50-4925-4abc-87ef-67f185b32864.png)


## Effect Of Changes
### Before
- Theme blocks connote news theme blocks only 

### After
- Theme blocks after can be brand or whatever brand 
- Keeping in one repo makes for easier cross-theme development and publishing

## Dependencies or Side Effects
- Other pr with renaming in feature pack https://github.com/WPMedia/Fusion-News-Theme/pull/201

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored). -> not applicable 
- [x] Confirmed relevant documentation has been updated/added. -> yes, renamed them 

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
