### PR TITLE
TMEDIA-765 - Open in new tab for Large and Medium Promos

### DIFF
--- a/blocks/shared-styles/_children/promos/large/index.jsx
+++ b/blocks/shared-styles/_children/promos/large/index.jsx
@@ -73,6 +73,7 @@ const LargePromoPresentation = ({
 											content={content}
 											customImageURL={promoImageURL}
 											linkURL={linkURL}
+											newTab={newTab}
 											showPromoLabel
 											promoSize="LG"
 											promoLabelSize="large"

--- a/blocks/shared-styles/_children/promos/medium/index.jsx
+++ b/blocks/shared-styles/_children/promos/medium/index.jsx
@@ -49,6 +49,7 @@ const MediumPromoPresentation = ({
 						>
 							<PromoImage
 								linkURL={linkURL}
+								newTab={newTab}
 								content={content}
 								customImageURL={promoImageURL}
 								showPromoLabel


### PR DESCRIPTION
## Description

Add missing newTab prop for large and medium PromoImage

## Jira Ticket

- [TMEDIA-765](https://arcpublishing.atlassian.net/browse/TMEDIA-765)

## Acceptance Criteria

When "open in new tab" is checked, the Headline and Image both open the URL in a new tab, on PC and Mac.

## Test Steps

Ensure you have the latest PageBuilder data for the all promo's page - https://corecomponents.arcpublishing.com/pf/test-all-promos/?_website=the-gazette 
You can export the page and import it locally

1. Checkout this branch `git checkout TMEDIA-765-promos-new-tab`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles`
3. Ensure the page is as per CoreComponents - Import the page via PageBuilder Editor
4. Publish Page
5. Visit Published Page - http://localhost/pf/test-all-promos/?_website=the-gazette
6. Click the Headline and Image links for the first four promo items 
7. All links should open a new tab

## Dependencies or Side Effects

Requires test data from CoreComponents

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
