### PR TITLE
TMEDIA-641 - Article Body Block - Image & Gallery Metadata options

### DIFF
--- a/blocks/article-body-block/chains/article-body/_children/list.test.jsx
+++ b/blocks/article-body-block/chains/article-body/_children/list.test.jsx
@@ -11,33 +11,11 @@ describe('the article body List component', () => {
           type: 'text',
           content: 'Indented under 2',
           _id: 'IOY3SN76GVFI3MUDN3PX4V32AA',
-          additional_properties: {
-            comments: [
-
-            ],
-            inline_comments: [
-
-            ],
-          },
-          block_properties: {
-
-          },
         },
         {
           type: 'text',
           content: 'Another thing indented under 2',
           _id: 'MX643WWQPZCYZHTZYMHCIML6SU',
-          additional_properties: {
-            comments: [
-
-            ],
-            inline_comments: [
-
-            ],
-          },
-          block_properties: {
-
-          },
         },
       ],
       _id: 'PSQTOBXAGZGKNOSBMOAUJ6EYSA',
@@ -58,33 +36,11 @@ describe('the article body List component', () => {
           type: 'text',
           content: 'Indented under 2',
           _id: 'OWQEXQT6N5BTPF2CDZYVND6IAQ',
-          additional_properties: {
-            comments: [
-
-            ],
-            inline_comments: [
-
-            ],
-          },
-          block_properties: {
-
-          },
         },
         {
           type: 'text',
           content: 'Another thing indented under 2',
           _id: 'UG52XTXHHRDN5KUPKCGTKE4NMM',
-          additional_properties: {
-            comments: [
-
-            ],
-            inline_comments: [
-
-            ],
-          },
-          block_properties: {
-
-          },
         },
       ],
       _id: 'FLXZDZLOFRGNLMALFGLJGLDPAM',
@@ -109,33 +65,11 @@ describe('the article body List component', () => {
               type: 'text',
               content: 'Indented under 2',
               _id: 'IOY3SN76GVFI3MUDN3PX4V32AA',
-              additional_properties: {
-                comments: [
-
-                ],
-                inline_comments: [
-
-                ],
-              },
-              block_properties: {
-
-              },
             },
             {
               type: 'text',
               content: 'Another thing indented under 2',
               _id: 'MX643WWQPZCYZHTZYMHCIML6SU',
-              additional_properties: {
-                comments: [
-
-                ],
-                inline_comments: [
-
-                ],
-              },
-              block_properties: {
-
-              },
             },
           ],
           _id: 'PSQTOBXAGZGKNOSBMOAUJ6EYSA',
@@ -144,17 +78,6 @@ describe('the article body List component', () => {
           type: 'text',
           content: 'Another thing indented under 3',
           _id: 'UG52XTXHHRDN5KUPKCGTKE4NMM',
-          additional_properties: {
-            comments: [
-
-            ],
-            inline_comments: [
-
-            ],
-          },
-          block_properties: {
-
-          },
         },
       ],
       _id: 'FLXZDZLOFRGNLMALFGLJGLDPAM',

