### PR TITLE
TMEDIA-537 - Checkout Block Shell + Cart

### DIFF
--- a/blocks/subscriptions-block/components/Cart/index.jsx
+++ b/blocks/subscriptions-block/components/Cart/index.jsx
@@ -15,7 +15,7 @@ const getPaymentInfo = ({
   origin,
   endpoint,
   priceCode,
-}) => fetch(`${origin}${endpoint}${priceCode}/1/1635969177000`, {})
+}) => fetch(`${origin}${endpoint}${priceCode}/1/${new Date().getTime()}`, {})
   .then((res) => res.json());
 
 const Cart = ({ offerURL }) => {

--- a/blocks/subscriptions-block/components/Cart/index.jsx
+++ b/blocks/subscriptions-block/components/Cart/index.jsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from '@arc-fusion/prop-types';
+import { useFusionContext } from 'fusion:context';
+import getProperties from 'fusion:properties';
+import getTranslatedPhrases from 'fusion:intl';
+import { PrimaryFont } from '@wpmedia/shared-styles';
+import useSales from '../useSales';
+import currency from '../../utils/currency';
+
+import Item from './item';
+
+import './styles.scss';
+
+const getPaymentInfo = ({
+  origin,
+  endpoint,
+  priceCode,
+}) => fetch(`${origin}${endpoint}${priceCode}/1/1635969177000`, {})
+  .then((res) => res.json());
+
+const Cart = ({ offerURL }) => {
+  const { arcSite } = useFusionContext();
+  const phrases = getTranslatedPhrases(getProperties(arcSite).locale || 'en');
+
+  const [isFetching, setIsFetching] = useState(true);
+  const [cartItems, setCartItems] = useState();
+
+  const { api: { retail: { origin } } } = getProperties(arcSite);
+
+  const {
+    Sales,
+  } = useSales();
+
+  useEffect(() => {
+    const fetchPaymentInfo = (priceCode) => getPaymentInfo({
+      origin,
+      endpoint: '/retail/public/v1/pricing/paymentInfo/',
+      priceCode,
+    });
+
+    const fetchCartItemSummaries = async (cartDetails) => {
+      const updatedCart = cartDetails;
+
+      if (!cartDetails.items) {
+        return cartDetails;
+      }
+
+      await Promise.all(
+        cartDetails.items.map((item) => fetchPaymentInfo(item.priceCode)
+          .then((priceSummary) => ({ ...item, priceSummary }))),
+      ).then((results) => {
+        updatedCart.items = results;
+      });
+
+      return updatedCart;
+    };
+
+    const getAllCart = async () => {
+      setCartItems(await Sales.getCart().then(fetchCartItemSummaries).catch(() => []));
+      setIsFetching(false);
+    };
+
+    getAllCart();
+  }, [Sales, origin]);
+
+  if (isFetching) {
+    return null;
+  }
+
+  if (!cartItems?.items || !cartItems?.items.length) {
+    return (
+      <div className="xpmedia-subscriptions-cart">
+        <a href={offerURL}>{phrases.t('checkout-block.empty-cart-message')}</a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="xpmedia-subscriptions-cart">
+      <PrimaryFont as="h2" className="xpmedia-subscriptions-cart-title">
+        {phrases.t('checkout-block.order-summary')}
+      </PrimaryFont>
+
+      <div className="xpmedia-subscriptions-cart-items">
+        {cartItems.items.map(
+          (itemDetails) => (
+            <Item
+              key={itemDetails.sku}
+              name={itemDetails.name}
+              description={itemDetails?.priceSummary?.pricingStrategy?.summary}
+            />
+          ),
+        )}
+        <Item
+          name={phrases.t('checkout-block.due-today')}
+          description={`${currency(cartItems.currency)}${cartItems.total}`}
+          additionalInfo={phrases.t('checkout-block.plus-sales-tax')}
+        />
+      </div>
+    </div>
+  );
+};
+
+Cart.propTypes = {
+  offerURL: PropTypes.string.isRequired,
+};
+
+export default Cart;

--- a/blocks/subscriptions-block/components/Cart/index.test.jsx
+++ b/blocks/subscriptions-block/components/Cart/index.test.jsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import useSales from '../useSales';
+
+import Cart from './index';
+
+jest.mock('fusion:properties', () => (jest.fn(() => ({ api: { retail: { origin: '' } } }))));
+
+jest.mock('fusion:intl', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ t: jest.fn((phrase) => phrase) })),
+}));
+
+jest.mock('../../components/useSales');
+
+describe('Cart', () => {
+  it('renders empty cart message if no cart items', async () => {
+    let wrapper;
+
+    useSales.mockReturnValue({
+      Sales: {
+        getCart: jest.fn(async () => Promise.resolve({ items: [] })),
+      },
+    });
+
+    await act(async () => {
+      wrapper = await mount(<Cart offerURL="/" />);
+    });
+    wrapper.update();
+
+    expect(wrapper.find('a').exists()).toBe(true);
+    expect(wrapper.text()).toBe('checkout-block.empty-cart-message');
+  });
+
+  it('renders empty cart message if no cart items', async () => {
+    let wrapper;
+
+    useSales.mockReturnValue({
+      Sales: {
+        getCart: jest.fn(async () => Promise.reject()),
+      },
+    });
+
+    await act(async () => {
+      wrapper = await mount(<Cart offerURL="/" />);
+    });
+    wrapper.update();
+
+    expect(wrapper.text()).toBe('checkout-block.empty-cart-message');
+  });
+
+  it('renders empty cart message if no cart items', async () => {
+    let wrapper;
+
+    useSales.mockReturnValue({
+      Sales: {
+        getCart: jest.fn(async () => Promise.resolve({})),
+      },
+    });
+
+    await act(async () => {
+      wrapper = await mount(<Cart offerURL="/" />);
+    });
+    wrapper.update();
+
+    expect(wrapper.text()).toBe('checkout-block.empty-cart-message');
+  });
+
+  it('renders cart', async () => {
+    let wrapper;
+
+    global.fetch = jest.fn(() => Promise.resolve({
+      json: () => Promise.resolve({
+        timeUMType: null,
+        timeQty: 0,
+        price: 0,
+        finalPayment: false,
+        pricingStrategy: {
+          pricingStrategyId: 1179,
+          priceCode: 'HUV7RS',
+          name: 'Sports: Free Trial + Monthly',
+          description: '<p>1 month free trial</p>',
+          gift: false,
+          summary: '<p>Free first month,then $5.00 every month until canceled.</p>',
+          currencyCode: 'USD',
+          currencyDisplayFormat: 'symbol',
+          currencyLocale: 'en-US',
+          rates: [{
+            amount: '0.00', billingCount: 1, billingFrequency: 'Month', durationCount: 1, duration: 'Month',
+          }, {
+            amount: '5.00', billingCount: 1, billingFrequency: 'Month', durationCount: 1, duration: 'UntilCancelled',
+          }],
+          taxInclusive: false,
+        },
+        paymentDate: 1638489600000,
+        currency: 'USD',
+      }),
+    }));
+
+    useSales.mockReturnValue({
+      Sales: {
+        getCart: jest.fn(async () => Promise.resolve({
+          total: 0,
+          subtotal: 0,
+          tax: 0,
+          shipping: 0,
+          items: [
+            {
+              sku: 'SPORTS',
+              quantity: 1,
+              shortDescription: "<p>It's all you care about! We understand.</p>",
+              name: 'Sports All Access',
+              price: 0,
+              tax: 0,
+              subtotal: 0,
+              total: 0,
+              priceCode: 'HUV7RS',
+              gift: false,
+            },
+          ],
+          currency: 'USD',
+          taxSupported: true,
+        })),
+      },
+    });
+
+    await act(async () => {
+      wrapper = await mount(<Cart offerURL="/" />);
+    });
+    wrapper.update();
+
+    expect(wrapper.find('.xpmedia-subscriptions-cart').exists()).toBe(true);
+    expect(wrapper.find('.xpmedia-subscriptions-cart-title').exists()).toBe(true);
+    expect(wrapper.find('Item').exists()).toBe(true);
+  });
+});

