### PR TITLE
Add 768 chromatic viewport for Top Table list

### DIFF
--- a/blocks/medium-manual-promo-block/index.story.jsx
+++ b/blocks/medium-manual-promo-block/index.story.jsx
@@ -7,7 +7,7 @@ export default {
   decorators: [withKnobs],
   parameters: {
     // Set the viewports in Chromatic at a component level.
-    chromatic: { viewports: [320, 1200] },
+    chromatic: { viewports: [320, 768, 1200] },
   },
 };
 

--- a/blocks/medium-promo-block/index.story.jsx
+++ b/blocks/medium-promo-block/index.story.jsx
@@ -7,7 +7,7 @@ export default {
   decorators: [withKnobs],
   parameters: {
     // Set the viewports in Chromatic at a component level.
-    chromatic: { viewports: [320, 1200] },
+    chromatic: { viewports: [320, 768, 1200] },
   },
 };
 

--- a/blocks/top-table-list-block/index.story.jsx
+++ b/blocks/top-table-list-block/index.story.jsx
@@ -4,7 +4,7 @@ import { TopTableList } from './features/top-table-list/default';
 export default {
   title: 'Blocks/Top Table List',
   parameters: {
-    chromatic: { viewports: [320, 1200] },
+    chromatic: { viewports: [320, 768, 1200] },
   },
 };
 


### PR DESCRIPTION
There was a report of an issue with the top table list medium promo rendering incorrectly at 768px - adding a story to have a baseline of what the top table list looks like today at that viewport