### PR TITLE
TBRANDS-30 : Quilted Image Block

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -90,7 +90,7 @@
 		// 104px
 		"spacing-14": 6.5rem,
 		// 112px
-		"spacing-16": 7.5em,
+		"spacing-15": 7rem,
 		// 120px
 		"spacing-16": 7.5rem,
 

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -367,6 +367,9 @@
 					),
 				),
 				quilted-image: (
+					margin: 0 auto,
+					max-width: 76rem,
+
 					components: (
 						heading: (
 							font-size: var(--global-font-size-11),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -288,6 +288,9 @@
 					),
 				),
 				quilted-image: (
+					margin: 0 auto,
+					max-width: 76rem,
+
 					components: (
 						heading: (
 							font-size: var(--global-font-size-7),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -174,7 +174,7 @@
 			components: (
 				body: (
 					font-family: var(--primary-font-family),
-					font-size: var(--global-font-size-3),
+					font-size: var(--global-font-size-4),
 				),
 				heading: (
 					font-weight: var(--global-font-weight-7),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -177,7 +177,6 @@
 			),
 		"primary-color": var(--global-neutral-10),
 		"primary-font-family": "Inter",
-		"layout-content-max-width": 1216,
 	),
 	$tokens: (
 		default: (

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -168,7 +168,7 @@
 	$alias: (
 		"primary-color": var(--global-neutral-10),
 		"primary-font-family": "Inter",
-		"layout-content-max-width": 1216,
+		"layout-content-max-width": 1216px,
 	),
 	$tokens: (
 		default: (
@@ -290,7 +290,7 @@
 				),
 				quilted-image: (
 					margin: 0 auto,
-					max-width: var(layout-content-max-width),
+					max-width: var(--layout-content-max-width),
 					components: (
 						heading: (
 							font-size: var(--global-font-size-7),
@@ -370,9 +370,6 @@
 					),
 				),
 				quilted-image: (
-					margin: 0 auto,
-					max-width: 76rem,
-
 					components: (
 						heading: (
 							font-size: var(--global-font-size-11),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -168,6 +168,7 @@
 	$alias: (
 		"primary-color": var(--global-neutral-10),
 		"primary-font-family": "Inter",
+		"layout-content-max-width": 1216,
 	),
 	$tokens: (
 		default: (
@@ -289,8 +290,7 @@
 				),
 				quilted-image: (
 					margin: 0 auto,
-					max-width: 76rem,
-
+					max-width: var(layout-content-max-width),
 					components: (
 						heading: (
 							font-size: var(--global-font-size-7),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -104,58 +104,58 @@
 		"font-weight-8": 800,
 		"font-weight-9": 900,
 
-		"font-size-1": 0.625rem,
 		// 10px
-		"font-size-2": 0.75rem,
+		"font-size-1": 0.625rem,
 		// 12px
-		"font-size-3": 0.875rem,
+		"font-size-2": 0.75rem,
 		// 14px
-		"font-size-4": 1rem,
+		"font-size-3": 0.875rem,
 		// 16px
-		"font-size-5": 1.125rem,
+		"font-size-4": 1rem,
 		// 18px
-		"font-size-6": 1.1875rem,
+		"font-size-5": 1.125rem,
 		// 19px
-		"font-size-7": 1.25rem,
+		"font-size-6": 1.1875rem,
 		// 20px
-		"font-size-8": 1.375rem,
+		"font-size-7": 1.25rem,
 		// 22px
-		"font-size-9": 1.5rem,
+		"font-size-8": 1.375rem,
 		// 24px
-		"font-size-10": 1.75rem,
+		"font-size-9": 1.5rem,
 		// 28px
-		"font-size-11": 2rem,
+		"font-size-10": 1.75rem,
 		// 32px
-		"font-size-12": 2.25rem,
+		"font-size-11": 2rem,
 		// 36px
-		"font-size-13": 2.56rem,
+		"font-size-12": 2.25rem,
 		// 41px
-		"font-size-14": 3rem,
+		"font-size-13": 2.56rem,
 		// 48px
+		"font-size-14": 3rem,
+		// 52px
 		"font-size-15": 3.25rem,
 
-		// 52px
-		"line-height-1": 0.875rem,
 		// 14px
-		"line-height-2": 1rem,
+		"line-height-1": 0.875rem,
 		// 16px
-		"line-height-3": 1.25rem,
+		"line-height-2": 1rem,
 		// 20px
-		"line-height-4": 1.5rem,
+		"line-height-3": 1.25rem,
 		// 24px
-		"line-height-5": 2rem,
+		"line-height-4": 1.5rem,
 		// 32px
-		"line-height-6": 2.125rem,
+		"line-height-5": 2rem,
 		// 34px
-		"line-height-7": 2.5rem,
+		"line-height-6": 2.125rem,
 		// 40px
-		"line-height-8": 3rem,
+		"line-height-7": 2.5rem,
 		// 48px
-		"line-height-9": 3.5rem,
+		"line-height-8": 3rem,
 		// 56px
+		"line-height-9": 3.5rem,
+		// 62px
 		"line-height-10": 3.875rem,
 
-		// 62px
 		"box-shadow-1": 0px 0px 16px rgba(25, 25, 25, 0.4),
 		"z-index-1": 1,
 		"z-index-2": 10,

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -168,7 +168,7 @@
 	$alias: (
 		"primary-color": var(--global-neutral-10),
 		"primary-font-family": "Inter",
-		"layout-content-max-width": 1216px,
+		"layout-content-max-width": 1216,
 	),
 	$tokens: (
 		default: (
@@ -290,7 +290,7 @@
 				),
 				quilted-image: (
 					margin: 0 auto,
-					max-width: var(--layout-content-max-width),
+					max-width: calc(var(--layout-content-max-width) * 1px),
 					components: (
 						heading: (
 							font-size: var(--global-font-size-7),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -61,39 +61,39 @@
 		"neutral-9": #10151c,
 		"neutral-10": #000000,
 
-		"spacing-1": 0.25em,
 		// 4px
-		"spacing-2": 0.5em,
+		"spacing-1": 0.25rem,
 		// 8px
-		"spacing-3": 1em,
+		"spacing-2": 0.5rem,
 		// 16px
-		"spacing-4": 1.5em,
+		"spacing-3": 1rem,
 		// 24px
-		"spacing-5": 2em,
+		"spacing-4": 1.5rem,
 		// 32px
-		"spacing-6": 2.5em,
+		"spacing-5": 2rem,
 		// 40px
-		"spacing-7": 3em,
+		"spacing-6": 2.5rem,
 		// 48px
-		"spacing-8": 3.5em,
+		"spacing-7": 3rem,
 		// 56px
-		"spacing-9": 4em,
+		"spacing-8": 3.5rem,
 		// 64px
-		"spacing-10": 4.5em,
+		"spacing-9": 4rem,
 		// 72px
-		"spacing-11": 5em,
+		"spacing-10": 4.5rem,
 		// 80px
-		"spacing-12": 5.5em,
+		"spacing-11": 5rem,
 		// 88px
-		"spacing-13": 6em,
+		"spacing-12": 5.5rem,
 		// 96px
-		"spacing-14": 6.5em,
+		"spacing-13": 6rem,
 		// 104px
-		"spacing-15": 7em,
+		"spacing-14": 6.5rem,
 		// 112px
-		"spacing-16": 7.5em,
-
+		"spacing-15": 7rem,
 		// 120px
+		"spacing-16": 7.5rem,
+
 		"font-weight-1": 100,
 		"font-weight-2": 200,
 		"font-weight-3": 300,

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -61,39 +61,39 @@
 		"neutral-9": #10151c,
 		"neutral-10": #000000,
 
-		// 4px
 		"spacing-1": 0.25rem,
-		// 8px
+		// 4px
 		"spacing-2": 0.5rem,
-		// 16px
+		// 8px
 		"spacing-3": 1rem,
-		// 24px
+		// 16px
 		"spacing-4": 1.5rem,
-		// 32px
+		// 24px
 		"spacing-5": 2rem,
-		// 40px
+		// 32px
 		"spacing-6": 2.5rem,
-		// 48px
+		// 40px
 		"spacing-7": 3rem,
-		// 56px
+		// 48px
 		"spacing-8": 3.5rem,
-		// 64px
+		// 56px
 		"spacing-9": 4rem,
-		// 72px
+		// 64px
 		"spacing-10": 4.5rem,
-		// 80px
+		// 72px
 		"spacing-11": 5rem,
-		// 88px
+		// 80px
 		"spacing-12": 5.5rem,
-		// 96px
+		// 88px
 		"spacing-13": 6rem,
-		// 104px
+		// 96px
 		"spacing-14": 6.5rem,
-		// 112px
+		// 104px
 		"spacing-15": 7rem,
-		// 120px
+		// 112px
 		"spacing-16": 7.5rem,
 
+		// 120px
 		"font-weight-1": 100,
 		"font-weight-2": 200,
 		"font-weight-3": 300,
@@ -104,58 +104,56 @@
 		"font-weight-8": 800,
 		"font-weight-9": 900,
 
-		// 10px
 		"font-size-1": 0.625rem,
-		// 12px
+		// 10px
 		"font-size-2": 0.75rem,
-		// 14px
+		// 12px
 		"font-size-3": 0.875rem,
-		// 16px
-		"font-size-4": 1rem,
-		// 18px
-		"font-size-5": 1.125rem,
-		// 19px
-		"font-size-6": 1.1875rem,
-		// 20px
-		"font-size-7": 1.25rem,
-		// 22px
-		"font-size-8": 1.375rem,
-		// 24px
-		"font-size-9": 1.5rem,
-		// 28px
-		"font-size-10": 1.75rem,
-		// 32px
-		"font-size-11": 2rem,
-		// 36px
-		"font-size-12": 2.25rem,
-		// 41px
-		"font-size-13": 2.56rem,
-		// 48px
-		"font-size-14": 3rem,
-		// 52px
-		"font-size-15": 3.25rem,
-
 		// 14px
-		"line-height-1": 0.875rem,
+		"font-size-4": 1rem,
 		// 16px
-		"line-height-2": 1rem,
+		"font-size-5": 1.125rem,
+		// 18px
+		"font-size-6": 1.1875rem,
+		// 19px
+		"font-size-7": 1.25rem,
 		// 20px
-		"line-height-3": 1.25rem,
+		"font-size-8": 1.375rem,
+		// 22px
+		"font-size-9": 1.5rem,
 		// 24px
-		"line-height-4": 1.5rem,
+		"font-size-10": 1.75rem,
+		// 28px
+		"font-size-11": 2rem,
 		// 32px
-		"line-height-5": 2rem,
-		// 34px
-		"line-height-6": 2.125rem,
-		// 40px
-		"line-height-7": 2.5rem,
+		"font-size-12": 2.25rem,
+		// 36px
+		"font-size-13": 2.56rem,
+		// 41px
+		"font-size-14": 3rem,
 		// 48px
+		"font-size-15": 3.25rem,
+		// 52px
+		"line-height-1": 0.875rem,
+		// 14px
+		"line-height-2": 1rem,
+		// 16px
+		"line-height-3": 1.25rem,
+		// 20px
+		"line-height-4": 1.5rem,
+		// 24px
+		"line-height-5": 2rem,
+		// 32px
+		"line-height-6": 2.125rem,
+		// 34px
+		"line-height-7": 2.5rem,
+		// 40px
 		"line-height-8": 3rem,
-		// 56px
+		// 48px
 		"line-height-9": 3.5rem,
-		// 62px
+		// 56px
 		"line-height-10": 3.875rem,
-
+		// 62px
 		"box-shadow-1": 0px 0px 16px rgba(25, 25, 25, 0.4),
 		"z-index-1": 1,
 		"z-index-2": 10,


### PR DESCRIPTION
## Description
Corrections were made to Quilted Image Block styling as Visual QA. 
Additional token changes were also made in Storybook, which can be testable from this PR.

Note: This PR corresponds to this PR in the `arc-themes-feature-pack` respository:
https://github.com/WPMedia/arc-themes-feature-pack/pull/222

### Visual QA
1. The Heading component had an incorrect left-margin for the default (mobile) viewport. It should now have a left-margin of 1rem (16px) and should vertically align with the content in the image overlays.
![image](https://user-images.githubusercontent.com/452134/164786993-979a8e24-5274-41d9-aec0-efdcf90c6c9f.png)
2. This block has a max width of 76rem (2016px) and is center-aligned when the width of the viewport increases above that value.

### Token Standardization Changes
1. Body font size was made 16px.
2. Spacing tokens were changed from `em` to use `rem`.
3. The comments showing pixel-equivalency are now moved to the line above token key-value pair. Initially they were on the same line, but prettier pushed them to the line below, which was confusing. Now the comments appear before the respective line, like this:
<img width="244" alt="image" src="https://user-images.githubusercontent.com/452134/164787663-95e82619-6868-49c4-99da-8a2a473c34cf.png">


## Jira Ticket

- [TBRANDS-30](https://arcpublishing.atlassian.net/browse/TBRANDS-30)

## Acceptance Criteria

VQA feedback can be seen in the comments of [TBRANDS-30](https://arcpublishing.atlassian.net/browse/TBRANDS-30) to:
1. Have correct left-margin on mobile viewport as per this [Figma feedback](https://www.figma.com/file/giQllWgtzGk42KwK2XD9rY/Brand-Browsing-Page-Designs?node-id=1232%3A19606).
2. Block should have a max-width of 2016px and center alignment that enables margin on viewports larger than that width.

## Test Steps

1. Checkout this branch `git checkout {TBRANDS-30}`
2. View "Quilted Image Block" in Storybook by running `npm run storybook`.

## Effect Of Changes

### Before

1. Block heading doesn't have a 1rem `left-margin` on a mobile viewport.
2. Block doesn't have a 76rem `max-width` and doesn't center align in a larger container.

### After

1. Block heading has a 1rem `left-margin` on a mobile viewport.
2. Block has a 76rem `max-width` and center aligns in a larger container.

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
