### PR TITLE
TMEDIA-598 Site Hierarchy - Account for no section

### DIFF
--- a/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.js
+++ b/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.js
@@ -9,13 +9,17 @@ export default {
     sectionId: 'text',
   },
   transform: (data, query) => {
-    const idMatch = data._id !== query.sectionId;
+    let idMatch = false;
+    if (query.sectionId) {
+      idMatch = data._id !== query.sectionId;
+    }
 
     if ((!query.hierarchy && idMatch) || (query.uri && idMatch)) {
       const error = new Error('Not found');
       error.statusCode = 404;
       throw error;
     }
+
     return data;
   },
 };

--- a/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.test.js
+++ b/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.test.js
@@ -48,6 +48,12 @@ describe('the site-service-hierarchy content source block', () => {
     expect(data._id).toEqual('/');
   });
 
+  it('when a hierarchy is provided and no sectionId', () => {
+    const data = contentSource.transform({ _id: '/' }, { hierarchy: 'links-bar', uri: '/test/test' });
+
+    expect(data._id).toEqual('/');
+  });
+
   it('when a hierarchy is not provided and sectionId is provided that matches the API data then the data is returned', () => {
     const data = contentSource.transform({ _id: '/sectionId' }, { hierarchy: '', sectionId: '/sectionId' });
 


### PR DESCRIPTION
## Description

Update site hierarchy content source to allow for no sectionId present to return data not a 404

## Jira Ticket
- [TMEDIA-598](https://arcpublishing.atlassian.net/browse/TMEDIA-598)

## Acceptance Criteria
* Update default section resolver to only run the section ID match if a section ID is present

## Test Steps
1. Checkout this branch `git checkout TMEDIA-598-account-for-no-section-id`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/site-hierarchy-content-block`
3. Create a new resolver
    * Resolver Name - Test
    * Resolver Priority - 6
    * Regex Pattern - `^\/mobile-hierarchy\/([\w\-/]+?)/?$`
    * Content Source - site-service-hierarchy
    * hierarchy - Pattern = 1
    * Default Template - section
    * Default output type - default
4. Go to the page - http://localhost/mobile-hierarchy/news/?_website=the-gazette
5. Validate the page does not return a 404

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
