### PR TITLE
TMEDIA-602 feat: Add link url display for image component if it's available to c…

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -112,23 +112,27 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 
       if (url) {
         const ArticleBodyImage = () => (
+          <Image
+            resizedImageOptions={resizedImageOptions}
+            url={url}
+            alt={altText}
+            smallWidth={widthsObject.small}
+            smallHeight={0}
+            mediumWidth={widthsObject.medium}
+            mediumHeight={0}
+            largeWidth={widthsObject.large}
+            largeHeight={0}
+            breakpoints={getProperties(arcSite)?.breakpoints}
+            resizerURL={getProperties(arcSite)?.resizerURL}
+          />
+        );
+
+        const ArticleBodyImageContainer = ({ children }) => (
           <figure
             className={figureImageClassName}
             key={key}
           >
-            <Image
-              resizedImageOptions={resizedImageOptions}
-              url={url}
-              alt={altText}
-              smallWidth={widthsObject.small}
-              smallHeight={0}
-              mediumWidth={widthsObject.medium}
-              mediumHeight={0}
-              largeWidth={widthsObject.large}
-              largeHeight={0}
-              breakpoints={getProperties(arcSite)?.breakpoints}
-              resizerURL={getProperties(arcSite)?.resizerURL}
-            />
+            {children}
             <figcaption>
               <ImageMetadata
                 subtitle={subtitle}
@@ -143,16 +147,19 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
         // if link url then make entire image clickable
         if (link) {
           return (
-            <a
-              href={link}
-              aria-hidden="true"
-              tabIndex="-1"
-            >
-              <ArticleBodyImage />
-            </a>
+            <ArticleBodyImageContainer>
+              <a href={link}>
+                <ArticleBodyImage />
+              </a>
+            </ArticleBodyImageContainer>
           );
         }
-        return <ArticleBodyImage />;
+
+        return (
+          <ArticleBodyImageContainer>
+            <ArticleBodyImage />
+          </ArticleBodyImageContainer>
+        );
       }
       return null;
     }

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -79,7 +79,11 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
         vanity_credits: vanityCredits,
         // alignment not always present
         alignment = '',
+        additional_properties: additionalProperties = {},
       } = item;
+
+      // link url set in composer
+      const { link = '' } = additionalProperties;
 
       let widthsObject = {
         small: 768,
@@ -106,34 +110,51 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
         figureImageClassName += allowedFloatValue === 'left' ? ' article-body-image-container--mobile-left-float' : ' article-body-image-container--mobile-right-float';
       }
 
