### PR TITLE
TMEDIA-594 freeze ads package due to uncertainty

### DIFF
--- a/blocks/ads-block/README.md
+++ b/blocks/ads-block/README.md
@@ -36,4 +36,4 @@ OR
 This block does not emit any events.
 
 ## Additional Considerations
-- This block is using arcads@4. See [here](https://github.com/washingtonpost/ArcAds) for more info on the library. It is a DFP wrapper created by Arc Publishing with publishers in mind. 
+- This block is using arcads@6.1.1. See [here](https://github.com/washingtonpost/ArcAds) for more info on the library. It is a DFP wrapper created by Arc Publishing with publishers in mind. Please note that this package is not supported by Themes developers.

--- a/blocks/ads-block/package.json
+++ b/blocks/ads-block/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint --ext js --ext jsx features"
   },
   "dependencies": {
-    "arcads": "^6.1.1",
+    "arcads": "6.1.1",
     "lazy-child": "^0.2.0"
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9441,9 +9441,9 @@
       "version": "file:blocks/double-chain-block"
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.12.6-canary.1",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.12.6-canary.1/1004177657d77b1a046169e3c1ec3cbbc8288019c21a1a238afe9dbf79f329cf",
-      "integrity": "sha512-FlTzbRiBdGMAcItyjug3jJlzBSz8tr3uujQWowcPPl5v13gx3IYlELRByho74SkNR+zftS8ssyO3NmqFgFZ4gA==",
+      "version": "2.12.6-canary.0",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.12.6-canary.0/73a8cc597a129c20eab4eb6491589fa82f0e07e354152c261105fff66081e5dc",
+      "integrity": "sha512-WepmbJrbZ+yIeEhUNU4iC0BKZiFUd+yVbTFNjEW5mwgexaNGzsZjdfZjjv+HE9kEFWWGAtRH2r/ZlGU/mZnfzw==",
       "dev": true,
       "requires": {
         "@arc-fusion/prop-types": "^0.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9390,7 +9390,7 @@
     "@wpmedia/ads-block": {
       "version": "file:blocks/ads-block",
       "requires": {
-        "arcads": "^6.1.1",
+        "arcads": "6.1.1",
         "lazy-child": "^0.2.0"
       }
     },
@@ -9441,9 +9441,9 @@
       "version": "file:blocks/double-chain-block"
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.12.6-canary.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.12.6-canary.0/73a8cc597a129c20eab4eb6491589fa82f0e07e354152c261105fff66081e5dc",
-      "integrity": "sha512-WepmbJrbZ+yIeEhUNU4iC0BKZiFUd+yVbTFNjEW5mwgexaNGzsZjdfZjjv+HE9kEFWWGAtRH2r/ZlGU/mZnfzw==",
+      "version": "2.12.6-canary.1",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.12.6-canary.1/1004177657d77b1a046169e3c1ec3cbbc8288019c21a1a238afe9dbf79f329cf",
+      "integrity": "sha512-FlTzbRiBdGMAcItyjug3jJlzBSz8tr3uujQWowcPPl5v13gx3IYlELRByho74SkNR+zftS8ssyO3NmqFgFZ4gA==",
       "dev": true,
       "requires": {
         "@arc-fusion/prop-types": "^0.1.5",


### PR DESCRIPTION
## Description
arc ads resolves to 6.1.1

## Jira Ticket
- [TMEDIA-594](https://arcpublishing.atlassian.net/browse/TMEDIA-594)

## Acceptance Criteria
package.json declaration of arc ads is exactly 6.1.1

## Test Steps
- Look at package.json and confirm

## Effect Of Changes
### Before
Package could have been upgraded to newer version of arc ads

### After
Package won't be upgradable via npm

## Dependencies or Side Effects
- arcads won't get new updates 
- still need to have a home for arc ads

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
