### PR TITLE
Tmedia 701 raw html static

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -141,6 +141,12 @@ class LeadArt extends Component {
 						customFields={{
 							playthrough: !!customFields?.playthrough,
 						}}
+						displayTitle={!hideTitle}
+						displayCaption={!hideCaption}
+						displayCredits={!hideCredits}
+						subtitle={lead_art?.headlines?.basic}
+						caption={lead_art?.description?.basic}
+						credits={lead_art.credits}
 					/>
 				);
 			}
@@ -260,19 +266,22 @@ LeadArt.propTypes = {
 		}),
 		...videoPlayerCustomFields(),
 		hideTitle: PropTypes.bool.tag({
-			description: "This display option applies to Lead Art media types: Images and Gallery",
+			description:
+				"This display option applies to Lead Art media types: Images, Gallery, and Video",
 			label: "Hide Title",
 			defaultValue: false,
 			group: "Display Options",
 		}),
 		hideCaption: PropTypes.bool.tag({
-			description: "This display option applies to Lead Art media types: Images and Gallery",
+			description:
+				"This display option applies to Lead Art media types: Images, Gallery, and Video",
 			label: "Hide Caption",
 			defaultValue: false,
 			group: "Display Options",
 		}),
 		hideCredits: PropTypes.bool.tag({
-			description: "This display option applies to Lead Art media types: Images and Gallery",
+			description:
+				"This display option applies to Lead Art media types: Images, Gallery, and Video",
 			label: "Hide Credits",
 			defaultValue: false,
 			group: "Display Options",

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -99,24 +99,6 @@ class LeadArt extends Component {
 			let caption = null;
 
 			if (lead_art.type === "raw_html") {
-				// this could be figure and figcaption, a react component
-				const mainContent = (
-					<>
-						<div dangerouslySetInnerHTML={{ __html: lead_art.content }} />
-					</>
-				);
-				lightbox = (
-					<>
-						{isOpen && (
-							<Lightbox
-								mainSrc={mainContent}
-								onCloseRequest={this.setIsOpenToFalse}
-								showImageCaption={false}
-							/>
-						)}
-					</>
-				);
-
 				return (
 					<div className="lead-art-wrapper">
 						<Static id={lead_art._id}>
@@ -125,7 +107,6 @@ class LeadArt extends Component {
 								dangerouslySetInnerHTML={{ __html: lead_art.content }}
 							/>
 						</Static>
-						{lightbox}
 					</div>
 				);
 			}

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -5,6 +5,7 @@ import Consumer from "fusion:consumer";
 import getThemeStyle from "fusion:themes";
 import getProperties from "fusion:properties";
 import getTranslatedPhrases from "fusion:intl";
+import Static from "fusion:static";
 import {
 	Gallery,
 	ImageMetadata,
@@ -118,7 +119,12 @@ class LeadArt extends Component {
 
 				return (
 					<div className="lead-art-wrapper">
-						<div className="inner-content" dangerouslySetInnerHTML={{ __html: lead_art.content }} />
+						<Static id={lead_art._id}>
+							<div
+								className="inner-content"
+								dangerouslySetInnerHTML={{ __html: lead_art.content }}
+							/>
+						</Static>
 						{lightbox}
 					</div>
 				);
@@ -135,12 +141,6 @@ class LeadArt extends Component {
 						customFields={{
 							playthrough: !!customFields?.playthrough,
 						}}
-						displayTitle={!hideTitle}
-						displayCaption={!hideCaption}
-						displayCredits={!hideCredits}
-						subtitle={lead_art?.headlines?.basic}
-						caption={lead_art?.description?.basic}
-						credits={lead_art.credits}
 					/>
 				);
 			}
@@ -260,22 +260,19 @@ LeadArt.propTypes = {
 		}),
 		...videoPlayerCustomFields(),
 		hideTitle: PropTypes.bool.tag({
-			description:
-				"This display option applies to Lead Art media types: Images, Gallery, and Video",
+			description: "This display option applies to Lead Art media types: Images and Gallery",
 			label: "Hide Title",
 			defaultValue: false,
 			group: "Display Options",
 		}),
 		hideCaption: PropTypes.bool.tag({
-			description:
-				"This display option applies to Lead Art media types: Images, Gallery, and Video",
+			description: "This display option applies to Lead Art media types: Images and Gallery",
 			label: "Hide Caption",
 			defaultValue: false,
 			group: "Display Options",
 		}),
 		hideCredits: PropTypes.bool.tag({
-			description:
-				"This display option applies to Lead Art media types: Images, Gallery, and Video",
+			description: "This display option applies to Lead Art media types: Images and Gallery",
 			label: "Hide Credits",
 			defaultValue: false,
 			group: "Display Options",

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -37,21 +37,6 @@ describe("LeadArt", () => {
 		expect(wrapper.find(".lead-art-wrapper").length).toEqual(1);
 	});
 
-	it("renders html lead art type lightbox if button pos is not hidden", () => {
-		const globalContent = {
-			promo_items: {
-				basic: {
-					type: "raw_html",
-				},
-			},
-		};
-
-		const wrapper = shallow(<LeadArt arcSite="the-sun" globalContent={globalContent} />);
-		wrapper.setState({ buttonPosition: "true", isOpen: true });
-		wrapper.update();
-		expect(wrapper.find("ReactImageLightbox").length).toEqual(1);
-	});
-
 	it("renders video lead art type without playthrough", () => {
 		const globalContent = {
 			promo_items: {


### PR DESCRIPTION
## Description

Use static for lead art raw html

- NOTE: Article body chain already uses static so this work was deferred for using raw_html https://github.com/WPMedia/arc-themes-blocks/blob/arc-themes-release-version-1.20/blocks/article-body-block/chains/article-body/default.jsx#L204 https://github.com/WPMedia/arc-themes-blocks/blob/arc-themes-release-version-1.20/blocks/article-body-block/chains/article-body/_children/html.jsx#L13

## Jira Ticket

- [TMEDIA-701](https://arcpublishing.atlassian.net/browse/TMEDIA-701)

## Acceptance Criteria

When a component is outputted on a page, fusion may re-render it a few times as state changes. For an HTML block, we don't want that and want React to ignore it.

## Test Steps

1. Checkout this branch `git checkout TMEDIA-701-raw-html-static`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/lead-art-block`
3. Pull down the story with raw html and a script tag in the lead art https://corecomponents.arcpublishing.com/composer/edit/VX2JWE3AFRBXXIR74Z3UICUGBU/
4. Create a page with the lead art block within an article body chain
5. Set the content source to be content-api with the id `VX2JWE3AFRBXXIR74Z3UICUGBU` 
6. Publish the page 
7. See the fusion static tags around the content. A unique id to the client- and server-side is also present
<img width="1440" alt="Screen Shot 2022-03-22 at 15 53 42" src="https://user-images.githubusercontent.com/5950956/159574399-39e0bbaf-1f93-4a4e-ad67-e8fea1f79a7b.png">
8. Validate in storybook that the html still renders as expected under lead art
<img width="578" alt="Screen Shot 2022-03-22 at 15 58 51" src="https://user-images.githubusercontent.com/5950956/159574936-faf925ac-b1db-43f3-8add-11cccf1960c9.png">

# Questions Answered

- Is putting a script tag around console.log the best way to test this? may need to cause a state change like with the image lightbox open and close to ensure this is properly not re-rendering. -> eh it's complicated. ensure that the fusion tags for static surround the content
- it looks like there's a mainContent that goes into the Lightbox in engine theme sdk. Then there's also a dangerously set html there as well? Might need to investigate more how that works.  -> not used in raw html
- I'm assuming then that this will be merged in 1.2 as well? -> yes

## Effect Of Changes

### Before

The html within was not using fusion static and could re-render 

### After

Based on using static with engine, the content inside the static tag will not re-render

## Dependencies or Side Effects
- Removed unreachable code with the lightbox and raw html

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
