### PR TITLE
TBRANDS-61 : Add a Full-Width Section to the Single Column Regular Width Layout

### DIFF
--- a/blocks/single-column-layout-block/README.md
+++ b/blocks/single-column-layout-block/README.md
@@ -1,6 +1,6 @@
 # @wpmedia/single-column-layout-block
 
-Basic single column layout with a standard confined width of 90rem(1440px) that has three Page Builder sections (navigation, main, and footer).
+Basic single column layout with a standard confined width of 90rem(1440px) that has three Page Builder sections (navigation, fullWidth, body, and footer).
 
 ## Props
 

--- a/blocks/single-column-layout-block/_index.scss
+++ b/blocks/single-column-layout-block/_index.scss
@@ -6,18 +6,26 @@
 		@include scss.block-components("single-column-regular-navigation");
 	}
 
-	&__main {
+	&__full-width {
+		width: 100%;
+		margin: auto;
+		@include scss.block-properties("single-column-regular-full-width");
+		@include scss.block-components("single-column-regular-full-width");
+	}
+
+	&__body {
 		max-width: 90rem; // 1440px
 		width: 100%;
 		margin: auto;
-		@include scss.block-properties("single-column-regular-main");
-		@include scss.block-components("single-column-regular-main");
+		@include scss.block-properties("single-column-regular-body");
+		@include scss.block-components("single-column-regular-body");
 	}
 
 	&__footer {
 		@include scss.block-properties("single-column-regular-footer");
 		@include scss.block-components("single-column-regular-footer");
 	}
+
 	@include scss.block-properties("single-column-regular");
 	@include scss.block-components("single-column-regular");
 }

