### PR TITLE
TMEDIA-593 - Update PromoLabel to be part of link within PromoImage

### DIFF
--- a/blocks/shared-styles/_children/promo-image/index.jsx
+++ b/blocks/shared-styles/_children/promo-image/index.jsx
@@ -62,6 +62,9 @@ const PromoImage = ({
 
   const hasLink = () => content?.websites?.[arcSite]?.website_url || linkURL;
 
+  const PromoLabelElement = (showPromoLabel && promoType)
+    ? <PromoLabel type={promoType} size={promoLabelSize} /> : null;
+
   const withLink = (item) => (
     <a
       href={content?.websites?.[arcSite]?.website_url || linkURL}
@@ -77,23 +80,28 @@ const PromoImage = ({
 
   const ImageOrPlaceholder = imageURL && resizedImageOptions
     ? (
-      <Image
-        url={imageURL}
-        alt={content && content.headlines ? content.headlines.basic : alt}
-        {...ratios}
-        breakpoints={getProperties(arcSite)?.breakpoints}
-        resizerURL={getProperties(arcSite)?.resizerURL}
-        resizedImageOptions={resizedImageOptions}
-      />
+      <>
+        <Image
+          url={imageURL}
+          alt={content && content.headlines ? content.headlines.basic : alt}
+          {...ratios}
+          breakpoints={getProperties(arcSite)?.breakpoints}
+          resizerURL={getProperties(arcSite)?.resizerURL}
+          resizedImageOptions={resizedImageOptions}
+        />
+        {PromoLabelElement}
+      </>
     )
     : (
-      <PlaceholderImage client={imageConfig === 'resize-image-api-client'} />
+      <>
+        <PlaceholderImage client={imageConfig === 'resize-image-api-client'} />
+        {PromoLabelElement}
+      </>
     );
 
   return (
     <div className="promo-image" key={imageURL}>
       {hasLink() ? withLink(ImageOrPlaceholder) : ImageOrPlaceholder}
-      {showPromoLabel && promoType ? <PromoLabel type={promoType} size={promoLabelSize} /> : null}
     </div>
   );
 };

--- a/blocks/shared-styles/_children/promo-image/index.story.jsx
+++ b/blocks/shared-styles/_children/promo-image/index.story.jsx
@@ -20,6 +20,18 @@ export const withLinkAndLabel = () => {
   );
 };
 
+export const withLinkAndSmallLabel = () => {
+  const props = {
+    customImageURL,
+    showPromoLabel: true,
+    content: { type: 'gallery', websites: { 'story-book': { website_url: 'https://arcxp.com' } } },
+  };
+
+  return (
+    <PromoImage {...props} />
+  );
+};
+
 export const withLinkAndNoLabel = () => {
   const props = {
     customImageURL,

--- a/blocks/shared-styles/_children/promo-image/styles.scss
+++ b/blocks/shared-styles/_children/promo-image/styles.scss
@@ -1,6 +1,13 @@
 .promo-image {
   position: relative;
 
+  img {
+    display: block;
+    height: auto;
+    vertical-align: middle;
+    width: 100%;
+  }
+
   .promo-label {
     .label {
       color: #fff;

--- a/blocks/shared-styles/scss/_extra-large-promo.scss
+++ b/blocks/shared-styles/scss/_extra-large-promo.scss
@@ -3,11 +3,6 @@
 
   a {
     color: $ui-primary-font-color;
-    position: relative;
-  }
-
-  a > picture > img {
-    vertical-align: middle;
   }
 
   .overline {
@@ -47,11 +42,6 @@
       font-size: calculateRem(16px);
       line-height: calculateRem(24px);
     }
-  }
-
-  img {
-    height: auto;
-    width: 100%;
   }
 
   .article-meta {

--- a/blocks/shared-styles/scss/_large-promo.scss
+++ b/blocks/shared-styles/scss/_large-promo.scss
@@ -3,11 +3,6 @@
 
   a {
     color: $ui-primary-font-color;
-    position: relative;
-  }
-
-  a > picture > img {
-    vertical-align: middle;
   }
 
   .overline {
@@ -44,11 +39,6 @@
       font-size: calculateRem(16px);
       line-height: calculateRem(24px);
     }
-  }
-
-  img {
-    height: auto;
-    width: 100%;
   }
 
   .article-meta {

--- a/blocks/shared-styles/scss/_medium-promo.scss
+++ b/blocks/shared-styles/scss/_medium-promo.scss
@@ -3,12 +3,7 @@
 
   a {
     color: $ui-primary-font-color;
-    position: relative;
     text-decoration: none;
-
-    img {
-      vertical-align: middle;
-    }
   }
 
   .md-promo-headline {
@@ -54,10 +49,8 @@
   }
 
   picture img {
-    height: auto;
-    max-width: 100px;
-    @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
-      max-width: calc(100%);
+    @media screen and (max-width: map-get($grid-breakpoints, 'md')) {
+      max-width: 100px;
     }
   }
 

--- a/blocks/shared-styles/scss/_small-promo.scss
+++ b/blocks/shared-styles/scss/_small-promo.scss
@@ -14,16 +14,10 @@
 
   a {
     color: $ui-primary-font-color;
-    position: relative;
 
     h2 {
       display: inline;
     }
-  }
-
-  a > picture > img {
-    vertical-align: middle;
-    width: 100%;
   }
 
   .sm-promo-headline {
@@ -37,11 +31,6 @@
     @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
       padding: 0;
     }
-  }
-
-  img {
-    height: auto;
-    max-width: 100%;
   }
 
   .flex-col {


### PR DESCRIPTION
## Description
Update the PromoLabel to render within the link of PromoImage to enable the entire area to be a link

Consolidated a lot of repeated styles, and made PromoImage full width to be useable within other areas

Also fixes the small bit of spacing under promo images that isn't supposed to be there

## Jira Ticket
- [TMEDIA-593](https://arcpublishing.atlassian.net/browse/TMEDIA-593)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-593-promo-label-within-link`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles`
3. Visit the homepage - http://localhost?_website=the-gazette
4. Validate promo items that have the label showing on an image is part of the link and you can use your mouse to click it

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