--- a/blocks/subscriptions-block/components/Cart/item.jsx
+++ b/blocks/subscriptions-block/components/Cart/item.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from '@arc-fusion/prop-types';
+import { PrimaryFont } from '@wpmedia/shared-styles';
+
+const Item = ({
+  name, description, additionalInfo,
+}) => (
+  <PrimaryFont as="div" className="xpmedia-subscriptions-cart-item">
+    <p className="xpmedia-subscriptions-cart-item--name">{name}</p>
+    {description ? <p className="xpmedia-subscriptions-cart-item--description" dangerouslySetInnerHTML={{ __html: description }} /> : null }
+    {additionalInfo ? <p className="xpmedia-subscriptions-cart-item--info">{additionalInfo}</p> : null}
+  </PrimaryFont>
+);
+
+Item.propTypes = {
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  additionalInfo: PropTypes.string,
+};
+
+export default Item;

--- a/blocks/subscriptions-block/components/Cart/item.test.jsx
+++ b/blocks/subscriptions-block/components/Cart/item.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Item from './item';
+
+describe('Cart Item', () => {
+  it('renders name, description and additional info', () => {
+    const props = {
+      name: 'Name',
+      description: 'Item description',
+      additionalInfo: 'Some addtional information for an item',
+    };
+    const wrapper = mount(
+      <Item {...props} />,
+    );
+
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item').exists()).toBe(true);
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item--name').text()).toBe(props.name);
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item--description').text()).toBe(props.description);
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item--info').text()).toBe(props.additionalInfo);
+  });
+
+  it('renders name, description', () => {
+    const props = {
+      name: 'Name',
+      description: 'Item description',
+    };
+    const wrapper = mount(
+      <Item {...props} />,
+    );
+
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item').exists()).toBe(true);
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item--name').text()).toBe(props.name);
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item--description').text()).toBe(props.description);
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item--info').exists()).toBe(false);
+  });
+
+  it('renders name only', () => {
+    const props = {
+      name: 'Name',
+    };
+    const wrapper = mount(
+      <Item {...props} />,
+    );
+
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item').exists()).toBe(true);
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item--name').text()).toBe(props.name);
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item--description').exists()).toBe(false);
+    expect(wrapper.find('.xpmedia-subscriptions-cart-item--info').exists()).toBe(false);
+  });
+});

