### PR TITLE
WIP Tmedia 701 raw html static

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -5,6 +5,7 @@ import Consumer from "fusion:consumer";
 import getThemeStyle from "fusion:themes";
 import getProperties from "fusion:properties";
 import getTranslatedPhrases from "fusion:intl";
+import Static from "fusion:static";
 import {
 	Gallery,
 	ImageMetadata,
@@ -118,7 +119,12 @@ class LeadArt extends Component {
 
 				return (
 					<div className="lead-art-wrapper">
-						<div className="inner-content" dangerouslySetInnerHTML={{ __html: lead_art.content }} />
+						<Static id={lead_art._id}>
+							<div
+								className="inner-content"
+								dangerouslySetInnerHTML={{ __html: lead_art.content }}
+							/>
+						</Static>
 						{lightbox}
 					</div>
 				);


### PR DESCRIPTION
# Questions 

- Is putting a script tag around console.log the best way to test this? may need to cause a state change like with the image lightbox open and close to ensure this is properly not re-rendering. 
- it looks like there's a mainContent that goes into the Lightbox in engine theme sdk. Then there's also a dangerously set html there as well? Might need to investigate more how that works. 
- I'm assuming then that this will be merged in 1.2 as well?

## Description

Use static for lead art raw html

## Jira Ticket

- [TMEDIA-701](https://arcpublishing.atlassian.net/browse/TMEDIA-701)

## Acceptance Criteria

When a component is outputted on a page, fusion may re-render it a few times as state changes. For an HTML block, we don't want that and want React to ignore it.

## Test Steps

1. Checkout this branch `git checkout TMEDIA-701-raw-html-static`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/lead-art-block`
3. Pull down the story with raw html and a script tag in the lead art https://corecomponents.arcpublishing.com/composer/edit/VX2JWE3AFRBXXIR74Z3UICUGBU/
4. See the rendering logged to the console

## Effect Of Changes

### Before

_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After

_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects

_Examples of dependencies or side effects are:_

- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
