### PR TITLE
Tmedia 578 account profile shell

### DIFF
--- a/blocks/identity-block/features/account-management/default.jsx
+++ b/blocks/identity-block/features/account-management/default.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from '@arc-fusion/prop-types';
+
+import { useFusionContext } from 'fusion:context';
+import getProperties from 'fusion:properties';
+import getTranslatedPhrases from 'fusion:intl';
+
+function AccountManagement({ customFields }) {
+  const { redirectURL } = customFields;
+
+  // get properties from context for using translations in intl.json
+  // See document for more info https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/2538275032/Lokalise+and+Theme+Blocks
+  const { arcSite } = useFusionContext();
+  const { locale = 'en' } = getProperties(arcSite);
+  const phrases = getTranslatedPhrases(locale);
+
+  // if logged in redirect to the url provided in customFields
+  console.log(redirectURL, 'redirect url');
+
+  return (
+    <h1>
+      {phrases.t('account-management-block.account-information')}
+    </h1>
+  );
+}
+
+AccountManagement.label = 'Account Management - Profile';
+
+AccountManagement.icon = 'monitor-use';
+
+AccountManagement.propTypes = {
+  customFields: PropTypes.shape({
+    redirectURL: PropTypes.string.tag({
+      name: 'Redirect URL',
+      defaultValue: '/account/login/',
+    }),
+  }),
+};
+
+export default AccountManagement;

--- a/blocks/identity-block/features/account-management/default.jsx
+++ b/blocks/identity-block/features/account-management/default.jsx
@@ -1,25 +1,42 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from '@arc-fusion/prop-types';
 
 import { useFusionContext } from 'fusion:context';
 import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
+import { useIdentity } from '../..';
 
 function AccountManagement({ customFields }) {
   const { redirectURL } = customFields;
 
   // get properties from context for using translations in intl.json
   // See document for more info https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/2538275032/Lokalise+and+Theme+Blocks
-  const { arcSite } = useFusionContext();
+  const { arcSite, isAdmin } = useFusionContext();
   const { locale = 'en' } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
 
-  // if logged in redirect to the url provided in customFields
-  console.log(redirectURL, 'redirect url');
+  const { isInitialized, Identity } = useIdentity();
 
+  useEffect(() => {
+    const checkLoggedInStatus = async () => {
+      const isLoggedIn = await Identity.isLoggedIn();
+      if (isLoggedIn) {
+        window.location = redirectURL;
+      }
+    };
+    if (Identity && !isAdmin) {
+      checkLoggedInStatus();
+    }
+  }, [Identity, isAdmin, redirectURL]);
+
+  if (!isInitialized) {
+    return null;
+  }
+
+  // if logged in, return account info
   return (
     <h1>
-      {phrases.t('account-management-block.account-information')}
+      {phrases.t('identity-block.account-information')}
     </h1>
   );
 }

--- a/blocks/identity-block/features/account-management/default.jsx
+++ b/blocks/identity-block/features/account-management/default.jsx
@@ -6,13 +6,19 @@ import getProperties from 'fusion:properties';
 import getTranslatedPhrases from 'fusion:intl';
 import { useIdentity } from '../..';
 
+export function AccountManagementPresentational({ header }) {
+  return (
+    <h1>{header}</h1>
+  );
+}
+
 function AccountManagement({ customFields }) {
   const { redirectURL } = customFields;
 
   // get properties from context for using translations in intl.json
   // See document for more info https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/2538275032/Lokalise+and+Theme+Blocks
   const { arcSite, isAdmin } = useFusionContext();
-  const { locale = 'en' } = getProperties(arcSite);
+  const { locale } = getProperties(arcSite);
   const phrases = getTranslatedPhrases(locale);
 
   const { isInitialized, Identity } = useIdentity();
@@ -33,11 +39,11 @@ function AccountManagement({ customFields }) {
     return null;
   }
 
+  const header = phrases.t('identity-block.account-information');
+
   // if logged in, return account info
   return (
-    <h1>
-      {phrases.t('identity-block.account-information')}
-    </h1>
+    <AccountManagementPresentational header={header} />
   );
 }
 

