### PR TITLE
Tmedia 601 show caption video options

### DIFF
--- a/blocks/article-body-block/chains/article-body/_articlebody.scss
+++ b/blocks/article-body-block/chains/article-body/_articlebody.scss
@@ -46,15 +46,13 @@
 		}
 	}
 
-	.gallery {
-		.image-metadata {
-			font-size: calculateRem(14px);
-			line-height: calculateRem(24px);
-			margin: 8px 0;
+	.image-metadata {
+		font-size: calculateRem(14px);
+		line-height: calculateRem(24px);
+		margin: 8px 0;
 
-			@media screen and (min-width: map-get($grid-breakpoints, "md")) {
-				line-height: calculateRem(20px);
-			}
+		@media screen and (min-width: map-get($grid-breakpoints, "md")) {
+			line-height: calculateRem(20px);
 		}
 	}
 

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -265,7 +265,6 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 					return <Quote key={key} element={item} />;
 			}
 		case "video":
-			console.log("video", item);
 			return (
 				<section key={key} className="block-margin-bottom">
 					<VideoPlayerPresentational
@@ -278,7 +277,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 						displayCredits={!hideVideoCredits}
 						subtitle="subtitle"
 						caption="caption"
-						credits={{}}
+						credits={item.credits}
 					/>
 				</section>
 			);

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -275,8 +275,8 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 						displayTitle={!hideVideoTitle}
 						displayCaption={!hideVideoCaption}
 						displayCredits={!hideVideoCredits}
-						subtitle="subtitle"
-						caption="caption"
+						subtitle={item.headlines.basic}
+						caption={item.description.basic}
 						credits={item.credits}
 					/>
 				</section>

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -44,6 +44,9 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		hideGalleryTitle = false,
 		hideGalleryCaption = false,
 		hideGalleryCredits = false,
+		hideVideoTitle = false,
+		hideVideoCaption = false,
+		hideVideoCredits = false,
 	} = customFields;
 
 	// TODO: Split each type into a separate reusable component
@@ -262,6 +265,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 					return <Quote key={key} element={item} />;
 			}
 		case "video":
+			console.log("video", item);
 			return (
 				<section key={key} className="block-margin-bottom">
 					<VideoPlayerPresentational
@@ -269,6 +273,12 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 						embedMarkup={item.embed_html}
 						shrinkToFit={customFields?.shrinkToFit}
 						viewportPercentage={customFields?.viewportPercentage}
+						displayTitle={!hideVideoTitle}
+						displayCaption={!hideVideoCaption}
+						displayCredits={!hideVideoCredits}
+						subtitle="subtitle"
+						caption="caption"
+						credits={{}}
 					/>
 				</section>
 			);
@@ -468,6 +478,24 @@ ArticleBodyChain.propTypes = {
 			label: "Hide Credits",
 			defaultValue: false,
 			group: "Gallery Display Options",
+		}),
+		hideVideoTitle: PropTypes.bool.tag({
+			description: "This display option applies to all Videos in the Article Body",
+			label: "Hide Title",
+			defaultValue: false,
+			group: "Video Display Options",
+		}),
+		hideVideoCaption: PropTypes.bool.tag({
+			description: "This display option applies to all Videos in the Article Body",
+			label: "Hide Caption",
+			defaultValue: false,
+			group: "Video Display Options",
+		}),
+		hideVideoCredits: PropTypes.bool.tag({
+			description: "This display option applies to all Videos in the Article Body",
+			label: "Hide Credits",
+			defaultValue: false,
+			group: "Video Display Options",
 		}),
 	}),
 };

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -275,8 +275,8 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 						displayTitle={!hideVideoTitle}
 						displayCaption={!hideVideoCaption}
 						displayCredits={!hideVideoCredits}
-						subtitle={item.headlines.basic}
-						caption={item.description.basic}
+						subtitle={item?.headlines?.basic}
+						caption={item?.description?.basic}
 						credits={item.credits}
 					/>
 				</section>

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -248,6 +248,26 @@ describe("article-body chain", () => {
 			expect(wrapper.find("article.article-body-wrapper").find("span")).toHaveLength(1);
 			expect(wrapper.find("article.article-body-wrapper").find("div")).toHaveLength(0);
 		});
