### PR TITLE
Tbrands 47 - Story Carousel  - Minimum 4 items to display

### DIFF
--- a/blocks/story-carousel-block/features/story-carousel/default.jsx
+++ b/blocks/story-carousel-block/features/story-carousel/default.jsx
@@ -70,9 +70,16 @@ const StoryCarousel = ({
 
 	const { content_elements: elements = [] } = content;
 	if (!elements.length) return null;
+	// if fewer than 4 elements, then render error message to admin
 	if (elements.length < 4 && isAdmin) {
 		return <p style={{ color: "red" }}>This feature requires 4 stories to display.</p>;
 	}
+
+	// if fewer than 4 elements, then render nothing to reader
+	if (elements.length < 4) {
+		return null;
+	}
+
 	const Wrapper = headerText ? HeadingSection : Fragment;
 
 	return (

--- a/blocks/story-carousel-block/features/story-carousel/default.jsx
+++ b/blocks/story-carousel-block/features/story-carousel/default.jsx
@@ -25,10 +25,9 @@ const StoryCarousel = ({
 	},
 }) => {
 	const { id } = useComponentContext();
-	const { arcSite } = useFusionContext();
+	const { arcSite, isAdmin } = useFusionContext();
 	const { locale } = getProperties(arcSite);
 	const phrases = getTranslatedPhrases(locale);
-
 	const content =
 		useContent({
 			source: contentService,
@@ -71,7 +70,9 @@ const StoryCarousel = ({
 
 	const { content_elements: elements = [] } = content;
 	if (!elements.length) return null;
-
+	if (elements.length < 4 && isAdmin) {
+		return <p style={{ color: "red" }}>This feature requires 4 stories to display.</p>;
+	}
 	const Wrapper = headerText ? HeadingSection : Fragment;
 
 	return (

--- a/blocks/story-carousel-block/features/story-carousel/default.test.jsx
+++ b/blocks/story-carousel-block/features/story-carousel/default.test.jsx
@@ -537,4 +537,27 @@ describe("Story Carousel", () => {
 		const { container } = render(<StoryCarousel customFields={mockCustomFields} />);
 		expect(container.querySelectorAll("p")).toHaveLength(1);
 	});
+	it("should display warning when content is under 4 items", () => {
+		// when content has fewer than 4 items
+		useContent.mockReturnValue(mockCollectionContent3);
+		// mocking fusion context once in this test
+		useFusionContext.mockReturnValueOnce({ isAdmin: false });
+
+		const mockCustomFields = {
+			carouselContentConfig: {
+				contentService: "something",
+				contentConfigValues: {
+					query: "some query",
+				},
+			},
+		};
+
+		const { container } = render(<StoryCarousel customFields={mockCustomFields} />);
+
+		// render nothing
+		// the b-story carousel comes from existing tests
+		expect(container.querySelectorAll("p")).toHaveLength(0);
+		expect(container.querySelectorAll(".b-story-carousel")).toHaveLength(0);
+		expect(container.querySelectorAll(".c-carousel__slide")).toHaveLength(0);
+	});
 });

--- a/blocks/story-carousel-block/features/story-carousel/default.test.jsx
+++ b/blocks/story-carousel-block/features/story-carousel/default.test.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { useContent } from "fusion:content";
+import { useFusionContext } from "fusion:context";
 import StoryCarousel from "./default";
 
 const testImageURL = "dummy.png";
@@ -518,5 +519,22 @@ describe("Story Carousel", () => {
 		expect(container.querySelectorAll(".b-story-carousel__story-card .c-paragraph")).toHaveLength(
 			0
 		);
+	});
+
+	it("should display warning when content is under 4 items", () => {
+		useContent.mockReturnValue(mockCollectionContent3);
+		useFusionContext.mockReturnValueOnce({ isAdmin: true });
+
+		const mockCustomFields = {
+			carouselContentConfig: {
+				contentService: "something",
+				contentConfigValues: {
+					query: "some query",
+				},
+			},
+		};
+
+		const { container } = render(<StoryCarousel customFields={mockCustomFields} />);
+		expect(container.querySelectorAll("p")).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
## Description

If the content selected for the story carousel is under 4 items, a message in the admin preview needs to be presented to the user.  Unit test was also added to account for this use case.

## Jira Ticket

- [TMEDIA-47](https://arcpublishing.atlassian.net/browse/TMEDIA-47)

## Acceptance Criteria

if there are less than 4 items there should be a message in the Admin that says - “This feature requires 4 stories to display.”

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout tbrands-47`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/story-carousel-block`
3. Create a new page and add the story carousel block to the page.
4. Under Configure Content, set Content Source to `content-api-collections`
5. Set content_alias to `t-shirts` (which has only one story
6. Preview should only display a paragraph that says `This feature requires 4 stories to display.`:

![image](https://user-images.githubusercontent.com/833461/166247191-a537ae74-8f2a-44a9-9aaf-286821df7fc0.png)


## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ x] Confirmed all the test steps a reviewer will follow above are working.
- [x ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x ] Confirmed this PR has unit test files
  - [x ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
