### PR TITLE
tbrands 48 - Don't render item of quilted image block without all of three values

### DIFF
--- a/blocks/quilted-image-block/README.md
+++ b/blocks/quilted-image-block/README.md
@@ -1,3 +1,5 @@
 # @wpmedia/quilted-image-block
 
 The Quilted Image block is a collection of three images, each with a text and button overlay. In a mobile viewport all three images will display above one another. On a larger viewport, the top or bottom image will become full width with the other two images stacked horizontally adjacent to it.
+
+Note: The block will only render an item if there's an overlay, image url and action url.

--- a/blocks/quilted-image-block/README.md
+++ b/blocks/quilted-image-block/README.md
@@ -2,4 +2,4 @@
 
 The Quilted Image block is a collection of three images, each with a text and button overlay. In a mobile viewport all three images will display above one another. On a larger viewport, the top or bottom image will become full width with the other two images stacked horizontally adjacent to it.
 
-Note: The block will only render an item if there's an overlay, image url and action url.
+Note: The block will only render an item if there's an overlay, image url, action url, and button text.

--- a/blocks/quilted-image-block/features/quilted-image/default.jsx
+++ b/blocks/quilted-image-block/features/quilted-image/default.jsx
@@ -53,61 +53,55 @@ function QuiltedImage({ customFields }) {
 			<HeadingSection>
 				{headline ? <Heading>{headline}</Heading> : null}
 				<div className={`${BLOCK_CLASS_NAME}__wrapper`}>
-					<Link
-						href={item1Action || "#"}
-						className={`${BLOCK_CLASS_NAME}__media-panel  ${
-							fullWidthImage === "top" ? `${BLOCK_CLASS_NAME}__wrapper-top` : ""
-						}`}
-					>
-						<Image src={image1URL} style={{ aspectRatio: image1AspectRatio }} />
-						<Stack className={`${BLOCK_CLASS_NAME}__overlay`} inline>
-							{overlay1Text ? (
+					{image1URL && item1Action && overlay1Text ? (
+						<Link
+							href={item1Action}
+							className={`${BLOCK_CLASS_NAME}__media-panel  ${
+								fullWidthImage === "top" ? `${BLOCK_CLASS_NAME}__wrapper-top` : ""
+							}`}
+						>
+							<Image src={image1URL} style={{ aspectRatio: image1AspectRatio }} />
+							<Stack className={`${BLOCK_CLASS_NAME}__overlay`} inline>
 								<Paragraph className={`${BLOCK_CLASS_NAME}__overlay-text--${overlay1TextVariant}`}>
 									{overlay1Text}
 								</Paragraph>
-							) : null}
-							{button1Text ? (
 								<Button variant={button1Variant} size="small" assistiveHidden>
 									{button1Text}
 								</Button>
-							) : null}
-						</Stack>
-					</Link>
-					<Link href={item2Action || "#"} className={`${BLOCK_CLASS_NAME}__media-panel`}>
-						<Image src={image2URL} style={{ aspectRatio: image2AspectRatio }} />
-						<Stack className={`${BLOCK_CLASS_NAME}__overlay`} inline>
-							{overlay2Text ? (
+							</Stack>
+						</Link>
+					) : null}
+					{image2URL && item2Action && overlay2Text ? (
+						<Link href={item2Action} className={`${BLOCK_CLASS_NAME}__media-panel`}>
+							<Image src={image2URL} style={{ aspectRatio: image2AspectRatio }} />
+							<Stack className={`${BLOCK_CLASS_NAME}__overlay`} inline>
 								<Paragraph className={`${BLOCK_CLASS_NAME}__overlay-text--${overlay2TextVariant}`}>
 									{overlay2Text}
 								</Paragraph>
-							) : null}
-							{button2Text ? (
 								<Button variant={button2Variant} size="small" assistiveHidden>
 									{button2Text}
 								</Button>
-							) : null}
-						</Stack>
-					</Link>
-					<Link
-						href={item3Action || "#"}
-						className={`${BLOCK_CLASS_NAME}__media-panel ${
-							fullWidthImage === "bottom" ? `${BLOCK_CLASS_NAME}__wrapper-bottom` : ""
-						}`}
-					>
-						<Image src={image3URL} style={{ aspectRatio: image3AspectRatio }} />
-						<Stack className={`${BLOCK_CLASS_NAME}__overlay`} inline>
-							{overlay3Text ? (
+							</Stack>
+						</Link>
+					) : null}
+					{image3URL && item3Action && overlay3Text ? (
+						<Link
+							href={item3Action}
+							className={`${BLOCK_CLASS_NAME}__media-panel ${
+								fullWidthImage === "bottom" ? `${BLOCK_CLASS_NAME}__wrapper-bottom` : ""
+							}`}
+						>
+							<Image src={image3URL} style={{ aspectRatio: image3AspectRatio }} />
+							<Stack className={`${BLOCK_CLASS_NAME}__overlay`} inline>
 								<Paragraph className={`${BLOCK_CLASS_NAME}__overlay-text--${overlay3TextVariant}`}>
 									{overlay3Text}
 								</Paragraph>
-							) : null}
-							{button3Text ? (
 								<Button variant={button3Variant} size="small" assistiveHidden>
 									{button3Text}
 								</Button>
-							) : null}
-						</Stack>
-					</Link>
+							</Stack>
+						</Link>
+					) : null}
 				</div>
 			</HeadingSection>
 		</div>

--- a/blocks/quilted-image-block/features/quilted-image/default.jsx
+++ b/blocks/quilted-image-block/features/quilted-image/default.jsx
@@ -53,7 +53,7 @@ function QuiltedImage({ customFields }) {
 			<HeadingSection>
 				{headline ? <Heading>{headline}</Heading> : null}
 				<div className={`${BLOCK_CLASS_NAME}__wrapper`}>
-					{image1URL && item1Action && overlay1Text ? (
+					{image1URL && item1Action && overlay1Text && button1Text ? (
 						<Link
 							href={item1Action}
 							className={`${BLOCK_CLASS_NAME}__media-panel  ${
@@ -71,7 +71,7 @@ function QuiltedImage({ customFields }) {
 							</Stack>
 						</Link>
 					) : null}
-					{image2URL && item2Action && overlay2Text ? (
+					{image2URL && item2Action && overlay2Text && button2Text ? (
 						<Link href={item2Action} className={`${BLOCK_CLASS_NAME}__media-panel`}>
 							<Image src={image2URL} style={{ aspectRatio: image2AspectRatio }} />
 							<Stack className={`${BLOCK_CLASS_NAME}__overlay`} inline>
@@ -84,7 +84,7 @@ function QuiltedImage({ customFields }) {
 							</Stack>
 						</Link>
 					) : null}
-					{image3URL && item3Action && overlay3Text ? (
+					{image3URL && item3Action && overlay3Text && button3Text ? (
 						<Link
 							href={item3Action}
 							className={`${BLOCK_CLASS_NAME}__media-panel ${

--- a/blocks/quilted-image-block/features/quilted-image/default.test.jsx
+++ b/blocks/quilted-image-block/features/quilted-image/default.test.jsx
@@ -78,11 +78,7 @@ describe("Quilted Image", () => {
 		);
 	});
 
-	/* 
-		NOTE : This test was written to overcome an unanticipated issue and should not be needed.
-           The "Overlay Action" custom fields all have a default value of "". 
-	*/
-	it("should give links with className 'b-quilted-image__media-panel' an href value of '#' 'Overlay Action' custom fields are empty strings.", () => {
+	it("should not render any media panels if one of three needed props custom fields are empty strings.", () => {
 		const { container } = render(
 			<QuiltedImage
 				customFields={{
@@ -94,10 +90,8 @@ describe("Quilted Image", () => {
 			/>
 		);
 
-		for (let i = 0; i < 3; i += 1) {
-			const linkElement = container.querySelectorAll("a.b-quilted-image__media-panel")[i];
-			expect(linkElement.getAttribute("href")).toBe("#");
-		}
+		const mediaPanels = container.querySelectorAll("a.b-quilted-image__media-panel");
+		expect(mediaPanels.length).toBe(0);
 	});
 
 	it("should not render button components if 'Button Text' custom fields are empty strings.", () => {

--- a/blocks/quilted-image-block/index.story.jsx
+++ b/blocks/quilted-image-block/index.story.jsx
@@ -63,3 +63,23 @@ export const lightTextColorOnOverlay = () => (
 		}}
 	/>
 );
+
+export const itemsNotRenderedWithoutActionCustomFields = () => (
+	<QuiltedImage
+		customFields={{
+			...customFields,
+			item1Action: "",
+			item2Action: "",
+			item3Action: "",
+		}}
+	/>
+);
+
+export const item1NotRenderedWithoutTextOverlay = () => (
+	<QuiltedImage
+		customFields={{
+			...customFields,
+			overlay1Text: "",
+		}}
+	/>
+);


### PR DESCRIPTION
## Description

Only render item if all three required fields filled in 

## Jira Ticket

- [TBRANDS-48](https://arcpublishing.atlassian.net/jira/software/c/projects/TMEDIA/boards/875?modal=detail&selectedIssue=TBRANDS-48)

## Acceptance Criteria

- Don't render an item without its required fields 

Manually input the following content using custom fields for each :

Image Overlay Text (not sure if this is the correct term) <required field>

Button Text <required field>

Overlay Link Url <required field>

## Test Steps


### Storybook 

1. Checkout this branch `git checkout TBRANDS-48-required-props-render`
2. Run `npm run storybook`
3. Go to a page for quilted image 
4. See one of the items http://localhost:60001/?path=/story/blocks-quilted-image--item-1-not-rendered-without-text-overlay not rendered without any overlay text 
5. See another render nothing if missing a link overlay url http://localhost:60001/?path=/story/blocks-quilted-image--item-1-not-rendered-without-text-overlay

### Fusion 

1. Make sure you're using the commerce content base and token in the feature pack `.env`. In general, make sure you have an all access token for the sandbox commerce env
2. Use the `commerce` branch in the feature pack
3. `npx fusion start -f -l @wpmedia/quilted-image-block`
4. Create a page 
5. Add a quilted image block
6. Add all three fields for item 1, overlay text, action link, and image url 
7. See everything render for that item when entered the last field 
<img width="1301" alt="Screen Shot 2022-05-06 at 12 09 58" src="https://user-images.githubusercontent.com/5950956/167179984-c2b6983f-520b-4ae8-8257-2434ad4b0ef7.png">
8. Remove one of the props. It should be an empty string
9. See the item be removed and not render
<img width="1380" alt="Screen Shot 2022-05-06 at 12 11 45" src="https://user-images.githubusercontent.com/5950956/167180200-90f8f448-4317-4d88-84be-4e7c8bf10111.png">


## Effect Of Changes

### Before

- Would render fallback of url of # if available 

### After

- Don't render any of the item if missing one of the three fields, overlay text, url or image url

## Dependencies or Side Effects

- Fallback of "#" is no longer at present
- Images can't load as you enter the fields

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
