### PR TITLE
Security and code health clean up unused logic

### DIFF
--- a/blocks/identity-block/layouts/single-column/index.story.jsx
+++ b/blocks/identity-block/layouts/single-column/index.story.jsx
@@ -30,7 +30,7 @@ const layoutItemStyles = {
 const getStyles = (name) => {
   const defaults = layoutItemStyles.default;
 
-  return { ...defaults, ...layoutItemStyles[name] } || defaults;
+  return { ...defaults, ...layoutItemStyles[name] };
 };
 
 const layoutItem = (name) => <div style={getStyles(name)}>{name}</div>;

--- a/blocks/resizer-image-block/index.js
+++ b/blocks/resizer-image-block/index.js
@@ -369,6 +369,7 @@ const getResizedImageData = (
     resizerURL,
     imageWidths,
     compressedParams: shouldCompressImageParams,
+    // filterQuality should be moved to the options object and other functions to make use of option
   });
 };
 

--- a/blocks/resizer-image-block/index.js
+++ b/blocks/resizer-image-block/index.js
@@ -329,7 +329,8 @@ export const extractResizedParams = (storyObject) => storyObject?.promo_items?.b
 */
 const getResizedImageData = (
   data,
-  filterQuality = 70,
+  // underscore added to mean it is unused
+  _filterQuality,
   onlyUrl = false,
   respectAspectRatio = false,
   arcSite,

--- a/blocks/resizer-image-block/index.js
+++ b/blocks/resizer-image-block/index.js
@@ -368,9 +368,7 @@ const getResizedImageData = (
     resizerURL,
     imageWidths,
     compressedParams: shouldCompressImageParams,
-  }, filterQuality);
-  // Note: filterQuality is passed in but never used...
-  // Should be moved to the options object and other functions to make use of option
+  });
 };
 
 export default getResizedImageData;

--- a/blocks/right-rail-advanced-block/index.story.jsx
+++ b/blocks/right-rail-advanced-block/index.story.jsx
@@ -51,7 +51,7 @@ const layoutItemStyles = {
 const getStyles = (name) => {
   const defaults = layoutItemStyles.default;
 
-  return { ...defaults, ...layoutItemStyles[name] } || defaults;
+  return { ...defaults, ...layoutItemStyles[name] };
 };
 
 const renderChildren = (name) => layoutItemStyles[name]?.children || null;

--- a/blocks/right-rail-block/index.story.jsx
+++ b/blocks/right-rail-block/index.story.jsx
@@ -33,7 +33,7 @@ const layoutItemStyles = {
 const getStyles = (name) => {
   const defaults = layoutItemStyles.default;
 
-  return { ...defaults, ...layoutItemStyles[name] } || defaults;
+  return { ...defaults, ...layoutItemStyles[name] };
 };
 
 const layoutItem = (name) => <div style={getStyles(name)}>{name}</div>;

--- a/blocks/shared-styles/_children/button/index.jsx
+++ b/blocks/shared-styles/_children/button/index.jsx
@@ -45,7 +45,7 @@ const UI_DARK_GRAY_COLOR = '#191919';
 const iconTypeStringToIconTypeComponent = (
   iconTypeString, iconHeightWidth, primaryColor, buttonStyle,
 ) => {
-  let iconColor = primaryColor;
+  let iconColor;
 
   switch (buttonStyle) {
     case BUTTON_STYLES.PRIMARY:
@@ -236,7 +236,7 @@ function Button(props) {
 
   const matchedButtonSizeClass = matchButtonSizeWithClass(buttonSize);
 
-  let iconHeightWidth = 16;
+  let iconHeightWidth;
 
   const primaryColor = getThemeStyle(arcSite)['primary-color'];
   const primaryFont = getThemeStyle(arcSite)['primary-font-family'];


### PR DESCRIPTION
Was really happy to remove the filterQuality parameter. Always been forgetting to update that 

Per code quality report from codeql https://lgtm.com/projects/g/WPMedia/arc-themes-blocks/alerts/?mode=list

Created another ticket to discuss and figure out the redirect issue if it's possible to fix https://arcpublishing.atlassian.net/browse/TMEDIA-611

No functional changes. Was watching security and removing unused or excess code was something that was helpful for security and definitely maintainability 

If we wanted to, could also add this badge for security and code health to readme [![Total alerts](https://img.shields.io/lgtm/alerts/g/WPMedia/arc-themes-blocks.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/WPMedia/arc-themes-blocks/alerts/)
