### PR TITLE
TMEDIA 708: Use subs subtitle rather than duplicating title

### DIFF
--- a/blocks/subscriptions-block/components/useOffer.test.jsx
+++ b/blocks/subscriptions-block/components/useOffer.test.jsx
@@ -165,6 +165,22 @@ it("useOffer hook runs correctly", async () => {
 	expect(container.textContent).toBe("Default subscription");
 });
 
+it("use offer uses fallback default string", async () => {
+	act(() => {
+		render(
+			<TestOfferComponent
+				code={{
+					campaignCode: "",
+				}}
+			/>,
+			container
+		);
+	});
+	expect(container.textContent).toBe("Fetching");
+	await act(() => sleep(500));
+	expect(container.textContent).toBe("Default subscription");
+});
+
 it("useOffer hook handles an error state during fetch", async () => {
 	global.fetch = jest.fn(() => Promise.reject(new Error("Error #2")));
 

--- a/blocks/subscriptions-block/features/offer/default.jsx
+++ b/blocks/subscriptions-block/features/offer/default.jsx
@@ -44,7 +44,7 @@ const Offer = ({ customFields }) => {
 				<>
 					<div className="xpmedia-subscription-offer-headings">
 						<PrimaryFont dangerouslySetInnerHTML={{ __html: offer.pageTitle }} as="h1" />
-						<SecondaryFont dangerouslySetInnerHTML={{ __html: offer.pageTitle }} as="h2" />
+						<SecondaryFont dangerouslySetInnerHTML={{ __html: offer.pageSubTitle }} as="h2" />
 					</div>
 
 					<div className="margin-md-top">

--- a/blocks/subscriptions-block/features/offer/default.test.jsx
+++ b/blocks/subscriptions-block/features/offer/default.test.jsx
@@ -3,7 +3,6 @@ import { mount } from "enzyme";
 import { isServerSide } from "@wpmedia/engine-theme-sdk";
 import Offer from "./default";
 import useOffer from "../../components/useOffer";
-import OfferCard from "../../components/OfferCard";
 
 jest.mock("@wpmedia/engine-theme-sdk", () => ({
 	...jest.requireActual("@wpmedia/engine-theme-sdk"),
@@ -210,7 +209,7 @@ describe("The Offer feature", () => {
 			/>
 		);
 
-		expect(wrapper.find(OfferCard)).toHaveLength(4);
+		expect(wrapper.find("div.xpmedia-subscription-offer-card")).toHaveLength(4);
 	});
 	it("renders sub-headline and subheadline", () => {
 		const wrapper = mount(
@@ -242,7 +241,7 @@ describe("The Offer feature", () => {
 		);
 
 		expect(wrapper.html()).not.toBeNull();
-		expect(wrapper.find(OfferCard)).toHaveLength(4);
+		expect(wrapper.find("div.xpmedia-subscription-offer-card")).toHaveLength(4);
 	});
 	it("is fetching and does not return offers", () => {
 		useOffer.mockReturnValue({
@@ -261,7 +260,7 @@ describe("The Offer feature", () => {
 			/>
 		);
 
-		expect(wrapper.find(OfferCard)).toHaveLength(0);
+		expect(wrapper.find("div.xpmedia-subscription-offer-card")).toHaveLength(0);
 		expect(wrapper.find(".xpmedia-subscription-offer-headings")).toHaveLength(0);
 	});
 	it("returns null on serverside", () => {

--- a/blocks/subscriptions-block/features/offer/default.test.jsx
+++ b/blocks/subscriptions-block/features/offer/default.test.jsx
@@ -25,7 +25,7 @@ const sampleOffer = {
 			canRenew: true,
 			canRestart: true,
 			canStart: true,
-			name: "allaccesfffs",
+			name: "allaccess",
 			validFrom: 1632146400000,
 			validUntil: null,
 		},

--- a/blocks/subscriptions-block/features/offer/default.test.jsx
+++ b/blocks/subscriptions-block/features/offer/default.test.jsx
@@ -4,6 +4,9 @@ import { isServerSide } from "@wpmedia/engine-theme-sdk";
 import Offer from "./default";
 import useOffer from "../../components/useOffer";
 
+jest.spyOn(URLSearchParams.prototype, "get").mockReturnValue("some value");
+jest.spyOn(URLSearchParams.prototype, "has").mockReturnValue(false);
+
 jest.mock("@wpmedia/engine-theme-sdk", () => ({
 	...jest.requireActual("@wpmedia/engine-theme-sdk"),
 	isServerSide: jest.fn(),
@@ -242,6 +245,20 @@ describe("The Offer feature", () => {
 
 		expect(wrapper.html()).not.toBeNull();
 		expect(wrapper.find("div.xpmedia-subscription-offer-card")).toHaveLength(4);
+	});
+	it("uses the fallback campaign code if url params does not have campaign present", () => {
+		jest.spyOn(URLSearchParams.prototype, "has").mockReturnValueOnce(true);
+
+		const wrapper = mount(
+			<Offer
+				customFields={{
+					loginURL: "/login/",
+					checkoutURL: "/checkout/",
+				}}
+			/>
+		);
+
+		expect(wrapper.html()).not.toBeNull();
 	});
 	it("is fetching and does not return offers", () => {
 		useOffer.mockReturnValue({


### PR DESCRIPTION
## Description

Use subheadline data not headline data

## Jira Ticket

- [TMEDIA-708](https://arcpublishing.atlassian.net/browse/TMEDIA-708)

## Acceptance Criteria
Actual Behavior
Subheadline is displaying the headline text.

Expected Behavior
Subheadline should be displaying the subheadline text.
## Test Steps

1. Checkout this branch `git checkout TMEDIA-708-sub-headline-subs`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/subscriptions-block`
3. Create page with an Offer on it
4. See data not duplicated 

<img width="1050" alt="Screen Shot 2022-03-21 at 14 49 20" src="https://user-images.githubusercontent.com/5950956/159352724-f0d4d84a-de59-4641-aafe-5999478c8e4a.png">
<img width="1226" alt="Screen Shot 2022-03-21 at 14 48 30" src="https://user-images.githubusercontent.com/5950956/159352740-854f104c-8d0f-4a4a-bf0d-781cf8e73927.png">


## Effect Of Changes

### Before

dup headlines
<img width="803" alt="Screen Shot 2022-03-21 at 14 53 32" src="https://user-images.githubusercontent.com/5950956/159353214-3ef43ada-224f-4d73-9154-18a9032cc921.png">

### After
<img width="1226" alt="Screen Shot 2022-03-21 at 14 48 30" src="https://user-images.githubusercontent.com/5950956/159353239-eb1a1193-94df-41b1-9a54-7fe47620f2e2.png">



## Dependencies or Side Effects

- none

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
