### PR TITLE
Add three fields for story label for Overline to use.

### DIFF
--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -139,7 +139,11 @@ export const TopTableList = (props) => {
           basic
         }
         label {
-          basic
+          basic {
+            display
+            url
+            text
+          }
         }
         owner {
           sponsored


### PR DESCRIPTION
## Description
As per a customer request in an ACS ticket, three fields were added to the `top-table-list-block` data source filter. This will allow the `Overline` in the list blocks use a Label/Kicker instead of a section when one is assigned to a story. The business logic in Overline is already set up to allow a Label/Kicker in an override:
https://github.com/WPMedia/fusion-news-theme-blocks/blob/canary/blocks/shared-styles/_children/overline/index.jsx#L26-L31
https://github.com/WPMedia/fusion-news-theme-blocks/blob/canary/blocks/shared-styles/_children/overline/index.jsx#L52-L54
This change makes these fields available for this option.

## Jira Ticket
- [TMEDIA-525](https://arcpublishing.atlassian.net/browse/TMEDIA-525)

## Acceptance Criteria
From Sebe Dale IV at Gray Media:
> On line 142 of the `top-table-list-block`, the filter is missing the children of `label.basic`. The way this filter is currently set, blocks the Overline block from properly displaying kicker/labels on the feature. 

## Test Steps
**Note:** The following configurations have been made to make testing possible.
1. The following Kicker/Label was added to [Composer settings in Core Components Production](https://corecomponents.arcpublishing.com/composer/settings):
![image](https://user-images.githubusercontent.com/452134/143309708-45116b99-25d8-4f38-b82e-efe4f929608e.png)
2. This Kicker/Label was applied to the following story: 
https://corecomponents.arcpublishing.com/composer/edit/Z2S5GKCWOFBCFDUYYL4EPHEP6A/
![image](https://user-images.githubusercontent.com/452134/143309897-dcbcd89c-0b95-4df3-859c-2ba2d15d4062.png)

**Current State:**
1. First start on the `canary` branch as the control and launch Fusion without any block linking - `npx fusion start`.
1. Create a new page locally and include the `top-table-list-block` in a page section. Give the block the following data configuration to target the story where the Label/Kicker was added:
![image](https://user-images.githubusercontent.com/452134/143310114-d3944a65-0e79-4ae3-a6c2-10a9575906a8.png)
2. Set the custom fields of `top-table-list-block` to list one Extra Large Story.
![image](https://user-images.githubusercontent.com/452134/143310267-0da19829-2ebe-4d0a-82fd-03379e30cfe0.png)
3. Publish the page. The `Overline` on the block should list the site section content with label "News" linking to URL `/news/`.
4. Change the configuration of the `top-table-list-block` to instead list one Large Story.
![image](https://user-images.githubusercontent.com/452134/143310730-a77a9cd5-f5e0-42b2-a66c-a1758d1b0c54.png)
5. Publish the page. The `Overline` on the block should again list the site section content with label "News" linking to URL `/news/`.

**Expected Results of Change:**
1. Stop Fusion.
2. Change to branch `TMEDIA-525` and restart Fusion with linking to `top-table-list-block`.  ( `npx fusion start -f -l @wpmedia/top-table-list-block` )
3. Navigate back to the page you created. Republish the page with the previous two configurations. The `Overline` feature should now be using the Label/Kicker with "Exclusive"

## Effect Of Changes
### Before
**Extra Large Story Display:**
![image](https://user-images.githubusercontent.com/452134/143311684-d04c7925-bb09-438c-ae01-bdd4905f2b57.png)

**Large Story Display:**
![image](https://user-images.githubusercontent.com/452134/143311708-8a8c9dea-192c-4f72-bdaa-2d4c07df7e98.png)

### After
**Extra Large Story Display:**
![image](https://user-images.githubusercontent.com/452134/143311809-578bc5f5-074a-46da-9544-e81db8f63b5a.png)
**Large Story Display:**
![image](https://user-images.githubusercontent.com/452134/143311828-446df1ef-5547-4ce6-8e44-274703d9a6a5.png)

## Dependencies or Side Effects
The Label/Kicker display in the `Overline` may be an unexpected change for clients already  using `top-table-list-block`. At the very least, this may need mention in respective release notes. 

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
