### PR TITLE
TBRANDS-26: Single Column Layout

### DIFF
--- a/blocks/single-column-layout-block/README.md
+++ b/blocks/single-column-layout-block/README.md
@@ -1,0 +1,49 @@
+# @wpmedia/single-column-layout-block
+
+Basic single column layout with a standard confied width of 90rem(1440px) that has three Page Builder sections (navigation, main, and footer.)
+
+## Acceptance Criteria
+
+- When I create a new page in Page Builder Editor, I see a layout named “Single Column - Regular Width” nested within the Layout field drop down that lives under the Setup view.
+
+- When I select the “Single Column - Regular Width” layout, I see a notification that says: “Successfully updated the Shared Draft with your changes.”
+
+- Once the “Single Column - Regular Width” layout is updated, I can begin to add blocks under the Curate view which shows the following Sections:
+
+  - navigation (should behave the same as existing Right Rail layouts)
+
+  - main (should have a maximum width of 1440 px)
+
+  - footer (should behave the same as existing Right Rail layouts)
+
+- If I want to, I can deselect the “Single Column - Regular Width” layout block and when I do I see a notification that says: “Successfully updated the Shared Draft with your changes.”
+
+- The “Single Column - Regular Width” layout block has a maximum width of 1440 px.
+
+## Props
+
+No props necessary for the use of this block.
+
+## ANS Schema
+
+No schema information necessary for the use of this block.
+
+### ANS Fields
+
+No ANS fields necessary for the use of this block.
+
+## Internationalization fields
+
+No Internationalization fields necessary for the use of this block.
+
+## Events
+
+No events are defined for the use of this block.
+
+### Event Listening
+
+This block does not emit any events.
+
+## Additional Considerations
+
+No additional considerations.

--- a/blocks/single-column-layout-block/README.md
+++ b/blocks/single-column-layout-block/README.md
@@ -1,24 +1,6 @@
 # @wpmedia/single-column-layout-block
 
-Basic single column layout with a standard confined width of 90rem(1440px) that has three Page Builder sections (navigation, main, and footer.)
-
-## Acceptance Criteria
-
-- When I create a new page in Page Builder Editor, I see a layout named “Single Column - Regular Width” nested within the Layout field drop down that lives under the Setup view.
-
-- When I select the “Single Column - Regular Width” layout, I see a notification that says: “Successfully updated the Shared Draft with your changes.”
-
-- Once the “Single Column - Regular Width” layout is updated, I can begin to add blocks under the Curate view which shows the following Sections:
-
-  - navigation (should behave the same as existing Right Rail layouts)
-
-  - main (should have a maximum width of 1440 px)
-
-  - footer (should behave the same as existing Right Rail layouts)
-
-- If I want to, I can deselect the “Single Column - Regular Width” layout block and when I do I see a notification that says: “Successfully updated the Shared Draft with your changes.”
-
-- The “Single Column - Regular Width” layout block has a maximum width of 1440 px.
+Basic single column layout with a standard confined width of 90rem(1440px) that has three Page Builder sections (navigation, main, and footer).
 
 ## Props
 

--- a/blocks/single-column-layout-block/README.md
+++ b/blocks/single-column-layout-block/README.md
@@ -1,6 +1,6 @@
 # @wpmedia/single-column-layout-block
 
-Basic single column layout with a standard confied width of 90rem(1440px) that has three Page Builder sections (navigation, main, and footer.)
+Basic single column layout with a standard confined width of 90rem(1440px) that has three Page Builder sections (navigation, main, and footer.)
 
 ## Acceptance Criteria
 

--- a/blocks/single-column-layout-block/index.js
+++ b/blocks/single-column-layout-block/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/blocks/single-column-layout-block/jest.config.js
+++ b/blocks/single-column-layout-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest/jest.config.base");
+
+module.exports = {
+	...base,
+};

--- a/blocks/single-column-layout-block/layouts/.npmignore
+++ b/blocks/single-column-layout-block/layouts/.npmignore
@@ -1,0 +1,3 @@
+*.test.js
+*.test.jsx
+mock*.*

