### PR TITLE
TMEDIA-601 - Blank Strings fix

### DIFF
--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -56,14 +56,14 @@ function getFetchedPassedOrInheritedTitleDescriptionCaption(
 
 	// since credits can't be passed in, the fallback is to use the fetched data
 	if (inheritGlobalContent) {
-		credits = globalContent?.credits || {};
+		credits = globalContent?.credits || null;
 	} else {
-		credits = fetchedData?.credits || {};
+		credits = fetchedData?.credits || null;
 	}
 
 	return {
-		headlineBasic: headlineBasic || "",
-		descriptionBasic: descriptionBasic || "",
+		headlineBasic: headlineBasic || null,
+		descriptionBasic: descriptionBasic || null,
 		credits,
 	};
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9317,7 +9317,7 @@
     "@wpmedia/collections-content-source-block": {
       "version": "file:blocks/collections-content-source-block",
       "requires": {
-        "axios": "^0.24.0"
+        "axios": "^0.26.0"
       },
       "dependencies": {
         "axios": {
@@ -9348,9 +9348,9 @@
       "version": "file:blocks/double-chain-block"
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.12.8-arc-themes-release-version-1-20.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.12.8-arc-themes-release-version-1-20.0/61df28278009cfe3ba20ff5b7bc4c9bf2da86f390fff91f7ad46a5792f52288b",
-      "integrity": "sha512-0Ip7Hu0VpspqnEiodaOhpTrzw2aLiT2Q/TO3KWWW9bIH8twAoBuZqLvv1cXVSNy0x4O80OsliAuMGvoeE0Dmjg==",
+      "version": "2.12.8-arc-themes-release-version-1-20.4",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.12.8-arc-themes-release-version-1-20.4/90b83f09283be9f703d6b207be6fd7e8e95fd4a736fc585f29e6cb53626fb844",
+      "integrity": "sha512-jJeYLUFF9loqqQl38/wXyCgkfwsG5KqdI2M9PyZFjLlSAEHJkHme/e+tSl+m2MajhczocywzVsj2Sic8kqIw+w==",
       "dev": true,
       "requires": {
         "@arc-fusion/prop-types": "^0.1.5",
@@ -27220,9 +27220,9 @@
       }
     },
     "react-swipeable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-6.2.0.tgz",
-      "integrity": "sha512-nWQ8dEM8e/uswZLSIkXUsAnQmnX4MTcryOHBQIQYRMJFDpgDBSiVbKsz/BZVCIScF4NtJh16oyxwaNOepR6xSw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-6.2.1.tgz",
+      "integrity": "sha512-JpTj+tjJTDcIWtoMkab6zfwWD1T1tBzUyEfXsXnohnNkwA2dTuNS0gtN7HoxU1Qa+e3GDnfNYk2z7vwzfO4SoQ==",
       "dev": true
     },
     "react-syntax-highlighter": {


### PR DESCRIPTION
## Description

Using latest SDK errors out with VideoPlayer when using blank strings

Package.json file is referencing an older version of the SDK - when using the latest version the VideoPlayer is erroring due to passing empty strings to the SDK which are truthy values

## Jira Ticket

- [TMEDIA-601](https://arcpublishing.atlassian.net/browse/TMEDIA-601)

## Test Steps

1. Checkout this branch `git checkout TMEDIA-601-video-captions-null-fix`
2. `npm i`
3. Run `npm run storybook`
4. Validate video stories are now working as expected - http://localhost:60001/?path=/story/blocks-video-player--video-only

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
