### PR TITLE
Tmedia 628 lead art default eager

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -291,6 +291,7 @@ LeadArt.propTypes = {
       {
         label: 'Image Loading Strategy',
         defaultValue: 'eager',
+        group: 'Display Options',
         labels: {
           eager: 'Eager',
           lazy: 'Lazy',

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -65,7 +65,12 @@ class LeadArt extends Component {
     } = this.state;
 
     const { arcSite, customFields, id } = this.props;
-    const { hideTitle = false, hideCaption = false, hideCredits = false } = customFields;
+    const {
+      hideTitle = false,
+      hideCaption = false,
+      hideCredits = false,
+      imageLoadingStrategy = 'eager',
+    } = customFields;
 
     let AdBlock;
 
@@ -186,6 +191,7 @@ class LeadArt extends Component {
                 breakpoints={getProperties(arcSite)?.breakpoints}
                 resizerURL={getProperties(arcSite)?.resizerURL}
                 resizedImageOptions={lead_art.resized_params}
+                loading={imageLoadingStrategy} // eager by default, otherwise lazy
               />
             </div>
             {lightbox}
@@ -273,6 +279,18 @@ LeadArt.propTypes = {
       defaultValue: false,
       group: 'Display Options',
     }),
+    imageLoadingStrategy: PropTypes.oneOf([
+      'lazy', 'eager',
+    ]).tag(
+      {
+        label: 'Image Loading Strategy',
+        defaultValue: 'eager',
+        labels: {
+          eager: 'Eager',
+          lazy: 'Lazy',
+        },
+      },
+    ),
   }),
 };
 

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -77,7 +77,6 @@ class LeadArt extends Component {
 
     let AdBlock;
 
-    // todo: refactor dynamic loading of another block
     try {
       /* istanbul ignore next */
       const { default: AdFeature } = require('@wpmedia/ads-block');

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -74,8 +74,11 @@ class LeadArt extends Component {
 
     let AdBlock;
 
+    // todo: refactor dynamic loading of another block
     try {
+      /* istanbul ignore next */
       const { default: AdFeature } = require('@wpmedia/ads-block');
+      /* istanbul ignore next */
       AdBlock = () => (
         <AdFeature customFields={{
           adType: '300x250_gallery',
@@ -84,6 +87,7 @@ class LeadArt extends Component {
         />
       );
     } catch (e) {
+      /* istanbul ignore next */
       AdBlock = () => <p>Ad block not found</p>;
     }
 
@@ -221,7 +225,7 @@ class LeadArt extends Component {
             controlsFont={getThemeStyle(arcSite)['primary-font-family']}
             autoplayPhrase={this.phrases.t('global.gallery-autoplay-button')}
             pausePhrase={this.phrases.t('global.gallery-pause-autoplay-button')}
-            pageCountPhrase={(current, total) => this.phrases.t('global.gallery-page-count-text', { current, total })}
+            pageCountPhrase={/* istanbul ignore next */ (current, total) => this.phrases.t('global.gallery-page-count-text', { current, total })}
             adElement={/* istanbul ignore next */ () => (<AdBlock />)}
             interstitialClicks={interstitialClicks}
             displayTitle={!hideTitle}

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -73,7 +73,7 @@ class LeadArt extends Component {
     } = customFields;
 
     // handles empty string for selecting no option and undefined for default
-    const allowedImageLoadingStrategy = imageLoadingStrategy ? imageLoadingStrategy : 'eager';
+    const allowedImageLoadingStrategy = imageLoadingStrategy || 'eager';
 
     let AdBlock;
 

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -69,8 +69,11 @@ class LeadArt extends Component {
       hideTitle = false,
       hideCaption = false,
       hideCredits = false,
-      imageLoadingStrategy = 'eager',
+      imageLoadingStrategy,
     } = customFields;
+
+    // handles empty string for selecting no option and undefined for default
+    const allowedImageLoadingStrategy = imageLoadingStrategy ? imageLoadingStrategy : 'eager';
 
     let AdBlock;
 
@@ -195,7 +198,7 @@ class LeadArt extends Component {
                 breakpoints={getProperties(arcSite)?.breakpoints}
                 resizerURL={getProperties(arcSite)?.resizerURL}
                 resizedImageOptions={lead_art.resized_params}
-                loading={imageLoadingStrategy} // eager by default, otherwise lazy
+                loading={allowedImageLoadingStrategy} // eager by default, otherwise lazy
               />
             </div>
             {lightbox}

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -289,6 +289,26 @@ describe('LeadArt', () => {
     expect(wrapper.find('Image').prop('loading')).toBe('eager');
   });
 
+  it('renders lazy loading strategy of eager if no option picked', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'image',
+        },
+      },
+    };
+
+    LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
+    const wrapper = shallow(<LeadArt
+      arcSite="the-sun"
+      globalContent={globalContent}
+      customFields={{
+        // can be empty string if no option picked
+        loadingStrategy: '',
+      }} />);
+    expect(wrapper.find('Image').prop('loading')).toBe('eager');
+  });
+
   it('renders lazy loading strategy if picked', () => {
     const globalContent = {
       promo_items: {

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -305,7 +305,8 @@ describe('LeadArt', () => {
       customFields={{
         // can be empty string if no option picked
         loadingStrategy: '',
-      }} />);
+      }}
+    />);
     expect(wrapper.find('Image').prop('loading')).toBe('eager');
   });
 

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -286,7 +286,6 @@ describe('LeadArt', () => {
 
     LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
     const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
-    console.log(wrapper.debug());
     expect(wrapper.find('Image').prop('loading')).toBe('eager');
   });
 
@@ -307,7 +306,7 @@ describe('LeadArt', () => {
         customFields={{
           loadingStrategy: 'lazy',
         }}
-      />
+      />,
     );
     expect(wrapper.find('Image').prop('loading')).toBe('eager');
   });

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -274,4 +274,41 @@ describe('LeadArt', () => {
     wrapper.update();
     expect(wrapper.state('isOpen')).toBeTruthy();
   });
+
+  it('renders eager loading strategy by default', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'image',
+        },
+      },
+    };
+
+    LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    console.log(wrapper.debug());
+    expect(wrapper.find('Image').prop('loading')).toBe('eager');
+  });
+
+  it('renders lazy loading strategy if picked', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'image',
+        },
+      },
+    };
+
+    LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
+    const wrapper = shallow(
+      <LeadArt
+        arcSite="the-sun"
+        globalContent={globalContent}
+        customFields={{
+          loadingStrategy: 'lazy',
+        }}
+      />
+    );
+    expect(wrapper.find('Image').prop('loading')).toBe('eager');
+  });
 });