--- a/blocks/single-column-layout-block/layouts/single-column-regular/default.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/default.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import PropTypes from "@arc-fusion/prop-types";
+
+const LAYOUT_CLASS_NAME = "single-column-regular";
+
+const SingleColumnRegular = ({ children }) => {
+	const [navigation, main, footer] = React.Children.toArray(children);
+
+	return (
+		<>
+			{navigation ? <header className={`${LAYOUT_CLASS_NAME}-header`}>{navigation}</header> : null}
+			{main ? (
+				<section role="main" id="main" className={`${LAYOUT_CLASS_NAME}`} tabIndex="-1">
+					{main}
+				</section>
+			) : null}
+			{footer ? <footer className={`${LAYOUT_CLASS_NAME}-footer`}>{footer}</footer> : null}
+		</>
+	);
+};
+
+SingleColumnRegular.label = "Single Column Regular Width Layout - Arc Block";
+
+SingleColumnRegular.icon = "layout-none";
+
+SingleColumnRegular.propTypes = {
+	children: PropTypes.array,
+};
+
+SingleColumnRegular.sections = ["navigation", "main", "footer"];
+
+export default SingleColumnRegular;

--- a/blocks/single-column-layout-block/layouts/single-column-regular/default.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/default.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 
-const LAYOUT_CLASS_NAME = "single-column-regular";
+const LAYOUT_CLASS_NAME = "b-single-column-regular";
 
 const SingleColumnRegular = ({ children }) => {
 	const [navigation, main, footer] = React.Children.toArray(children);

--- a/blocks/single-column-layout-block/layouts/single-column-regular/default.test.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/default.test.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { mount } from "enzyme";
+import SingleColumnRegular from "./default";
+
+const testText = "Single Column Regular Layout";
+
+describe("Single Column Regular Layout", () => {
+	describe("when it is first rendered", () => {
+		it("should render a header when the first child is provided", () => {
+			const wrapper = mount(
+				<SingleColumnRegular>
+					<h1>{testText}</h1>
+				</SingleColumnRegular>
+			);
+			expect(wrapper.find("header h1").html()).toBe(`<h1>${testText}</h1>`);
+			expect(wrapper.find("section")).not.toExist();
+			expect(wrapper.find("footer")).not.toExist();
+		});
+
+		it("should render a header and main content when two children are provided", () => {
+			const wrapper = mount(
+				<SingleColumnRegular>
+					<></>
+					<p>{testText}</p>
+				</SingleColumnRegular>
+			);
+			expect(wrapper.find("header")).toExist();
+			expect(wrapper.find("section p").html()).toBe(`<p>${testText}</p>`);
+			expect(wrapper.find("footer")).not.toExist();
+		});
+
+		it("should render a footer when three children are provided", () => {
+			const wrapper = mount(
+				<SingleColumnRegular>
+					<></>
+					<></>
+					<div>{testText}</div>
+				</SingleColumnRegular>
+			);
+			expect(wrapper.find("header")).toExist();
+			expect(wrapper.find("section")).toExist();
+			expect(wrapper.find("footer div").html()).toBe(`<div>${testText}</div>`);
+		});
+
+		it("should render null when null is the child", () => {
+			const wrapper = mount(<SingleColumnRegular>{null}</SingleColumnRegular>);
+
+			expect(wrapper.text()).toBe("");
+			expect(wrapper.html()).toBe(null);
+		});
+
+		it("should render null when no child", () => {
+			const wrapper = mount(<SingleColumnRegular />);
+
+			expect(wrapper.text()).toBe("");
+			expect(wrapper.html()).toBe(null);
+		});
+	});
+});

--- a/blocks/single-column-layout-block/layouts/single-column-regular/default.test.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/default.test.jsx
@@ -1,59 +1,51 @@
 import React from "react";
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+
 import SingleColumnRegular from "./default";
 
 const testText = "Single Column Regular Layout";
 
 describe("Single Column Regular Layout", () => {
 	describe("when it is first rendered", () => {
-		it("should render a header when the first child is provided", () => {
-			const wrapper = mount(
+		it("should render the content in the heading when the first child is provided", () => {
+			render(
 				<SingleColumnRegular>
 					<h1>{testText}</h1>
 				</SingleColumnRegular>
 			);
-			expect(wrapper.find("header h1").html()).toBe(`<h1>${testText}</h1>`);
-			expect(wrapper.find("section")).not.toExist();
-			expect(wrapper.find("footer")).not.toExist();
+			expect(screen.getByRole("heading")).toHaveTextContent(testText);
 		});
 
-		it("should render a header and main content when two children are provided", () => {
-			const wrapper = mount(
+		it("should render content into the main when two children are provided", () => {
+			render(
 				<SingleColumnRegular>
 					<></>
 					<p>{testText}</p>
 				</SingleColumnRegular>
 			);
-			expect(wrapper.find("header")).toExist();
-			expect(wrapper.find("section p").html()).toBe(`<p>${testText}</p>`);
-			expect(wrapper.find("footer")).not.toExist();
+			expect(screen.getByRole("main")).toHaveTextContent(testText);
 		});
 
-		it("should render a footer when three children are provided", () => {
-			const wrapper = mount(
+		it("should render a content into the contentinfo (footer) when three children are provided", () => {
+			render(
 				<SingleColumnRegular>
 					<></>
 					<></>
 					<div>{testText}</div>
 				</SingleColumnRegular>
 			);
-			expect(wrapper.find("header")).toExist();
-			expect(wrapper.find("section")).toExist();
-			expect(wrapper.find("footer div").html()).toBe(`<div>${testText}</div>`);
+			expect(screen.getByRole("contentinfo")).toHaveTextContent(testText);
 		});
 
 		it("should render null when null is the child", () => {
-			const wrapper = mount(<SingleColumnRegular>{null}</SingleColumnRegular>);
-
-			expect(wrapper.text()).toBe("");
-			expect(wrapper.html()).toBe(null);
+			render(<SingleColumnRegular>{null}</SingleColumnRegular>);
+			expect(screen.queryByText(testText)).not.toBeInTheDocument();
 		});
 
 		it("should render null when no child", () => {
-			const wrapper = mount(<SingleColumnRegular />);
-
-			expect(wrapper.text()).toBe("");
-			expect(wrapper.html()).toBe(null);
+			render(<SingleColumnRegular />);
+			expect(screen.queryByText(testText)).not.toBeInTheDocument();
 		});
 	});
 });

--- a/blocks/single-column-layout-block/layouts/single-column-regular/default.test.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/default.test.jsx
@@ -39,13 +39,13 @@ describe("Single Column Regular Layout", () => {
 		});
 
 		it("should render null when null is the child", () => {
-			render(<SingleColumnRegular>{null}</SingleColumnRegular>);
-			expect(screen.queryByText(testText)).not.toBeInTheDocument();
+			const { container } = render(<SingleColumnRegular>{null}</SingleColumnRegular>);
+			expect(container).toBeEmptyDOMElement();
 		});
 
 		it("should render null when no child", () => {
-			render(<SingleColumnRegular />);
-			expect(screen.queryByText(testText)).not.toBeInTheDocument();
+			const { container } = render(<SingleColumnRegular />);
+			expect(container).toBeEmptyDOMElement();
 		});
 	});
 });

--- a/blocks/single-column-layout-block/layouts/single-column-regular/index.story.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/index.story.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import SingleColumnRegularLayout from "./default";
+
+export default {
+	title: "Layouts/Single Column Regular Layout",
+	parameters: {
+		chromatic: { viewports: [320, 768, 1600] },
+	},
+};
+
+// some styling to make the appearance more apparent
+
+const styles = {
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	height: "15vh",
+	backgroundColor: "rgb(240 240 240)",
+	border: "1px solid rgb(200, 200, 200)",
+};
+
+// with enhanced styling not being active,
+// we need to manually define these styles for the content items.
+// - from styles.scss
+
+const styles2 = {
+	...styles,
+	maxWidth: "90rem",
+	margin: "auto",
+};
+
+const Navigation = () => <div style={styles}>Navigation</div>;
+const Comp1 = () => <div style={styles2}>1</div>;
+const Comp2 = () => <div style={styles2}>2</div>;
+const Footer = () => <div style={styles}>Footer</div>;
+
+export const layoutWithOneChild = () => (
+	<SingleColumnRegularLayout>
+		<Navigation />
+		<>
+			<Comp1 />
+		</>
+		<Footer />
+	</SingleColumnRegularLayout>
+);
+
+export const layoutWithTwoChildren = () => (
+	<SingleColumnRegularLayout>
+		<Navigation />
+		<>
+			<Comp1 />
+			<Comp2 />
+		</>
+		<Footer />
+	</SingleColumnRegularLayout>
+);

--- a/blocks/single-column-layout-block/layouts/single-column-regular/index.story.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/index.story.jsx
@@ -30,15 +30,14 @@ const styles2 = {
 };
 
 const Navigation = () => <div style={styles}>Navigation</div>;
-const Comp1 = () => <div style={styles2}>1</div>;
-const Comp2 = () => <div style={styles2}>2</div>;
+const Component = ({ children }) => <div style={styles2}>{children}</div>;
 const Footer = () => <div style={styles}>Footer</div>;
 
 export const layoutWithOneChild = () => (
 	<SingleColumnRegularLayout>
 		<Navigation />
 		<>
-			<Comp1 />
+			<Component>Main 1</Component>
 		</>
 		<Footer />
 	</SingleColumnRegularLayout>
@@ -48,8 +47,8 @@ export const layoutWithTwoChildren = () => (
 	<SingleColumnRegularLayout>
 		<Navigation />
 		<>
-			<Comp1 />
-			<Comp2 />
+			<Component>Main 1</Component>
+			<Component>Main 2</Component>
 		</>
 		<Footer />
 	</SingleColumnRegularLayout>

--- a/blocks/single-column-layout-block/layouts/single-column-regular/styles.scss
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/styles.scss
@@ -1,0 +1,13 @@
+@use '@wpmedia/arc-themes-components/scss';
+
+.single-column-regular-header {
+	@include scss.block-properties("single-column-regular-header");
+}
+.single-column-regular {
+	max-width: 90rem; // 1440px
+	margin: auto;
+	@include scss.block-properties("single-column-regular");
+}
+.single-column-regular-footer {
+	@include scss.block-properties("single-column-regular-footer");
+}

--- a/blocks/single-column-layout-block/layouts/single-column-regular/styles.scss
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/styles.scss
@@ -1,13 +1,15 @@
-@use '@wpmedia/arc-themes-components/scss';
+@use "@wpmedia/arc-themes-components/scss";
 
 .single-column-regular-header {
 	@include scss.block-properties("single-column-regular-header");
 }
+
 .single-column-regular {
 	max-width: 90rem; // 1440px
 	margin: auto;
 	@include scss.block-properties("single-column-regular");
 }
+
 .single-column-regular-footer {
 	@include scss.block-properties("single-column-regular-footer");
 }

--- a/blocks/single-column-layout-block/layouts/single-column-regular/styles.scss
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/styles.scss
@@ -5,6 +5,7 @@
 }
 
 .b-single-column-regular {
+	/* stylelint-disable order/order */
 	max-width: 90rem; // 1440px
 	margin: auto;
 	@include scss.block-properties("single-column-regular");

--- a/blocks/single-column-layout-block/layouts/single-column-regular/styles.scss
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/styles.scss
@@ -1,15 +1,15 @@
 @use "@wpmedia/arc-themes-components/scss";
 
-.single-column-regular-header {
+.b-single-column-regular-header {
 	@include scss.block-properties("single-column-regular-header");
 }
 
-.single-column-regular {
+.b-single-column-regular {
 	max-width: 90rem; // 1440px
 	margin: auto;
 	@include scss.block-properties("single-column-regular");
 }
 
-.single-column-regular-footer {
+.b-single-column-regular-footer {
 	@include scss.block-properties("single-column-regular-footer");
 }

--- a/blocks/single-column-layout-block/package.json
+++ b/blocks/single-column-layout-block/package.json
@@ -6,7 +6,7 @@
   "license": "CC-BY-NC-ND-4.0",
   "main": "index.js",
   "files": [
-    "chains",
+    "layouts",
     "intl.json"
   ],
   "publishConfig": {

--- a/blocks/single-column-layout-block/package.json
+++ b/blocks/single-column-layout-block/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@wpmedia/single-column-layout-block",
+  "version": "0.1.0",
+  "description": "Single Column Layout Block",
+  "homepage": "https://github.com/WPMedia/arc-themes-blocks",
+  "license": "CC-BY-NC-ND-4.0",
+  "main": "index.js",
+  "files": [
+    "chains",
+    "intl.json"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+    "directory": "blocks/single-column-layout-block"
+  },
+  "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9317,7 +9317,7 @@
     "@wpmedia/collections-content-source-block": {
       "version": "file:blocks/collections-content-source-block",
       "requires": {
-        "axios": "^0.24.0"
+        "axios": "^0.26.0"
       },
       "dependencies": {
         "axios": {
@@ -9524,6 +9524,9 @@
     },
     "@wpmedia/single-chain-block": {
       "version": "file:blocks/single-chain-block"
+    },
+    "@wpmedia/single-column-layout-block": {
+      "version": "file:blocks/single-column-layout-block"
     },
     "@wpmedia/site-hierarchy-content-block": {
       "version": "file:blocks/site-hierarchy-content-block"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@wpmedia/shared-styles": "file:blocks/shared-styles",
     "@wpmedia/simple-list-block": "file:blocks/simple-list-block",
     "@wpmedia/single-chain-block": "file:blocks/single-chain-block",
-    "@wpmedia/single-column-layout-block": "file:blocks/single-column-layout-block",
+    "@wpmedia/single-column-layout-block@local": "file:blocks/single-column-layout-block",
     "@wpmedia/site-hierarchy-content-block": "file:blocks/site-hierarchy-content-block",
     "@wpmedia/small-manual-promo-block": "file:blocks/small-manual-promo-block",
     "@wpmedia/small-promo-block": "file:blocks/small-promo-block",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@wpmedia/shared-styles": "file:blocks/shared-styles",
     "@wpmedia/simple-list-block": "file:blocks/simple-list-block",
     "@wpmedia/single-chain-block": "file:blocks/single-chain-block",
-    "@wpmedia/single-column-layout-block@local": "file:blocks/single-column-layout-block",
+    "@wpmedia/single-column-layout-block": "file:blocks/single-column-layout-block",
     "@wpmedia/site-hierarchy-content-block": "file:blocks/site-hierarchy-content-block",
     "@wpmedia/small-manual-promo-block": "file:blocks/small-manual-promo-block",
     "@wpmedia/small-promo-block": "file:blocks/small-promo-block",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "@wpmedia/shared-styles": "file:blocks/shared-styles",
     "@wpmedia/simple-list-block": "file:blocks/simple-list-block",
     "@wpmedia/single-chain-block": "file:blocks/single-chain-block",
+    "@wpmedia/single-column-layout-block": "file:blocks/single-column-layout-block",
     "@wpmedia/site-hierarchy-content-block": "file:blocks/site-hierarchy-content-block",
     "@wpmedia/small-manual-promo-block": "file:blocks/small-manual-promo-block",
     "@wpmedia/small-promo-block": "file:blocks/small-promo-block",


### PR DESCRIPTION
## Description
Single Column Layout

## Jira Ticket

- [TBRANDS-26](https://arcpublishing.atlassian.net/browse/TBRANDS-26)

## Acceptance Criteria

1. When I create a new page in Page Builder Editor, I see a layout named “Single Column - Regular Width” nested within the Layout field drop down that lives under the Setup view.
2. When I select the “Single Column - Regular Width” layout, I see a notification that says: “Successfully updated the Shared Draft with your changes.”
3. Once the “Single Column - Regular Width” layout is updated, I can begin to add blocks under the Curate view which shows the following Sections:
    - navigation (should behave the same as existing Right Rail layouts)
    - main (should have a maximum width of 1440 px)
    - footer (should behave the same as existing Right Rail layouts)
4. If I want to, I can deselect the “Single Column - Regular Width” layout block and when I do I see a notification that says: “Successfully updated the Shared Draft with your changes.”
5. The “Single Column - Regular Width” layout block has a maximum width of 1440 px.

## Test Steps

1. Checkout this branch `git checkout TBRANDS-26-single-column-layout`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/single-column-layout-block`
3. Update `arc-themes-feature-pack/blocks.json` and add `"@wpmedia/single-column-layout-block@local",` to the `blocks` array.
![image](https://user-images.githubusercontent.com/2287238/157904913-4fff9db7-8e84-46ec-8a40-1a5db45d6e70.png)
4. Open local pagebuilder and modify an existing page or create a new page to set the layout to `Single Column Regular Width Layout - Arc Block`
![image](https://user-images.githubusercontent.com/2287238/157905053-b95e44c3-a565-49ce-b989-9604e0b40a64.png)
5. Verify the sections on the curate tab:
![image](https://user-images.githubusercontent.com/2287238/157905262-ea25a7cd-24c3-4c99-b0c1-7f93244e561f.png)
6.  Run local storybook: 'npm run storybook' and validate layout exists with docs

## Dependencies or Side Effects

- Update `arc-themes-feature-pack/blocks.json` and add `"@wpmedia/single-column-layout-block@local",` to the `blocks` array.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
