### PR TITLE
TMEDIA-667 - Full Author Bio Block - Account for no socials

### DIFF
--- a/blocks/full-author-bio-block/features/full-author-bio/default.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.jsx
@@ -70,95 +70,83 @@ export const FullAuthorBioPresentational = (props) => {
   const phrases = getTranslatedPhrases(locale);
 
   const socials = [];
-  if (content.authors) {
-    // get keys and values author object
-    /*
-      // don't render non social key and value
-      longBio: 'Jane Doe is a senior product manager for Arc Publishing. This is a Long bio. ',
+  // get keys and values author object
+  /*
+    // don't render non social key and value
+    longBio: 'Jane Doe is a senior product manager for Arc Publishing. This is a Long bio. ',
 
-      // render social key with a truthy value
-      instagram: 'janedoe',
-      rss: 'someusername',
+    // render social key with a truthy value
+    instagram: 'janedoe',
+    rss: 'someusername',
 
-      // don't render social key with a falsy value
-      linkedin: '',
-      twitter: null,
-    */
-    Object.entries(content.authors[0]).forEach(([socialMediaNameKey, socialMediaValue]) => {
-      if (SUPPORTED_SOCIALS_KEYS.includes(socialMediaNameKey) && socialMediaValue) {
-        socials.push(socialMediaNameKey);
-      }
-    });
-  }
+    // don't render social key with a falsy value
+    linkedin: '',
+    twitter: null,
+  */
+  Object.entries(content.authors[0]).forEach(([socialMediaNameKey, socialMediaValue]) => {
+    if (SUPPORTED_SOCIALS_KEYS.includes(socialMediaNameKey) && socialMediaValue) {
+      socials.push(socialMediaNameKey);
+    }
+  });
 
   return (
-    <>
+    <div className="full-author-bio">
       <div className="image-container">
-        {
-            (content.authors[0].image) && (
-              <Image
-                url={content.authors[0].image}
-                alt={(content.authors[0].byline) ? content.authors[0].byline : ''}
-                smallWidth={158}
-                smallHeight={158}
-                mediumWidth={158}
-                mediumHeight={158}
-                largeWidth={158}
-                largeHeight={158}
-                resizedImageOptions={content.authors[0].resized_params}
-                resizerURL={getProperties(arcSite)?.resizerURL}
-                breakpoints={getProperties(arcSite)?.breakpoints}
-              />
-            )
-          }
+        {(content.authors[0].image) ? (
+          <Image
+            url={content.authors[0].image}
+            alt={(content.authors[0].byline) ? content.authors[0].byline : ''}
+            smallWidth={158}
+            smallHeight={158}
+            mediumWidth={158}
+            mediumHeight={158}
+            largeWidth={158}
+            largeHeight={158}
+            resizedImageOptions={content.authors[0].resized_params}
+            resizerURL={getProperties(arcSite)?.resizerURL}
+            breakpoints={getProperties(arcSite)?.breakpoints}
+          />
+        ) : null}
       </div>
-      <div>
-        <PrimaryFont
-          as="div"
-          className="author-content"
-        >
-          {
-              (content.authors[0].byline) ? (
-                <h1 className="author-name">{content.authors[0].byline}</h1>
-              ) : null
-            }
-          {
-              (content.authors[0].role) ? (
-                <h2 className="author-title h4-primary">{content.authors[0].role}</h2>
-              ) : null
-            }
-          {
-              (content.authors[0].bio || content.authors[0].longBio) ? (
-                <SecondaryFont className="author-bio">
-                  {content.authors[0].longBio || content.authors[0].bio}
-                </SecondaryFont>
-              ) : null
-            }
-        </PrimaryFont>
-      </div>
+      <PrimaryFont
+        as="div"
+        className="author-content"
+      >
+        {(content.authors[0].byline) ? (
+          <h1 className="author-name">{content.authors[0].byline}</h1>
+        ) : null}
+        {(content.authors[0].role) ? (
+          <h2 className="author-title h4-primary">{content.authors[0].role}</h2>
+        ) : null}
+        {(content.authors[0].bio || content.authors[0].longBio) ? (
+          <SecondaryFont className="author-bio">
+            {content.authors[0].longBio || content.authors[0].bio}
+          </SecondaryFont>
+        ) : null}
+      </PrimaryFont>
 
-      <div className="social-container">
-        <p className="connect-label">
-          <strong>{phrases.t('full-author-bio-block.connect-text')}</strong>
-        </p>
-        <div className="social-items">
-          {
-              socials.map((item) => (
-                <a
-                  className={`social-column ${item}`}
-                  href={constructSocialURL(item, content.authors[0][item])}
-                  key={item}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  title={phrases.t(`full-author-bio-block.social-${item.toLowerCase()}`)}
-                >
-                  {logos[item]}
-                </a>
-              ))
-            }
+      {socials.length ? (
+        <div className="social-container">
+          <p className="connect-label">
+            <strong>{phrases.t('full-author-bio-block.connect-text')}</strong>
+          </p>
+          <div className="social-items">
+            {socials.map((item) => (
+              <a
+                className={`social-column ${item}`}
+                href={constructSocialURL(item, content.authors[0][item])}
+                key={item}
+                rel="noopener noreferrer"
+                target="_blank"
+                title={phrases.t(`full-author-bio-block.social-${item.toLowerCase()}`)}
+              >
+                {logos[item]}
+              </a>
+            ))}
+          </div>
         </div>
-      </div>
-    </>
+      ) : null}
+    </div>
   );
 };
 

