### PR TITLE
TMEDIA 581 Lint locally and in canary test action only changed files against canary base

### DIFF
--- a/.github/workflows/test-coverage-blocks-canary.yml
+++ b/.github/workflows/test-coverage-blocks-canary.yml
@@ -1,4 +1,4 @@
-name: Test Blocks - Changed from Canary Base
+name: Test Blocks And Linting - Changed from Canary Base
 
 on:
   pull_request:
@@ -43,8 +43,8 @@ jobs:
       - name: Run tests on changed since canary with coverage
         run: npm run test:changed-feature-branch
 
-      - name: Check linting
-        run: npm run lint
+      - name: Check linting of changed since canary
+        run: npm run lint:changed-feature-branch
 
       - name: Check failure status
         uses: act10ns/slack@v1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-# changed-feature-branch is only for targeting canary at the moment
-# todo: run lint only on changed files 
+# this only for targeting canary at the moment 
 # fetching latest changes to ensure the origin/canary is up to date
-npm run lint && git fetch -a --depth 100 && npm run test:changed-feature-branch
+git fetch -a --depth 100 && npm run lint:changed-feature-branch && npm run test:changed-feature-branch

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "release:stable": "lerna publish --dist-tag stable minor -y",
     "generate:feature": "hygen feature new",
     "prepare": "husky install",
-    "test:changed-feature-branch": "jest --changedSince=origin/canary --coverage --passWithNoTests"
+    "test:changed-feature-branch": "jest --changedSince=origin/canary --coverage --passWithNoTests",
+    "lint:changed-feature-branch": "eslint --max-warnings 0 --no-error-on-unmatched-pattern $(git diff --name-only origin/canary | grep -E \"(.js$|.jsx$)\" || echo \"no js/jsx files changed\")",
+    "lint:changed-feature-branch:fix": "npm run lint:changed-feature-branch -- --fix"
   },
   "license": "CC-BY-NC-ND-4.0",
   "devDependencies": {


### PR DESCRIPTION
## Description
Lint locally and in action only changed js and jsx files

## Jira Ticket
- [TMEDIA-581](https://arcpublishing.atlassian.net/browse/TMEDIA-581)

## Acceptance Criteria
- On developer push, linting should only occur on files that changed vs canary
- GitHub Actions run on changed as well rather than all of the linting. This will include pr test GitHub Action.

## Test Steps

1. Checkout this branch `git checkout TMEDIA-581-lint-changed-canary`
2. Ensure you have reinstalled deps (mostly for husky) `rm -rf node_modules && npm i`
3. Add a `console.log('fail linting')` to a js file 
4. Run `git push`. This should fail

See failing giithub action  
eslint failing https://github.com/WPMedia/arc-themes-blocks/runs/4741172720?check_suite_focus=true 

See passing action https://github.com/WPMedia/arc-themes-blocks/runs/4741254665?check_suite_focus=true 
## Effect Of Changes
### Before
- All linting runs on push (takes minutes)
- All linting on github action (takes mins)

### After
- Only necessary files are linted (usually seconds depending on changeset) in github action and locally on push

## Dependencies or Side Effects
- none (husky was upgraded already)

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress. -> na
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
