### PR TITLE
style: Keep stylelint in line with our enhanced styling standards 

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -35,8 +35,17 @@
 			}
 		],
 		"media-feature-name-no-unknown": [
+			true,
 			{
 				"ignoreMediaFeatureNames": ["max-width"]
+			}
+		],
+		"order/order": [
+			"declarations",
+			"rules",
+			{
+				"type": "at-rule",
+				"name": "include"
 			}
 		]
 	}


### PR DESCRIPTION
# Goal

- Enforces `@include` as last in order 
- Fixes some of your warnings @ecarlisle 
- Leans into our new goal that we want everything to be overridable 

# Test

- npm run lint:styles 
- You should not see an error for order/order for the quilted image block now that the @include is last in the order

# Resources 

- https://github.com/stylelint-scss/stylelint-scss/issues/43