### PR TITLE
TMEDIA-536 - Checkout Create Order

### DIFF
--- a/blocks/subscriptions-block/features/checkout/_children/PaymentInfo/index.jsx
+++ b/blocks/subscriptions-block/features/checkout/_children/PaymentInfo/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PaymentInfo = () => (
+  <div>Payment Form</div>
+);
+
+export default PaymentInfo;

--- a/blocks/subscriptions-block/features/checkout/_children/PaymentInfo/index.test.jsx
+++ b/blocks/subscriptions-block/features/checkout/_children/PaymentInfo/index.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import PaymentInfo from './index';
 

--- a/blocks/subscriptions-block/features/checkout/_children/PaymentInfo/index.test.jsx
+++ b/blocks/subscriptions-block/features/checkout/_children/PaymentInfo/index.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import PaymentInfo from './index';
+
+jest.mock('fusion:intl', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ t: jest.fn((phrase) => phrase) })),
+}));
+
+describe('PaymentInfo', () => {
+  it('renders', () => {
+    const wrapper = shallow(
+      <PaymentInfo />,
+    );
+
+    expect(wrapper.html()).not.toBe(null);
+  });
+});

--- a/blocks/subscriptions-block/features/checkout/default.test.jsx
+++ b/blocks/subscriptions-block/features/checkout/default.test.jsx
@@ -1,6 +1,14 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import useIdentity from '@wpmedia/identity-block/components/Identity';
+import useSales from '../../components/useSales';
+
 import Checkout from './default';
+
+jest.mock('@wpmedia/identity-block/components/Identity');
+
+jest.mock('../../components/useSales');
 
 jest.mock('fusion:properties', () => (jest.fn(() => ({ api: { retail: { origin: '' } } }))));
 
@@ -9,8 +17,18 @@ jest.mock('fusion:intl', () => ({
   default: jest.fn(() => ({ t: jest.fn((phrase) => phrase) })),
 }));
 
-describe('The Offer feature', () => {
-  it('renders the correct number of offer cards', () => {
+describe('Checkout Feature', () => {
+  it('renders link, cart and contact info', () => {
+    useIdentity.mockImplementation(() => ({
+      Identity: {
+        isLoggedIn: jest.fn(async () => false),
+      },
+    }));
+
+    useSales.mockReturnValue({
+      Sales: {},
+    });
+
     const wrapper = shallow(
       <Checkout
         customFields={{
@@ -21,5 +39,63 @@ describe('The Offer feature', () => {
 
     expect(wrapper.find('a').prop('href')).toBe('/offer-url/');
     expect(wrapper.find('Cart').exists()).toBe(true);
+    expect(wrapper.find('ContactInfo').exists()).toBe(true);
+  });
+
+  it('Renders PaymentInfo after creating an order', async () => {
+    let wrapper;
+
+    const userProfile = Promise.resolve({ email: 'email@email.com', firstName: 'first name', lastName: 'last name' });
+    const updateUserProfileMock = jest.fn();
+
+    useIdentity.mockImplementation(() => ({
+      Identity: {
+        isLoggedIn: jest.fn(async () => true),
+        getUserProfile: jest.fn(() => userProfile),
+        updateUserProfile: updateUserProfileMock,
+      },
+    }));
+
+    const createNewOrderMock = Promise.resolve({ orderNumber: 1 });
+    const getPaymentOptionsMock = Promise.resolve([{ paymentMethodID: 11 }]);
+    const initializePaymentMock = Promise.resolve({});
+
+    useSales.mockReturnValue({
+      Sales: {
+        getCart: jest.fn(async () => Promise.resolve({})),
+        createNewOrder: jest.fn(() => createNewOrderMock),
+        getPaymentOptions: jest.fn(() => getPaymentOptionsMock),
+        initializePayment: jest.fn(() => initializePaymentMock),
+      },
+    });
+
+    await act(async () => {
+      wrapper = await mount(
+        <Checkout
+          customFields={{
+            offerURL: '/offer-url/',
+          }}
+        />,
+      );
+    });
+    await userProfile;
+    wrapper.update();
+
+    expect(wrapper.find('ContactInfo').exists()).toBe(true);
+
+    wrapper.find('option').at(1).instance().selected = true;
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+      await initializePaymentMock;
+    });
+
+    wrapper.update();
+
+    expect(updateUserProfileMock).toHaveBeenCalled();
+
+
+    expect(wrapper.find('ContactInfo').exists()).toBe(false);
+    expect(wrapper.find('PaymentInfo').exists()).toBe(true);
   });
 });

--- a/blocks/subscriptions-block/features/checkout/default.test.jsx
+++ b/blocks/subscriptions-block/features/checkout/default.test.jsx
@@ -94,7 +94,6 @@ describe('Checkout Feature', () => {
 
     expect(updateUserProfileMock).toHaveBeenCalled();
 
-
     expect(wrapper.find('ContactInfo').exists()).toBe(false);
     expect(wrapper.find('PaymentInfo').exists()).toBe(true);
   });


### PR DESCRIPTION
## Description

Hook up the Contact Info proceed to checkout functionality, and load placeholder payment component

## Jira Ticket
- [TMEDIA-536](https://arcpublishing.atlassian.net/browse/TMEDIA-536)

## Acceptance Criteria
* “Create order” happens upon click of “Proceed to Payment” button on Contact Info 
* Use the values from the ContactInfo component 
* Save the FirstName and LastName from the contactInfo to the users profile if logged in
* createNewOrder via the Sales SDK
* Upon successful creation of a new order
   * Using Sales getPaymentOptions
   * Then initializePayment with the OrderNumber and paymentMethodID
* Remove the ConactInfo component from view and show a placeholder payment element

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-517-checkout-new-order`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles,@wpmedia/subscriptions-block,@wpmedia/identity-block`
3. Ensure you have an Offer page - http://localhost/offer/?_website=the-gazette
4. Ensure you have a checkout page - http://localhost/checkout/?_website=the-gazette
4. From the offer page - http://localhost/offer/?_website=the-gazette
5. Select and offer and follow the flow of logging in until you reach the checkout page
6. Fill in the contact info as per #1185
7. Click the "Continue to Checkout" button
8. Validate the Payment placeholder is shown and contact info details are removed


## Dependencies or Side Effects

This work is built upon #1185 


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