--- a/blocks/identity-block/features/account-management/default.jsx
+++ b/blocks/identity-block/features/account-management/default.jsx
@@ -20,7 +20,7 @@ function AccountManagement({ customFields }) {
   useEffect(() => {
     const checkLoggedInStatus = async () => {
       const isLoggedIn = await Identity.isLoggedIn();
-      if (isLoggedIn) {
+      if (!isLoggedIn) {
         window.location = redirectURL;
       }
     };
@@ -43,7 +43,7 @@ function AccountManagement({ customFields }) {
 
 AccountManagement.label = 'Account Management - Profile';
 
-AccountManagement.icon = 'monitor-use';
+AccountManagement.icon = 'monitor-user';
 
 AccountManagement.propTypes = {
   customFields: PropTypes.shape({

--- a/blocks/identity-block/features/account-management/default.test.jsx
+++ b/blocks/identity-block/features/account-management/default.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import useIdentity from '../../components/Identity';
+import AccountManagement, { AccountManagementPresentational } from './default';
+
+jest.mock('fusion:properties', () => (jest.fn(() => ({
+  locale: 'en',
+}))));
+
+jest.mock('../../components/Identity');
+
+jest.mock('fusion:intl', () => ({
+  __esModule: true,
+  default: jest.fn((locale) => ({ t: jest.fn((phrase) => require('../../intl.json')[phrase][locale]) })),
+}));
+
+const loginMock = jest.fn(() => Promise.resolve({}));
+
+describe('Account management', () => {
+  beforeEach(async () => {
+    useIdentity.mockImplementation(() => ({
+      isInitialized: true,
+      isLoggedIn: () => true,
+      Identity: {
+        isLoggedIn: jest.fn(async () => false),
+        getConfig: jest.fn(async () => ({})),
+        login: loginMock,
+      },
+    }));
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders header text', () => {
+    const wrapper = mount(<AccountManagementPresentational header="header" />);
+    expect(wrapper.find('h1').text()).toEqual('header');
+  });
+
+  it('should render account management if logged in and initialized', async () => {
+    await act(async () => {
+      const wrapper = await mount(
+        <AccountManagement customFields={{}} />,
+      );
+      expect(wrapper.find('h1').text()).toEqual('Account Information');
+    });
+  });
+
+  it('should not render if not logged in and not initialized', async () => {
+    useIdentity.mockImplementation(() => ({
+      isInitialized: false,
+      isLoggedIn: () => false,
+      Identity: {
+        isLoggedIn: jest.fn(async () => false),
+        getConfig: jest.fn(async () => ({})),
+      },
+    }));
+
+    await act(async () => {
+      const wrapper = await mount(
+        <AccountManagement customFields={{}} />,
+      );
+      expect(wrapper.html()).toBe(null);
+    });
+  });
+});

--- a/blocks/identity-block/intl.json
+++ b/blocks/identity-block/intl.json
@@ -240,5 +240,14 @@
 		"no": "Sign up for an account.",
 		"pt": "Sign up for an account.",
 		"sv": "Sign up for an account."
-	}
+	},
+	"identity-block.account-information": {
+        "de": "Account Information",
+        "es": "Account Information",
+        "fr": "Account Information",
+        "ja": "Account Information",
+        "no": "Account Information",
+        "pt": "Account Information",
+        "sv": "Account Information"
+    }
 }

--- a/blocks/identity-block/intl.json
+++ b/blocks/identity-block/intl.json
@@ -248,6 +248,7 @@
         "ja": "Account Information",
         "no": "Account Information",
         "pt": "Account Information",
-        "sv": "Account Information"
+        "sv": "Account Information",
+		"en": "Account Information"
     }
 }


### PR DESCRIPTION
## Description
Setup shell with basic login

## Jira Ticket
- [TMEDIA-578](https://arcpublishing.atlassian.net/browse/TMEDIA-578)

## Acceptance Criteria
Ability to drop block “Account Management - Profile” on to a page

Icon is  monitor-user from the blocks icon library

If not logged in, redirect to login page 

Include Custom Field default of /account/login/

If logged in, show placeholder “Account Information” heading

## Test Steps

1. Checkout this branch `git checkout TMEDIA-578-account-profile-shell`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/identity-block`
3. Create account management page with the account management block
4. Go to that page and see redirect when not logged in
5. login
6. Go to the account management page. See the header account management

## Effect Of Changes
### Before
No new block

### After
New block with dynamic login

## Dependencies or Side Effects
-none

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