--- a/blocks/full-author-bio-block/features/full-author-bio/default.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.jsx
@@ -91,39 +91,41 @@ export const FullAuthorBioPresentational = (props) => {
 
   return (
     <div className="full-author-bio">
-      <div className="image-container">
-        {(content.authors[0].image) ? (
-          <Image
-            url={content.authors[0].image}
-            alt={(content.authors[0].byline) ? content.authors[0].byline : ''}
-            smallWidth={158}
-            smallHeight={158}
-            mediumWidth={158}
-            mediumHeight={158}
-            largeWidth={158}
-            largeHeight={158}
-            resizedImageOptions={content.authors[0].resized_params}
-            resizerURL={getProperties(arcSite)?.resizerURL}
-            breakpoints={getProperties(arcSite)?.breakpoints}
-          />
-        ) : null}
+      <div className="full-author-bio--details">
+        <div className="image-container">
+          {(content.authors[0].image) ? (
+            <Image
+              url={content.authors[0].image}
+              alt={(content.authors[0].byline) ? content.authors[0].byline : ''}
+              smallWidth={158}
+              smallHeight={158}
+              mediumWidth={158}
+              mediumHeight={158}
+              largeWidth={158}
+              largeHeight={158}
+              resizedImageOptions={content.authors[0].resized_params}
+              resizerURL={getProperties(arcSite)?.resizerURL}
+              breakpoints={getProperties(arcSite)?.breakpoints}
+            />
+          ) : null}
+        </div>
+        <PrimaryFont
+          as="div"
+          className="author-content"
+        >
+          {(content.authors[0].byline) ? (
+            <h1 className="author-name">{content.authors[0].byline}</h1>
+          ) : null}
+          {(content.authors[0].role) ? (
+            <h2 className="author-title h4-primary">{content.authors[0].role}</h2>
+          ) : null}
+          {(content.authors[0].bio || content.authors[0].longBio) ? (
+            <SecondaryFont className="author-bio">
+              {content.authors[0].longBio || content.authors[0].bio}
+            </SecondaryFont>
+          ) : null}
+        </PrimaryFont>
       </div>
-      <PrimaryFont
-        as="div"
-        className="author-content"
-      >
-        {(content.authors[0].byline) ? (
-          <h1 className="author-name">{content.authors[0].byline}</h1>
-        ) : null}
-        {(content.authors[0].role) ? (
-          <h2 className="author-title h4-primary">{content.authors[0].role}</h2>
-        ) : null}
-        {(content.authors[0].bio || content.authors[0].longBio) ? (
-          <SecondaryFont className="author-bio">
-            {content.authors[0].longBio || content.authors[0].bio}
-          </SecondaryFont>
-        ) : null}
-      </PrimaryFont>
 
       {socials.length ? (
         <div className="social-container">

--- a/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
@@ -30,57 +30,57 @@ jest.mock('@wpmedia/engine-theme-sdk', () => ({
 }));
 
 jest.mock('fusion:themes', () => (jest.fn(() => ({}))));
-jest.mock('fusion:context', () => ({
-  useFusionContext: jest.fn(() => ({
-    globalContent: {
-      authors: [
-        {
-          _id: 'janedoe',
-          firstName: 'Jane',
-          lastName: 'Doe',
-          secondLastName: 'Deo',
-          byline: 'Jane Da Doe',
-          role: 'Senior Product Manager',
-          image: 'https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg',
-          email: 'jane@doe.com',
-          facebook: 'https://facebook.com/janedoe',
-          affiliations: '',
-          education: [],
-          awards: [],
-          books: [],
-          podcasts: [],
-          rss: 'somersslink',
-          twitter: 'janedoe',
-          bio_page: '/author/jane doe/',
-          bio: 'Jane Doe is a senior product manager for Arc Publishing. This is a short bio. ',
-          longBio: 'Jane Doe is a senior product manager for Arc Publishing. \nShe works on Arc Themes',
-          slug: 'jane-doe',
-          instagram: 'janedoe',
-          native_app_rendering: false,
-          fuzzy_match: false,
-          contributor: false,
-          status: true,
-          last_updated_date: '2019-01-24T23:15:45.348Z',
-          type: 'author',
-          resized_params: {
-            '158x158': '',
-          },
-        },
-      ],
-      last: 'c2FyYWNhcm90aGVycw==',
-      more: false,
-      _id: 'aea0c7ea37263d5d663cbb6844a506d39dfb7e02a76ab932d6e740c4e2807906',
-    },
-  })),
-}));
 
-describe('the full author bio block', () => {
-  it('should return null if lazyLoad on the server and not in the admin', () => {
-    const wrapper = mount(<FullAuthorBio customFields={{ lazyLoad: true }} />);
-    expect(wrapper.html()).toBe(null);
+describe('Full author bio block', () => {
+  describe('lazy load and isAdmin', () => {
+    it('should return null if lazyLoad on the server and not in the admin', () => {
+      const wrapper = mount(<FullAuthorBio customFields={{ lazyLoad: true }} />);
+      expect(wrapper.html()).toBe(null);
+    });
+
+    it('should not return null if lazyLoad on the server and isAdmin', () => {
+      useFusionContext.mockImplementation(() => ({
+        isAdmin: true,
+        globalContent: {
+          authors: [
+            {
+              _id: 'janedoe',
+              firstName: 'Jane',
+            },
+          ],
+        },
+      }));
+      const wrapper = mount(<FullAuthorBio customFields={{ lazyLoad: true }} />);
+      expect(wrapper.html()).not.toBe(null);
+    });
   });
 
   describe('when fields from globalContent are present', () => {
+    beforeEach(() => {
+      useFusionContext.mockImplementation(() => ({
+        arcSite: 'no-site',
+        globalContent: {
+          authors: [
+            {
+              _id: 'janedoe',
+              firstName: 'Jane',
+              lastName: 'Doe',
+              byline: 'Jane Da Doe',
+              role: 'Senior Product Manager',
+              image: 'https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg',
+              resized_params: { '158x158': '' },
+              email: 'jane@doe.com',
+              facebook: 'https://facebook.com/janedoe',
+              rss: 'somersslink',
+              twitter: 'janedoe',
+              longBio: 'Jane Doe is a senior product manager for Arc Publishing. \nShe works on Arc Themes',
+              instagram: 'janedoe',
+            },
+          ],
+        },
+      }));
+    });
+
     it('should render a h1', () => {
       const wrapper = mount(<FullAuthorBio />);
 
@@ -147,7 +147,6 @@ describe('the full author bio block', () => {
               _id: 'janedoe',
               firstName: 'Jane',
               lastName: 'Doe',
-              byline: 'Jane Da Doe',
               role: 'Senior Product Manager',
               image: 'https://s3.amazonaws.com/arc-authors/corecomponents/b80bd029-16d8-4a28-a874-78fc07ebc14a.jpg',
               resized_params: { '158x158': '' },
@@ -298,6 +297,7 @@ describe('when there are falsy values as social media links', () => {
     expect(wrapper.find('.twitter')).toHaveLength(0);
     expect(wrapper.find('.instagram')).toHaveLength(1);
   });
+
   it('should not render empty string value', () => {
     useFusionContext.mockImplementation(() => ({
       arcSite: 'no-site',
@@ -315,6 +315,7 @@ describe('when there are falsy values as social media links', () => {
     expect(wrapper.find('.twitter')).toHaveLength(0);
     expect(wrapper.find('.instagram')).toHaveLength(1);
   });
+
   it('should not render if no key social value', () => {
     useFusionContext.mockImplementation(() => ({
       arcSite: 'no-site',
@@ -330,5 +331,26 @@ describe('when there are falsy values as social media links', () => {
     const wrapper = mount(<FullAuthorBio />);
     expect(wrapper.find('.twitter')).toHaveLength(0);
     expect(wrapper.find('.instagram')).toHaveLength(1);
+    expect(wrapper.find('.social-container')).toHaveLength(1);
+  });
+
+  it('should not render social elements when no socials', () => {
+    useFusionContext.mockImplementation(() => ({
+      arcSite: 'no-site',
+      globalContent: {
+        authors: [
+          {
+            _id: 'janedoe',
+          },
+          {
+            _id: 'janedoes',
+          },
+        ],
+      },
+    }));
+    const wrapper = mount(<FullAuthorBio />);
+    expect(wrapper.find('.twitter')).toHaveLength(0);
+    expect(wrapper.find('.instagram')).toHaveLength(0);
+    expect(wrapper.find('.social-container')).toHaveLength(0);
   });
 });

--- a/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
+++ b/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
@@ -8,7 +8,7 @@
   margin-top: map-get($spacers, 'lg');
 
   @media screen and (max-width: map-get($grid-breakpoints, 'lg')) {
-    margin-top: map-get($spacers, 'sm');
+    margin-top: 0;
   }
 }
 
@@ -39,6 +39,10 @@
 
 .author-name {
   margin-bottom: map-get($spacers, 'xs');
+
+  @media screen and (max-width: map-get($grid-breakpoints, 'lg')) {
+    margin-top: map-get($spacers, 'sm');
+  }
 }
 
 .author-title {

--- a/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
+++ b/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
@@ -5,11 +5,6 @@
 .full-author-bio--details {
   display: flex;
   flex-wrap: wrap;
-  margin-top: map-get($spacers, 'lg');
-
-  @media screen and (max-width: map-get($grid-breakpoints, 'lg')) {
-    margin-top: 0;
-  }
 }
 
 .image-container {

--- a/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
+++ b/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
@@ -2,13 +2,17 @@
   border-bottom: 1px solid $border-rule-color;
 }
 
+.full-author-bio--details {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .image-container {
   @media screen and (max-width: map-get($grid-breakpoints, 'lg')) {
     float: none;
     text-align: center;
     width: 100%;
   }
-  float: left;
   margin-right: map-get($spacers, 'md');
   margin-top: map-get($spacers, 'lg');
   width: 30%;

--- a/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
+++ b/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
@@ -1,3 +1,7 @@
+.full-author-bio {
+  border-bottom: 1px solid $border-rule-color;
+}
+
 .image-container {
   @media screen and (max-width: map-get($grid-breakpoints, 'lg')) {
     float: none;
@@ -42,7 +46,6 @@
     padding: map-get($spacers, 'sm') 0 map-get($spacers, 'sm') 0;
     text-align: center;
   }
-  border-bottom: 1px solid $border-rule-color;
   border-top: 1px solid $border-rule-color;
   display: flex;
   flex-direction: row;

--- a/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
+++ b/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
@@ -5,16 +5,21 @@
 .full-author-bio--details {
   display: flex;
   flex-wrap: wrap;
+  margin-top: map-get($spacers, 'lg');
+
+  @media screen and (max-width: map-get($grid-breakpoints, 'lg')) {
+    margin-top: map-get($spacers, 'sm');
+  }
 }
 
 .image-container {
   @media screen and (max-width: map-get($grid-breakpoints, 'lg')) {
     float: none;
+    margin-right: 0;
     text-align: center;
     width: 100%;
   }
   margin-right: map-get($spacers, 'md');
-  margin-top: map-get($spacers, 'lg');
   width: 30%;
 
   img {
@@ -33,11 +38,7 @@
 }
 
 .author-name {
-  @media screen and (max-width: map-get($grid-breakpoints, 'lg')) {
-    margin-top: map-get($spacers, 'sm');
-  }
   margin-bottom: map-get($spacers, 'xs');
-  margin-top: map-get($spacers, 'lg');
 }
 
 .author-title {

--- a/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
+++ b/blocks/full-author-bio-block/features/full-author-bio/full-author-bio.scss
@@ -5,6 +5,11 @@
 .full-author-bio--details {
   display: flex;
   flex-wrap: wrap;
+  margin-top: map-get($spacers, 'lg');
+
+  @media screen and (max-width: map-get($grid-breakpoints, 'lg')) {
+    margin-top: 0;
+  }
 }
 
 .image-container {


### PR DESCRIPTION
## Description
Update full author bio block to not show social elements when an author has no social accounts in their data
Update tests to get 100% test coverage

## Jira Ticket
- [TMEDIA-667](https://arcpublishing.atlassian.net/browse/TMEDIA-667)

## Acceptance Criteria
When an author has not social accounts, no social icons/links are shown and the text "Connect" is not shown either. We can leave the top border and remove the bottom border. Update tests.
## Test Steps
- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-667-full-author-bio-connect-text`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/full-author-bio-block`
3. Visit an author with no social accounts - http://localhost/author/taylor-doe/?_website=the-gazette
    * Validate social elements do not appear, Connect text is no longer showing
4. Visit and author with social accounts and verify there are no changes - http://localhost/author/sara-carothers/?_website=the-gazette

## Effect Of Changes
### Before

<img width="965" alt="Microsoft Edge-2022-02-21-11-45 49" src="https://user-images.githubusercontent.com/868127/154949275-856650f2-dad3-4c78-b53e-857d5aaf6c82.png">


### After


<img width="977" alt="Microsoft Edge-2022-02-21-11-45 25" src="https://user-images.githubusercontent.com/868127/154949215-3eee5523-95c0-4a29-8d6d-31f781467d0f.png">


## Author Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist
_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