--- a/blocks/subscriptions-block/components/Cart/styles.scss
+++ b/blocks/subscriptions-block/components/Cart/styles.scss
@@ -1,0 +1,32 @@
+.xpmedia-subscriptions-cart {
+  margin-top: map-get($spacers, 'lg');
+
+  &-title {
+    margin-bottom: map-get($spacers, 'md');
+  }
+}
+
+.xpmedia-subscriptions-cart-items {
+  border: 1px solid $border-rule-color;
+  padding: map-get($spacers, 'xs');
+
+  > * + *  {
+    border-top: 1px solid $border-rule-color;
+  }
+}
+
+.xpmedia-subscriptions-cart-item {
+  color: $ui-medium-gray;
+  font-size: calculateRem(16px);
+  margin: 0 map-get($spacers, 'xxs');
+  padding: map-get($spacers, 'xxs') 0;
+
+  &--name {
+    font-size: calculateRem(20px);
+    font-weight: bold;
+  }
+
+  &--info {
+    font-size: calculateRem(12px);
+  }
+}

--- a/blocks/subscriptions-block/components/Cart/styles.scss
+++ b/blocks/subscriptions-block/components/Cart/styles.scss
@@ -10,7 +10,7 @@
   border: 1px solid $border-rule-color;
   padding: map-get($spacers, 'xs');
 
-  > * + *  {
+  > * + * {
     border-top: 1px solid $border-rule-color;
   }
 }

