### PR TITLE
TMEDIA-549 - Button Updates - Invalid child element and updated tests

### DIFF
--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -171,56 +171,48 @@ function renderButtonContents(
   text,
   iconComponent,
   secondaryIconComponent,
-  isHTMLText = false,
+  isHTMLText,
 ) {
+  const buttonText = isHTMLText
+    ? <span dangerouslySetInnerHTML={{ __html: text }} />
+    : text;
+
   switch (matchedButtonType) {
     case BUTTON_TYPES.LABEL_AND_TWO_ICONS:
       return (
         <>
-          <div className="xpmedia-button--left-icon-container">
+          <span className="xpmedia-button--left-icon-container">
             {iconComponent}
-          </div>
-          { isHTMLText
-            ? <span dangerouslySetInnerHTML={{ __html: text }} />
-            : text}
-          <div className="xpmedia-button--right-icon-container">
+          </span>
+          {buttonText}
+          <span className="xpmedia-button--right-icon-container">
             {secondaryIconComponent}
-          </div>
+          </span>
         </>
       );
     case BUTTON_TYPES.LABEL_AND_ICON:
       return (
         <>
-          <div className="xpmedia-button--left-icon-container">
+          <span className="xpmedia-button--left-icon-container">
             {iconComponent}
-          </div>
-          { isHTMLText
-            ? <span dangerouslySetInnerHTML={{ __html: text }} />
-            : text}
+          </span>
+          {buttonText}
         </>
       );
     case BUTTON_TYPES.LABEL_AND_RIGHT_ICON:
       return (
         <>
-          { isHTMLText
-            ? <span dangerouslySetInnerHTML={{ __html: text }} />
-            : text}
-          <div className="xpmedia-button--right-icon-container">
+          {buttonText}
+          <span className="xpmedia-button--right-icon-container">
             {iconComponent}
-          </div>
+          </span>
         </>
       );
     case BUTTON_TYPES.ICON_ONLY:
       return (iconComponent);
     case BUTTON_TYPES.LABEL_ONLY:
     default:
-      return (
-        <>
-          { isHTMLText
-            ? <span dangerouslySetInnerHTML={{ __html: text }} />
-            : text}
-        </>
-      );
+      return (buttonText);
   }
 }
 

--- a/blocks/shared-styles/_children/button/index.test.jsx
+++ b/blocks/shared-styles/_children/button/index.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import Button from '.';
-import { BUTTON_SIZES, BUTTON_TYPES } from '../..';
+import { BUTTON_SIZES, BUTTON_TYPES, BUTTON_STYLES } from '../..';
 
 it('renders medium button by default', () => {
   const wrapper = mount(<Button />);
@@ -21,6 +21,30 @@ it('renders small button if buttonSize is small', () => {
   expect(wrapper.find('button').prop('className')).toContain('xpmedia-button--small');
 });
 
+it('renders button as primary reverse', () => {
+  const wrapper = mount(<Button buttonStyle={BUTTON_STYLES.PRIMARY_REVERSE} />);
+
+  expect(wrapper.find('button').prop('className')).toContain('xpmedia-button xpmedia-button--medium');
+});
+
+it('renders button as secondary', () => {
+  const wrapper = mount(<Button buttonStyle={BUTTON_STYLES.SECONDARY} />);
+
+  expect(wrapper.find('button').prop('className')).toContain('xpmedia-button xpmedia-button--medium');
+});
+
+it('renders button as secondary reverse', () => {
+  const wrapper = mount(<Button buttonStyle={BUTTON_STYLES.SECONDARY_REVERSE} />);
+
+  expect(wrapper.find('button').prop('className')).toContain('xpmedia-button xpmedia-button--medium');
+});
+
+it('renders button text using HTML', () => {
+  const wrapper = mount(<Button isHTMLText text="<span>Button Text</span>" />);
+
+  expect(wrapper.find('button span').text()).toBe('Button Text');
+});
+
 it('renders a label and a found user icon for buttonType', () => {
   const wrapper = mount(<Button
     buttonType={BUTTON_TYPES.LABEL_AND_ICON}
@@ -28,7 +52,7 @@ it('renders a label and a found user icon for buttonType', () => {
     iconType="user"
   />);
 
-  expect(wrapper.find('div').prop('className')).toContain('xpmedia-button--left-icon-container');
+  expect(wrapper.find('.xpmedia-button--left-icon-container').exists()).toBe(true);
   expect(wrapper.find('svg')).toHaveLength(1);
 });
 
@@ -39,7 +63,7 @@ it('renders a label and a found user icon for buttonType', () => {
     iconType="something else"
   />);
 
-  expect(wrapper.find('div').prop('className')).toContain('xpmedia-button--left-icon-container');
+  expect(wrapper.find('.xpmedia-button--left-icon-container').exists()).toBe(true);
   expect(wrapper.find('svg')).toHaveLength(0);
   expect(wrapper.text()).toEqual('Hello button and icon');
 });
@@ -89,6 +113,7 @@ it('renders label and two icons', () => {
 it('renders label and right icon', () => {
   const wrapper = mount(<Button
     buttonType={BUTTON_TYPES.LABEL_AND_RIGHT_ICON}
+    buttonStyle={BUTTON_STYLES.PRIMARY}
     text="Hello button and right icon"
     iconType="user"
   />);


### PR DESCRIPTION
[TMEDIA-549](https://arcpublishing.atlassian.net/browse/TMEDIA-549)

Small updates to button and tests

* `div` is invalid markup within a `button` - switched to using `span`
* Tests are now 100% coverage

<img width="630" alt="button-tests-before" src="https://user-images.githubusercontent.com/868127/140312198-99c936d1-78da-44f4-a34d-0fd543567077.png">

<img width="634" alt="button-tests-after" src="https://user-images.githubusercontent.com/868127/140312209-e5c9acb5-d113-4fe3-88de-56d16f548f84.png">

