### PR TITLE
TMEDIA-519 - Facebook Redirect

### DIFF
--- a/blocks/identity-block/components/SocialSignOn/default.test.jsx
+++ b/blocks/identity-block/components/SocialSignOn/default.test.jsx
@@ -15,6 +15,63 @@ describe('Subscriptions Social Login Component', () => {
     );
     expect(uninitializedWrapper.html()).toBe(null);
   });
+
+  it('renders nothing if config settings are false', () => {
+    useIdentity.mockImplementation(() => ({
+      isInitialized: true,
+      isLoggedIn: () => false,
+      Identity: {
+        configOptions: {
+          googleClientId: false,
+          facebookAppId: false,
+        },
+      },
+    }));
+
+    const wrapper = shallow(
+      <SocialSignOn onError={() => null} redirectURL="#" />,
+    );
+    expect(wrapper.html()).toBe(null);
+  });
+
+  it('renders only Google button', () => {
+    useIdentity.mockImplementation(() => ({
+      isInitialized: true,
+      isLoggedIn: () => false,
+      Identity: {
+        configOptions: {
+          googleClientId: true,
+          facebookAppId: false,
+        },
+      },
+    }));
+
+    const wrapper = shallow(
+      <SocialSignOn onError={() => null} redirectURL="#" />,
+    );
+    expect(wrapper.find('#google-sign-in-button')).toHaveLength(1);
+    expect(wrapper.find('.fb-login-button')).toHaveLength(0);
+  });
+
+  it('renders only Facebook button', () => {
+    useIdentity.mockImplementation(() => ({
+      isInitialized: true,
+      isLoggedIn: () => false,
+      Identity: {
+        configOptions: {
+          googleClientId: false,
+          facebookAppId: true,
+        },
+      },
+    }));
+
+    const wrapper = shallow(
+      <SocialSignOn onError={() => null} redirectURL="#" />,
+    );
+    expect(wrapper.find('#google-sign-in-button')).toHaveLength(0);
+    expect(wrapper.find('.fb-login-button')).toHaveLength(1);
+  });
+
   it('renders', () => {
     useIdentity.mockImplementation(() => ({
       isInitialized: true,
@@ -43,6 +100,7 @@ describe('Subscriptions Social Login Component', () => {
     );
     expect(wrapper.html()).not.toBe(null);
   });
+
   it('renders placeholders for Google and Facebook sign-in buttons', () => {
     let wrapper;
     useIdentity.mockImplementation(() => ({

--- a/blocks/identity-block/components/SocialSignOn/index.jsx
+++ b/blocks/identity-block/components/SocialSignOn/index.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { isServerSide } from '@wpmedia/engine-theme-sdk';
 import PropTypes from '@arc-fusion/prop-types';
 import useIdentity from '../Identity';
 import './styles.scss';
@@ -12,7 +11,7 @@ const SocialSignOn = ({ onError, redirectURL }) => {
 
   const isGoogleReset = useRef(false);
 
-  if (!isServerSide() && !window.onFacebookSignOn) {
+  useEffect(() => {
     window.onFacebookSignOn = async () => {
       try {
         await Identity.facebookSignOn();
@@ -21,7 +20,7 @@ const SocialSignOn = ({ onError, redirectURL }) => {
         onError();
       }
     };
-  }
+  });
 
   useEffect(() => {
     const fetchConfig = async () => {


### PR DESCRIPTION
## Description

Update facebook window code to ensure it's getting the correct redirectURL

As the `redirectURL` changes in a parent component the code was only setting `window.onFacebookSignOn` based on the first run and not getting the updated `redirectURL`

## Jira Ticket
- [TMEDIA-519](https://arcpublishing.atlassian.net/browse/TMEDIA-519)

## Acceptance Criteria
If a `redirect` query param is present after logging in with Facebook you get redirected to the value of the `redirect` query param

## Test Steps

This is a little tricky to fully test due to Facebook requiring a https connection locally, but you are able to validate the value is as it should be inside the `useEffect`

1. Checkout this branch `git checkout TMEDIA-519-facebook-login-redirect`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/identity-block`
3. In `blocks/identity-block/components/SocialSignOn/index.jsx` on line 15 add the following `console.log(redirectURL)`
4. Go to the login page - http://localhost/account/login/?_website=the-gazette&redirect=/checkout/
5. Validate the console logs out `/checkout/` as the last item

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
