### PR TITLE
Update center logo story to have logo in center

### DIFF
--- a/blocks/header-nav-chain-block/index.story.jsx
+++ b/blocks/header-nav-chain-block/index.story.jsx
@@ -120,8 +120,6 @@ export const centerLogo = () => (
 		mediumBreakpoint={768}
 		closeDrawer={() => {}}
 		customFields={CUSTOM_FIELDS_BASE}
-		displayLinks
-		horizontalLinksHierarchy="horizontal-links"
 		isAdmin={false}
 		isSectionDrawerOpen={false}
 		logoAlignment="center"


### PR DESCRIPTION
center logo story is misconfigured for center logo showing in the center - this updates the story to be correct as per pagebuilder rendering