### PR TITLE
Tmedia 604 sync retag themes release branch

### DIFF
--- a/.github/workflows/arc-themes-base-to-new-tag.yml
+++ b/.github/workflows/arc-themes-base-to-new-tag.yml
@@ -1,0 +1,63 @@
+name: Tag New Arc Theme Release
+on: 
+  workflow_dispatch:
+    inputs:
+      target_release_tag:
+        description: 'Base tag (eg, 1.18 if arc-themes-release-1.18 -> arc-themes-release-1.19)'
+        required: true
+      new_release_tag:
+        description: 'New tag (eg, 1.19 if arc-themes-release-1.18 -> arc-themes-release-1.19)'
+        required: true
+
+jobs:
+  validate_tags:
+    name: Validate release numbers
+    runs-on: ubuntu-latest
+    # ensure new and target release tags match regex: 
+    # {numbers}.{numbers} requirement per product
+    steps:
+      - name: Check target release tag name
+        id: check-target-tag
+        run: |
+          if [[ ${{ github.event.inputs.target_release_tag }} =~ ^([0-9]+)\.([0-9]+)\.?$ ]]; then
+              echo ::set-output name=match::true
+          fi
+      
+      - name: Check new release tag name
+        id: check-new-tag
+        run: |
+          if [[ ${{ github.event.inputs.new_release_tag }} =~ ^([0-9]+)\.([0-9]+)\.?$ ]]; then
+              echo ::set-output name=match::true
+          fi
+
+      - name: Validate release tag numbers
+        id: validate-release-tag-numbers
+        if: steps.check-target-tag.outputs.match != 'true' && steps.check-new-tag.outputs.match != 'true'
+        # fail if one check fails
+        # passes by default
+        # exit 0 is pass
+        run: exit 1
+
+  retag:
+    name: Tag base tag to new tag
+    runs-on: ubuntu-latest
+    # previous and any future jobs need this needs property
+    needs: validate_tags
+    env: 
+      TARGET_RELEASE_TAG: arc-themes-release-${{ github.event.inputs.target_release_tag }}
+      NEW_RELEASE_TAG: arc-themes-release-${{ github.event.inputs.new_release_tag }}
+    
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node and NPM
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+          registry-url: 'https://npm.pkg.github.com'
+          
+      - name: Get version of target tag and point the new tag to that version
+        run: npx lerna exec --stream --no-bail --concurrency 1 -- 'PKG_VERSION=$(npm view ${LERNA_PACKAGE_NAME}@${{ env.TARGET_RELEASE_TAG }} version); [ -n "$PKG_VERSION" ] && (npm dist-tag add ${LERNA_PACKAGE_NAME}@${PKG_VERSION} ${{ env.NEW_RELEASE_TAG }}) || exit 0'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/arc-themes-base-to-new-tag.yml
+++ b/.github/workflows/arc-themes-base-to-new-tag.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
     inputs:
       target_release_tag:
-        description: 'Base tag (eg, 1.18 if arc-themes-release-1.18 -> arc-themes-release-1.19)'
+        description: 'Base tag (eg, 1.18 if arc-themes-release-version-1.18 -> arc-themes-release-version-1.19)'
         required: true
       new_release_tag:
-        description: 'New tag (eg, 1.19 if arc-themes-release-1.18 -> arc-themes-release-1.19)'
+        description: 'New tag (eg, 1.19 if arc-themes-release-version-1.18 -> arc-themes-release-version-1.19)'
         required: true
 
 jobs:
@@ -44,8 +44,8 @@ jobs:
     # previous and any future jobs need this needs property
     needs: validate_tags
     env: 
-      TARGET_RELEASE_TAG: arc-themes-release-${{ github.event.inputs.target_release_tag }}
-      NEW_RELEASE_TAG: arc-themes-release-${{ github.event.inputs.new_release_tag }}
+      TARGET_RELEASE_TAG: arc-themes-release-version-${{ github.event.inputs.target_release_tag }}
+      NEW_RELEASE_TAG: arc-themes-release-version-${{ github.event.inputs.new_release_tag }}
     
     steps:
       - name: Checkout repo

--- a/.github/workflows/sync-themes-branch-with-themes-tag.yml
+++ b/.github/workflows/sync-themes-branch-with-themes-tag.yml
@@ -1,0 +1,51 @@
+name: Publish to themes target tag based off of themes branch name
+on:
+  push:
+    branches:
+      # only run on branch names that match:
+      # arc-themes-release-{numbers}.{numbers} per product
+      - arc-themes-release-[0-9]+\.[0-9]+
+    # only run on changes to these files
+    paths:
+      - "**.js"
+      - "**.jsx"
+      - "**.scss"
+      - "**/intl.json"
+      - "**/README.md"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      SYNCED_RELEASE_TAG: ${{ github.ref_name }} # targets branch name ref_name
+    steps:
+      - name: Set git username
+        run: git config --global user.email "jack.howard@washpost.com" && git config --global user.name "Jack Howard"
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.NODE_AUTH_TOKEN }}
+        
+      # pulls all tags (needed for lerna / semantic release to correctly version)
+      - name: Pull tags to give lerna access to git info
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: Clean install (CI) dependencies if lockfile (above) changed
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+
+      - name: Run all tests
+        run: npm run test
+
+      - name: Publish to target tag based off of branch name
+        run: npx lerna publish --dist-tag ${{ env.SYNCED_RELEASE_TAG }} --canary --preid ${{ env.SYNCED_RELEASE_TAG }} -y