+		it("should not render on lazy load set and is server side on engine theme sdk is true", () => {
+			const customFields = { lazyLoad: true };
+			jest.mock("@wpmedia/engine-theme-sdk", () => ({
+				VideoPlayer: () => <div />,
+				Image: () => <div />,
+				ImageMetadata: () => <div />,
+				LazyLoad: ({ children }) => <>{children}</>,
+				isServerSide: () => true,
+			}));
+			const { default: ArticleBodyChain } = require("./default");
+			const wrapper = mount(
+				<ArticleBodyChain customFields={customFields}>
+					<div>1</div>
+					<div>2</div>
+					<span>3</span>
+				</ArticleBodyChain>
+			);
+			expect(wrapper.find("article.article-body-wrapper")).toHaveLength(0);
+			expect(wrapper.html()).toBeNull();
+		});
 	});
 
 	describe("when it is initialized with elementPlacement greater than contentElements length", () => {
@@ -2394,6 +2414,12 @@ describe("article-body chain", () => {
 							{
 								_id: "TLF25CWTCBBOHOVFPK4C2RR5JA",
 								type: "video",
+								headlines: {
+									basic: "Title",
+								},
+								description: {
+									basic: "Caption",
+								},
 							},
 						],
 					},

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -68,6 +68,9 @@ class LeadArt extends Component {
 			hideCaption = false,
 			hideCredits = false,
 			imageLoadingStrategy,
+			hideVideoTitle = false,
+			hideVideoCaption = false,
+			hideVideoCredits = false,
 		} = customFields;
 
 		// handles empty string for selecting no option and undefined for default
@@ -135,6 +138,12 @@ class LeadArt extends Component {
 						customFields={{
 							playthrough: !!customFields?.playthrough,
 						}}
+						displayTitle={!hideVideoTitle}
+						displayCaption={!hideVideoCaption}
+						displayCredits={!hideVideoCredits}
+						subtitle={lead_art.headlines.basic}
+						caption={lead_art.description.basic}
+						credits={lead_art.credits}
 					/>
 				);
 			}
@@ -279,6 +288,24 @@ LeadArt.propTypes = {
 				eager: "Eager",
 				lazy: "Lazy",
 			},
+		}),
+		hideVideoTitle: PropTypes.bool.tag({
+			description: "This display option applies to all Videos in the Lead Art block",
+			label: "Hide Title",
+			defaultValue: false,
+			group: "Video Display Options",
+		}),
+		hideVideoCaption: PropTypes.bool.tag({
+			description: "This display option applies to all Videos in the Lead Art block",
+			label: "Hide Caption",
+			defaultValue: false,
+			group: "Video Display Options",
+		}),
+		hideVideoCredits: PropTypes.bool.tag({
+			description: "This display option applies to all Videos in the Lead Art block",
+			label: "Hide Credits",
+			defaultValue: false,
+			group: "Video Display Options",
 		}),
 	}),
 };

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -141,8 +141,8 @@ class LeadArt extends Component {
 						displayTitle={!hideVideoTitle}
 						displayCaption={!hideVideoCaption}
 						displayCredits={!hideVideoCredits}
-						subtitle={lead_art.headlines.basic}
-						caption={lead_art.description.basic}
+						subtitle={lead_art?.headlines?.basic}
+						caption={lead_art?.description?.basic}
 						credits={lead_art.credits}
 					/>
 				);

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -68,9 +68,6 @@ class LeadArt extends Component {
 			hideCaption = false,
 			hideCredits = false,
 			imageLoadingStrategy,
-			hideVideoTitle = false,
-			hideVideoCaption = false,
-			hideVideoCredits = false,
 		} = customFields;
 
 		// handles empty string for selecting no option and undefined for default