--- a/blocks/subscriptions-block/components/useSales.jsx
+++ b/blocks/subscriptions-block/components/useSales.jsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import Identity from '@arc-publishing/sdk-identity';
+import Sales from '@arc-publishing/sdk-sales';
+import { useFusionContext } from 'fusion:context';
+import getProperties from 'fusion:properties';
+
+const useSales = () => {
+  const { arcSite } = useFusionContext();
+  const { api } = getProperties(arcSite);
+  const [isInit, setIsInit] = useState(!!Identity.apiOrigin);
+
+  if (!isInit && arcSite && api?.identity?.origin) {
+    Identity.options({ apiOrigin: api.identity.origin });
+
+    Sales.options({
+      apiOrigin: api?.retail?.origin,
+      Identity,
+    });
+
+    setIsInit(true);
+  }
+
+  return {
+    Sales,
+    isInitialized: isInit,
+  };
+};
+
+export default useSales;

--- a/blocks/subscriptions-block/components/useSales.test.jsx
+++ b/blocks/subscriptions-block/components/useSales.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SalesObject from '@arc-publishing/sdk-sales';
+
+import useSales from './useSales';
+
+jest.mock('@arc-publishing/sdk-identity', () => ({
+  __esModule: true,
+  default: {
+    apiOrigin: '',
+    options: jest.fn(),
+  },
+}));
+
+jest.mock('@arc-publishing/sdk-sales', () => ({
+  __esModule: true,
+  default: {
+    apiOrigin: '',
+    options: jest.fn(),
+  },
+}));
+
+jest.mock('fusion:properties', () => jest.fn(
+  () => ({ // arcSite
+    api: {
+      identity: {
+        origin: 'http://origin/',
+      },
+      retail: {
+        origin: 'http://retail-origin/',
+      },
+    },
+  }),
+));
+
+jest.mock('fusion:context', () => ({
+  __esModule: true,
+  useFusionContext: () => ({
+    arcSite: 'Test Site',
+  }),
+}));
+
+describe('Sales useSales Hook', () => {
+  it('returns itself and changes the option to http://origin', () => {
+    const Test = () => {
+      const { Sales } = useSales();
+      expect(Sales).toBe(SalesObject);
+      return <div />;
+    };
+    mount(<Test />);
+    expect(SalesObject.options).toHaveBeenLastCalledWith({
+      apiOrigin: 'http://retail-origin/',
+      Identity: {
+        apiOrigin: '',
+        options: expect.any(Function),
+      },
+    });
+  });
+
+  it('initializes', () => {
+    const testInitialization = jest.fn();
+
+    const Test = () => {
+      const { isInitialized } = useSales();
+      testInitialization(isInitialized);
+      return <div />;
+    };
+
+    mount(<Test />);
+
+    expect(testInitialization).toHaveBeenCalledWith(false);
+    expect(testInitialization).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/blocks/subscriptions-block/features/checkout/default.jsx
+++ b/blocks/subscriptions-block/features/checkout/default.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from '@arc-fusion/prop-types';
+import { useFusionContext } from 'fusion:context';
+import getProperties from 'fusion:properties';
+import getTranslatedPhrases from 'fusion:intl';
+import { PrimaryFont } from '@wpmedia/shared-styles';
+
+import Cart from '../../components/Cart';
+
+import './styles.scss';
+
+const Checkout = ({
+  customFields,
+}) => {
+  const {
+    offerURL,
+  } = customFields;
+
+  const { arcSite } = useFusionContext();
+  const phrases = getTranslatedPhrases(getProperties(arcSite).locale || 'en');
+
+  return (
+    <PrimaryFont as="div" className="xpmedia-subscriptions-checkout">
+      <PrimaryFont as="h1">{phrases.t('checkout-block.headline')}</PrimaryFont>
+      <a href={offerURL} className="xpmedia-subscriptions-checkout--backlink">{phrases.t('checkout-block.back-to-offer-page')}</a>
+
+      <Cart offerURL={offerURL} />
+    </PrimaryFont>
+  );
+};
+
+Checkout.label = 'Checkout - Arc Block';
+
+Checkout.icon = 'shop-cart';
+
+Checkout.propTypes = {
+  customFields: {
+    offerURL: PropTypes.string.tag({
+      defaultValue: '/offer/',
+    }),
+  },
+};
+
+export default Checkout;

--- a/blocks/subscriptions-block/features/checkout/default.test.jsx
+++ b/blocks/subscriptions-block/features/checkout/default.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Checkout from './default';
+
+jest.mock('fusion:properties', () => (jest.fn(() => ({ api: { retail: { origin: '' } } }))));
+
+jest.mock('fusion:intl', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ t: jest.fn((phrase) => phrase) })),
+}));
+
+describe('The Offer feature', () => {
+  it('renders the correct number of offer cards', () => {
+    const wrapper = shallow(
+      <Checkout
+        customFields={{
+          offerURL: '/offer-url/',
+        }}
+      />,
+    );
+
+    expect(wrapper.find('a').prop('href')).toBe('/offer-url/');
+    expect(wrapper.find('Cart').exists()).toBe(true);
+  });
+});

