### PR TITLE
tmedia 741: docs: Add videoPlayInPlace example along with an explanation 

### DIFF
--- a/blocks/large-promo-block/index.story.jsx
+++ b/blocks/large-promo-block/index.story.jsx
@@ -93,6 +93,13 @@ export const imageAndDescription = () => {
 	return <Promo customFields={updatedCustomFields} />;
 };
 
+/*
+ 	note: 
+	`content` from `customFields` prop is overriding content from useContent because "return <LargePromoPresentation content={content} {...customFields} />;" in the stories below.
+	
+	In order for storybook to test the following, this logic would need to be maintained or the mock data would need to be updated.
+*/
+
 export const withGalleryLabelAndImage = () => {
 	const updatedCustomFields = {
 		...allCustomFields,
@@ -108,6 +115,21 @@ export const withVideoLabelAndImage = () => {
 		...allCustomFields,
 		showImage: true,
 		content: { type: "video" },
+	};
+
+	return <Promo customFields={updatedCustomFields} />;
+};
+
+export const playVideoInPlaceOfImage = () => {
+	const updatedCustomFields = {
+		...allCustomFields,
+		// playVideoInPlace will override showImage
+		showImage: true,
+		playVideoInPlace: true,
+		content: {
+			embed_html: `<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>`,
+			type: "video",
+		},
 	};
 
 	return <Promo customFields={updatedCustomFields} />;


### PR DESCRIPTION
- This will enable #1411 to test out play in place logic 
- @malavikakoppula this will unblock you for using the playInPlace logic 
- Note: https://corecomponents.arcpublishing.com/pagebuilder/editor/curate?p=p5L7YlCEItGrJh3Ns&v=v7ewsAN0aAHrJh3Ns and https://corecomponents.arcpublishing.com/pf/collection-play-in-place/?_website=the-gazette are example I used for content. These are not large promo but should be helpful for context
![Screen Shot 2022-07-12 at 15 17 32](https://user-images.githubusercontent.com/5950956/178512325-53fb3131-9dbf-4707-b8b5-b26801da9791.png)
![Screen Shot 2022-07-12 at 15 19 48](https://user-images.githubusercontent.com/5950956/178512388-e54cf41b-f44e-4dfd-b5bd-824f738843fe.png)

