### PR TITLE
docs: Add large promo label examples for video and gallery icon

### DIFF
--- a/blocks/large-promo-block/index.story.jsx
+++ b/blocks/large-promo-block/index.story.jsx
@@ -92,3 +92,23 @@ export const imageAndDescription = () => {
 
 	return <Promo customFields={updatedCustomFields} />;
 };
+
+export const withGalleryLabelAndImage = () => {
+	const updatedCustomFields = {
+		...allCustomFields,
+		showImage: true,
+		content: { type: "gallery" },
+	};
+
+	return <Promo customFields={updatedCustomFields} />;
+};
+
+export const withVideoLabelAndImage = () => {
+	const updatedCustomFields = {
+		...allCustomFields,
+		showImage: true,
+		content: { type: "video" },
+	};
+
+	return <Promo customFields={updatedCustomFields} />;
+};


### PR DESCRIPTION
- This should be merged into the base arc-themes-release-version-x branch BEFORE the feature branch so we can compare the labels 
- This will help achieve the "implement show promo label with like gallery icon. if content has a label for gallery, it looks it up in the content object to show" task in https://github.com/WPMedia/arc-themes-blocks/pull/1411


test 

- `npm run storybook`
- Go to large promo to see the video and gallery icons in the images