### PR TITLE
TMEDIA-591 - Lead Art Display Options - Image and Galleries

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -256,19 +256,19 @@ LeadArt.propTypes = {
     }),
     ...(videoPlayerCustomFields()),
     displayTitle: PropTypes.bool.tag({
-      description: 'This display option applies to all Lead Art media types: Images, Gallery, and Video',
+      description: 'This display option applies to Lead Art media types: Images and Gallery',
       label: 'Display Title',
       defaultValue: true,
       group: 'Display Options',
     }),
     displayCaption: PropTypes.bool.tag({
-      description: 'This display option applies to all Lead Art media types: Images, Gallery, and Video',
+      description: 'This display option applies to Lead Art media types: Images and Gallery',
       label: 'Display Caption',
       defaultValue: true,
       group: 'Display Options',
     }),
     displayCredits: PropTypes.bool.tag({
-      description: 'This display option applies to all Lead Art media types: Images, Gallery, and Video',
+      description: 'This display option applies to Lead Art media types: Images and Gallery',
       label: 'Display Credits',
       defaultValue: true,
       group: 'Display Options',

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -65,7 +65,7 @@ class LeadArt extends Component {
     } = this.state;
 
     const { arcSite, customFields, id } = this.props;
-    const { displayTitle = true, displayCaption = true, displayCredits = true } = customFields;
+    const { hideTitle = false, hideCaption = false, hideCredits = false } = customFields;
 
     let AdBlock;
 
@@ -142,7 +142,7 @@ class LeadArt extends Component {
                 <Lightbox
                   mainSrc={this.lightboxImgHandler()}
                   onCloseRequest={this.setIsOpenToFalse}
-                  imageCaption={displayCaption ? lead_art.caption : null}
+                  imageCaption={!hideCaption ? lead_art.caption : null}
                 />
               )}
             </>
@@ -151,9 +151,9 @@ class LeadArt extends Component {
 
         caption = (
           <ImageMetadata
-            subtitle={displayTitle ? lead_art.subtitle : null}
-            caption={displayCaption ? lead_art.caption : null}
-            credits={displayCredits ? lead_art.credits : null}
+            subtitle={!hideTitle ? lead_art.subtitle : null}
+            caption={!hideCaption ? lead_art.caption : null}
+            credits={!hideCredits ? lead_art.credits : null}
           />
         );
 
@@ -189,7 +189,7 @@ class LeadArt extends Component {
               />
             </div>
             {lightbox}
-            {(displayTitle || displayCaption || displayCredits) ? (
+            {(!hideTitle || !hideCaption || !hideCredits) ? (
               <figcaption>
                 {caption}
               </figcaption>
@@ -218,9 +218,9 @@ class LeadArt extends Component {
             pageCountPhrase={(current, total) => this.phrases.t('global.gallery-page-count-text', { current, total })}
             adElement={/* istanbul ignore next */ () => (<AdBlock />)}
             interstitialClicks={interstitialClicks}
-            displayTitle={displayTitle}
-            displayCaption={displayCaption}
-            displayCredits={displayCredits}
+            displayTitle={!hideTitle}
+            displayCaption={!hideCaption}
+            displayCredits={!hideCredits}
           />
         );
       }
@@ -255,22 +255,22 @@ LeadArt.propTypes = {
       group: 'Video',
     }),
     ...(videoPlayerCustomFields()),
-    displayTitle: PropTypes.bool.tag({
+    hideTitle: PropTypes.bool.tag({
       description: 'This display option applies to Lead Art media types: Images and Gallery',
-      label: 'Display Title',
-      defaultValue: true,
+      label: 'Hide Title',
+      defaultValue: false,
       group: 'Display Options',
     }),
-    displayCaption: PropTypes.bool.tag({
+    hideCaption: PropTypes.bool.tag({
       description: 'This display option applies to Lead Art media types: Images and Gallery',
-      label: 'Display Caption',
-      defaultValue: true,
+      label: 'Hide Caption',
+      defaultValue: false,
       group: 'Display Options',
     }),
-    displayCredits: PropTypes.bool.tag({
+    hideCredits: PropTypes.bool.tag({
       description: 'This display option applies to Lead Art media types: Images and Gallery',
-      label: 'Display Credits',
-      defaultValue: true,
+      label: 'Hide Credits',
+      defaultValue: false,
       group: 'Display Options',
     }),
   }),

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -65,6 +65,7 @@ class LeadArt extends Component {
     } = this.state;
 
     const { arcSite, customFields, id } = this.props;
+    const { displayTitle = true, displayCaption = true, displayCredits = true } = customFields;
 
     let AdBlock;
 
@@ -131,7 +132,9 @@ class LeadArt extends Component {
             }}
           />
         );
-      } if (lead_art.type === 'image') {
+      }
+
+      if (lead_art.type === 'image') {
         if (buttonPosition !== 'hidden') {
           lightbox = (
             <>
@@ -139,7 +142,7 @@ class LeadArt extends Component {
                 <Lightbox
                   mainSrc={this.lightboxImgHandler()}
                   onCloseRequest={this.setIsOpenToFalse}
-                  imageCaption={lead_art.caption}
+                  imageCaption={displayCaption ? lead_art.caption : null}
                 />
               )}
             </>
@@ -148,9 +151,9 @@ class LeadArt extends Component {
 
         caption = (
           <ImageMetadata
-            subtitle={lead_art.subtitle}
-            caption={lead_art.caption}
-            credits={lead_art.credits}
+            subtitle={displayTitle ? lead_art.subtitle : null}
+            caption={displayCaption ? lead_art.caption : null}
+            credits={displayCredits ? lead_art.credits : null}
           />
         );
 
@@ -186,11 +189,11 @@ class LeadArt extends Component {
               />
             </div>
             {lightbox}
-            {caption && (
+            {(displayTitle || displayCaption || displayCredits) ? (
               <figcaption>
                 {caption}
               </figcaption>
-            )}
+            ) : null}
 
           </figure>
         );
@@ -215,6 +218,9 @@ class LeadArt extends Component {
             pageCountPhrase={(current, total) => this.phrases.t('global.gallery-page-count-text', { current, total })}
             adElement={/* istanbul ignore next */ () => (<AdBlock />)}
             interstitialClicks={interstitialClicks}
+            displayTitle={displayTitle}
+            displayCaption={displayCaption}
+            displayCredits={displayCredits}
           />
         );
       }
@@ -249,6 +255,24 @@ LeadArt.propTypes = {
       group: 'Video',
     }),
     ...(videoPlayerCustomFields()),
+    displayTitle: PropTypes.bool.tag({
+      description: 'This display option applies to all Lead Art media types: Images, Gallery, and Video',
+      label: 'Display Title',
+      defaultValue: true,
+      group: 'Display Options',
+    }),
+    displayCaption: PropTypes.bool.tag({
+      description: 'This display option applies to all Lead Art media types: Images, Gallery, and Video',
+      label: 'Display Caption',
+      defaultValue: true,
+      group: 'Display Options',
+    }),
+    displayCredits: PropTypes.bool.tag({
+      description: 'This display option applies to all Lead Art media types: Images, Gallery, and Video',
+      label: 'Display Credits',
+      defaultValue: true,
+      group: 'Display Options',
+    }),
   }),
 };
 

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -53,93 +53,26 @@ describe('LeadArt', () => {
     expect(wrapper.find('ReactImageLightbox').length).toEqual(1);
   });
 
-  // it('renders video lead art type without playthrough', () => {
-  //   const globalContent = {
-  //     promo_items: {
-  //       lead_art: {
-  //         type: 'video',
-  //       },
-  //     },
-  //   };
+  it('renders video lead art type without playthrough', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'video',
+        },
+      },
+    };
 
-  //   const wrapper = shallow(
-  //     <LeadArt
-  //       arcSite="the-sun"
-  //       globalContent={globalContent}
-  //       customFields={{ playthrough: false }}
-  //     />,
-  //   );
-  //   const vidPlayer = wrapper.find('VideoPlayer');
-  //   expect(vidPlayer.length).toEqual(1);
-  //   expect(vidPlayer.props().customFields.playthrough).toBeFalsy();
-  // });
-
-  // not sure if these tests are reliable
-  // it('renders video lead art type with playthrough', () => {
-  //   const globalContent = {
-  //     promo_items: {
-  //       lead_art: {
-  //         type: 'video',
-  //         embedHTML: 'here',
-  //       },
-  //     },
-  //   };
-
-  //   const wrapper = shallow(
-  //     <LeadArt
-  //       arcSite="the-sun"
-  //       globalContent={globalContent}
-  //       customFields={{ playthrough: true }}
-  //     />,
-  //   );
-  //   const vidPlayer = wrapper.find('VideoPlayer');
-  //   expect(vidPlayer.length).toEqual(1);
-  //   expect(vidPlayer.props().customFields.playthrough).toBeDefined();
-  //   expect(vidPlayer.props().customFields.playthrough).toEqual(true);
-  // });
-
-  // it('renders video lead art type without auto-play', () => {
-  //   const globalContent = {
-  //     promo_items: {
-  //       lead_art: {
-  //         type: 'video',
-  //       },
-  //     },
-  //   };
-
-  //   const wrapper = shallow(
-  //     <LeadArt
-  //       arcSite="the-sun"
-  //       globalContent={globalContent}
-  //       customFields={{ enableAutoplay: false }}
-  //     />,
-  //   );
-  //   const vidPlayer = wrapper.find('VideoPlayer');
-  //   expect(vidPlayer.length).toEqual(1);
-  //   expect(vidPlayer.prop('enableAutoplay')).toBeFalsy();
-  // });
-
-  // it('renders video lead art type with auto-play', () => {
-  //   const globalContent = {
-  //     promo_items: {
-  //       lead_art: {
-  //         type: 'video',
-  //       },
-  //     },
-  //   };
-
-  //   const wrapper = shallow(
-  //     <LeadArt
-  //       arcSite="the-sun"
-  //       globalContent={globalContent}
-  //       customFields={{ enableAutoplay: true }}
-  //     />,
-  //   );
-  //   const vidPlayer = wrapper.find('VideoPlayer');
-  //   expect(vidPlayer.length).toEqual(1);
-  //   expect(vidPlayer.prop('enableAutoplay')).toBeDefined();
-  //   expect(vidPlayer.prop('enableAutoplay')).toEqual(true);
-  // });
+    const wrapper = shallow(
+      <LeadArt
+        arcSite="the-sun"
+        globalContent={globalContent}
+        customFields={{ playthrough: false }}
+      />,
+    );
+    const vidPlayer = wrapper.find('VideoPlayer');
+    expect(vidPlayer.length).toEqual(1);
+    expect(vidPlayer.props().customFields.playthrough).toBeFalsy();
+  });
 
   it('renders image type', () => {
     const globalContent = {
@@ -153,6 +86,28 @@ describe('LeadArt', () => {
     LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
     const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
     expect(wrapper.find('ImageMetadata').length).toEqual(1);
+  });
+
+  it('renders image type and no meta data', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'image',
+        },
+      },
+    };
+
+    LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
+    const wrapper = shallow(<LeadArt
+      arcSite="the-sun"
+      globalContent={globalContent}
+      customFields={{
+        displayTitle: false,
+        displayCaption: false,
+        displayCredits: false,
+      }}
+    />);
+    expect(wrapper.find('ImageMetadata').length).toEqual(0);
   });
 
   it('renders gallery lead image type', () => {

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -102,9 +102,9 @@ describe('LeadArt', () => {
       arcSite="the-sun"
       globalContent={globalContent}
       customFields={{
-        displayTitle: false,
-        displayCaption: false,
-        displayCredits: false,
+        hideTitle: true,
+        hideCaption: true,
+        hideCredits: true,
       }}
     />);
     expect(wrapper.find('ImageMetadata').length).toEqual(0);

--- a/blocks/lead-art-block/index.story.jsx
+++ b/blocks/lead-art-block/index.story.jsx
@@ -139,23 +139,6 @@ export const gallery = () => {
   );
 };
 
-export const galleryNoTitleCaptionCredits = () => {
-  const globalContent = {
-    arcSite: 'story-book',
-    promo_items: {
-      lead_art: leadArtGallery,
-    },
-  };
-  const customFields = {
-    displayTitle: false,
-    displayCaption: false,
-    displayCredit: false,
-  };
-  return (
-    <LeadArt globalContent={globalContent} customFields={customFields} />
-  );
-};
-
 export const image = () => {
   const globalContent = {
     arcSite: 'story-book',
@@ -177,7 +160,7 @@ export const imageNoTitle = () => {
   };
 
   return (
-    <LeadArt globalContent={globalContent} customFields={{ displayTitle: false }} />
+    <LeadArt globalContent={globalContent} customFields={{ hideTitle: true }} />
   );
 };
 
@@ -193,8 +176,8 @@ export const imageNoTitleCaption = () => {
     <LeadArt
       globalContent={globalContent}
       customFields={{
-        displayTitle: false,
-        displayCaption: false,
+        hideTitle: true,
+        hideCaption: true,
       }}
     />
   );
@@ -212,9 +195,9 @@ export const imageNoTitleCaptionCredits = () => {
     <LeadArt
       globalContent={globalContent}
       customFields={{
-        displayTitle: false,
-        displayCaption: false,
-        displayCredits: false,
+        hideTitle: true,
+        hideCaption: true,
+        hideCredits: true,
       }}
     />
   );

--- a/blocks/lead-art-block/index.story.jsx
+++ b/blocks/lead-art-block/index.story.jsx
@@ -15,7 +15,15 @@ const leadArtImage = {
   type: 'image',
   caption: 'Reimagining a tried-and-true staple can invigorate the senses. Tired of tomato soup with grilled cheese? Why not try a hearty gazpacho with a caprese focaccia?',
   credits: {
-    affiliation: [],
+    affiliation: [{
+      name: 'Affiliation Name',
+    }],
+    by: [{
+      type: 'author',
+      name: 'Author Name',
+      org: 'Author Org',
+      slug: '',
+    }],
   },
   subtitle: 'Switching It Up',
   url: 'https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/47JS2DECTBGPZDHNCYVFQFKWLQ.jpg',
@@ -131,6 +139,23 @@ export const gallery = () => {
   );
 };
 
+export const galleryNoTitleCaptionCredits = () => {
+  const globalContent = {
+    arcSite: 'story-book',
+    promo_items: {
+      lead_art: leadArtGallery,
+    },
+  };
+  const customFields = {
+    displayTitle: false,
+    displayCaption: false,
+    displayCredit: false,
+  };
+  return (
+    <LeadArt globalContent={globalContent} customFields={customFields} />
+  );
+};
+
 export const image = () => {
   const globalContent = {
     arcSite: 'story-book',
@@ -140,6 +165,58 @@ export const image = () => {
   };
   return (
     <LeadArt globalContent={globalContent} />
+  );
+};
+
+export const imageNoTitle = () => {
+  const globalContent = {
+    arcSite: 'story-book',
+    promo_items: {
+      lead_art: leadArtImage,
+    },
+  };
+
+  return (
+    <LeadArt globalContent={globalContent} customFields={{ displayTitle: false }} />
+  );
+};
+
+export const imageNoTitleCaption = () => {
+  const globalContent = {
+    arcSite: 'story-book',
+    promo_items: {
+      lead_art: leadArtImage,
+    },
+  };
+
+  return (
+    <LeadArt
+      globalContent={globalContent}
+      customFields={{
+        displayTitle: false,
+        displayCaption: false,
+      }}
+    />
+  );
+};
+
+export const imageNoTitleCaptionCredits = () => {
+  const globalContent = {
+    arcSite: 'story-book',
+    promo_items: {
+      lead_art: leadArtImage,
+    },
+  };
+
+  return (
+    <LeadArt
+      globalContent={globalContent}
+      customFields={{
+        displayTitle: false,
+        displayCaption: false,
+        displayCredits: false,
+      }}
+    />
   );
 };
 


### PR DESCRIPTION
## Description
Update lead art block to have three new custom field options for setting display of title, caption and credits on Image and Gallery lead art types

## Jira Ticket
- [TMEDIA-591](https://arcpublishing.atlassian.net/browse/TMEDIA-591)

## Acceptance Criteria
* Lead Art Block has new custom field checkboxes:
    * “Display Title”
    * “Display Caption”
    * “Display Credits”
* All three are checked by default
* Image Title and Caption and Credit are displayed based on the checkbox setting for Images (including Expanded Image), Gallery, and Video in the Lead Art Block. 
* Help text says “This display option applies to Lead Art media types: Images and Gallery”

## Test Steps

This requires the SDK PR - https://github.com/WPMedia/engine-theme-sdk/pull/534

Make sure you have your local SDK checked out to the PR noted above and have it linked in your .env file with `ENGINE_SDK_REPO` set

1. Checkout this branch `git checkout TMEDIA-591-lead-art-display-options`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/lead-art-block`
3. Using the `article-right-rail` template 
4. Find the Lead Art block and validate there are now three new custom fields showing in editor
5. For Gallery article - update Preview Content data in the template editor to have `website_url` = /local/2020/01/14/five-affordable-destinations-for-a-do-it-yourself-wellness-vacation/
6. Edit the settings of the lead art to toggle the display values and validate the items that should not be shown are not shown
7. For Image lead art - update Preview content data in the template editor to have `website_url` = /arts/2020/01/17/a-huge-loss-for-lovers-of-romantic-music-chamin-correa-legendary-mexican-guitarist-dies-at-90/
8. Edit the settings of the lead art to toggle the display values and validate the items that should not be shown are not shown

## Effect Of Changes


<img width="306" alt="Microsoft Edge-2021-12-15-14-13 58" src="https://user-images.githubusercontent.com/868127/146202557-d3808db6-3d7c-43ac-9d6d-bf3fc9b8c960.png">


## Dependencies or Side Effects

Requires SDK PR - https://github.com/WPMedia/engine-theme-sdk/pull/534


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