@@ -138,9 +135,9 @@ class LeadArt extends Component {
 						customFields={{
 							playthrough: !!customFields?.playthrough,
 						}}
-						displayTitle={!hideVideoTitle}
-						displayCaption={!hideVideoCaption}
-						displayCredits={!hideVideoCredits}
+						displayTitle={!hideTitle}
+						displayCaption={!hideCaption}
+						displayCredits={!hideCredits}
 						subtitle={lead_art?.headlines?.basic}
 						caption={lead_art?.description?.basic}
 						credits={lead_art.credits}
@@ -263,19 +260,22 @@ LeadArt.propTypes = {
 		}),
 		...videoPlayerCustomFields(),
 		hideTitle: PropTypes.bool.tag({
-			description: "This display option applies to Lead Art media types: Images and Gallery",
+			description:
+				"This display option applies to Lead Art media types: Images, Gallery, and Video",
 			label: "Hide Title",
 			defaultValue: false,
 			group: "Display Options",
 		}),
 		hideCaption: PropTypes.bool.tag({
-			description: "This display option applies to Lead Art media types: Images and Gallery",
+			description:
+				"This display option applies to Lead Art media types: Images, Gallery, and Video",
 			label: "Hide Caption",
 			defaultValue: false,
 			group: "Display Options",
 		}),
 		hideCredits: PropTypes.bool.tag({
-			description: "This display option applies to Lead Art media types: Images and Gallery",
+			description:
+				"This display option applies to Lead Art media types: Images, Gallery, and Video",
 			label: "Hide Credits",
 			defaultValue: false,
 			group: "Display Options",
@@ -288,24 +288,6 @@ LeadArt.propTypes = {
 				eager: "Eager",
 				lazy: "Lazy",
 			},
-		}),
-		hideVideoTitle: PropTypes.bool.tag({
-			description: "This display option applies to all Videos in the Lead Art block",
-			label: "Hide Title",
-			defaultValue: false,
-			group: "Video Display Options",
-		}),
-		hideVideoCaption: PropTypes.bool.tag({
-			description: "This display option applies to all Videos in the Lead Art block",
-			label: "Hide Caption",
-			defaultValue: false,
-			group: "Video Display Options",
-		}),
-		hideVideoCredits: PropTypes.bool.tag({
-			description: "This display option applies to all Videos in the Lead Art block",
-			label: "Hide Credits",
-			defaultValue: false,
-			group: "Video Display Options",
 		}),
 	}),
 };

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -57,6 +57,12 @@ describe("LeadArt", () => {
 			promo_items: {
 				lead_art: {
 					type: "video",
+					headlines: {
+						basic: "Title",
+					},
+					description: {
+						basic: "Description",
+					},
 				},
 			},
 		};

--- a/blocks/lead-art-block/features/leadart/leadart.scss
+++ b/blocks/lead-art-block/features/leadart/leadart.scss
@@ -11,7 +11,7 @@
 	figcaption {
 		margin-top: map-get($spacers, "xs");
 
-		p.image-metadata {
+		.image-metadata {
 			font-size: calculateRem(14px);
 			line-height: calculateRem(24px);
 			margin: 8px 0;

--- a/blocks/lead-art-block/features/leadart/leadart.scss
+++ b/blocks/lead-art-block/features/leadart/leadart.scss
@@ -12,7 +12,6 @@
 		margin-top: map-get($spacers, "xs");
 
 		p.image-metadata {
-			color: $image-caption-rule-color;
 			font-size: calculateRem(14px);
 			line-height: calculateRem(24px);
 			margin: 8px 0;

--- a/blocks/lead-art-block/index.story.jsx
+++ b/blocks/lead-art-block/index.story.jsx
@@ -141,6 +141,12 @@ const leadArtVideo = {
 			},
 		],
 	},
+	headlines: {
+		basic: "Title",
+	},
+	description: {
+		basic: "Caption",
+	},
 	subtitles: {},
 	embed_html:
 		'<div class="powa" id="powa-ba52f779-47be-46b9-8bd5-58dcb4318101" data-org="corecomponents" data-env="prod" data-uuid="ba52f779-47be-46b9-8bd5-58dcb4318101" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>',

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -138,8 +138,6 @@ const VideoPlayer = (props) => {
 			fetchedData
 		);
 
-	console.log(credits, "credits");
-
 	return (
 		<div className="container-fluid">
 			{alertBadge && (

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -21,16 +21,7 @@ const AlertBadge = styled.span`
 	font-weight: bold;
 `;
 
-// same logic as embed html
-// if inherit global content
-//    then use that
-// else if title and description passed in and truthy
-//    use those next
-// else if electing to use fetched data based off config
-//    use fetched data
-// else
-// 	  return empty strings for title and description
-function getFetchedPassedOrInheritedTitleDescription(
+function getFetchedPassedOrInheritedTitleDescriptionCaption(
 	globalContent,
 	inheritGlobalContent,
 	title,
@@ -41,6 +32,15 @@ function getFetchedPassedOrInheritedTitleDescription(
 	let headlineBasic;
 	let descriptionBasic;
 
+	// same logic as embed html
+	// if inherit global content
+	//    then use that
+	// else if title and description passed in and truthy
+	//    use those next
+	// else if electing to use fetched data based off config
+	//    use fetched data
+	// else
+	// 	  return empty strings for title and description
 	if (inheritGlobalContent) {
 		headlineBasic = globalContent?.headlines?.basic;
 		descriptionBasic = globalContent?.description?.basic;
@@ -52,9 +52,19 @@ function getFetchedPassedOrInheritedTitleDescription(
 		descriptionBasic = fetchedData?.description?.basic;
 	}
 
+	let credits;
+
+	// since credits can't be passed in, the fallback is to use the fetched data
+	if (inheritGlobalContent) {
+		credits = globalContent?.credits || {};
+	} else {
+		credits = fetchedData?.credits || {};
+	}
+
 	return {
 		headlineBasic: headlineBasic || "",
 		descriptionBasic: descriptionBasic || "",
+		credits,
 	};
 }
 
@@ -118,14 +128,17 @@ const VideoPlayer = (props) => {
 		}
 	});
 
-	const { headlineBasic, descriptionBasic } = getFetchedPassedOrInheritedTitleDescription(
-		globalContent,
-		inheritGlobalContent,
-		title,
-		description,
-		doFetch,
-		fetchedData
-	);
+	const { headlineBasic, descriptionBasic, credits } =
+		getFetchedPassedOrInheritedTitleDescriptionCaption(
+			globalContent,
+			inheritGlobalContent,
+			title,
+			description,
+			doFetch,
+			fetchedData
+		);
+
+	console.log(credits, "credits");
 
 	return (
 		<div className="container-fluid">
@@ -155,7 +168,7 @@ const VideoPlayer = (props) => {
 					displayCredits={!hideVideoCredits}
 					subtitle={headlineBasic}
 					caption={descriptionBasic}
-					credits={globalContent.credits}
+					credits={credits}
 				/>
 			)}
 			{description && (

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -21,6 +21,43 @@ const AlertBadge = styled.span`
 	font-weight: bold;
 `;
 
+// same logic as embed html
+// if inherit global content
+//    then use that
+// else if title and description passed in and truthy
+//    use those next
+// else if electing to use fetched data based off config
+//    use fetched data
+// else
+// 	  return empty strings for title and description
+function getFetchedPassedOrInheritedTitleDescription(
+	globalContent,
+	inheritGlobalContent,
+	title,
+	description,
+	doFetch,
+	fetchedData
+) {
+	let headlineBasic;
+	let descriptionBasic;
+
+	if (inheritGlobalContent) {
+		headlineBasic = globalContent?.headlines?.basic;
+		descriptionBasic = globalContent?.description?.basic;
+	} else if (title && description) {
+		headlineBasic = title;
+		descriptionBasic = description;
+	} else if (doFetch) {
+		headlineBasic = fetchedData?.headlines?.basic;
+		descriptionBasic = fetchedData?.description?.basic;
+	}
+
+	return {
+		headlineBasic: headlineBasic || "",
+		descriptionBasic: descriptionBasic || "",
+	};
+}
+
 const VideoPlayer = (props) => {
 	const { customFields = {}, embedMarkup, enableAutoplay = false } = props;
 
@@ -32,6 +69,9 @@ const VideoPlayer = (props) => {
 		title,
 		description,
 		websiteURL,
+		hideVideoTitle = false,
+		hideVideoCaption = false,
+		hideVideoCredits = false,
 	} = customFields;
 
 	const { id, globalContent = {}, arcSite } = useFusionContext();
@@ -78,6 +118,15 @@ const VideoPlayer = (props) => {
 		}
 	});
 
+	const { headlineBasic, descriptionBasic } = getFetchedPassedOrInheritedTitleDescription(
+		globalContent,
+		inheritGlobalContent,
+		title,
+		description,
+		doFetch,
+		fetchedData
+	);
+
 	return (
 		<div className="container-fluid">
 			{alertBadge && (
@@ -101,6 +150,12 @@ const VideoPlayer = (props) => {
 						autoplay,
 						playthrough,
 					}}
+					displayTitle={!hideVideoTitle}
+					displayCaption={!hideVideoCaption}
+					displayCredits={!hideVideoCredits}
+					subtitle={headlineBasic}
+					caption={descriptionBasic}
+					credits={globalContent.credits}
 				/>
 			)}
 			{description && (
@@ -154,6 +209,27 @@ VideoPlayer.propTypes = {
 	}),
 	embedMarkup: PropTypes.string,
 	enableAutoplay: PropTypes.bool,
+	// eslint-disable-next-line react/no-unused-prop-types
+	hideVideoTitle: PropTypes.bool.tag({
+		description: "This display option applies to all Videos in the Video Center Player block",
+		label: "Hide Title",
+		defaultValue: false,
+		group: "Video Display Options",
+	}),
+	// eslint-disable-next-line react/no-unused-prop-types
+	hideVideoCaption: PropTypes.bool.tag({
+		description: "This display option applies to all Videos in the Video Center Player block",
+		label: "Hide Caption",
+		defaultValue: false,
+		group: "Video Display Options",
+	}),
+	// eslint-disable-next-line react/no-unused-prop-types
+	hideVideoCredits: PropTypes.bool.tag({
+		description: "This display option applies to all Videos in the Video Center Player block",
+		label: "Hide Credits",
+		defaultValue: false,
+		group: "Video Display Options",
+	}),
 };
 
 VideoPlayer.label = "Video Center Player - Arc Block";

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -204,6 +204,24 @@ VideoPlayer.propTypes = {
 			defaultValue: false,
 			group: "Video Settings",
 		}),
+		hideVideoTitle: PropTypes.bool.tag({
+			description: "This display option applies to all Videos in the Video Center Player block",
+			label: "Hide Title",
+			defaultValue: false,
+			group: "Video Display Options",
+		}),
+		hideVideoCaption: PropTypes.bool.tag({
+			description: "This display option applies to all Videos in the Video Center Player block",
+			label: "Hide Caption",
+			defaultValue: false,
+			group: "Video Display Options",
+		}),
+		hideVideoCredits: PropTypes.bool.tag({
+			description: "This display option applies to all Videos in the Video Center Player block",
+			label: "Hide Credits",
+			defaultValue: false,
+			group: "Video Display Options",
+		}),
 		...videoPlayerCustomFields(),
 		title: PropTypes.string.tag({
 			label: "Title",
@@ -218,29 +236,9 @@ VideoPlayer.propTypes = {
 			group: "Display settings",
 		}),
 	}),
+
 	embedMarkup: PropTypes.string,
 	enableAutoplay: PropTypes.bool,
-	// eslint-disable-next-line react/no-unused-prop-types
-	hideVideoTitle: PropTypes.bool.tag({
-		description: "This display option applies to all Videos in the Video Center Player block",
-		label: "Hide Title",
-		defaultValue: false,
-		group: "Video Display Options",
-	}),
-	// eslint-disable-next-line react/no-unused-prop-types
-	hideVideoCaption: PropTypes.bool.tag({
-		description: "This display option applies to all Videos in the Video Center Player block",
-		label: "Hide Caption",
-		defaultValue: false,
-		group: "Video Display Options",
-	}),
-	// eslint-disable-next-line react/no-unused-prop-types
-	hideVideoCredits: PropTypes.bool.tag({
-		description: "This display option applies to all Videos in the Video Center Player block",
-		label: "Hide Credits",
-		defaultValue: false,
-		group: "Video Display Options",
-	}),
 };
 
 VideoPlayer.label = "Video Center Player - Arc Block";


### PR DESCRIPTION
## Description

Add caption, title, and credit to below videos. Add ability to hide and show each. Based this off of the Gallery implementation of showing and hiding fields in the engine theme sdk

## Jira Ticket

- [TMEDIA-601](https://arcpublishing.atlassian.net/browse/TMEDIA-601)

## Acceptance Criteria

Re-purpose existing image metadata component in the Engine-Theme SDK to nest this component within the video implementation (Basically, Video caption looks just like the caption on Image and Gallery)

Display caption (Title, Caption, Credit) underneath video on Video Center Block, Lead Art Block and Article Body Chain

Title - Title in Video Center

Caption - Caption in Video Center

Credit - Credit in Video Center

For Lead Art block, hook into the existing Display Options:

Hide Title

Hide Caption

Hide Credit

Update the help text of each to include Videos (“This display option applies to Lead Art media types: Images, Gallery and Video”)

For Video Center Block, include Video Display Options:

Hide Title

Hide Caption

Hide Credit

For Article Body block, include Video Display Options (we can overwrite Video Settings since it’s empty):

Hide Title

Hide Caption

Hide Credit

Include help text: “This display option applies to all Videos in the Article Body.”

## Test Steps

1. Checkout this branch `git checkout TMEDIA-601-show-caption-video-options`
2. Ensure your engine theme sdk is linked via .env `ENGINE_SDK_REPO=/{your path}/engine-theme-sdk`
3. On the engine theme sdk, make sure this branch is checked out `TMEDIA-601-videos-caption`
4. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/lead-art-block,@wpmedia/video-player-block,@wpmedia/article-body-block`
5. See `after` below for showing the pages with default options as well as toggling them in editor 

## Effect Of Changes

### Before

- Article body block has no options for video display and does not show captions, etc
<img width="967" alt="Screen Shot 2022-03-09 at 15 12 48" src="https://user-images.githubusercontent.com/5950956/157536943-4a77657e-21a3-4ef9-9a88-1cd3141f8b35.png">

- lead art video player does not have caption, etc
<img width="879" alt="Screen Shot 2022-03-09 at 15 13 49" src="https://user-images.githubusercontent.com/5950956/157537063-eaf3e040-63ad-4f57-9d51-86328a8f0ec0.png">

- Video Center Player shows title above
<img width="879" alt="Screen Shot 2022-03-09 at 15 15 37" src="https://user-images.githubusercontent.com/5950956/157537285-5919c0b0-206a-4fc7-9b5c-cc7d87f40bb2.png">

### After

#### With default display options 

- Video Center Block 
![Screen Shot 2022-03-09 at 14 47 12](https://user-images.githubusercontent.com/5950956/157533142-61571fc9-828b-4bcb-95d7-4ebba3fb0dc9.png)
http://localhost/pf/demo-video-leaf-page/?_website=the-gazette 
- No caption on video yet it throws no errors 

- Article Body Block 
![Screen Shot 2022-03-09 at 14 48 50](https://user-images.githubusercontent.com/5950956/157533281-0ee98655-d4ea-43cc-8c19-74771135eb1a.png)
http://localhost/pf/kitchen-sink-article-jc/?_website=the-sun

- Lead Art Block with video 

-> Clone an article page with lead art. Then set the global content to be `K4BJO2CRQFCGXB6Z3KCCEKARDE`
https://corecomponents.arcpublishing.com/composer/edit/K4BJO2CRQFCGXB6Z3KCCEKARDE/ 
![Screen Shot 2022-03-09 at 14 52 17](https://user-images.githubusercontent.com/5950956/157533881-20dfa1db-b24b-4b1d-80cf-d4dfa8fe736a.png)

#### With toggling each display settings

- Video Center Player block 

<img width="970" alt="Screen Shot 2022-03-09 at 15 07 12" src="https://user-images.githubusercontent.com/5950956/157536223-0f16691b-8c2f-454b-846b-32b5bc07f272.png">

- Article body block 

- toggling the article body title for all videos within 
<img width="956" alt="Screen Shot 2022-03-09 at 15 09 04" src="https://user-images.githubusercontent.com/5950956/157536501-c49652c2-e314-48f1-bc16-6d3cb48e1171.png">
<img width="268" alt="Screen Shot 2022-03-09 at 15 09 54" src="https://user-images.githubusercontent.com/5950956/157536573-ff32de8d-5ab7-4657-bceb-4815c2c86298.png">

- Lead Art Block with video 

- Notice that the help desk is different from the others based on ac 
![Screen Shot 2022-03-09 at 14 54 33](https://user-images.githubusercontent.com/5950956/157534378-85d40a26-0ef0-401c-a96c-4c0030630539.png)

- With no options set, the spacing remains constant in engine theme sdk
![Screen Shot 2022-03-09 at 14 54 19](https://user-images.githubusercontent.com/5950956/157534383-db551117-8089-4a7f-bf54-f1c5b583e688.png)

- toggling different options 
![Screen Shot 2022-03-09 at 14 54 12](https://user-images.githubusercontent.com/5950956/157534443-2cd3bcbf-f42a-4221-8b48-35006216aad9.png)



## Dependencies or Side Effects

_Examples of dependencies or side effects are:_

- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