--- a/blocks/article-body-block/chains/article-body/_children/oembed.test.jsx
+++ b/blocks/article-body-block/chains/article-body/_children/oembed.test.jsx
@@ -5,6 +5,19 @@ import Oembed from './oembed';
 describe('the article body OEmbed component', () => {
   it('renders passed in html', () => {
     const wrapper = mount(<Oembed element={{
+      subtype: 'other',
+      raw_oembed: {
+        html: '<div>Hello</div>',
+      },
+    }}
+    />);
+
+    expect(wrapper.find('.embed-responsive-16by9').length).toEqual(0);
+    expect(wrapper.html()).toContain('<div>Hello</div>');
+  });
+
+  it('renders when no subtype element key', () => {
+    const wrapper = mount(<Oembed element={{
       raw_oembed: {
         html: '<div>Hello</div>',
       },

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -37,6 +37,15 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
     _id: key = index, type, content,
   } = item;
 
+  const {
+    hideImageTitle = false,
+    hideImageCaption = false,
+    hideImageCredits = false,
+    hideGalleryTitle = false,
+    hideGalleryCaption = false,
+    hideGalleryCredits = false,
+  } = customFields;
+
   // TODO: Split each type into a separate reusable component
   switch (type) {
     case 'text': {
@@ -130,15 +139,14 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
         const ArticleBodyImageContainer = ({ children }) => (
           <figure
             className={figureImageClassName}
-            key={key}
           >
             {children}
             <figcaption>
               <ImageMetadata
-                subtitle={subtitle}
-                caption={caption}
-                credits={credits}
-                vanityCredits={vanityCredits}
+                subtitle={!hideImageTitle ? subtitle : null}
+                caption={!hideImageCaption ? caption : null}
+                credits={!hideImageCredits ? credits : null}
+                vanityCredits={!hideImageCredits ? vanityCredits : null}
               />
             </figcaption>
           </figure>
@@ -147,7 +155,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
         // if link url then make entire image clickable
         if (link) {
           return (
-            <ArticleBodyImageContainer>
+            <ArticleBodyImageContainer key={key}>
               <a href={link}>
                 <ArticleBodyImage />
               </a>
@@ -156,7 +164,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
         }
 
         return (
-          <ArticleBodyImageContainer>
+          <ArticleBodyImageContainer key={key}>
             <ArticleBodyImage />
           </ArticleBodyImageContainer>
         );
@@ -286,7 +294,10 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
             expandPhrase={phrases.t('global.gallery-expand-button')}
             autoplayPhrase={phrases.t('global.gallery-autoplay-button')}
             pausePhrase={phrases.t('global.gallery-pause-autoplay-button')}
-            pageCountPhrase={(current, total) => phrases.t('global.gallery-page-count-text', { current, total })}
+            pageCountPhrase={/* istanbul ignore next */ (current, total) => phrases.t('global.gallery-page-count-text', { current, total })}
+            displayTitle={!hideGalleryTitle}
+            displayCaption={!hideGalleryCaption}
+            displayCredits={!hideGalleryCredits}
           />
         </section>
       );
@@ -431,6 +442,42 @@ ArticleBodyChain.propTypes = {
       description: 'Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.',
     }),
     ...(videoPlayerCustomFields()),
+    hideImageTitle: PropTypes.bool.tag({
+      description: 'This display option applies to all Images in the Article Body.',
+      label: 'Hide Title',
+      defaultValue: false,
+      group: 'Image Display Options',
+    }),
+    hideImageCaption: PropTypes.bool.tag({
+      description: 'This display option applies to all Images in the Article Body.',
+      label: 'Hide Caption',
+      defaultValue: false,
+      group: 'Image Display Options',
+    }),
+    hideImageCredits: PropTypes.bool.tag({
+      description: 'This display option applies to all Images in the Article Body.',
+      label: 'Hide Credits',
+      defaultValue: false,
+      group: 'Image Display Options',
+    }),
+    hideGalleryTitle: PropTypes.bool.tag({
+      description: 'This display option applies to all Galleries in the Article Body',
+      label: 'Hide Title',
+      defaultValue: false,
+      group: 'Gallery Display Options',
+    }),
+    hideGalleryCaption: PropTypes.bool.tag({
+      description: 'This display option applies to all Galleries in the Article Body',
+      label: 'Hide Caption',
+      defaultValue: false,
+      group: 'Gallery Display Options',
+    }),
+    hideGalleryCredits: PropTypes.bool.tag({
+      description: 'This display option applies to all Galleries in the Article Body',
+      label: 'Hide Credits',
+      defaultValue: false,
+      group: 'Gallery Display Options',
+    }),
   }),
 };
 

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -13,6 +13,7 @@ jest.mock('fusion:intl', () => ({
 }));
 
 jest.mock('@wpmedia/engine-theme-sdk', () => ({
+  VideoPlayer: () => <div />,
   Image: () => <div />,
   ImageMetadata: () => <div />,
   LazyLoad: ({ children }) => <>{ children }</>,
@@ -415,26 +416,14 @@ describe('article-body chain', () => {
                 content_elements: [{
                   type: 'text',
                   content: 'A pull quote is for pulling out an individual quote from your story, to highlight it to the reader.',
-                  additional_properties: {
-                    comments: [],
-                    inline_comments: [],
-                  },
                   _id: 'HKJ3ZUOCFZBEJJZWGVQZXE6PR1Q',
                 }, {
                   type: 'text',
                   content: 'Pull quotes can have multiple paragraphs.',
-                  additional_properties: {
-                    comments: [],
-                    inline_comments: [],
-                  },
                   _id: 'LQH5LHMNX5BHJJNDTGGAXUT2O3Y',
                 }, {
                   type: 'text',
                   content: 'Here’s a third paragraph.',
-                  additional_properties: {
-                    comments: [],
-                    inline_comments: [],
-                  },
                   _id: '3E3BCEBT23NAR7EEGXWI42RZSYQ',
                 }],
                 subtype: 'pullquote',
@@ -452,44 +441,33 @@ describe('article-body chain', () => {
                 content_elements: [{
                   type: 'text',
                   content: 'A block quote is for when you’re citing another text at length. It’s important that it’s formatted differently so that readers know you’re quoting from another source. Block quotes an have multiple paragraphs – this one has 4 total.',
-                  additional_properties: {
-                    comments: [],
-                    inline_comments: [],
-                  },
                   _id: 'F6UMSFZWKNANBH5QV5A44CRSRGI',
                 }, {
                   type: 'text',
                   content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc nulla ligula, lobortis egestas urna vel, pulvinar dapibus nunc. Nulla rutrum, ligula ac rutrum tempor, erat lectus posuere ipsum, quis facilisis velit neque quis erat.',
-                  additional_properties: {
-                    comments: [],
-                    inline_comments: [],
-                  },
                   _id: 'ULIZJUZ3PZ6CHHKO42KZUZMASDU',
+                }, {
+                  _id: 'NFS4D2FLDBEURJ2J7257O6ATBY',
+                  items: [{
+                    _id: 'H22DDRIVWJGNZEVUAPI5YWFJP4',
+                    content: 'List item?',
+                    type: 'text',
+                  }],
+                  list_type: 'unordered',
+                  type: 'list',
                 }, {
                   type: 'text',
                   content: 'Proin massa massa, suscipit et pretium vitae, posuere non turpis. Phasellus vel augue non mi dapibus congue vel vel eros. Cras id mattis metus, eget varius justo. Morbi quis erat quam.',
-                  additional_properties: {
-                    comments: [],
-                    inline_comments: [],
-                  },
                   _id: 'UNSELKNBF8BCVRCYKHGIG3FND44',
                 }, {
                   type: 'text',
                   content: 'Quisque tristique facilisis lorem, nec interdum nisi tristique vel. Donec dapibus ac velit quis consequat. Donec hendrerit purus risus, congue convallis risus vehicula non. Morbi mi nisi, hendrerit sit amet ornare a, scelerisque posuere nunc. Aliquam metus odio, finibus non pulvinar non, venenatis sit amet sem.',
-                  additional_properties: {
-                    comments: [],
-                    inline_comments: [],
-                  },
                   _id: 'KWMRNJ6DJ5D12HJHGFNZF52JGIFI',
                 }],
                 subtype: 'blockquote',
                 citation: {
                   type: 'text',
                   content: 'Lorem Ipsum Generator',
-                },
-                additional_properties: {
-                  _id: '4RTIZEM4Y5CFXI344IF3RO64DCYA',
-                  comments: [],
                 },
               },
             ],
@@ -2375,6 +2353,33 @@ describe('article-body chain', () => {
       );
 
       expect(wrapper.find('article.article-body-wrapper').find('p.body-paragraph').length).toEqual(0);
+    });
+  });
+
+  describe('Renders Video type', () => {
+    it('should render Vidoe type', () => {
+      jest.mock('fusion:context', () => ({
+        useFusionContext: jest.fn(() => ({
+          globalContent: {
+            _id: 'NGGXZJ4HAJH5DI3SS65EVBMEMQ',
+            type: 'story',
+            version: '0.10.6',
+            content_elements: [
+              {
+                _id: 'TLF25CWTCBBOHOVFPK4C2RR5JA',
+                type: 'video',
+              },
+            ],
+          },
+          arcSite: 'the-sun',
+        })),
+      }));
+      const { default: ArticleBodyChain } = require('./default');
+      const wrapper = mount(
+        <ArticleBodyChain />,
+      );
+
+      expect(wrapper.find('VideoPlayer').length).toEqual(1);
     });
   });
 });

--- a/blocks/article-body-block/index.story.jsx
+++ b/blocks/article-body-block/index.story.jsx
@@ -529,6 +529,29 @@ export const contentGallery = () => {
   );
 };
 
+export const contentGalleryNoTitleCaptionOrCredits = () => {
+  const mockContext = {
+    ...mockContextBase,
+    globalContent: {
+      ...mockContextGlobalContent,
+      content_elements: [
+        mockGallery,
+      ],
+    },
+  };
+
+  return (
+    <ArticleBodyChainPresentation
+      context={mockContext}
+      customFields={{
+        hideGalleryTitle: true,
+        hideGalleryCaption: true,
+        hideGalleryCredits: true,
+      }}
+    />
+  );
+};
+
 export const contentHeader2 = () => {
   const mockContext = {
     ...mockContextBase,
@@ -597,6 +620,29 @@ export const contentImage = () => {
   return (
     <ArticleBodyChainPresentation
       context={mockContext}
+    />
+  );
+};
+
+export const contentImageNoTitleCaptionOrCredits = () => {
+  const mockContext = {
+    ...mockContextBase,
+    globalContent: {
+      ...mockContextGlobalContent,
+      content_elements: [
+        mockImage,
+      ],
+    },
+  };
+
+  return (
+    <ArticleBodyChainPresentation
+      context={mockContext}
+      customFields={{
+        hideImageTitle: true,
+        hideImageCaption: true,
+        hideImageCredits: true,
+      }}
     />
   );
 };


### PR DESCRIPTION
## Description
Update Article Body chain to have controls for image and gallery meta data options
Updated tests to increase coverage
Added additional stories to cover the ability for Images and Galleries to now not have any meta data displaying

## Jira Ticket
- [TMEDIA-641](https://arcpublishing.atlassian.net/browse/TMEDIA-641)

## Acceptance Criteria
* Add Display Image Options to Article Body chain:
     * Hide Title 
     * Hide Caption
     * Hide Credit
     * Include tooltip on each option: “This display option applies to all Images in the Article Body.”
* Add Display Gallery Options to Article Body chain 
     * Hide Title 
     * Hide Caption
     * Hide Credit
     * Include tooltip on each option: “This display option applies to all Galleries in the Article Body.”
* By default, checkboxes are false (title, caption and credit is shown)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-641-article-body-image-gallery-metadata-controls`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/article-body-block`
3. Using the template `article-right-rail` in PageBuilder
4. Set the preview content url to be `/entertainment/2021/06/28/jenaes-global-kitchen-sink-article/`
5. In the main section of the layout there is a Article Body block
6. Validate the block now has 6 additional custom fields that all do as they say they should

Accept the chromatic changes if they are deemed acceptable

## Effect Of Changes
### After

<img width="1046" alt="TMEDIA-641-custom-fields" src="https://user-images.githubusercontent.com/868127/151817304-7f18dc17-c84a-46ca-befe-92d7bd637476.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
