### PR TITLE
TMEDIA-655 : Article Tag Block - Account for long tag names

### DIFF
--- a/blocks/article-tag-block/features/tag/tags.scss
+++ b/blocks/article-tag-block/features/tag/tags.scss
@@ -19,6 +19,7 @@
   justify-content: center;
   line-height: calculateRem(24px);
   margin: 0.5rem;
+  min-height: 1.5rem;
   padding: 0 0.9375rem;
   text-decoration: none;
   text-align: center;

--- a/blocks/article-tag-block/features/tag/tags.scss
+++ b/blocks/article-tag-block/features/tag/tags.scss
@@ -16,12 +16,12 @@
   color: #fff;
   display: flex;
   font-size: 0.75rem;
-  height: 1.5rem;
   justify-content: center;
   line-height: calculateRem(24px);
   margin: 0.5rem;
   padding: 0 0.9375rem;
   text-decoration: none;
+  text-align: center;
   @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
     line-height: 0.875rem;
   }


### PR DESCRIPTION
## Description
I made a styling change to in the Article Tag Block for tag pills w/ long text. As per acceptance criteria I removed the height restriction and centered text within tag pills.

## Jira Ticket
- [TMEDIA-655](https://arcpublishing.atlassian.net/browse/TMEDIA-655)

## Acceptance Criteria
1. Remove the height restriction so that if text wraps to a second line all text is visible
2. Center the text

## Test Steps
- Checkout the `TMEDIA-655` branch and run `npm run storybook`.

1. Checkout this branch `git checkout TMEDIA-655`
2. Run storybook with `npm run storybook`.
3. In Storybook, navigate to [Tags > Really Long Tag Text](http://localhost:60001/?id=blocks-tags-bar--really-long-tag-text&viewMode=story).
4. Reduce the viewport width, either with Storybook or with the main viewport, so that the tag text starts to wrap within its container.
5. You should now see that pill grows taller as line breaks are needed and the tag text alignment is centered.

## Effect Of Changes
### Before
Visual of the tag pill before the change:
<img width="368" alt="image" src="https://user-images.githubusercontent.com/452134/153274865-17468854-ed3b-4dc5-9da7-8cf737cec553.png">

### After
Visual of the tag pill after the change:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/452134/153274687-62c90997-a06d-443a-a82e-4cb237d4b90a.png">

## Dependencies or Side Effects
n/a

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
