### PR TITLE
Tmedia 746 medium manual modifiers

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -938,6 +938,7 @@
 							font-size: var(--global-font-size-7),
 							font-weight: var(--global-font-weight-7),
 							line-height: var(--global-line-height-4),
+							margin-bottom: var(--global-spacing-4),
 						),
 						paragraph: (
 							font-size: var(--global-font-size-4),
@@ -950,7 +951,6 @@
 						heading: (
 							// hard-coded based on previous implementation and product requirements for such
 							width: 68%,
-							margin-bottom: var(--global-spacing-4),
 						),
 					),
 				),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -938,13 +938,19 @@
 							font-size: var(--global-font-size-7),
 							font-weight: var(--global-font-weight-7),
 							line-height: var(--global-line-height-4),
-							// hard-coded based on previous implementation and product requirements for such
-							width: 68%,
-							margin-bottom: var(--global-spacing-4),
 						),
 						paragraph: (
 							font-size: var(--global-font-size-4),
 							line-height: var(--global-line-height-4),
+						),
+					),
+				),
+				medium-manual-promo-show-image: (
+					components: (
+						heading: (
+							// hard-coded based on previous implementation and product requirements for such
+							width: 68%,
+							margin-bottom: var(--global-spacing-4),
 						),
 					),
 				),
@@ -1424,13 +1430,21 @@
 						heading: (
 							font-size: var(--global-font-size-11),
 							line-height: var(--global-line-height-7),
+						),
+						paragraph: (
+							display: block,
+						),
+					),
+				),
+				medium-manual-promo-show-image: (
+					components: (
+						heading: (
 							// hard-coded based on previous implementation and product requirements for such
 							margin-left: 39%,
 							width: 60%,
 						),
 						paragraph: (
 							margin-left: 39%,
-							display: block,
 						),
 					),
 				),