-      return (url && url.length > 0) ? (
-        <figure
-          className={figureImageClassName}
-          key={key}
-        >
-          <Image
-            resizedImageOptions={resizedImageOptions}
-            url={url}
-            alt={altText}
-            smallWidth={widthsObject.small}
-            smallHeight={0}
-            mediumWidth={widthsObject.medium}
-            mediumHeight={0}
-            largeWidth={widthsObject.large}
-            largeHeight={0}
-            breakpoints={getProperties(arcSite)?.breakpoints}
-            resizerURL={getProperties(arcSite)?.resizerURL}
-          />
-          <figcaption>
-            <ImageMetadata
-              subtitle={subtitle}
-              caption={caption}
-              credits={credits}
-              vanityCredits={vanityCredits}
+      if (url) {
+        const ArticleBodyImage = () => (
+          <figure
+            className={figureImageClassName}
+            key={key}
+          >
+            <Image
+              resizedImageOptions={resizedImageOptions}
+              url={url}
+              alt={altText}
+              smallWidth={widthsObject.small}
+              smallHeight={0}
+              mediumWidth={widthsObject.medium}
+              mediumHeight={0}
+              largeWidth={widthsObject.large}
+              largeHeight={0}
+              breakpoints={getProperties(arcSite)?.breakpoints}
+              resizerURL={getProperties(arcSite)?.resizerURL}
             />
-          </figcaption>
-        </figure>
-      ) : null;
+            <figcaption>
+              <ImageMetadata
+                subtitle={subtitle}
+                caption={caption}
+                credits={credits}
+                vanityCredits={vanityCredits}
+              />
+            </figcaption>
+          </figure>
+        );
+
+        // if link url then make entire image clickable
+        if (link) {
+          return (
+            <a
+              href={link}
+              aria-hidden="true"
+              tabIndex="-1"
+            >
+              <ArticleBodyImage />
+            </a>
+          );
+        }
+        return <ArticleBodyImage />;
+      }
+      return null;
     }
 
     case 'interstitial_link': {

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -159,10 +159,12 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 
     case 'interstitial_link': {
       const { url } = item;
+      // link string will have to be truthy (non-zero length string) to render below
       if (!(url && content)) return null;
       const beforeContent = '[&nbsp;';
       const afterContent = '&nbsp;]';
-      return (url && url.length > 0) ? (
+
+      return (
         <Fragment key={key}>
           <p className="interstitial-link block-margin-bottom">
             <span dangerouslySetInnerHTML={{ __html: beforeContent }} />
@@ -175,7 +177,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
             <span dangerouslySetInnerHTML={{ __html: afterContent }} />
           </p>
         </Fragment>
-      ) : null;
+      );
     }
 
     case 'raw_html': {

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -1279,6 +1279,89 @@ describe('article-body chain', () => {
   });
 
   describe('Render image correctly', () => {
+    const MOCK_IMAGE_DATA = {
+      _id: 'CITIAYX2ERDOPP2TPJGEUV7SNQ',
+      additional_properties: {
+        fullSizeResizeUrl: '/photo/resize/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+        galleries: [
+          {
+            headlines: {
+              basic: 'A day at the beach',
+            },
+            _id: 'ZMTIFZGC2NCYTDVU7GIGHJKEUY',
+          },
+        ],
+        ingestionMethod: 'manual',
+        keywords: [
+
+        ],
+        mime_type: 'image/jpeg',
+        originalName: 'DeathtoStock_EnergyandSerenity4.jpg',
+        originalUrl: 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+        owner: 'sara.carothers@washpost.com',
+        proxyUrl: '/photo/resize/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+        published: true,
+        resizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+        restricted: false,
+        thumbnailResizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/aMX7W71KcKyhfbNdL5RBDpt4RY8=/300x0/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+        version: 1,
+        comments: [
+
+        ],
+        _id: 'VRN2LG34XNDX5MZD64SPU4UNYY',
+      },
+      address: {
+
+      },
+      alt_text: 'A person walks down a path with their surfboard towards the ocean.',
+      caption: "Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break. ",
+      created_date: '2019-07-09T22:26:02Z',
+      credits: {
+        affiliation: [
+          {
+            name: 'Death to Stock Photo',
+            type: 'author',
+          },
+        ],
+        by: [
+          {
+            byline: 'Brett Danielsen (custom credit)',
+            name: 'Brett Danielsen',
+            type: 'author',
+          },
+        ],
+      },
+      distributor: {
+        mode: 'reference',
+        reference_id: '508c6d12-f2bb-47db-a836-b2b5de225c43',
+      },
+      height: 3744,
+      image_type: 'photograph',
+      last_updated_date: '2019-07-09T22:29:42Z',
+      licensable: false,
+      owner: {
+        id: 'corecomponents',
+        sponsored: false,
+      },
+      source: {
+        name: 'Death to Stock Photo',
+        source_type: 'stock',
+        edit_url: 'https://corecomponents.arcpublishing.com/photo/CITIAYX2ERDOPP2TPJGEUV7SNQ',
+        system: 'Anglerfish',
+      },
+      subtitle: 'Australia surf trip',
+      taxonomy: {
+        associated_tasks: [
+
+        ],
+      },
+      type: 'image',
+      url: 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
+      version: '0.9.0',
+      width: 5616,
+      resized_params: { '1440x0': '' },
+    };
+
     it('should render image with figcaption and author', () => {
       jest.mock('fusion:properties', () => (jest.fn(() => ({
         resizerURL: 'https://fake.cdn.com/resizer',
@@ -1301,88 +1384,7 @@ describe('article-body chain', () => {
             type: 'story',
             version: '0.10.2',
             content_elements: [
-              {
-                _id: 'CITIAYX2ERDOPP2TPJGEUV7SNQ',
-                additional_properties: {
-                  fullSizeResizeUrl: '/photo/resize/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
-                  galleries: [
-                    {
-                      headlines: {
-                        basic: 'A day at the beach',
-                      },
-                      _id: 'ZMTIFZGC2NCYTDVU7GIGHJKEUY',
-                    },
-                  ],
-                  ingestionMethod: 'manual',
-                  keywords: [
-
-                  ],
-                  mime_type: 'image/jpeg',
-                  originalName: 'DeathtoStock_EnergyandSerenity4.jpg',
-                  originalUrl: 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
-                  owner: 'sara.carothers@washpost.com',
-                  proxyUrl: '/photo/resize/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
-                  published: true,
-                  resizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/x3tXYyoI4592s_zt6DAIHhv2kEw=/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
-                  restricted: false,
-                  thumbnailResizeUrl: 'http://thumbor-prod-us-east-1.photo.aws.arc.pub/aMX7W71KcKyhfbNdL5RBDpt4RY8=/300x0/arc-anglerfish-arc2-prod-corecomponents/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
-                  version: 1,
-                  comments: [
-
-                  ],
-                  _id: 'VRN2LG34XNDX5MZD64SPU4UNYY',
-                },
-                address: {
-
-                },
-                alt_text: 'A person walks down a path with their surfboard towards the ocean.',
-                caption: "Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break. ",
-                created_date: '2019-07-09T22:26:02Z',
-                credits: {
-                  affiliation: [
-                    {
-                      name: 'Death to Stock Photo',
-                      type: 'author',
-                    },
-                  ],
-                  by: [
-                    {
-                      byline: 'Brett Danielsen (custom credit)',
-                      name: 'Brett Danielsen',
-                      type: 'author',
-                    },
-                  ],
-                },
-                distributor: {
-                  mode: 'reference',
-                  reference_id: '508c6d12-f2bb-47db-a836-b2b5de225c43',
-                },
-                height: 3744,
-                image_type: 'photograph',
-                last_updated_date: '2019-07-09T22:29:42Z',
-                licensable: false,
-                owner: {
-                  id: 'corecomponents',
-                  sponsored: false,
-                },
-                source: {
-                  name: 'Death to Stock Photo',
-                  source_type: 'stock',
-                  edit_url: 'https://corecomponents.arcpublishing.com/photo/CITIAYX2ERDOPP2TPJGEUV7SNQ',
-                  system: 'Anglerfish',
-                },
-                subtitle: 'Australia surf trip',
-                taxonomy: {
-                  associated_tasks: [
-
-                  ],
-                },
-                type: 'image',
-                url: 'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg',
-                version: '0.9.0',
-                width: 5616,
-                resized_params: { '1440x0': '' },
-              },
+              MOCK_IMAGE_DATA,
             ],
           },
           arcSite: 'the-sun',
@@ -2043,6 +2045,119 @@ describe('article-body chain', () => {
 
       expect(figureElClassNames.includes('article-body-image-container--mobile-left-float')).toBe(false);
       expect(figureElClassNames.includes('article-body-image-container')).toBe(true);
+    });
+    it('should render a link url around the image if one is available', () => {
+      jest.mock('fusion:context', () => ({
+        useAppContext: jest.fn(() => ({
+          globalContent: {
+            content_elements: [
+              {
+                caption: 'my cool caption',
+                subtitle: 'my cool subtitle',
+              },
+            ],
+          },
+        })),
+        useFusionContext: jest.fn(() => ({
+          globalContent: {
+            _id: '22ACHIRFI5CD5GRFON6AL3JSJE',
+            type: 'story',
+            version: '0.10.2',
+            content_elements: [
+              {
+                ...MOCK_IMAGE_DATA,
+                additional_properties: {
+                  ...MOCK_IMAGE_DATA.additional_properties,
+                  link: 'https://wwww.arcxp.com',
+                },
+              },
+            ],
+          },
+          arcSite: 'the-sun',
+        })),
+      }));
+      const { default: ArticleBodyChain } = require('./default');
+
+      const wrapper = mount(
+        <ArticleBodyChain />,
+      );
+
+      expect(wrapper.find('a').prop('href')).toEqual('https://wwww.arcxp.com');
+    });
+    it('still renders image without additional_properties', () => {
+      const {
+        additional_properties: _additionalProperties,
+        ...mockDataWithoutAdditionalProperties
+      } = MOCK_IMAGE_DATA;
+      jest.mock('fusion:context', () => ({
+        useAppContext: jest.fn(() => ({
+          globalContent: {
+            content_elements: [
+              {
+                caption: 'my cool caption',
+                subtitle: 'my cool subtitle',
+              },
+            ],
+          },
+        })),
+        useFusionContext: jest.fn(() => ({
+          globalContent: {
+            _id: '22ACHIRFI5CD5GRFON6AL3JSJE',
+            type: 'story',
+            version: '0.10.2',
+            content_elements: [
+              mockDataWithoutAdditionalProperties,
+            ],
+          },
+          arcSite: 'the-sun',
+        })),
+      }));
+      const { default: ArticleBodyChain } = require('./default');
+
+      const wrapper = mount(
+        <ArticleBodyChain />,
+      );
+
+      const figureEl = wrapper.find('figure');
+      expect(figureEl).toHaveLength(1);
+      expect(figureEl.find('Image')).toHaveLength(1);
+      const figCaptionEl = figureEl.find('figcaption');
+      expect(figCaptionEl).toHaveLength(1);
+    });
+    it('renders alignment float right image', () => {
+      jest.mock('fusion:context', () => ({
+        useAppContext: jest.fn(() => ({
+          globalContent: {
+            content_elements: [
+              {
+                caption: 'my cool caption',
+                subtitle: 'my cool subtitle',
+              },
+            ],
+          },
+        })),
+        useFusionContext: jest.fn(() => ({
+          globalContent: {
+            _id: '22ACHIRFI5CD5GRFON6AL3JSJE',
+            type: 'story',
+            version: '0.10.2',
+            content_elements: [
+              {
+                ...MOCK_IMAGE_DATA,
+                alignment: 'right',
+              },
+            ],
+          },
+          arcSite: 'the-sun',
+        })),
+      }));
+      const { default: ArticleBodyChain } = require('./default');
+
+      const wrapper = mount(
+        <ArticleBodyChain />,
+      );
+
+      expect(wrapper.find('figure.article-body-image-container--mobile-right-float').length).toBe(1);
     });
   });
 

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -2293,12 +2293,12 @@ describe('article-body chain', () => {
             content_elements: [
               {
                 _id: 'TLF25CWTCBBOHOVFPK4C2RR5JA',
-                type: 'text',
+                type: 'copyright',
                 additional_properties: {
                   comments: [],
                   inline_comments: [],
                 },
-                content: 'Paragraph with Copyright Following',
+                content: '',
               },
             ],
           },
@@ -2314,6 +2314,67 @@ describe('article-body chain', () => {
         </ArticleBodyChain>,
       );
       expect(wrapper.find('article.article-body-wrapper').find('p.body-copyright').length).toEqual(0);
+    });
+  });
+
+  describe('Renders text type', () => {
+    it('should render text type', () => {
+      jest.mock('fusion:context', () => ({
+        useFusionContext: jest.fn(() => ({
+          globalContent: {
+            _id: 'NGGXZJ4HAJH5DI3SS65EVBMEMQ',
+            type: 'story',
+            version: '0.10.6',
+            content_elements: [
+              {
+                _id: 'TLF25CWTCBBOHOVFPK4C2RR5JA',
+                type: 'text',
+                additional_properties: {
+                  comments: [],
+                  inline_comments: [],
+                },
+                content: 'Paragraph with Copyright Following',
+              },
+            ],
+          },
+          arcSite: 'the-sun',
+        })),
+      }));
+      const { default: ArticleBodyChain } = require('./default');
+      const wrapper = mount(
+        <ArticleBodyChain />,
+      );
+
+      expect(wrapper.find('article.article-body-wrapper').find('p.body-paragraph').length).toEqual(1);
+    });
+    it('should not render text type if no content', () => {
+      jest.mock('fusion:context', () => ({
+        useFusionContext: jest.fn(() => ({
+          globalContent: {
+            _id: 'NGGXZJ4HAJH5DI3SS65EVBMEMQ',
+            type: 'story',
+            version: '0.10.6',
+            content_elements: [
+              {
+                _id: 'TLF25CWTCBBOHOVFPK4C2RR5JA',
+                type: 'text',
+                additional_properties: {
+                  comments: [],
+                  inline_comments: [],
+                },
+                content: '',
+              },
+            ],
+          },
+          arcSite: 'the-sun',
+        })),
+      }));
+      const { default: ArticleBodyChain } = require('./default');
+      const wrapper = mount(
+        <ArticleBodyChain />,
+      );
+
+      expect(wrapper.find('article.article-body-wrapper').find('p.body-paragraph').length).toEqual(0);
     });
   });
 });

--- a/blocks/article-body-block/index.story.jsx
+++ b/blocks/article-body-block/index.story.jsx
@@ -601,6 +601,30 @@ export const contentImage = () => {
   );
 };
 
+export const imageWithLinkContainer = () => {
+  const mockContext = {
+    ...mockContextBase,
+    globalContent: {
+      ...mockContextGlobalContent,
+      content_elements: [
+        {
+          ...mockImage,
+          additional_properties: {
+            ...mockImage.additional_properties,
+            link: 'https://wwww.arcxp.com',
+          },
+        },
+      ],
+    },
+  };
+
+  return (
+    <ArticleBodyChainPresentation
+      context={mockContext}
+    />
+  );
+};
+
 export const contentInterstitial = () => {
   const mockContext = {
     ...mockContextBase,


### PR DESCRIPTION
## Description
If link url available for image, then wrap the link around the image

## Jira Ticket
- [TMEDIA-602](https://arcpublishing.atlassian.net/browse/TMEDIA-602)

## Acceptance Criteria
If a Link URL is set on an image within a story in Composer, then readers are able to click on that image and go to the specified URL

## Notes
- Kept the image to be no new tab like card list 

## Test Steps

1. Checkout this branch `git checkout TMEDIA-602-link-url-article-body`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/article-body-block`
3. Clone an article block page. In the clone, set with the image with link url that sara set /local/2021/10/11/saras-test-story-2/

<img width="347" alt="The Gazette" src="https://user-images.githubusercontent.com/5950956/151217898-0906c344-a28f-48dc-94a6-ddb00c77a913.png">

4. publish that page with the article 
5. Hover over the image to see the image set 
<img width="507" alt="Screen Shot 2022-01-26 at 11 47 12" src="https://user-images.githubusercontent.com/5950956/151218081-93f3dbc0-f8a2-4da0-bfc9-074eaa70478e.png">

6. It should be set to google.com
7. Go to the cloned article page and see the image. The image should look as it did before with no change if no link url 


## Effect Of Changes
### Before

with link url, no link shown 
![Uploading Screen Shot 2022-01-26 at 11.48.19.png…]()

### After

on hover, you see the link 

no link on captions 
![Screen Shot 2022-01-26 at 13 59 02](https://user-images.githubusercontent.com/5950956/151237657-b98b6160-7509-44cd-8a79-b01ab88e8060.png)



## Dependencies or Side Effects
- Added more test coverage to the block to pass the threshold


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