--- a/blocks/subscriptions-block/features/checkout/styles.scss
+++ b/blocks/subscriptions-block/features/checkout/styles.scss
@@ -1,5 +1,4 @@
 .xpmedia-subscriptions-checkout {
-
   &--backlink {
     text-decoration: underline;
 

--- a/blocks/subscriptions-block/features/checkout/styles.scss
+++ b/blocks/subscriptions-block/features/checkout/styles.scss
@@ -1,0 +1,10 @@
+.xpmedia-subscriptions-checkout {
+
+  &--backlink {
+    text-decoration: underline;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}

--- a/blocks/subscriptions-block/intl.json
+++ b/blocks/subscriptions-block/intl.json
@@ -1,0 +1,68 @@
+{
+	"checkout-block.headline": {
+		"de": "Review Subscription Order",
+		"en": "Review Subscription Order",
+		"es": "Review Subscription Order",
+		"fr": "Review Subscription Order",
+		"ja": "Review Subscription Order",
+		"ko": "Review Subscription Order",
+		"no": "Review Subscription Order",
+		"pt": "Review Subscription Order",
+		"sv": "Review Subscription Order"
+	},
+	"checkout-block.back-to-offer-page": {
+		"de": "Back to subcription selection",
+		"en": "Back to subcription selection",
+		"es": "Back to subcription selection",
+		"fr": "Back to subcription selection",
+		"ja": "Back to subcription selection",
+		"ko": "Back to subcription selection",
+		"no": "Back to subcription selection",
+		"pt": "Back to subcription selection",
+		"sv": "Back to subcription selection"
+	},
+	"checkout-block.order-summary": {
+		"de": "Order Summary",
+		"en": "Order Summary",
+		"es": "Order Summary",
+		"fr": "Order Summary",
+		"ja": "Order Summary",
+		"ko": "Order Summary",
+		"no": "Order Summary",
+		"pt": "Order Summary",
+		"sv": "Order Summary"
+	},
+	"checkout-block.due-today": {
+		"de": "Due today",
+		"en": "Due today",
+		"es": "Due today",
+		"fr": "Due today",
+		"ja": "Due today",
+		"ko": "Due today",
+		"no": "Due today",
+		"pt": "Due today",
+		"sv": "Due today"
+	},
+	"checkout-block.plus-sales-tax": {
+		"de": "Plus applicable sales tax",
+		"en": "Plus applicable sales tax",
+		"es": "Plus applicable sales tax",
+		"fr": "Plus applicable sales tax",
+		"ja": "Plus applicable sales tax",
+		"ko": "Plus applicable sales tax",
+		"no": "Plus applicable sales tax",
+		"pt": "Plus applicable sales tax",
+		"sv": "Plus applicable sales tax"
+	},
+	"checkout-block.empty-cart-message": {
+		"de": "Select from one of our offers",
+		"en": "Select from one of our offers",
+		"es": "Select from one of our offers",
+		"fr": "Select from one of our offers",
+		"ja": "Select from one of our offers",
+		"ko": "Select from one of our offers",
+		"no": "Select from one of our offers",
+		"pt": "Select from one of our offers",
+		"sv": "Select from one of our offers"
+	}
+}

--- a/blocks/subscriptions-block/intl.json
+++ b/blocks/subscriptions-block/intl.json
@@ -11,15 +11,15 @@
 		"sv": "Review Subscription Order"
 	},
 	"checkout-block.back-to-offer-page": {
-		"de": "Back to subcription selection",
-		"en": "Back to subcription selection",
-		"es": "Back to subcription selection",
-		"fr": "Back to subcription selection",
-		"ja": "Back to subcription selection",
-		"ko": "Back to subcription selection",
-		"no": "Back to subcription selection",
-		"pt": "Back to subcription selection",
-		"sv": "Back to subcription selection"
+		"de": "Back to subscription selection",
+		"en": "Back to subscription selection",
+		"es": "Back to subscription selection",
+		"fr": "Back to subscription selection",
+		"ja": "Back to subscription selection",
+		"ko": "Back to subscription selection",
+		"no": "Back to subscription selection",
+		"pt": "Back to subscription selection",
+		"sv": "Back to subscription selection"
 	},
 	"checkout-block.order-summary": {
 		"de": "Order Summary",

--- a/blocks/subscriptions-block/package.json
+++ b/blocks/subscriptions-block/package.json
@@ -10,7 +10,8 @@
     "features",
     "sources",
     "chains",
-    "components"
+    "components",
+    "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/blocks/subscriptions-block/utils/currency.js
+++ b/blocks/subscriptions-block/utils/currency.js
@@ -1,0 +1,18 @@
+const CURRECY_MAP = {
+  USD: '$',
+  NZD: '$',
+  EUR: '€',
+  PEN: 'S/.',
+  JPY: '¥',
+  CLP: '$',
+  COP: '$',
+  KRW: '₩',
+  MXN: '$',
+  BRL: 'R$',
+};
+
+const currency = (
+  name,
+) => CURRECY_MAP[name] || null;
+
+export default currency;

--- a/blocks/subscriptions-block/utils/currency.test.jsx
+++ b/blocks/subscriptions-block/utils/currency.test.jsx
@@ -1,0 +1,11 @@
+import currency from './currency';
+
+describe('Currency', () => {
+  it('returns currency symbol based on name', () => {
+    expect(currency('USD')).toBe('$');
+  });
+
+  it('returns null if currency is not supported', () => {
+    expect(currency('HKD')).toBe(null);
+  });
+});

--- a/locale/de.json
+++ b/locale/de.json
@@ -126,5 +126,13 @@
     "identity-block.login-form-error": "There's been an error logging you in",
     "identity-block.login-links-login": "Already have an account? Log in.",
     "identity-block.login-links-signup": "Sign up for an account."
+  },
+  "subscriptions-block": {
+    "checkout-block.headline": "Review Subscription Order",
+    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.order-summary": "Order Summary",
+    "checkout-block.due-today": "Due today",
+    "checkout-block.plus-sales-tax": "Plus applicable sales tax",
+    "checkout-block.empty-cart-message": "Select from one of our offers"
   }
 }

--- a/locale/de.json
+++ b/locale/de.json
@@ -129,7 +129,7 @@
   },
   "subscriptions-block": {
     "checkout-block.headline": "Review Subscription Order",
-    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.back-to-offer-page": "Back to subscription selection",
     "checkout-block.order-summary": "Order Summary",
     "checkout-block.due-today": "Due today",
     "checkout-block.plus-sales-tax": "Plus applicable sales tax",

--- a/locale/en.json
+++ b/locale/en.json
@@ -126,5 +126,13 @@
     "identity-block.login-form-error": "There's been an error logging you in",
     "identity-block.login-links-login": "Already have an account? Log in.",
     "identity-block.login-links-signup": "Sign up for an account."
+  },
+  "subscriptions-block": {
+    "checkout-block.headline": "Review Subscription Order",
+    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.order-summary": "Order Summary",
+    "checkout-block.due-today": "Due today",
+    "checkout-block.plus-sales-tax": "Plus applicable sales tax",
+    "checkout-block.empty-cart-message": "Select from one of our offers"
   }
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -129,7 +129,7 @@
   },
   "subscriptions-block": {
     "checkout-block.headline": "Review Subscription Order",
-    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.back-to-offer-page": "Back to subscription selection",
     "checkout-block.order-summary": "Order Summary",
     "checkout-block.due-today": "Due today",
     "checkout-block.plus-sales-tax": "Plus applicable sales tax",

--- a/locale/es.json
+++ b/locale/es.json
@@ -126,5 +126,13 @@
     "identity-block.login-form-error": "There's been an error logging you in",
     "identity-block.login-links-login": "Already have an account? Log in.",
     "identity-block.login-links-signup": "Sign up for an account."
+  },
+  "subscriptions-block": {
+    "checkout-block.headline": "Review Subscription Order",
+    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.order-summary": "Order Summary",
+    "checkout-block.due-today": "Due today",
+    "checkout-block.plus-sales-tax": "Plus applicable sales tax",
+    "checkout-block.empty-cart-message": "Select from one of our offers"
   }
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -129,7 +129,7 @@
   },
   "subscriptions-block": {
     "checkout-block.headline": "Review Subscription Order",
-    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.back-to-offer-page": "Back to subscription selection",
     "checkout-block.order-summary": "Order Summary",
     "checkout-block.due-today": "Due today",
     "checkout-block.plus-sales-tax": "Plus applicable sales tax",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -126,5 +126,13 @@
     "identity-block.login-form-error": "There's been an error logging you in",
     "identity-block.login-links-login": "Already have an account? Log in.",
     "identity-block.login-links-signup": "Sign up for an account."
+  },
+  "subscriptions-block": {
+    "checkout-block.headline": "Review Subscription Order",
+    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.order-summary": "Order Summary",
+    "checkout-block.due-today": "Due today",
+    "checkout-block.plus-sales-tax": "Plus applicable sales tax",
+    "checkout-block.empty-cart-message": "Select from one of our offers"
   }
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -129,7 +129,7 @@
   },
   "subscriptions-block": {
     "checkout-block.headline": "Review Subscription Order",
-    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.back-to-offer-page": "Back to subscription selection",
     "checkout-block.order-summary": "Order Summary",
     "checkout-block.due-today": "Due today",
     "checkout-block.plus-sales-tax": "Plus applicable sales tax",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -126,5 +126,13 @@
     "identity-block.login-form-error": "There's been an error logging you in",
     "identity-block.login-links-login": "Already have an account? Log in.",
     "identity-block.login-links-signup": "Sign up for an account."
+  },
+  "subscriptions-block": {
+    "checkout-block.headline": "Review Subscription Order",
+    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.order-summary": "Order Summary",
+    "checkout-block.due-today": "Due today",
+    "checkout-block.plus-sales-tax": "Plus applicable sales tax",
+    "checkout-block.empty-cart-message": "Select from one of our offers"
   }
 }

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -129,7 +129,7 @@
   },
   "subscriptions-block": {
     "checkout-block.headline": "Review Subscription Order",
-    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.back-to-offer-page": "Back to subscription selection",
     "checkout-block.order-summary": "Order Summary",
     "checkout-block.due-today": "Due today",
     "checkout-block.plus-sales-tax": "Plus applicable sales tax",

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -126,5 +126,13 @@
     "identity-block.login-form-error": "There's been an error logging you in",
     "identity-block.login-links-login": "Already have an account? Log in.",
     "identity-block.login-links-signup": "Sign up for an account."
+  },
+  "subscriptions-block": {
+    "checkout-block.headline": "Review Subscription Order",
+    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.order-summary": "Order Summary",
+    "checkout-block.due-today": "Due today",
+    "checkout-block.plus-sales-tax": "Plus applicable sales tax",
+    "checkout-block.empty-cart-message": "Select from one of our offers"
   }
 }

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -129,7 +129,7 @@
   },
   "subscriptions-block": {
     "checkout-block.headline": "Review Subscription Order",
-    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.back-to-offer-page": "Back to subscription selection",
     "checkout-block.order-summary": "Order Summary",
     "checkout-block.due-today": "Due today",
     "checkout-block.plus-sales-tax": "Plus applicable sales tax",

--- a/locale/no.json
+++ b/locale/no.json
@@ -126,5 +126,13 @@
     "identity-block.login-form-error": "There's been an error logging you in",
     "identity-block.login-links-login": "Already have an account? Log in.",
     "identity-block.login-links-signup": "Sign up for an account."
+  },
+  "subscriptions-block": {
+    "checkout-block.headline": "Review Subscription Order",
+    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.order-summary": "Order Summary",
+    "checkout-block.due-today": "Due today",
+    "checkout-block.plus-sales-tax": "Plus applicable sales tax",
+    "checkout-block.empty-cart-message": "Select from one of our offers"
   }
 }

