### PR TITLE
TMEDIA-553 - Redirect to a fallback 404 page when section URL is not found

### DIFF
--- a/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.js
+++ b/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.js
@@ -9,7 +9,9 @@ export default {
     sectionId: 'text',
   },
   transform: (data, query) => {
-    if (!query.hierarchy && data._id !== query.sectionId) {
+    const idMatch = data._id !== query.sectionId;
+
+    if ((!query.hierarchy && idMatch) || (query.uri && idMatch)) {
       const error = new Error('Not found');
       error.statusCode = 404;
       throw error;

--- a/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.test.js
+++ b/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.test.js
@@ -57,4 +57,14 @@ describe('the site-service-hierarchy content source block', () => {
   it('when a hierarchy is not provided and sectionId is provided that does not match the API data a 404 is thrown', () => {
     expect(() => contentSource.transform({ _id: '/' }, { hierarchy: '', sectionId: '/sectionId' })).toThrow(Error);
   });
+
+  it('when a uri does not match section a 404 is thrown', () => {
+    expect(() => contentSource.transform({ _id: '/' }, { hierarchy: '', sectionId: '/sectionId', uri: '/' })).toThrow(Error);
+  });
+
+  it('when uri and section match return data', () => {
+    const data = contentSource.transform({ _id: '/sectionId' }, { hierarchy: 'hierarchy', sectionId: '/sectionId', uri: '/sectionId' });
+
+    expect(data._id).toEqual('/sectionId');
+  });
 });


### PR DESCRIPTION
## Description
Redirect to 404 if uri present and id and sectionId do not match

## Jira Ticket
- [TMEDIA-533](https://arcpublishing.atlassian.net/browse/TMEDIA-533)

## Acceptance Criteria
Invalid sections return a 404 page

## Test Steps

1. Checkout this branch `git checkout TMEDIA-553-section-404-redirect`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/site-hierarchy-content-block`
3. Validate homepage still works - http://localhost/?_website=the-gazette
4. Validate a section page still works - http://localhost/news/business/?_website=the-gazette
5. Validate a section page that does not exist now renders 404 - http://localhost/news-not-found/?_website=the-gazette


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