--- a/blocks/medium-manual-promo-block/_index.scss
+++ b/blocks/medium-manual-promo-block/_index.scss
@@ -1,6 +1,10 @@
 @use "@wpmedia/arc-themes-components/scss";
 
 .b-medium-manual-promo {
+	&--show-image {
+		@include scss.block-properties("medium-manual-promo-show-image");
+		@include scss.block-components("medium-manual-promo-show-image");
+	}
 	@include scss.block-properties("medium-manual-promo");
 	@include scss.block-components("medium-manual-promo");
 }

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -42,7 +42,9 @@ const MediumManualPromo = ({ customFields }) => {
 	return (
 		<LazyLoad enabled={shouldLazyLoad}>
 			<HeadingSection>
-				<article className={BLOCK_CLASS_NAME}>
+				<article
+					className={`${BLOCK_CLASS_NAME}${showImage ? ` ${BLOCK_CLASS_NAME}--show-image` : ""}`}
+				>
 					{showImage ? (
 						<MediaItem {...searchableField("imageURL")} suppressContentEditableWarning>
 							<Conditional

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
@@ -52,7 +52,7 @@ describe("the medium promo feature", () => {
 	it("should render all fields", () => {
 		const wrapper = mount(<MediumManualPromo customFields={customFieldData} />);
 		expect(wrapper.html()).toMatchInlineSnapshot(
-			`"<article class=\\"b-medium-manual-promo\\"><figure class=\\"c-media-item\\"><a class=\\"c-link\\" href=\\"arcxp.com\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></a></figure><h2 class=\\"c-heading\\"><a class=\\"c-link\\" href=\\"arcxp.com\\">Headline</a></h2><p class=\\"c-paragraph\\">Description</p></article>"`
+			`"<article class=\\"b-medium-manual-promo b-medium-manual-promo--show-image\\"><figure class=\\"c-media-item\\"><a class=\\"c-link\\" href=\\"arcxp.com\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></a></figure><h2 class=\\"c-heading\\"><a class=\\"c-link\\" href=\\"arcxp.com\\">Headline</a></h2><p class=\\"c-paragraph\\">Description</p></article>"`
 		);
 	});
 
@@ -74,7 +74,7 @@ describe("the medium promo feature", () => {
 		};
 		const wrapper = mount(<MediumManualPromo customFields={fallbackImage} />);
 		expect(wrapper.html()).toMatchInlineSnapshot(
-			`"<article class=\\"b-medium-manual-promo\\"><figure class=\\"c-media-item\\"><a class=\\"c-link\\" href=\\"arcxp.com\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"http://fallback.img\\"></a></figure><h2 class=\\"c-heading\\"><a class=\\"c-link\\" href=\\"arcxp.com\\">Headline</a></h2><p class=\\"c-paragraph\\">Description</p></article>"`
+			`"<article class=\\"b-medium-manual-promo b-medium-manual-promo--show-image\\"><figure class=\\"c-media-item\\"><a class=\\"c-link\\" href=\\"arcxp.com\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"http://fallback.img\\"></a></figure><h2 class=\\"c-heading\\"><a class=\\"c-link\\" href=\\"arcxp.com\\">Headline</a></h2><p class=\\"c-paragraph\\">Description</p></article>"`
 		);
 	});
 
@@ -85,7 +85,7 @@ describe("the medium promo feature", () => {
 		};
 		const wrapper = mount(<MediumManualPromo customFields={noDescription} />);
 		expect(wrapper.html()).toMatchInlineSnapshot(
-			`"<article class=\\"b-medium-manual-promo\\"><figure class=\\"c-media-item\\"><a class=\\"c-link\\" href=\\"arcxp.com\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></a></figure><h2 class=\\"c-heading\\"><a class=\\"c-link\\" href=\\"arcxp.com\\">Headline</a></h2></article>"`
+			`"<article class=\\"b-medium-manual-promo b-medium-manual-promo--show-image\\"><figure class=\\"c-media-item\\"><a class=\\"c-link\\" href=\\"arcxp.com\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></a></figure><h2 class=\\"c-heading\\"><a class=\\"c-link\\" href=\\"arcxp.com\\">Headline</a></h2></article>"`
 		);
 	});
 
@@ -96,7 +96,7 @@ describe("the medium promo feature", () => {
 		};
 		const wrapper = mount(<MediumManualPromo customFields={noHeadline} />);
 		expect(wrapper.html()).toMatchInlineSnapshot(
-			`"<article class=\\"b-medium-manual-promo\\"><figure class=\\"c-media-item\\"><a class=\\"c-link\\" href=\\"arcxp.com\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></a></figure><p class=\\"c-paragraph\\">Description</p></article>"`
+			`"<article class=\\"b-medium-manual-promo b-medium-manual-promo--show-image\\"><figure class=\\"c-media-item\\"><a class=\\"c-link\\" href=\\"arcxp.com\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></a></figure><p class=\\"c-paragraph\\">Description</p></article>"`
 		);
 	});
 
@@ -107,7 +107,7 @@ describe("the medium promo feature", () => {
 		};
 		const wrapper = mount(<MediumManualPromo customFields={noHeadline} />);
 		expect(wrapper.html()).toMatchInlineSnapshot(
-			`"<article class=\\"b-medium-manual-promo\\"><figure class=\\"c-media-item\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></figure><h2 class=\\"c-heading\\"></h2><p class=\\"c-paragraph\\">Description</p></article>"`
+			`"<article class=\\"b-medium-manual-promo b-medium-manual-promo--show-image\\"><figure class=\\"c-media-item\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></figure><h2 class=\\"c-heading\\"></h2><p class=\\"c-paragraph\\">Description</p></article>"`
 		);
 	});
 });


### PR DESCRIPTION
- Ready to merge into your branch if desired @ecarlisle. Based on your q of how to use css classnames and react with enhanced styles 
- For more info on bem, here's a good link http://getbem.com/naming/
- This is using a parent block modifier


> ^^ I will have some questions in tomorrow's huddle regarding CSS approach in manual-medium-promo-blocks.  Specifically, the v1 block uses different combinations of CSS classes to render correctly for the different custom field options (e.g. "Show Image", "Show Headline", "Show Description." I'm wondering if anyone has run into this and if so, how similar the CSS approach was for Enhanced Styling. Thanks