### PR TITLE
TBRANDS-31 - Product Assortment Carousel Block

### DIFF
--- a/.storybook/alias/content.js
+++ b/.storybook/alias/content.js
@@ -8,6 +8,7 @@ import { simpleListMock } from "../mock-content/simpleList";
 import { smallPromoMock } from "../mock-content/smallPromo";
 import { topTableListMock } from "../mock-content/topTableList";
 import { storyCarouselMock } from "../mock-content/storyCarousel";
+import { algoliaProductMock } from "../mock-content/algoliaProduct";
 
 const featureMocks = {
 	footer: footerContentMock,
@@ -22,6 +23,7 @@ const featureMocks = {
 	"results-list": resultsList,
 	"top-table-list": topTableListMock,
 	"story-carousel": storyCarouselMock,
+	"product-assortment-carousel": algoliaProductMock,
 };
 
 export const useEditableContent = () => ({

--- a/.storybook/mock-content/algoliaProduct.js
+++ b/.storybook/mock-content/algoliaProduct.js
@@ -1,0 +1,80 @@
+import testImageURL from "../../resources/camera.jpg";
+
+// eslint-disable-next-line import/prefer-default-export
+export const algoliaProductMock = [
+	{
+		name: "Item 1",
+		image: testImageURL,
+		sku: "sku-1",
+		prices: [
+			{
+				amount: 26,
+				type: "List",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+		],
+		attributes: [
+			{
+				name: "product_url",
+				value: "a-url",
+			},
+		],
+	},
+	{
+		name: "Item 2",
+		image: testImageURL,
+		sku: "sku-2",
+		prices: [
+			{
+				amount: 16,
+				type: "Sale",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+			{
+				amount: 26,
+				type: "List",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+		],
+	},
+	{
+		name: "Item 3",
+		image: testImageURL,
+		sku: "sku-3",
+		prices: [
+			{
+				amount: 26,
+				type: "List",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+		],
+	},
+	{
+		image: testImageURL,
+		sku: "sku-4",
+		prices: [
+			{
+				amount: 26,
+				type: "List",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+		],
+	},
+	{
+		image: testImageURL,
+		sku: "sku-5",
+		prices: [
+			{
+				amount: 26,
+				type: "List",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+		],
+	},
+];

--- a/blocks/product-assortment-carousel-block/README.md
+++ b/blocks/product-assortment-carousel-block/README.md
@@ -1,0 +1,49 @@
+# @wpmedia/product-assortment-carousel-block
+
+A carousel block to display product assortments (rules) from Algolia.
+
+The block is dependent on the PageBuilder Product Assortment integration to enable selecting the assortment to display.
+
+## Props
+
+| **Prop**     | **Required** | **Type**        | **Description**           |
+| ------------ | ------------ | --------------- | ------------------------- |
+| customFields | yes          | PropTypes.shape | Pagebuilder Custom Fields |
+
+### customFields
+
+| **Prop**       | **Required** | **Type**         | **Description**                                           |
+| -------------- | ------------ | ---------------- | --------------------------------------------------------- |
+| carouselLabel  | no           | PropTypes.string | Label to apply to the Carousel for assistive technologies |
+| headerText     | no           | PropTypes.string | Carousel Header text                                      |
+| itemsToDisplay | no           | PropTypes.number | Number of items to show in Carousel, Min: 4, Max: 12      |
+
+## Algolia Data
+
+The block relies on Algolia data to render the products in the carousel. The fields the block uses is
+
+- Name
+- Image
+- Attributes - array of objects
+  - `name = product_url`
+- Prices - array of object
+  - `type = List`
+  - `type = Sale`
+  - For each price
+    - `currencyLocale`
+    - `currencyCode`
+    - `amount`
+    - `type`
+
+## Internationalization fields
+
+| Phrase key                                      | Default (English)                |
+| ----------------------------------------------- | -------------------------------- |
+| `product-assortment-carousel.aria-label`        | `Stories`                        |
+| `product-assortment-carousel.right-arrow-label` | `Next`                           |
+| `product-assortment-carousel.left-arrow-label`  | `Previous`                       |
+| `product-assortment-carousel.slide-indicator`   | `Slide %{current} of %{maximum}` |
+
+### Event Listening
+
+This block does not emit any events.

--- a/blocks/product-assortment-carousel-block/_index.scss
+++ b/blocks/product-assortment-carousel-block/_index.scss
@@ -1,0 +1,30 @@
+@use "@wpmedia/arc-themes-components/scss";
+
+.b-product-assortment-carousel {
+	&__main-title {
+		@include scss.block-properties("product-assortment-carousel-title");
+		@include scss.block-components("product-assortment-carousel-title");
+	}
+
+	&__product {
+		display: flex;
+		flex-direction: column;
+		text-decoration: none;
+		padding: 0;
+
+		img {
+			width: 100%;
+		}
+
+		@include scss.block-properties("product-assortment-carousel-product");
+		@include scss.block-components("product-assortment-carousel-product");
+	}
+
+	&__product-single-price {
+		@include scss.block-properties("product-assortment-carousel-product-single-price");
+		@include scss.block-components("product-assortment-carousel-product-single-price");
+	}
+
+	@include scss.block-properties("product-assortment-carousel");
+	@include scss.block-components("product-assortment-carousel");
+}

--- a/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
+++ b/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
@@ -1,0 +1,216 @@
+import React, { Fragment } from "react";
+import PropTypes from "@arc-fusion/prop-types";
+
+import { useFusionContext, useComponentContext } from "fusion:context";
+import getProperties from "fusion:properties";
+import getTranslatedPhrases from "fusion:intl";
+import { useContent, useEditableContent } from "fusion:content";
+
+import {
+	Carousel,
+	Image,
+	Icon,
+	Heading,
+	Price,
+	Stack,
+	HeadingSection,
+	Link,
+} from "@wpmedia/arc-themes-components";
+
+const BLOCK_CLASS_NAME = "b-product-assortment-carousel";
+const MIN_SLIDES = 4;
+const MAX_SLIDES = 12;
+
+const getProductURL = (item) => item.filter((x) => x.name === "product_url")[0]?.value || {};
+
+const getPrice = (type, prices) => prices.filter((x) => x.type === type)[0] || {};
+
+const parseCondition = (condition) => {
+	try {
+		return JSON.parse(condition);
+	} catch {
+		return {};
+	}
+};
+
+function ProductAssortmentCarousel({ customFields = {} }) {
+	const {
+		assortmentIndex,
+		assortmentCondition,
+		carouselLabel,
+		headerText,
+		itemsToDisplay = 4,
+	} = customFields;
+	const { id } = useComponentContext();
+	const { searchableField } = useEditableContent();
+	const { arcSite, isAdmin } = useFusionContext();
+	const { locale } = getProperties(arcSite);
+	const phrases = getTranslatedPhrases(locale);
+
+	// assortmentCondition is a stringified JSON object set by the Product Assortment
+	// integration from PageBuilder and requires it to be parsed to an object.
+	const assortmentQuery = parseCondition(assortmentCondition);
+
+	const content =
+		useContent({
+			source: "algolia-assortment",
+			query: {
+				feature: "product-assortment-carousel",
+				index: assortmentIndex,
+				query: assortmentQuery?.pattern,
+				ruleContexts: assortmentQuery?.context,
+				filters: assortmentQuery?.filters,
+				hitsPerPage: itemsToDisplay,
+			},
+		}) || [];
+
+	if (isAdmin && (content.length < MIN_SLIDES || content.length > MAX_SLIDES)) {
+		return (
+			<p
+				style={{ color: "red" }}
+				{...searchableField(
+					{ assortmentIndex: "index", assortmentCondition: "condition" },
+					"assortment"
+				)}
+				suppressContentEditableWarning
+			>
+				This feature requires a minimum of 4 products and a maximum of 12 to display.
+			</p>
+		);
+	}
+
+	if (
+		!content.length ||
+		(!isAdmin && (content.length < MIN_SLIDES || content.length > MAX_SLIDES))
+	) {
+		return null;
+	}
+
+	const Wrapper = headerText ? HeadingSection : Fragment;
+
+	return (
+		<Wrapper>
+			<Stack
+				className={BLOCK_CLASS_NAME}
+				{...searchableField(
+					{ assortmentIndex: "index", assortmentCondition: "condition" },
+					"assortment"
+				)}
+				suppressContentEditableWarning
+			>
+				{headerText ? (
+					<Heading className={`${BLOCK_CLASS_NAME}__main-title`}>{headerText}</Heading>
+				) : null}
+
+				<Carousel
+					id={id}
+					label={carouselLabel || phrases.t("product-assortment-carousel.aria-label")}
+					nextButton={
+						<Carousel.Button
+							id={id}
+							label={phrases.t("product-assortment-carousel.right-arrow-label")}
+						>
+							<Icon name="ChevronRight" />
+						</Carousel.Button>
+					}
+					previousButton={
+						<Carousel.Button
+							id={id}
+							label={phrases.t("product-assortment-carousel.left-arrow-label")}
+						>
+							<Icon name="ChevronLeft" />
+						</Carousel.Button>
+					}
+				>
+					{content.map((item, carouselIndex) => {
+						const SalePrice = getPrice("Sale", item.prices);
+						const ListPrice = getPrice("List", item.prices);
+
+						return (
+							<Carousel.Item
+								key={item.sku}
+								label={`${phrases.t("product-assortment-carousel.slide-indicator", {
+									current: carouselIndex + 1,
+									maximum: content.length,
+								})}`}
+							>
+								{({ viewable }) => (
+									<Link
+										className={`${BLOCK_CLASS_NAME}__product`}
+										href={item.attributes ? getProductURL(item?.attributes) : "#"}
+										assistiveHidden={viewable ? null : true}
+									>
+										<Image alt={item.name ? "" : item.name} src={item.image} />
+										{item.name ? (
+											<HeadingSection>
+												<Heading>{item.name}</Heading>
+											</HeadingSection>
+										) : null}
+										<Price
+											className={`${
+												!SalePrice?.amount ? `${BLOCK_CLASS_NAME}__product-single-price` : null
+											}`}
+										>
+											{SalePrice?.amount ? (
+												<Price.Sale>
+													{new Intl.NumberFormat(SalePrice.currencyLocale, {
+														style: "currency",
+														currency: SalePrice.currencyCode,
+														minimumFractionDigits: 2,
+													}).format(SalePrice.amount)}
+												</Price.Sale>
+											) : null}
+											<Price.List>
+												{new Intl.NumberFormat(ListPrice.currencyLocale, {
+													style: "currency",
+													currency: ListPrice.currencyCode,
+													minimumFractionDigits: 2,
+												}).format(ListPrice.amount)}
+											</Price.List>
+										</Price>
+									</Link>
+								)}
+							</Carousel.Item>
+						);
+					})}
+				</Carousel>
+			</Stack>
+		</Wrapper>
+	);
+}
+
+ProductAssortmentCarousel.label = "Product Assortment Carousel – Arc Block";
+
+ProductAssortmentCarousel.icon = "ui-browser-slider";
+
+ProductAssortmentCarousel.propTypes = {
+	customFields: PropTypes.shape({
+		assortmentIndex: PropTypes.string.tag({
+			name: "Assortment Index",
+			hidden: true,
+		}),
+		assortmentCondition: PropTypes.string.tag({
+			name: "Assortment Condition",
+			hidden: true,
+		}),
+		carouselLabel: PropTypes.string.tag({
+			label: "Carousel Label",
+			description:
+				"Label is applied to the carousel to provide assistive technologies a description of what the carousel contains.",
+		}),
+		headerText: PropTypes.string.tag({
+			label: "Headline",
+			description: "Add a headline for the product carousel component.",
+		}),
+		itemsToDisplay: PropTypes.number.tag({
+			label: "Amount of products to dispay",
+			defaultValue: 4,
+			min: 4,
+			max: 12,
+			description:
+				"The Product Assortment block will display a minimum of 4 items and a maximum of 12 items",
+		}),
+	}),
+};
+
+export default ProductAssortmentCarousel;

--- a/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.test.jsx
+++ b/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.test.jsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { useContent } from "fusion:content";
+import { useFusionContext } from "fusion:context";
+
+import ProductAssortmentCarousel from "./default";
+
+const mockContent = [
+	{
+		name: "Item 1",
+		image: "image-url",
+		sku: "sku-1",
+		prices: [
+			{
+				amount: 26,
+				type: "List",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+		],
+		attributes: [
+			{
+				name: "product_url",
+				value: "a-url",
+			},
+		],
+	},
+	{
+		name: "Item 2",
+		image: "image-url",
+		sku: "sku-2",
+		prices: [
+			{
+				amount: 16,
+				type: "Sale",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+			{
+				amount: 26,
+				type: "List",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+		],
+	},
+	{
+		name: "Item 3",
+		image: "image-url",
+		sku: "sku-3",
+		prices: [
+			{
+				amount: 26,
+				type: "List",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+		],
+	},
+	{
+		image: "image-url",
+		sku: "sku-4",
+		prices: [
+			{
+				amount: 26,
+				type: "List",
+				currencyLocale: "en-US",
+				currencyCode: "USD",
+			},
+		],
+	},
+];
+
+jest.mock("fusion:content", () => ({
+	useContent: jest.fn(() => {}),
+	useEditableContent: jest.fn(() => ({
+		searchableField: () => {},
+	})),
+}));
+
+describe("Product Assortment Carousel", () => {
+	it("should not render with no content", () => {
+		useContent.mockReturnValue([]);
+		const { container } = render(<ProductAssortmentCarousel />);
+
+		expect(container.querySelectorAll(".b-product-assortment-carousel")).toHaveLength(0);
+	});
+
+	it("should render nothing if not in Admin and has less than 4 items", () => {
+		useContent.mockReturnValue([{ _id: 1 }]);
+		const { container } = render(<ProductAssortmentCarousel />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("should render with content", () => {
+		useContent.mockReturnValue(mockContent);
+		const { container } = render(<ProductAssortmentCarousel />);
+
+		expect(container.querySelectorAll(".b-product-assortment-carousel__main-title")).toHaveLength(
+			0
+		);
+		expect(container.querySelectorAll(".b-product-assortment-carousel")).toHaveLength(1);
+	});
+
+	it("should render with header content", () => {
+		useContent.mockReturnValue(mockContent);
+		const { container } = render(
+			<ProductAssortmentCarousel customFields={{ headerText: "Header" }} />
+		);
+
+		expect(container.querySelectorAll(".b-product-assortment-carousel__main-title")).toHaveLength(
+			1
+		);
+		expect(container.querySelectorAll(".b-product-assortment-carousel")).toHaveLength(1);
+	});
+
+	it("should render admin message when no content and isAdmin", () => {
+		useContent.mockReturnValue([]);
+		useFusionContext.mockReturnValue({
+			isAdmin: true,
+		});
+
+		render(<ProductAssortmentCarousel />);
+
+		expect(
+			screen.queryByText(
+				"This feature requires a minimum of 4 products and a maximum of 12 to display."
+			)
+		).not.toBeNull();
+	});
+});

--- a/blocks/product-assortment-carousel-block/index.story.jsx
+++ b/blocks/product-assortment-carousel-block/index.story.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import ProductAssortmentCarousel from "./features/product-assortment-carousel/default";
+
+// for more info on storybook and using the component explorer
+// https://storybook.js.org/
+export default {
+	title: "Blocks/Product Assortment Carousel",
+	parameters: {
+		chromatic: { viewports: [320, 1200] },
+	},
+};
+
+export const withHeader = () => (
+	<ProductAssortmentCarousel customFields={{ headerText: "Product Assortment Carousel" }} />
+);
+
+export const withOutHeader = () => <ProductAssortmentCarousel customFields={{}} />;

--- a/blocks/product-assortment-carousel-block/intl.json
+++ b/blocks/product-assortment-carousel-block/intl.json
@@ -1,0 +1,46 @@
+{
+	"product-assortment-carousel.aria-label": {
+		"de": "Products",
+		"en": "Products",
+		"es": "Products",
+		"fr": "Products",
+		"ja": "Products",
+		"ko": "Products",
+		"no": "Products",
+		"pt": "Products",
+		"sv": "Products"
+	},
+	"product-assortment-carousel.right-arrow-label": {
+		"de": "Next",
+		"en": "Next",
+		"es": "Next",
+		"fr": "Next",
+		"ja": "Next",
+		"ko": "Next",
+		"no": "Next",
+		"pt": "Next",
+		"sv": "Next"
+	},
+	"product-assortment-carousel.left-arrow-label": {
+		"de": "Previous",
+		"en": "Previous",
+		"es": "Previous",
+		"fr": "Previous",
+		"ja": "Previous",
+		"ko": "Previous",
+		"no": "Previous",
+		"pt": "Previous",
+		"sv": "Previous"
+	},
+	"product-assortment-carousel.slide-indicator": {
+		"de": "Slide %{current} of %{maximum}",
+		"en": "Slide %{current} of %{maximum}",
+		"es": "Slide %{current} of %{maximum}",
+		"fr": "Slide %{current} of %{maximum}",
+		"ja": "Slide %{current} of %{maximum}",
+		"ko": "Slide %{current} of %{maximum}",
+		"no": "Slide %{current} of %{maximum}",
+		"pt": "Slide %{current} of %{maximum}",
+		"sv": "Slide %{current} of %{maximum}"
+	}
+}

--- a/blocks/product-assortment-carousel-block/jest.config.js
+++ b/blocks/product-assortment-carousel-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest/jest.config.base");
+
+module.exports = {
+	...base,
+};

--- a/blocks/product-assortment-carousel-block/package.json
+++ b/blocks/product-assortment-carousel-block/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@wpmedia/product-assortment-carousel-block",
+  "version": "0.1.0",
+  "description": "Product Assortment Carousel Block",
+  "homepage": "https://github.com/WPMedia/arc-themes-blocks",
+  "license": "CC-BY-NC-ND-4.0",
+  "main": "",
+  "files": [
+    "_index.scss",
+    "features",
+    "intl.json"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+    "directory": "blocks/product-assortment-carousel-block"
+  },
+  "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
+    "@wpmedia/arc-themes-components": "*"
+  }
+}

--- a/locale/de.json
+++ b/locale/de.json
@@ -435,5 +435,11 @@
     "category-carousel.right-arrow-label": "Next",
     "category-carousel.left-arrow-label": "Previous",
     "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "product-assortment-carousel-block": {
+    "product-assortment-carousel.aria-label": "Products",
+    "product-assortment-carousel.right-arrow-label": "Next",
+    "product-assortment-carousel.left-arrow-label": "Previous",
+    "product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -435,5 +435,11 @@
     "category-carousel.right-arrow-label": "Next",
     "category-carousel.left-arrow-label": "Previous",
     "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "product-assortment-carousel-block": {
+    "product-assortment-carousel.aria-label": "Products",
+    "product-assortment-carousel.right-arrow-label": "Next",
+    "product-assortment-carousel.left-arrow-label": "Previous",
+    "product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -435,5 +435,11 @@
     "category-carousel.right-arrow-label": "Next",
     "category-carousel.left-arrow-label": "Previous",
     "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "product-assortment-carousel-block": {
+    "product-assortment-carousel.aria-label": "Products",
+    "product-assortment-carousel.right-arrow-label": "Next",
+    "product-assortment-carousel.left-arrow-label": "Previous",
+    "product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -435,5 +435,11 @@
     "category-carousel.right-arrow-label": "Next",
     "category-carousel.left-arrow-label": "Previous",
     "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "product-assortment-carousel-block": {
+    "product-assortment-carousel.aria-label": "Products",
+    "product-assortment-carousel.right-arrow-label": "Next",
+    "product-assortment-carousel.left-arrow-label": "Previous",
+    "product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -435,5 +435,11 @@
     "category-carousel.right-arrow-label": "Next",
     "category-carousel.left-arrow-label": "Previous",
     "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "product-assortment-carousel-block": {
+    "product-assortment-carousel.aria-label": "Products",
+    "product-assortment-carousel.right-arrow-label": "Next",
+    "product-assortment-carousel.left-arrow-label": "Previous",
+    "product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -435,5 +435,11 @@
     "category-carousel.right-arrow-label": "Next",
     "category-carousel.left-arrow-label": "Previous",
     "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "product-assortment-carousel-block": {
+    "product-assortment-carousel.aria-label": "Products",
+    "product-assortment-carousel.right-arrow-label": "Next",
+    "product-assortment-carousel.left-arrow-label": "Previous",
+    "product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/no.json
+++ b/locale/no.json
@@ -435,5 +435,11 @@
     "category-carousel.right-arrow-label": "Next",
     "category-carousel.left-arrow-label": "Previous",
     "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "product-assortment-carousel-block": {
+    "product-assortment-carousel.aria-label": "Products",
+    "product-assortment-carousel.right-arrow-label": "Next",
+    "product-assortment-carousel.left-arrow-label": "Previous",
+    "product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -435,5 +435,11 @@
     "category-carousel.right-arrow-label": "Next",
     "category-carousel.left-arrow-label": "Previous",
     "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "product-assortment-carousel-block": {
+    "product-assortment-carousel.aria-label": "Products",
+    "product-assortment-carousel.right-arrow-label": "Next",
+    "product-assortment-carousel.left-arrow-label": "Previous",
+    "product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -435,5 +435,11 @@
     "category-carousel.right-arrow-label": "Next",
     "category-carousel.left-arrow-label": "Previous",
     "category-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+  },
+  "product-assortment-carousel-block": {
+    "product-assortment-carousel.aria-label": "Products",
+    "product-assortment-carousel.right-arrow-label": "Next",
+    "product-assortment-carousel.left-arrow-label": "Previous",
+    "product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
   }
 }


### PR DESCRIPTION
## Description

New Block - Product Assortment Carousel Block

## Jira Ticket

- [TBRANDS-31](https://arcpublishing.atlassian.net/browse/TBRANDS-31)

## Acceptance Criteria

See Ticket

## Test Steps

Depends on Feature Pack PR - https://github.com/WPMedia/arc-themes-feature-pack/pull/227

**Ensure your access token is ALL ACCESS**

1. Checkout this branch `git checkout TBRANDS-31`
2. Checkout the feature pack branch - `TBRANDS-31`
3. Set your env file to have the following
    * `FUSION_RELEASE=3.3.0-bugBash.1`
    * `PB_EDITOR=latest`
    * `PB_RELEASE=debug`
4. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/product-assortment-carousel-block`
5. Ensure you clear cache on your browser to ensure PageBuilder loads fresh
6. Open up PageBuilder
7. Create a new page
8. Select the Single Column Layout
9. Using the "Add block" feature in PageBuilder add the new block - Product Assortment Carousel – Arc Block
10. Block will show Admin message to start with
11. Hover over the block and you see the PageBuilder actions appear - there will be a new Icon of the far right for "Select Assortment"
12. Click the "Select Assortment" button and a right panel will open
13. Under Algolia Index choose - `arccommerce-product-commerceqa`
14. Assortment will load below
15. Select the first result - "Boots with Filters"
16. See PageBuilder update with the products from Algolia
17. Publish Page
18. Visit Published Page and validate Block renders on published page

Select Assortment Option -
<img width="256" alt="Microsoft Edge-2022-05-04-11-44 25" src="https://user-images.githubusercontent.com/868127/166667049-dd134bd5-d099-4c3e-9938-4326ba767740.png">


## Effect Of Changes


https://user-images.githubusercontent.com/868127/166667764-29c112a0-d2be-45dc-a02a-8fadffbaabf5.mp4


## Dependencies or Side Effects

Requires Feature Pack Pull Request - https://github.com/WPMedia/arc-themes-feature-pack/pull/227

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
