### PR TITLE
TMEDIA-222 - Header Nav Chain with no hamburger items

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -169,7 +169,7 @@ export function PresentationalNav(props) {
           focusTrapOptions={{
             allowOutsideClick: true,
             returnFocusOnDeactivate: true,
-            onDeactivate: () => {
+            onDeactivate: /* istanbul ignore next */ () => {
             // Focus the next focusable element in the navbar
             // Workaround for issue where 'nav-sections-btn' wont programatically focus
               const focusElement = document.querySelector(`
@@ -182,9 +182,16 @@ export function PresentationalNav(props) {
                 focusElement.blur();
               }
             },
+            fallbackFocus: /* istanbul ignore next */ () => document.getElementById('nav-sections'),
           }}
         >
-          <div className="inner-drawer-nav" style={{ zIndex: 10 }}>
+          {/**
+           * Need to disable tabindex lint as this is a fallback for when section menu
+           * has no items and FocusTrap requires at least one tabable element
+           * which would be the follow container thats used wuth `fallbackFocus`
+          */}
+          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+          <div className="inner-drawer-nav" style={{ zIndex: 10 }} tabIndex={!sections.length ? '-1' : null}>
             <SectionNav
               sections={sections}
               isHidden={!isSectionDrawerOpen}
@@ -333,6 +340,7 @@ const Nav = (props) => {
     };
   }, []);
 
+  // istanbul ignore next
   useEffect(() => {
     const vw = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
     if (!shrinkDesktopNavivationHeight || vw < mediumBreakpoint) {

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -328,6 +328,7 @@ describe('the header navigation feature for the default output type', () => {
       expect(wrapper.find('div#nav-sections').hasClass('closed')).toBe(false);
     });
   });
+
   describe('primary color background color option', () => {
     it('if has navBarBackground as primary color, use primary color as background color', () => {
       getProperties.mockImplementation(() => ({ navColor: 'light', navBarBackground: 'primary-color' }));
@@ -336,7 +337,15 @@ describe('the header navigation feature for the default output type', () => {
       const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
       expect(wrapper.find('StyledComponent').at(0).prop('navBarBackground')).toEqual('#1B6FA6');
     });
+
+    it('if has navColor as light', () => {
+      getProperties.mockImplementation(() => ({ navColor: 'light' }));
+
+      const wrapper = mount(<Navigation customFields={DEFAULT_SELECTIONS} />);
+      expect(wrapper.find('StyledComponent').at(0).prop('navBarBackground')).toEqual('#fff');
+    });
   });
+
   describe('dealing with accessibility and screen readers', () => {
     it('should render the block with the default aria-label', () => {
       const wrapper = mount(
@@ -354,6 +363,7 @@ describe('the header navigation feature for the default output type', () => {
       expect(wrapper.find('nav').props()).toHaveProperty('aria-label', 'Links');
     });
   });
+
   describe('primary image', () => {
     it('shown without deployment function prefix if external http url', () => {
       getProperties.mockReturnValueOnce({
@@ -372,6 +382,7 @@ describe('the header navigation feature for the default output type', () => {
       expect(navLogoImg).toHaveLength(1);
       expect(navLogoImg.prop('src')).toEqual('http://www.example.com/logo.png');
     });
+
     it('shows image rendered from depoyment function if no http or base64 found', () => {
       getProperties.mockReturnValueOnce({
         primaryLogo: 'resources/images/logo.png',
@@ -388,6 +399,7 @@ describe('the header navigation feature for the default output type', () => {
       expect(navLogoImg).toHaveLength(1);
       expect(navLogoImg.prop('src')).toEqual('rendered-from-deployment');
     });
+
     it('shows image with deployment function used with base64', () => {
       getProperties.mockReturnValueOnce({
         primaryLogo: 'base64, iVBORw0KGgoAAAANSUhEUgAAAAUA',

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.test.js
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/nav-helper.test.js
@@ -26,6 +26,11 @@ describe('nav-helper', () => {
       const result = getNavComponentLabel('left', 'desktop', 1);
       expect(result).toEqual('Left Component 1 - Desktop');
     });
+
+    it('returns nav item custom field label', () => {
+      const result = getNavComponentLabel('right', 'desktop', 1);
+      expect(result).toEqual('Right Component 1 - Desktop');
+    });
   });
 
   describe('getNavComponentPropTypeKey()', () => {


### PR DESCRIPTION
## Description
Update header nav to account for FocusTrap errors when no site service content

## Jira Ticket
- [TMEDIA-222](https://arcpublishing.atlassian.net/browse/TMEDIA-222)

## Acceptance Criteria
When user interacts with the navigation bar and the site service hierarchy is missing, the hamburger menu should still open with no links in it

## Test Steps

1. Checkout this branch `git checkout TMEDIA-222-header-nav-no-site-service`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Create a new page in pagebuilder and add the the Header Nav Chain Block to the page
4. Do not adjust any of the configuration
5. Publish the page 
6. On the published page open the Section Menu
7. The sections menu will open for sites that do not have a default navigation set up

Site with no default navigation - the-water-cooler
Site with default navigation - the-gazette

## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
