### PR TITLE
Storybook updates for components loading

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -32,26 +32,33 @@ module.exports = {
 			},
 		};
 
-		config.module.rules.push({
-			test: /\.scss$/,
-			use: [
-				"style-loader",
-				"css-loader",
-				{
-					loader: "sass-loader",
-					options: {
-						prependData: () => `
+		config.module.rules.push(
+			{
+				test: /\.scss$/,
+				use: [
+					"style-loader",
+					"css-loader",
+					{
+						loader: "sass-loader",
+						options: {
+							prependData: () => `
               @import '~@wpmedia/news-theme-css/scss';
 
               // Should look for a better way to do this ->
               // This should be defaulted in the news-theme-css repo too!
               $theme-primary-font-family: $primary-font-family !default;
             `,
+						},
 					},
-				},
-			],
-			include: path.resolve(__dirname, "../"),
-		});
+				],
+				include: path.resolve(__dirname, "../"),
+			},
+			{
+				test: /\.(js|jsx)$/,
+				include: path.resolve(__dirname, "../node_modules/@wpmedia/arc-themes-components"),
+				use: ["babel-loader"],
+			}
+		);
 
 		// Return the altered config
 		return config;

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -2,5 +2,5 @@ import { addons } from "@storybook/addons";
 import arcTheme from "./arcTheme";
 
 addons.setConfig({
-	thene: arcTheme,
+	theme: arcTheme,
 });

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,15 +1,6 @@
 import { addons } from "@storybook/addons";
-import { addParameters } from "@storybook/react";
 import arcTheme from "./arcTheme";
 
-// Sort stories alphabetically
-addParameters({
-	options: {
-		storySort: (a, b) =>
-			a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
-	},
-});
-
 addons.setConfig({
-	theme: arcTheme,
+	thene: arcTheme,
 });


### PR DESCRIPTION
## Description

The `arc-themes-components` are distributed as is - they are compiled before being package. The current expectation is PageBuilder Engine's WebPack handles the compilation via Babel. In order to update the blocks on to the v2 architecture we will need to import the components into blocks, and in doing so storybook needs to compile the components via babel

## Test Steps

1. Checkout this branch `git checkout storybook-updates-for-components-loading`
2. Run `npm i`
3. Run `npm run storybook`
4. Update any block that has a storybook file to import and use an arc-themes-component and validate the story still works in storybook

```jsx
// import Link from "./_children/link";
import { Link } from "@wpmedia/arc-themes-components";

```


change ->
```jsx
<Link href={item.url} name={item.display_name} />
) : (
	<Link href={item._id} name={item.name} />
)}
```

to be

```jsx
<Link href={item.url} name={item.display_name}>
	{item.display_name}
	</Link>
) : (
<Link href={item._id} name={item.name}>
	{item.name}
</Link>
```

Validate story still shows link -> http://localhost:60001/?path=/story/blocks-links-bar--one-link

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
