### PR TITLE
TMEDIA-631: Fix centered logo on mobile

### DIFF
--- a/blocks/header-nav-chain-block/index.story.jsx
+++ b/blocks/header-nav-chain-block/index.story.jsx
@@ -111,3 +111,29 @@ export const squareLogo = () => (
     primaryLogoAlt="Shows dimensions of 100 by 100 for tall testing purposes"
   />
 );
+
+export const centerLogo = () => (
+  <PresentationalNav
+    backgroundColor="#fddede"
+    mediumBreakpoint={768}
+    closeDrawer={() => {}}
+    customFields={CUSTOM_FIELDS_BASE}
+    displayLinks
+    horizontalLinksHierarchy="horizontal-links"
+    isAdmin={false}
+    isSectionDrawerOpen={false}
+    logoAlignment="center"
+    menuButtonClickAction={() => { }}
+    navColor="light"
+    navColorClass="light"
+    navHeight={100}
+    scrollAdjustedNavHeight={100}
+    scrolled={false}
+    sectionAriaLabel="Menu des sections"
+    sections={[]}
+    showDotSeparators={false}
+    signInOrder={1}
+    primaryLogoPath="https://place-hold.it/100x100"
+    primaryLogoAlt="Shows dimensions of 100 by 100 for tall testing purposes"
+  />
+);

--- a/blocks/shared-styles/scss/_header-nav.scss
+++ b/blocks/shared-styles/scss/_header-nav.scss
@@ -233,6 +233,14 @@ body.nav-open {
   }
 
   &.logo {
+    &-center .nav-logo {
+      margin: 0 calculateRem(16px) 0 calculateRem(16px);
+
+      a {
+        justify-content: center;
+      }
+    }
+
     &-left {
       .nav-logo {
         justify-content: flex-start;
@@ -253,19 +261,6 @@ body.nav-open {
       }
     }
 
-    &-center {
-      > div {
-        flex: 1;
-
-        &.nav-logo {
-          margin: 0 calculateRem(16px) 0 calculateRem(16px);
-
-          a {
-            justify-content: center;
-          }
-        }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
## Description
Fix for logo being too small on mobile devices.  The log was set to `flex: 1` which is shorthand for `flex: 1 1 0%` so the image was setting the basis to `0%` causing it to shrink to `0`.  Removing this restores the default `flex: 0 1 auto` allowing the image to use up all of its space and shrink to fit.  Also moved the style definition to appease the lint gods and simplified the specified style.

## Jira Ticket
- [TMEDIA-631](https://arcpublishing.atlassian.net/browse/TMEDIA-631)

## Acceptance Criteria
Logo does shrink on mobile viewports but proportionally based on the space available 

## Test Steps
1. Checkout this branch `git checkout tmedia-631`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles`
3. Open any page with a header and change the Logo alignment from left to center:
![image](https://user-images.githubusercontent.com/2287238/150221222-553ecb29-c1fc-4961-b6e2-b974d2038f57.png)
4.  Shrink the window to notice that the log fills the available height.

## Effect Of Changes
### Before
![image](https://user-images.githubusercontent.com/2287238/150221450-9587d004-afa0-4493-a65e-3d3e62bdb472.png)

### After
![image](https://user-images.githubusercontent.com/2287238/150221324-da3d5b55-1959-4600-9a54-e63877c924ad.png)

## Dependencies or Side Effects
N/A

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
