### PR TITLE
Adding intl for carousels

### DIFF
--- a/locale/de.json
+++ b/locale/de.json
@@ -423,5 +423,17 @@
     "subscriptions-block.payment-information": "Credit card information",
     "subscriptions-block.submit-payment": "Purchase Subscription",
     "subscriptions-block.payment-error": "There was an error processing your payment."
+  },
+  "story-carousel-block": {
+    "story-carousel.aria-label": "Stories",
+    "story-carousel.right-arrow-label": "Next",
+    "story-carousel.left-arrow-label": "Previous",
+    "story-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "category-carousel-block": {
+    "category-carousel.aria-label": "Categories",
+    "category-carousel.right-arrow-label": "Next",
+    "category-carousel.left-arrow-label": "Previous",
+    "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -423,5 +423,17 @@
     "subscriptions-block.payment-information": "Credit card information",
     "subscriptions-block.submit-payment": "Purchase Subscription",
     "subscriptions-block.payment-error": "There was an error processing your payment."
+  },
+  "story-carousel-block": {
+    "story-carousel.aria-label": "Stories",
+    "story-carousel.right-arrow-label": "Next",
+    "story-carousel.left-arrow-label": "Previous",
+    "story-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "category-carousel-block": {
+    "category-carousel.aria-label": "Categories",
+    "category-carousel.right-arrow-label": "Next",
+    "category-carousel.left-arrow-label": "Previous",
+    "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -423,5 +423,17 @@
     "subscriptions-block.payment-information": "Credit card information",
     "subscriptions-block.submit-payment": "Purchase Subscription",
     "subscriptions-block.payment-error": "There was an error processing your payment."
+  },
+  "story-carousel-block": {
+    "story-carousel.aria-label": "Stories",
+    "story-carousel.right-arrow-label": "Next",
+    "story-carousel.left-arrow-label": "Previous",
+    "story-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "category-carousel-block": {
+    "category-carousel.aria-label": "Categories",
+    "category-carousel.right-arrow-label": "Next",
+    "category-carousel.left-arrow-label": "Previous",
+    "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -423,5 +423,17 @@
     "subscriptions-block.payment-information": "Credit card information",
     "subscriptions-block.submit-payment": "Purchase Subscription",
     "subscriptions-block.payment-error": "There was an error processing your payment."
+  },
+  "story-carousel-block": {
+    "story-carousel.aria-label": "Stories",
+    "story-carousel.right-arrow-label": "Next",
+    "story-carousel.left-arrow-label": "Previous",
+    "story-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "category-carousel-block": {
+    "category-carousel.aria-label": "Categories",
+    "category-carousel.right-arrow-label": "Next",
+    "category-carousel.left-arrow-label": "Previous",
+    "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -423,5 +423,17 @@
     "subscriptions-block.payment-information": "Credit card information",
     "subscriptions-block.submit-payment": "Purchase Subscription",
     "subscriptions-block.payment-error": "There was an error processing your payment."
+  },
+  "story-carousel-block": {
+    "story-carousel.aria-label": "Stories",
+    "story-carousel.right-arrow-label": "Next",
+    "story-carousel.left-arrow-label": "Previous",
+    "story-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "category-carousel-block": {
+    "category-carousel.aria-label": "Categories",
+    "category-carousel.right-arrow-label": "Next",
+    "category-carousel.left-arrow-label": "Previous",
+    "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -423,5 +423,17 @@
     "subscriptions-block.payment-information": "Credit card information",
     "subscriptions-block.submit-payment": "Purchase Subscription",
     "subscriptions-block.payment-error": "There was an error processing your payment."
+  },
+  "story-carousel-block": {
+    "story-carousel.aria-label": "Stories",
+    "story-carousel.right-arrow-label": "Next",
+    "story-carousel.left-arrow-label": "Previous",
+    "story-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "category-carousel-block": {
+    "category-carousel.aria-label": "Categories",
+    "category-carousel.right-arrow-label": "Next",
+    "category-carousel.left-arrow-label": "Previous",
+    "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/no.json
+++ b/locale/no.json
@@ -423,5 +423,17 @@
     "subscriptions-block.payment-information": "Credit card information",
     "subscriptions-block.submit-payment": "Purchase Subscription",
     "subscriptions-block.payment-error": "There was an error processing your payment."
+  },
+  "story-carousel-block": {
+    "story-carousel.aria-label": "Stories",
+    "story-carousel.right-arrow-label": "Next",
+    "story-carousel.left-arrow-label": "Previous",
+    "story-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "category-carousel-block": {
+    "category-carousel.aria-label": "Categories",
+    "category-carousel.right-arrow-label": "Next",
+    "category-carousel.left-arrow-label": "Previous",
+    "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -423,5 +423,17 @@
     "subscriptions-block.payment-information": "Credit card information",
     "subscriptions-block.submit-payment": "Purchase Subscription",
     "subscriptions-block.payment-error": "There was an error processing your payment."
+  },
+  "story-carousel-block": {
+    "story-carousel.aria-label": "Stories",
+    "story-carousel.right-arrow-label": "Next",
+    "story-carousel.left-arrow-label": "Previous",
+    "story-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "category-carousel-block": {
+    "category-carousel.aria-label": "Categories",
+    "category-carousel.right-arrow-label": "Next",
+    "category-carousel.left-arrow-label": "Previous",
+    "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -423,5 +423,17 @@
     "subscriptions-block.payment-information": "Credit card information",
     "subscriptions-block.submit-payment": "Purchase Subscription",
     "subscriptions-block.payment-error": "There was an error processing your payment."
+  },
+  "story-carousel-block": {
+    "story-carousel.aria-label": "Stories",
+    "story-carousel.right-arrow-label": "Next",
+    "story-carousel.left-arrow-label": "Previous",
+    "story-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "category-carousel-block": {
+    "category-carousel.aria-label": "Categories",
+    "category-carousel.right-arrow-label": "Next",
+    "category-carousel.left-arrow-label": "Previous",
+    "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }


### PR DESCRIPTION
## Description

Updated localization files, primarily to add localization for the component and story carousel

**Note: A previous attempt PR was attempted here:  https://github.com/WPMedia/arc-themes-blocks/pull/1328.  In this PR I copied all built local files from lokalise and this caused a reevaluation of the code coverage on the Identity block.  In this PR, I only updated the local files with just the carousel entries and than re-ran `npm run generate:intl`**

## Jira Ticket

https://arcpublishing.atlassian.net/browse/TMEDIA-848

## Acceptance Criteria

Update the locale files in the repo en.json
Add the missing translations to Lokalise 
To generate block intl.json files use the npm command npm run generate:intl


## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
