### PR TITLE
poc: Update storybook copyright text example

### DIFF
--- a/.storybook/alias/properties.js
+++ b/.storybook/alias/properties.js
@@ -5,7 +5,7 @@ export default (site) => ({
 	facebookPage: true,
 	twitterUsername: true,
 	rssUrl: true,
-	copyrightText: true,
+	copyrightText: 'The Prophet © 1994 - 2019',
 	lightBackgroundLogo: 'https://design.arcxp.com/arc-glyph-light.svg',
 	lightBackgroundLogoAlt: 'light logo alt text',
 	primaryLogo: 'https://www.klartale.no/img/klartale/klartale-logo-new.svg',


### PR DESCRIPTION
- Ted asked if the copyright text was dynamic
- Just wanted to document that it's a string in the storybook to ensure this is known 

<img width="1089" alt="Screen Shot 2021-11-23 at 16 03 08" src="https://user-images.githubusercontent.com/5950956/143136344-8d33e2ae-7da1-4c6d-a1c1-8d4603da6364.png">


