### PR TITLE
Tmedia 746 medium manual rpromo block feedback

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1290,6 +1290,7 @@
 					components: (
 						media-item: (
 							float: left,
+							margin: 0 var(--global-spacing-4) var(--global-spacing-4) 0,
 						),
 						heading: (
 							font-size: var(--global-font-size-11),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -860,7 +860,6 @@
 					padding: 0,
 				),
 				medium-manual-promo: (
-					display: block,
 					components: (
 						media-item: (
 							margin: 0 0 var(--global-spacing-4) var(--global-spacing-4),
@@ -1294,12 +1293,12 @@
 					components: (
 						media-item: (
 							float: left,
-							margin: 0 var(--global-spacing-4) var(--global-spacing-4) 0,
+							margin: 0 var(--global-spacing-6) var(--global-spacing-6) 0,
 							max-width: 35%,
 						),
 						heading: (
 							font-size: var(--global-font-size-11),
-							line-height: var(--global-line-height-4),
+							line-height: var(--global-line-height-7),
 						),
 						paragraph: (),
 					),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -870,7 +870,7 @@
 						heading: (
 							font-size: var(--global-font-size-7),
 							font-weight: var(--global-font-weight-7),
-							line-height: var(--global-line-height-5),
+							line-height: var(--global-line-height-4),
 							margin: 0 0 var(--global-spacing-4) 0,
 						),
 					),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1287,27 +1287,15 @@
 					display: flex,
 				),
 				medium-manual-promo: (
-					display: grid,
-					grid-template-columns: 1fr 2fr,
-					column-gap: var(--global-spacing-6),
-					row-gap: var(--global-spacing-4),
-					grid-template-areas: "mediaitem paragraph" "mediaitem paragraph",
 					components: (
 						media-item: (
-							grid-area: "mediaitem",
-							margin: 0,
-							float: none,
-							max-width: 100%,
+							float: left,
 						),
 						heading: (
 							font-size: var(--global-font-size-11),
-							grid-area: "heading",
 							line-height: var(--global-line-height-4),
-							margin: 0,
 						),
-						paragraph: (
-							grid-area: "paragraph",
-						),
+						paragraph: (),
 					),
 				),
 				quad-chain: (

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1291,6 +1291,7 @@
 						media-item: (
 							float: left,
 							margin: 0 var(--global-spacing-4) var(--global-spacing-4) 0,
+							max-width: 35%,
 						),
 						heading: (
 							font-size: var(--global-font-size-11),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -873,6 +873,10 @@
 							line-height: var(--global-line-height-4),
 							margin: 0 0 var(--global-spacing-4) 0,
 						),
+						paragraph: (
+							line-height: var(--global-line-height-4),
+							font-size: var(--global-font-size-4),
+						),
 					),
 				),
 				numbered-list: (

--- a/blocks/medium-manual-promo-block/_index.scss
+++ b/blocks/medium-manual-promo-block/_index.scss
@@ -1,21 +1,6 @@
 @use "@wpmedia/arc-themes-components/scss";
 
 .b-medium-manual-promo {
-	&--image {
-		@include scss.block-properties("medium-manual-promo-image");
-		@include scss.block-components("medium-manual-promo-image");
-	}
-
-	&--title {
-		@include scss.block-properties("medium-manual-promo-title");
-		@include scss.block-components("medium-manual-promo-title");
-	}
-
-	&--description {
-		@include scss.block-properties("medium-manual-promo-description");
-		@include scss.block-components("medium-manual-promo-description");
-	}
-
 	@include scss.block-properties("medium-manual-promo");
 	@include scss.block-components("medium-manual-promo");
 }

--- a/blocks/medium-manual-promo-block/index.story.jsx
+++ b/blocks/medium-manual-promo-block/index.story.jsx
@@ -113,3 +113,18 @@ export const imageAndDescription = () => {
 
 	return <MediumManualPromo customFields={customFields} />;
 };
+
+export const reallyLongText = () => {
+	const customFields = {
+		...sampleData,
+		headline:
+			"This is a really long headline. This is a really long headline. This is a really long headline. This is a really long headline. This is a really long headline. This is a really long headline. This is a really long headline. This is a really long headline.",
+		description:
+			"This is a really long description. This is a really long description. This is a really long descriptionThis is a really long description. This is a really long description. This is a really long description. This is a really long description. This is a really long description. This is a really long description. This is a really long descriptionThis is a really long description. This is a really long description. This is a really long description. This is a really long description.",
+		showHeadline: true,
+		showImage: true,
+		showDescription: true,
+	};
+
+	return <MediumManualPromo customFields={customFields} />;
+};

--- a/blocks/medium-manual-promo-block/package.json
+++ b/blocks/medium-manual-promo-block/package.json
@@ -21,6 +21,7 @@
   },
   "peerDependencies": {
     "@arc-fusion/prop-types": "^0.1.5",
+    "@wpmedia/arc-themes-components": "*",
     "@wpmedia/engine-theme-sdk": "*"
   },
   "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"


### PR DESCRIPTION
- Match the font size and line height per the figma designs 
- Float left and right based on feedback in the channel. Ditch hybrid approach of using grid in one area but not  the other 
- Update the margins to match the v2 designs 
- Some other v2 migration small work 

todo: 
- [ ] Update docs fully to have no placeholders out 
- [ ] Update tests 
- [ ] Clarify the discrepancies around line-height. I updated them https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3138945094/Blocks+Design+Discrepancies
- [ ] Looks like the desktop 35% is for the image wrapper -- not the image itself. So the image should not grow past its intrinsic size I presume https://www.chromatic.com/test?appId=5f91e4721ccaba0022a10782&id=62bdaac106af0525b2b9adbd -> this may be an improvement (cc @matthewroach )