### PR TITLE
Code coverage/quality - Refactor unused state lead art

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-# this only for targeting canary at the moment 
-# fetching latest changes to ensure the origin/canary is up to date
+# this only for targeting arc-themes-release-version-1.19 at the moment 
+# fetching latest changes to ensure the origin/arc-themes-release-version-1.19 is up to date
 git fetch -a --depth 100 && npm run lint:changed-feature-branch && npm run test:changed-feature-branch

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -61,7 +61,7 @@ class LeadArt extends Component {
 
   render() {
     const {
-      isOpen, buttonPosition, content, buttonLabel,
+      isOpen, content, buttonLabel,
     } = this.state;
 
     const { arcSite, customFields, id } = this.props;
@@ -99,25 +99,23 @@ class LeadArt extends Component {
       let caption = null;
 
       if (lead_art.type === 'raw_html') {
-        if (buttonPosition !== 'hidden') {
-          // this could be figure and figcaption, a react component
-          const mainContent = (
-            <>
-              <div dangerouslySetInnerHTML={{ __html: lead_art.content }} />
-            </>
-          );
-          lightbox = (
-            <>
-              {isOpen && (
-                <Lightbox
-                  mainSrc={mainContent}
-                  onCloseRequest={this.setIsOpenToFalse}
-                  showImageCaption={false}
-                />
-              )}
-            </>
-          );
-        }
+        // this could be figure and figcaption, a react component
+        const mainContent = (
+          <>
+            <div dangerouslySetInnerHTML={{ __html: lead_art.content }} />
+          </>
+        );
+        lightbox = (
+          <>
+            {isOpen && (
+              <Lightbox
+                mainSrc={mainContent}
+                onCloseRequest={this.setIsOpenToFalse}
+                showImageCaption={false}
+              />
+            )}
+          </>
+        );
 
         return (
           <div className="lead-art-wrapper">
@@ -146,19 +144,17 @@ class LeadArt extends Component {
       }
 
       if (lead_art.type === 'image') {
-        if (buttonPosition !== 'hidden') {
-          lightbox = (
-            <>
-              {isOpen && (
-                <Lightbox
-                  mainSrc={this.lightboxImgHandler()}
-                  onCloseRequest={this.setIsOpenToFalse}
-                  imageCaption={!hideCaption ? lead_art.caption : null}
-                />
-              )}
-            </>
-          );
-        }
+        lightbox = (
+          <>
+            {isOpen && (
+              <Lightbox
+                mainSrc={this.lightboxImgHandler()}
+                onCloseRequest={this.setIsOpenToFalse}
+                imageCaption={!hideCaption ? lead_art.caption : null}
+              />
+            )}
+          </>
+        );
 
         caption = (
           <ImageMetadata

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -146,36 +146,6 @@ describe('LeadArt', () => {
     expect(wrapper).toEqual({});
   });
 
-  it('if raw html type has buttonPosition as hidden return null lightbox', () => {
-    const globalContent = {
-      promo_items: {
-        basic: {
-          type: 'raw_html',
-        },
-      },
-    };
-
-    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
-    wrapper.setState({ buttonPosition: 'hidden', isOpen: true });
-    wrapper.update();
-    expect(wrapper.find('ReactImageLightbox').length).toEqual(0);
-  });
-
-  it('if image type has buttonPosition as hidden return null lightbox', () => {
-    const globalContent = {
-      promo_items: {
-        basic: {
-          type: 'image',
-        },
-      },
-    };
-
-    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
-    wrapper.setState({ buttonPosition: 'hidden', isOpen: true });
-    wrapper.update();
-    expect(wrapper.find('ReactImageLightbox').length).toEqual(0);
-  });
-
   it('uses english phrases if no locale available', () => {
     getProperties.mockImplementation(() => (
       { locale: undefined }));

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -125,6 +125,22 @@ describe('LeadArt', () => {
     expect(wrapper.find('Gallery').length).toEqual(1);
   });
 
+  it('renders gallery with an empty ans headline if no basic headline provided', () => {
+    const globalContent = {
+      promo_items: {
+        lead_art: {
+          type: 'gallery',
+          headlines: {},
+        },
+      },
+    };
+
+    LeadArt.prototype.imgRef = { current: { querySelector: jest.fn() } };
+    const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
+    expect(wrapper.find('Gallery').length).toEqual(1);
+    expect(wrapper.find('Gallery').props().ansHeadline).toEqual('');
+  });
+
   it('returns null if invalid lead art type', () => {
     const globalContent = {
       promo_items: {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "generate:feature": "hygen feature new",
     "generate:chain": "hygen chain new",
     "prepare": "husky install",
-    "test:changed-feature-branch": "jest --changedSince=origin/canary --coverage --passWithNoTests",
-    "lint:changed-feature-branch": "eslint --max-warnings 0 --no-error-on-unmatched-pattern $(git diff --name-only origin/canary | grep -E \"(.js$|.jsx$)\" || echo \"no js/jsx files changed\")",
+    "test:changed-feature-branch": "jest --changedSince=origin/arc-themes-release-version-1.19 --coverage --passWithNoTests",
+    "lint:changed-feature-branch": "eslint --max-warnings 0 --no-error-on-unmatched-pattern $(git diff --name-only origin/arc-themes-release-version-1.19 | grep -E \"(.js$|.jsx$)\" || echo \"no js/jsx files changed\")",
     "lint:changed-feature-branch:fix": "npm run lint:changed-feature-branch -- --fix"
   },
   "license": "CC-BY-NC-ND-4.0",


### PR DESCRIPTION
Follow-up to lead art ticket https://github.com/WPMedia/arc-themes-blocks/pull/1237

- Remove state that is not set any where and still tested https://lgtm.com/projects/g/WPMedia/arc-themes-blocks/snapshot/01710503dd7dfcea1c0c9532af2a38a1f7732d63/files/blocks/lead-art-block/features/leadart/default.jsx?sort=name&dir=ASC&mode=heatmap#x57e2cbf10483ca92:1
- Add test with empty headline to improve test coverage (forgot this test)

after
![Screen Shot 2022-01-27 at 13 47 33](https://user-images.githubusercontent.com/5950956/151433748-ff172475-99d8-4b75-80ee-ad24b4bfb713.png)

