### PR TITLE
TMEIA-916 generator update

### DIFF
--- a/_templates/content-source/content-source/default-entry.ejs.t
+++ b/_templates/content-source/content-source/default-entry.ejs.t
@@ -2,20 +2,30 @@
 # helper funcs https://www.hygen.io/docs/templates/#helpers-and-inflections
 to: blocks/<%= h.inflection.dasherize(block_name) %>-content-source-block/sources/<%= h.inflection.dasherize(content_source_name) %>/index.js
 ---
+import axios from "axios";
+import { CONTENT_BASE, ARC_ACCESS_TOKEN } from "fusion:environment";
+
 const params = {
   input: 'text',
 };
 
-const resolve = (key) => {
+const fetch = (key) => {
   const {
     input, 'arc-site': arcSite,
   } = key;
 
-  return `${arcSite}-${input}`;
+	return axios({
+		url: `${CONTENT_BASE}/-- API - ENDPOINT URI HERE --?website=${arcSite}`,
+		headers: {
+			'content-type': 'application/json',
+			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
+		},
+		method: 'GET',
+	}).then(({ data: content }) => content);
 };
 
 export default {
-  resolve,
+  fetch,
   params,
   transform: (data) => data,
 };

--- a/_templates/content-source/content-source/default-test.ejs.t
+++ b/_templates/content-source/content-source/default-test.ejs.t
@@ -4,24 +4,35 @@ to: blocks/<%= h.inflection.dasherize(block_name) %>-content-source-block/source
 ---
 import contentSource from './index';
 
-describe('Test <%= h.changeCase.title(content_source_name) %> content source', () => {
-  it('should build the correct url', () => {
-    const key = {
-      'arc-site': 'arc-site',
-      input: 'test-input',
-    };
-    const url = contentSource.resolve(key);
+jest.mock("fusion:environment", () => ({
+	CONTENT_BASE: "",
+}));
 
-    expect(url).toEqual(`${key['arc-site']}-${key.input}`);
+jest.mock("axios", () => ({
+	__esModule: true,
+	default: jest.fn((data) => Promise.resolve({ data })),
+}));
+
+describe('Test <%= h.changeCase.title(content_source_name) %> content source', () => {
+  it('should build the correct url', async () => {
+	const key = {
+		'arc-site': 'arc-site',
+		input: 'test-input',
+	};
+	const contentSourceRequest = await contentSource.fetch(key);
+
+	expect(contentSourceRequest.url).toEqual(
+		`/-- API - ENDPOINT URI HERE --?website=${key["arc-site"]}`
+	);
   });
 
   it('should transform data', () => {
-    const key = {
-      'arc-site': 'arc-site',
-      input: 'test-input',
-    };
-    const dataTransform = contentSource.transform(key);
+	 const key = {
+		'arc-site': 'arc-site',
+		input: 'test-input',
+	 };
+	 const dataTransform = contentSource.transform(key);
 
-    expect(dataTransform).toEqual(key);
+	 expect(dataTransform).toEqual(key);
   });
 });

--- a/_templates/content-source/new/default-entry.ejs.t
+++ b/_templates/content-source/new/default-entry.ejs.t
@@ -2,20 +2,30 @@
 # helper funcs https://www.hygen.io/docs/templates/#helpers-and-inflections
 to: blocks/<%= h.inflection.dasherize(block_name) %>-content-source-block/sources/<%= h.inflection.dasherize(block_name) %>.js
 ---
+import axios from "axios";
+import { CONTENT_BASE, ARC_ACCESS_TOKEN } from "fusion:environment";
+
 const params = {
   input: 'text',
 };
 
-const resolve = (key) => {
+const fetch = (key) => {
   const {
     input, 'arc-site': arcSite,
   } = key;
 
-  return `${arcSite}-${input}`;
+	return axios({
+		url: `${CONTENT_BASE}/-- API - ENDPOINT URI HERE --?website=${arcSite}`,
+		headers: {
+			'content-type': 'application/json',
+			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
+		},
+		method: 'GET',
+	}).then(({ data: content }) => content);
 };
 
 export default {
-  resolve,
+  fetch,
   params,
   transform: (data) => data,
 };

--- a/_templates/content-source/new/default-test.ejs.t
+++ b/_templates/content-source/new/default-test.ejs.t
@@ -4,24 +4,35 @@ to: blocks/<%= h.inflection.dasherize(block_name) %>-content-source-block/source
 ---
 import contentSource from './<%= h.inflection.dasherize(block_name) %>';
 
-describe('Test <%= h.changeCase.title(block_name) %> content source', () => {
-  it('should build the correct url', () => {
-    const key = {
-      'arc-site': 'arc-site',
-      input: 'test-input',
-    };
-    const url = contentSource.resolve(key);
+jest.mock("fusion:environment", () => ({
+	CONTENT_BASE: "",
+}));
 
-    expect(url).toEqual(`${key['arc-site']}-${key.input}`);
+jest.mock("axios", () => ({
+	__esModule: true,
+	default: jest.fn((data) => Promise.resolve({ data })),
+}));
+
+describe('Test <%= h.changeCase.title(block_name) %> content source', () => {
+  it('should build the correct url', async () => {
+	 const key = {
+		'arc-site': 'arc-site',
+		input: 'test-input',
+	 };
+	const contentSourceRequest = await contentSource.fetch(key);
+
+	expect(contentSourceRequest.url).toEqual(
+		`/-- API - ENDPOINT URI HERE --?website=${key["arc-site"]}`
+	);
   });
 
   it('should tansform data', () => {
-    const key = {
-      'arc-site': 'arc-site',
-      input: 'test-input',
-    };
-    const dataTransform = contentSource.transform(key);
+	 const key = {
+		'arc-site': 'arc-site',
+		input: 'test-input',
+	 };
+	 const dataTransform = contentSource.transform(key);
 
-    expect(dataTransform).toEqual(key);
+	 expect(dataTransform).toEqual(key);
   });
 });

--- a/_templates/content-source/new/package.ejs.t
+++ b/_templates/content-source/new/package.ejs.t
@@ -20,5 +20,8 @@ to: blocks/<%= h.inflection.dasherize(block_name) %>-content-source-block/packag
     "type": "git",
     "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
     "directory": "blocks/<%= h.inflection.dasherize(block_name) %>-content-source-block"
+  },
+  "dependencies": {
+    "axios": "^0.26.0"
   }
 }

--- a/_templates/feature/content-source/default-entry.ejs.t
+++ b/_templates/feature/content-source/default-entry.ejs.t
@@ -2,20 +2,30 @@
 # helper funcs https://www.hygen.io/docs/templates/#helpers-and-inflections
 to: blocks/<%= h.inflection.dasherize(block_name) %>-block/sources/<%= h.inflection.dasherize(content_source_name) %>/index.js
 ---
+import axios from "axios";
+import { CONTENT_BASE, ARC_ACCESS_TOKEN } from "fusion:environment";
+
 const params = {
   input: 'text',
 };
 
-const resolve = (key) => {
+const fetch = (key) => {
   const {
     input, 'arc-site': arcSite,
   } = key;
 
-  return `${arcSite}-${input}`;
+	return axios({
+		url: `${CONTENT_BASE}/-- API - ENDPOINT URI HERE --?website=${arcSite}`,
+		headers: {
+			'content-type': 'application/json',
+			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
+		},
+		method: 'GET',
+	}).then(({ data: content }) => content);
 };
 
 export default {
-  resolve,
+  fetch,
   params,
   transform: (data) => data,
 };

--- a/_templates/feature/content-source/default-test.ejs.t
+++ b/_templates/feature/content-source/default-test.ejs.t
@@ -4,24 +4,35 @@ to: blocks/<%= h.inflection.dasherize(block_name) %>-block/sources/<%= h.inflect
 ---
 import contentSource from './index';
 
-describe('Test <%= h.changeCase.title(content_source_name) %> content source', () => {
-  it('should build the correct url', () => {
-    const key = {
-      'arc-site': 'arc-site',
-      input: 'test-input',
-    };
-    const url = contentSource.resolve(key);
+jest.mock("fusion:environment", () => ({
+	CONTENT_BASE: "",
+}));
 
-    expect(url).toEqual(`${key['arc-site']}-${key.input}`);
+jest.mock("axios", () => ({
+	__esModule: true,
+	default: jest.fn((data) => Promise.resolve({ data })),
+}));
+
+describe('Test <%= h.changeCase.title(content_source_name) %> content source', () => {
+  it('should build the correct url', async () => {
+	const key = {
+		'arc-site': 'arc-site',
+		input: 'test-input',
+	};
+	const contentSourceRequest = await contentSource.fetch(key);
+
+	expect(contentSourceRequest.url).toEqual(
+		`/-- API - ENDPOINT URI HERE --?website=${key["arc-site"]}`
+	);
   });
 
   it('should transform data', () => {
-    const key = {
-      'arc-site': 'arc-site',
-      input: 'test-input',
-    };
-    const dataTransform = contentSource.transform(key);
+	 const key = {
+		'arc-site': 'arc-site',
+		input: 'test-input',
+	 };
+	 const dataTransform = contentSource.transform(key);
 
-    expect(dataTransform).toEqual(key);
+	 expect(dataTransform).toEqual(key);
   });
 });


### PR DESCRIPTION
## Description

Update content source generators to use the `fetch` method within Fusion utilizing `axios`

## Jira Ticket

- [TMEDIA-916](https://arcpublishing.atlassian.net/browse/TMEDIA-916)

## Test Steps

1. Checkout this branch `git checkout {branch name}`
2. Use the npm generator commands to test the updated templates generate the code as expected
3. `npm run generate:content-source` - creates a new content source block
4. `npm run generate:content-source:content-source` - adds a new content source to an existing content source block
5. `npm run generate:content-source:feature` - adds a new content source to an existing feature block


## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