--- a/blocks/single-column-layout-block/layouts/single-column-regular/default.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/default.jsx
@@ -5,25 +5,29 @@ import { Stack } from "@wpmedia/arc-themes-components";
 const LAYOUT_CLASS_NAME = "b-single-column-regular";
 
 const SingleColumnRegular = ({ children }) => {
-	const [navigation, main, footer] = React.Children.toArray(children);
+	const [navigation, body, fullWidth, footer] = React.Children.toArray(children);
 
-	if (!navigation && !main && !footer) {
+	if (!navigation && !body && !fullWidth && !footer) {
 		return null;
 	}
+
 	return (
 		<Stack className={LAYOUT_CLASS_NAME}>
 			{navigation ? (
-				<Stack role="banner" className={`${LAYOUT_CLASS_NAME}__navigation`}>
+				<Stack as="header" role="banner" className={`${LAYOUT_CLASS_NAME}__navigation`}>
 					{navigation}
 				</Stack>
 			) : null}
-			{main ? (
-				<Stack role="main" id="main" className={`${LAYOUT_CLASS_NAME}__main`} tabIndex="-1">
-					{main}
+			{body || fullWidth ? (
+				<Stack as="main" id="main" className={`${LAYOUT_CLASS_NAME}__main`} tabIndex="-1">
+					{fullWidth ? (
+						<Stack className={`${LAYOUT_CLASS_NAME}__full-width`}>{fullWidth}</Stack>
+					) : null}
+					{body ? <Stack className={`${LAYOUT_CLASS_NAME}__body`}>{body}</Stack> : null}
 				</Stack>
 			) : null}
 			{footer ? (
-				<Stack role="contentinfo" className={`${LAYOUT_CLASS_NAME}__footer`}>
+				<Stack as="footer" className={`${LAYOUT_CLASS_NAME}__footer`}>
 					{footer}
 				</Stack>
 			) : null}
@@ -39,6 +43,6 @@ SingleColumnRegular.propTypes = {
 	children: PropTypes.array,
 };
 
-SingleColumnRegular.sections = ["navigation", "main", "footer"];
+SingleColumnRegular.sections = ["navigation", "fullWidth", "body", "footer"];
 
 export default SingleColumnRegular;

--- a/blocks/single-column-layout-block/layouts/single-column-regular/default.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/default.jsx
@@ -14,7 +14,7 @@ const SingleColumnRegular = ({ children }) => {
 	return (
 		<Stack className={LAYOUT_CLASS_NAME}>
 			{navigation ? (
-				<Stack as="header" role="banner" className={`${LAYOUT_CLASS_NAME}__navigation`}>
+				<Stack as="header" className={`${LAYOUT_CLASS_NAME}__navigation`}>
 					{navigation}
 				</Stack>
 			) : null}

--- a/blocks/single-column-layout-block/layouts/single-column-regular/default.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/default.jsx
@@ -5,7 +5,7 @@ import { Stack } from "@wpmedia/arc-themes-components";
 const LAYOUT_CLASS_NAME = "b-single-column-regular";
 
 const SingleColumnRegular = ({ children }) => {
-	const [navigation, body, fullWidth, footer] = React.Children.toArray(children);
+	const [navigation, fullWidth, body, footer] = React.Children.toArray(children);
 
 	if (!navigation && !body && !fullWidth && !footer) {
 		return null;

--- a/blocks/single-column-layout-block/layouts/single-column-regular/default.test.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/default.test.jsx
@@ -8,7 +8,7 @@ const testText = "Single Column Regular Layout";
 
 describe("Single Column Regular Layout", () => {
 	describe("when it is first rendered", () => {
-		it("should render the content in the header (role banner) when the first child is provided", () => {
+		it("should render content into the header (role banner) section when the one child is provided", () => {
 			render(
 				<SingleColumnRegular>
 					<h1>{testText}</h1>
@@ -17,7 +17,7 @@ describe("Single Column Regular Layout", () => {
 			expect(screen.getByRole("banner")).toHaveTextContent(testText);
 		});
 
-		it("should render content into the main when two children are provided", () => {
+		it("should render content into the main (role main) section when two children are provided", () => {
 			render(
 				<SingleColumnRegular>
 					<></>
@@ -27,9 +27,21 @@ describe("Single Column Regular Layout", () => {
 			expect(screen.getByRole("main")).toHaveTextContent(testText);
 		});
 
-		it("should render a content into the contentinfo (footer) when three children are provided", () => {
+		it("should render content into the main (role main) section when three children are provided", () => {
 			render(
 				<SingleColumnRegular>
+					<></>
+					<></>
+					<p>{testText}</p>
+				</SingleColumnRegular>
+			);
+			expect(screen.getByRole("main")).toHaveTextContent(testText);
+		});
+
+		it("should render a content into the contentinfo (footer) when four children are provided", () => {
+			render(
+				<SingleColumnRegular>
+					<></>
 					<></>
 					<></>
 					<div>{testText}</div>

--- a/blocks/single-column-layout-block/layouts/single-column-regular/index.story.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/index.story.jsx
@@ -26,6 +26,7 @@ const Footer = () => <div style={styles}>Footer</div>;
 export const oneChildInBody = () => (
 	<SingleColumnRegularLayout>
 		<Navigation />
+		<></>
 		<>
 			<Component>Body 1</Component>
 		</>
@@ -36,6 +37,7 @@ export const oneChildInBody = () => (
 export const childrenInBody = () => (
 	<SingleColumnRegularLayout>
 		<Navigation />
+		<></>
 		<>
 			<Component>Body 1</Component>
 			<Component>Body 2</Component>
@@ -48,10 +50,10 @@ export const oneChildInFullWidthAndBody = () => (
 	<SingleColumnRegularLayout>
 		<Navigation />
 		<>
-			<Component>Body 1</Component>
+			<Component>Full Width 1</Component>
 		</>
 		<>
-			<Component>Full Width 1</Component>
+			<Component>Body 1</Component>
 		</>
 		<Footer />
 	</SingleColumnRegularLayout>
@@ -61,12 +63,12 @@ export const childrenInFullWidthAndBody = () => (
 	<SingleColumnRegularLayout>
 		<Navigation />
 		<>
-			<Component>Body 1</Component>
-			<Component>Body 2</Component>
-		</>
-		<>
 			<Component>Full Width 1</Component>
 			<Component>Full Width 2</Component>
+		</>
+		<>
+			<Component>Body 1</Component>
+			<Component>Body 2</Component>
 		</>
 		<Footer />
 	</SingleColumnRegularLayout>

--- a/blocks/single-column-layout-block/layouts/single-column-regular/index.story.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/index.story.jsx
@@ -23,22 +23,53 @@ const Navigation = () => <div style={styles}>Navigation</div>;
 const Component = ({ children }) => <div style={styles}>{children}</div>;
 const Footer = () => <div style={styles}>Footer</div>;
 
-export const layoutWithOneChild = () => (
+export const oneChildInBody = () => (
+	<SingleColumnRegularLayout
+		children={[
+			Navigation,
+			null,
+			<>
+				<Component>Body 1</Component>
+			</>,
+			Footer,
+		]}
+	/>
+);
+
+export const childrenInBody = () => (
 	<SingleColumnRegularLayout>
 		<Navigation />
 		<>
-			<Component>Main 1</Component>
+			<Component>Body 1</Component>
+			<Component>Body 2</Component>
+			<Footer />
+		</>
+	</SingleColumnRegularLayout>
+);
+
+export const oneChildInFullWidthAndBody = () => (
+	<SingleColumnRegularLayout>
+		<Navigation />
+		<>
+			<Component>Body 1</Component>
+		</>
+		<>
+			<Component>Full Width 1</Component>
 		</>
 		<Footer />
 	</SingleColumnRegularLayout>
 );
 
-export const layoutWithTwoChildren = () => (
+export const childrenInFullWidthAndBody = () => (
 	<SingleColumnRegularLayout>
 		<Navigation />
 		<>
-			<Component>Main 1</Component>
-			<Component>Main 2</Component>
+			<Component>Body 1</Component>
+			<Component>Body 2</Component>
+		</>
+		<>
+			<Component>Full Width 1</Component>
+			<Component>Full Width 2</Component>
 		</>
 		<Footer />
 	</SingleColumnRegularLayout>

--- a/blocks/single-column-layout-block/layouts/single-column-regular/index.story.jsx
+++ b/blocks/single-column-layout-block/layouts/single-column-regular/index.story.jsx
@@ -24,16 +24,13 @@ const Component = ({ children }) => <div style={styles}>{children}</div>;
 const Footer = () => <div style={styles}>Footer</div>;
 
 export const oneChildInBody = () => (
-	<SingleColumnRegularLayout
-		children={[
-			Navigation,
-			null,
-			<>
-				<Component>Body 1</Component>
-			</>,
-			Footer,
-		]}
-	/>
+	<SingleColumnRegularLayout>
+		<Navigation />
+		<>
+			<Component>Body 1</Component>
+		</>
+		<Footer />
+	</SingleColumnRegularLayout>
 );
 
 export const childrenInBody = () => (
@@ -42,8 +39,8 @@ export const childrenInBody = () => (
 		<>
 			<Component>Body 1</Component>
 			<Component>Body 2</Component>
-			<Footer />
 		</>
+		<Footer />
 	</SingleColumnRegularLayout>
 );
 


### PR DESCRIPTION
## Description

The following changes where made to the `single-column-regular` block.
1. A `fullWidth` section with 100% viewport width was added.
2. The `main` section was renamed to `body`.
3. Both `fullWidth` and `body` sections are both contained in a `<main>` tag.
4. The unit testing coverage is as per requirements. 2 lines are uncovered.

## Jira Ticket

- [TBRANDS-61](https://arcpublishing.atlassian.net/browse/TBRANDS-61)

## Acceptance Criteria

1. When I have selected the layout: `Single Column Regular Width Layout - Arc Block` and I am viewing the Curate tab, I see the following sections:
    a. `navigation`
    b. `full-width`
    c. `main` update this section to `body`
    d. `footer`
2. I can nest blocks within the full-width section and those blocks will display full-width on a consumer user’s device.
3. All current functionality is maintained in the following sections:
    a. navigation
    b. ~~main!! body
    c. footer

**Accessibility note:** Skip to content would skip to main element which contain full-width and body sections.

## Test Steps
1. Checkout this branch `git checkout TBRANDS-61-add-full-width-section-to-layout`
2. Start storybook `git run storybook`.
3. Verify Storybook items listed under "Single Column Regular Layout."

## Open Question
1. With some Storybook examples, sections are appearing in an unexpected order. This may be because the child objects are not given as an array, where each object has an index. Should we use an array of objects for `children={}` for testing and Storybook? That's not error as per our Linting setup but we've done this before:
    a. https://github.com/WPMedia/arc-themes-blocks/blob/arc-themes-release-version-2.0.1/blocks/right-rail-block/index.story.jsx#L45
    b. https://github.com/WPMedia/arc-themes-blocks/blob/arc-themes-release-version-2.0.1/blocks/right-rail-block/index.story.jsx#L45

2. With this change, does the name "Single Column Regular Width Layout" accurately describe the layout?

## Effect Of Changes

There are some change management concerns we need to consider when publishing the new layout. For the new layout configuration to take effect, we'll need to change a page/template layout to "---" and reset it to Single Column Regular Width Layout.
<img width="423" alt="image" src="https://user-images.githubusercontent.com/452134/172719912-30569129-a2de-48bc-a0bc-535244a3c5e1.png">
This will move all page blocks to the first section (navigation).

### Before

Here's an example of blocks placed into multiple sections:
![image](https://user-images.githubusercontent.com/452134/172720375-6863c1c6-96e8-4c3f-b9af-4a4d2f809ef6.png)

### After
After the update, block configuration data appears to stay intact but is moved into the first section.
<img width="313" alt="image" src="https://user-images.githubusercontent.com/452134/172720735-15c9501f-aaea-4a77-80d9-12de81ac7f06.png">

## Dependencies or Side Effects

See **Before** and **After** in **Effect Of Changes.**

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
