### PR TITLE
(Small Improvement) Unnecessary boolean logic included in input

### DIFF
--- a/blocks/identity-block/components/EditableFormInputField/index.jsx
+++ b/blocks/identity-block/components/EditableFormInputField/index.jsx
@@ -97,20 +97,15 @@ function EditableFieldPresentational({
                   <p className="editable-form-input--label-text">
                     {label}
                   </p>
-                  {
-                    !isEditable
-                      && (
-                        <PrimaryFont
-                          as="button"
-                          className="editable-form-input--edit-button-link"
-                          type="button"
-                          onClick={() => setIsEditable(true)}
-                          fontColor="primary-color"
-                        >
-                          {editText}
-                        </PrimaryFont>
-                      )
-                    }
+                  <PrimaryFont
+                    as="button"
+                    className="editable-form-input--edit-button-link"
+                    type="button"
+                    onClick={() => setIsEditable(true)}
+                    fontColor="primary-color"
+                  >
+                    {editText}
+                  </PrimaryFont>
                 </div>
                 <p className="editable-form-input--value-text">
                   {initialValue}


### PR DESCRIPTION
- `isEditable` will always evaluate to true in this instance due to the logic around it 
- Can validate in storybook as well
- Fixes https://lgtm.com/projects/g/WPMedia/arc-themes-blocks/snapshot/0c48d85dd4570ea95a437b8b78de5557b29c52f3/files/blocks/identity-block/components/EditableFormInputField/index.jsx?sort=name&dir=ASC&mode=heatmap#x6899697fbbfc5de:1