--- a/locale/no.json
+++ b/locale/no.json
@@ -129,7 +129,7 @@
   },
   "subscriptions-block": {
     "checkout-block.headline": "Review Subscription Order",
-    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.back-to-offer-page": "Back to subscription selection",
     "checkout-block.order-summary": "Order Summary",
     "checkout-block.due-today": "Due today",
     "checkout-block.plus-sales-tax": "Plus applicable sales tax",

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -126,5 +126,13 @@
     "identity-block.login-form-error": "There's been an error logging you in",
     "identity-block.login-links-login": "Already have an account? Log in.",
     "identity-block.login-links-signup": "Sign up for an account."
+  },
+  "subscriptions-block": {
+    "checkout-block.headline": "Review Subscription Order",
+    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.order-summary": "Order Summary",
+    "checkout-block.due-today": "Due today",
+    "checkout-block.plus-sales-tax": "Plus applicable sales tax",
+    "checkout-block.empty-cart-message": "Select from one of our offers"
   }
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -129,7 +129,7 @@
   },
   "subscriptions-block": {
     "checkout-block.headline": "Review Subscription Order",
-    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.back-to-offer-page": "Back to subscription selection",
     "checkout-block.order-summary": "Order Summary",
     "checkout-block.due-today": "Due today",
     "checkout-block.plus-sales-tax": "Plus applicable sales tax",

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -126,5 +126,13 @@
     "identity-block.login-form-error": "There's been an error logging you in",
     "identity-block.login-links-login": "Already have an account? Log in.",
     "identity-block.login-links-signup": "Sign up for an account."
+  },
+  "subscriptions-block": {
+    "checkout-block.headline": "Review Subscription Order",
+    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.order-summary": "Order Summary",
+    "checkout-block.due-today": "Due today",
+    "checkout-block.plus-sales-tax": "Plus applicable sales tax",
+    "checkout-block.empty-cart-message": "Select from one of our offers"
   }
 }

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -129,7 +129,7 @@
   },
   "subscriptions-block": {
     "checkout-block.headline": "Review Subscription Order",
-    "checkout-block.back-to-offer-page": "Back to subcription selection",
+    "checkout-block.back-to-offer-page": "Back to subscription selection",
     "checkout-block.order-summary": "Order Summary",
     "checkout-block.due-today": "Due today",
     "checkout-block.plus-sales-tax": "Plus applicable sales tax",


### PR DESCRIPTION
## Description
Adding the shell for the checkout block and cart display

## Jira Ticket
- [TMEDIA-537](https://arcpublishing.atlassian.net/browse/TMEDIA-537)

## Acceptance Criteria
* “Review Subscription Order” translation key as a headline
* “Back to Subscription Selection” link which clears the users cart and directs them back to offer page
* “Order Summary” translation key as section headline
* Offer details of chosen offer in cart
* “Due today” translation key with the offer price
* “Plus applicable sales tax” translation key

## Test Steps

Ensure you have offer page previously set up - may need to pull data from Core Components

1. Checkout this branch `git checkout TMEDIA-537-checkout-block-shell`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/subscriptions-block`
3. Add a new page
    * Page Name - Checkout
    * Page URI - /checkout/
    * Layout - Single Column Layout
    * Blocks - 
        * navigation = Header Nav Chain
        * main = Checkout - Arc Block 
    * Publish Page
4. Visit the published page - http://localhost/pf/checkout/?_website=the-gazette
    * Validate the cart is empty and shows the empty message
5. From the offer page - http://localhost/offer/ - click on an offer
6. Login
7. Validate you are taken to the checkout page and the cart is showing with the offer you selected



## Effect Of Changes

<img width="695" alt="Checkout Block with cart example" src="https://user-images.githubusercontent.com/868127/140303712-5638229f-dfc3-4004-9e8a-bbd199c7a342.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