--- a/.github/workflows/sync-themes-branch-with-themes-tag.yml
+++ b/.github/workflows/sync-themes-branch-with-themes-tag.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       # only run on branch names that match:
-      # arc-themes-release-{numbers}.{numbers} per product
-      - arc-themes-release-[0-9]+\.[0-9]+
+      # arc-themes-release-version-{numbers}.{numbers} per product
+      - arc-themes-release-version-[0-9]+\.[0-9]+
     # only run on changes to these files
     paths:
       - "**.js"


### PR DESCRIPTION
## Description
Tag new branch and sync changeset publish that branch

## Jira Ticket
- [TMEDIA-604](https://arcpublishing.atlassian.net/browse/TMEDIA-604)

## Acceptance Criteria
Acceptance Criteria (product-facing branches)

Create new branch for each product-facing tag release

Ensure the new tag is first tagged to all blocks in that new branch at the time of the branch’s creation 

Changeset releases for any ensuing updates to that release/branch 

This will start with 1.19. The new branch will be called `arc-themes-release-version-1.19`, following product-facing syntax arc-themes-release-version-xxx

## Test Steps

- Go to lerna playground https://github.com/WPMedia/themes-lerna-playground
- Starting with 1.19 release, I created a manual release to all packages of the branch to point to 1.19 using the github action for releasing all. This gives us a clean slate: https://github.com/WPMedia/themes-lerna-playground/runs/4819897756?check_suite_focus=true
```
 - @wpmedia/description: 0.1.0 => 0.0.0-arc-themes-release-1.19.d5cfca0.20220114170700
 - @wpmedia/testheadline: 1.8.0 => 0.0.0-arc-themes-release-1.19.d5cfca0.20220114170700
 - @wpmedia/test-sub-headline: 1.4.0 => 0.0.0-arc-themes-release-1.19.d5cfca0.20220114170700
 ```
- Create new branch `arc-themes-release-1.20`
- Tag everything in 1.19 to 1.20 with arc themes retag action 
<img width="1292" alt="Screen Shot 2022-01-14 at 11 09 22" src="https://user-images.githubusercontent.com/5950956/149556214-31e15b8f-49cb-4e8a-ad5e-5e6d444a6a0e.png">

https://github.com/WPMedia/themes-lerna-playground/actions/runs/1698763360 

```
@wpmedia/description: +arc-themes-release-1.20: @wpmedia/description@0.0.0-arc-themes-release-1.19.d5cfca0.20220114170700
@wpmedia/testheadline: +arc-themes-release-1.20: @wpmedia/testheadline@0.0.0-arc-themes-release-1.19.d5cfca0.20220114170700
@wpmedia/test-sub-headline: +arc-themes-release-1.20: @wpmedia/test-sub-headline@0.0.0-arc-themes-release-1.19.d5cfca0.20220114170700
```

- Make a change to only the headline in 1.20. See the changeset publish only that package

https://github.com/WPMedia/themes-lerna-playground/actions/runs/1698779060

```
Found 1 package to publish:
 - @wpmedia/testheadline => 1.8.1-arc-themes-release-1.20.199+8922857
lerna info auto-confirmed 
lerna success published 1 package
 - @wpmedia/testheadline@1.8.1-arc-themes-release-1.20.199+8922857
```
- Create a new branch 1.21 `git checkout -b arc-themes-release-1.21`. Tag everything in 1.20 to 1.21 with the arc themes retagging action

https://github.com/WPMedia/themes-lerna-playground/actions/runs/1698789667

```
@wpmedia/description: +arc-themes-release-1.21: @wpmedia/description@0.0.0-arc-themes-release-1.19.d5cfca0.20220114170700
@wpmedia/testheadline: +arc-themes-release-1.21: @wpmedia/testheadline@1.8.1-arc-themes-release-1.20.199
@wpmedia/test-sub-headline: +arc-themes-release-1.21: @wpmedia/test-sub-headline@0.0.0-arc-themes-release-1.19.d5cfca0.20220114170700
```

- Make a change to description package only in that branch. Only see publish of that description package

https://github.com/WPMedia/themes-lerna-playground/runs/4820037002?check_suite_focus=true

```
Found 1 package to publish:
 - @wpmedia/description => 0.1.1-arc-themes-release-1.21.200+2789c6c
lerna info auto-confirmed 

```

## Effect Of Changes
### Before
- Environment-based `canary` -> `stable` releases

### After
- Releases that are maintained over time 

## Dependencies or Side Effects
- Maintaining canary previous releases prior to 1.19
- In the test repo, I used `arc-themes-release-{numbers}.{numbers}` rather than `arc-themes-release-version-{numbers}.{numbers}`
## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added. -> dev technical documentation available https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/2983788608/How+To+Do+Product-Facing+Tag+Release

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
