### PR TITLE
Tmedia 745 image click

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1417,6 +1417,8 @@
 				),
 				large-manual-promo: (
 					gap: var(--global-spacing-6),
+				),
+				large-manual-promo-text: (
 					components: (
 						heading: (
 							font-size: var(--global-font-size-12),

--- a/blocks/large-manual-promo-block/_index.scss
+++ b/blocks/large-manual-promo-block/_index.scss
@@ -1,11 +1,10 @@
 @use "@wpmedia/arc-themes-components/scss";
 
 .b-large-manual-promo {
+	&__text {
+		@include scss.block-components("large-manual-promo-text");
+		@include scss.block-properties("large-manual-promo-text");
+	}
 	@include scss.block-components("large-manual-promo");
 	@include scss.block-properties("large-manual-promo");
-}
-
-.b-large-manual-promo__text {
-	@include scss.block-components("large-manual-promo-text");
-	@include scss.block-properties("large-manual-promo-text");
 }

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -87,7 +87,7 @@ const LargeManualPromo = ({ customFields }) => {
 	return (
 		<LazyLoad enabled={shouldLazyLoad}>
 			<HeadingSection>
-				<Grid role="article" className={BLOCK_CLASS_NAME}>
+				<Grid as="article" className={BLOCK_CLASS_NAME}>
 					<PromoImage />
 					<Grid className={`${BLOCK_CLASS_NAME}__text`}>
 						<PromoOverline />

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -15,6 +15,7 @@ import {
 	Image,
 	Paragraph,
 	Stack,
+	Conditional,
 } from "@wpmedia/arc-themes-components";
 
 const BLOCK_CLASS_NAME = "b-large-manual-promo";
@@ -48,13 +49,9 @@ const LargeManualPromo = ({ customFields }) => {
 
 		return showImage ? (
 			<MediaItem {...searchableField("imageURL")} suppressContentEditableWarning>
-				{linkURL ? (
-					<Link href={formatURL(linkURL)} openInNewTab={newTab}>
-						<Image alt={headline} src={imageURL} searchableField />
-					</Link>
-				) : (
+				<Conditional href={formatURL(linkURL)} openInNewTab={newTab} component={Link}>
 					<Image alt={headline} src={imageURL} searchableField />
-				)}
+				</Conditional>
 			</MediaItem>
 		) : null;
 	};
@@ -62,13 +59,15 @@ const LargeManualPromo = ({ customFields }) => {
 	const PromoHeading = () =>
 		showHeadline ? (
 			<Heading>
-				{linkURL ? (
-					<Link href={formatURL(linkURL)} openInNewTab={newTab} onClick={registerSuccessEvent}>
-						{headline}
-					</Link>
-				) : (
-					headline
-				)}
+				<Conditional
+					component={Link}
+					condition={linkURL}
+					href={formatURL(linkURL)}
+					openInNewTab={newTab}
+					onClick={registerSuccessEvent}
+				>
+					{headline}
+				</Conditional>
 			</Heading>
 		) : null;
 

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -48,7 +48,13 @@ const LargeManualPromo = ({ customFields }) => {
 
 		return showImage ? (
 			<MediaItem {...searchableField("imageURL")} suppressContentEditableWarning>
-				<Image alt={headline} src={imageURL} searchableField />
+				{linkURL ? (
+					<Link href={formatURL(linkURL)} openInNewTab={newTab}>
+						<Image alt={headline} src={imageURL} searchableField />
+					</Link>
+				) : (
+					<Image alt={headline} src={imageURL} searchableField />
+				)}
 			</MediaItem>
 		) : null;
 	};

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
@@ -104,7 +104,7 @@ describe("the large promo feature", () => {
 	it("should render Link component inside the Header component when linkURL is provided", () => {
 		const wrapper = mount(<LargeManualPromo customFields={config} />);
 		expect(wrapper.find(Heading)).toHaveLength(1);
-		expect(wrapper.find(Link)).toHaveLength(2);
+		expect(wrapper.find(Link)).toHaveLength(1);
 	});
 
 	it("should not render Link inside the Header component when linkURL is not provided", () => {

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
@@ -104,7 +104,7 @@ describe("the large promo feature", () => {
 	it("should render Link component inside the Header component when linkURL is provided", () => {
 		const wrapper = mount(<LargeManualPromo customFields={config} />);
 		expect(wrapper.find(Heading)).toHaveLength(1);
-		expect(wrapper.find(Link)).toHaveLength(1);
+		expect(wrapper.find(Link)).toHaveLength(2);
 	});
 
 	it("should not render Link inside the Header component when linkURL is not provided", () => {


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description

Implemented image onClick and fixed desktop headline font-size to 36px

## Jira Ticket

- [TMEDIA-745](https://arcpublishing.atlassian.net/browse/TMEDIA-745)

## Acceptance Criteria

https://arcpublishing.atlassian.net/browse/TMEDIA-745?focusedCommentId=776023

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-745-image-click`
2. run application `npm run storybook`
3. click on the large-manual-promo block on the storybook menu
4. clock on All fields and click image to redirect

## Effect Of Changes

### Before

image is not clickable, Desktop view headline font-size is 28px

<img width="1530" alt="Screen Shot 2022-07-07 at 10 21 59 AM" src="https://user-images.githubusercontent.com/83021791/177797029-33887bdd-ba80-474a-821a-c379e354d760.png">
<img width="1526" alt="Screen Shot 2022-07-07 at 10 20 25 AM" src="https://user-images.githubusercontent.com/83021791/177797059-42098609-d489-4cf9-b88e-693368e38568.png">


### After

Image is clickable and desktop view headline font-size is 36px

<img width="1533" alt="Screen Shot 2022-07-07 at 10 26 08 AM" src="https://user-images.githubusercontent.com/83021791/177797938-5cfbbbab-d7cd-46f7-9668-4a3b597834a6.png">
<img width="1529" alt="Screen Shot 2022-07-07 at 10 24 43 AM" src="https://user-images.githubusercontent.com/83021791/177797969-8c88fbae-c00f-4cc0-b63a-7084f429b3fc.png">

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
