### PR TITLE
TBRANDS-31 - Content source logic update

### DIFF
--- a/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
+++ b/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
@@ -53,15 +53,17 @@ function ProductAssortmentCarousel({ customFields = {} }) {
 
 	const content =
 		useContent({
-			source: "algolia-assortment",
-			query: {
-				feature: "product-assortment-carousel",
-				index: assortmentIndex,
-				query: assortmentQuery?.pattern,
-				ruleContexts: assortmentQuery?.context,
-				filters: assortmentQuery?.filters,
-				hitsPerPage: itemsToDisplay,
-			},
+			source: assortmentCondition ? "algolia-assortment" : null,
+			query: assortmentCondition
+				? {
+						feature: "product-assortment-carousel",
+						index: assortmentIndex,
+						query: assortmentQuery?.pattern,
+						ruleContexts: assortmentQuery?.context,
+						filters: assortmentQuery?.filters,
+						hitsPerPage: itemsToDisplay,
+				  }
+				: {},
 		}) || [];
 
 	if (isAdmin && (content.length < MIN_SLIDES || content.length > MAX_SLIDES)) {

--- a/blocks/product-assortment-carousel-block/index.story.jsx
+++ b/blocks/product-assortment-carousel-block/index.story.jsx
@@ -11,7 +11,20 @@ export default {
 };
 
 export const withHeader = () => (
-	<ProductAssortmentCarousel customFields={{ headerText: "Product Assortment Carousel" }} />
+	<ProductAssortmentCarousel
+		customFields={{
+			headerText: "Product Assortment Carousel",
+			assortmentCondition:
+				'{"anchoring":"contains","pattern":"boot","alternatives":true,"context":"Boots"}',
+		}}
+	/>
 );
 
-export const withOutHeader = () => <ProductAssortmentCarousel customFields={{}} />;
+export const withOutHeader = () => (
+	<ProductAssortmentCarousel
+		customFields={{
+			assortmentCondition:
+				'{"anchoring":"contains","pattern":"boot","alternatives":true,"context":"Boots"}',
+		}}
+	/>
+);


### PR DESCRIPTION
## Description

Ensure content source values are only being set when there is data to avoid content source calls returning errors

## Jira Ticket

- [TBRANDS-31](https://arcpublishing.atlassian.net/browse/TBRANDS-31)

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TBRANDS-31-content-source-logic-update`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/product-assortment-carousel-block`
3. In PageBuilder add the Product Assortment Carousel Block to the page and verify there are no API errors in the network tab

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
