### PR TITLE
showing headline if no link available

### DIFF
--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -78,7 +78,9 @@ const LargeManualPromo = ({ customFields }) => {
 					>
 						{headline}
 					</Conditional>
-				) : null}
+				) : (
+					headline
+				)}
 			</Heading>
 		) : null;
 

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -68,19 +68,15 @@ const LargeManualPromo = ({ customFields }) => {
 	const PromoHeading = () =>
 		showHeadline ? (
 			<Heading>
-				{linkURL ? (
-					<Conditional
-						component={Link}
-						condition={linkURL}
-						href={formatURL(linkURL)}
-						openInNewTab={newTab}
-						onClick={registerSuccessEvent}
-					>
-						{headline}
-					</Conditional>
-				) : (
-					headline
-				)}
+				<Conditional
+					component={Link}
+					condition={linkURL}
+					href={formatURL(linkURL)}
+					openInNewTab={newTab}
+					onClick={registerSuccessEvent}
+				>
+					{headline}
+				</Conditional>
 			</Heading>
 		) : null;
 


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description

showing headline if no link available

## Jira Ticket

- [TMEDIA-745](https://arcpublishing.atlassian.net/browse/TMEDIA-TMEDIA-745)

## Acceptance Criteria

https://arcpublishing.atlassian.net/browse/TMEDIA-745?focusedCommentId=779322

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-745-large-manual-promo-noLink`
2. Run storybook `npm run storybook`
3. Goto Large-manual-promo block and check for no link headline

## Effect Of Changes

### Before

_Example: When no link has passed, it's hiding the headline

### After

_Example: When no link has passed, it's showing the headline

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