--- a/blocks/lead-art-block/index.story.jsx
+++ b/blocks/lead-art-block/index.story.jsx
@@ -151,6 +151,30 @@ export const image = () => {
   );
 };
 
+export const imageDefaultNativeEagerLoading = () => {
+  const globalContent = {
+    arcSite: 'story-book',
+    promo_items: {
+      lead_art: leadArtImage,
+    },
+  };
+  return (
+    <LeadArt globalContent={globalContent} customFields={{ imageLoadingStrategy: 'eager' }} />
+  );
+};
+
+export const imageNativeLazyLoading = () => {
+  const globalContent = {
+    arcSite: 'story-book',
+    promo_items: {
+      lead_art: leadArtImage,
+    },
+  };
+  return (
+    <LeadArt globalContent={globalContent} customFields={{ imageLoadingStrategy: 'lazy' }} />
+  );
+};
+
 export const imageNoTitle = () => {
   const globalContent = {
     arcSite: 'story-book',


### PR DESCRIPTION
## Description
Set image loading on the lead art image type to be eager by default 

## Jira Ticket
- [TMEDIA-628](https://arcpublishing.atlassian.net/browse/TMEDIA-628)

## Acceptance Criteria
- Show eager by default for image type lead art 
- New custom field called Image Loading Strategy for Lead Art block, set to ‘eager’ by default with ‘lazy’ as the other option

## Test Steps

1. Checkout this branch `git checkout TMEDIA-628-lead-art-default-eager`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/lead-art-block`
3. Go to http://localhost/pf/test-article-page/?_website=the-gazette to see the fallback of eager 
![Screen Shot 2022-01-25 at 13 57 10](https://user-images.githubusercontent.com/5950956/151049909-3a146aa7-5c4b-4160-9054-79661b0c7b90.png)

Verify options available 
1. Clone pr test article 
<img width="582" alt="Screen Shot 2022-01-25 at 13 58 01" src="https://user-images.githubusercontent.com/5950956/151050040-e7a71ce1-e15a-4949-bdcb-89accc136f88.png">
2. Set the loading strategy to be lazy 
<img width="939" alt="Screen Shot 2022-01-25 at 13 59 07" src="https://user-images.githubusercontent.com/5950956/151050420-13cc90fd-708e-44e2-92d1-b12874ed42b0.png">

3. See lazy image shown on the page 
<img width="1387" alt="Screen Shot 2022-01-25 at 13 59 52" src="https://user-images.githubusercontent.com/5950956/151050387-0ef2ed0f-303c-44d6-8d7d-2afa4f175041.png">

Verify via storybook
1. See chromatic storybook
2. Go to lead art
3. See native eager and lazy loading stories
4. Inspect the image to see the loading lazy and eager respectively 

## Effect Of Changes
### Before
Lead art image type loaded lazy by default

### After
Lead art image loads eager by default. Lazy is helpful if unaware on the image location

## Dependencies or Side Effects

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
