### PR TITLE
Tmedia 746 medium manual promo block

### DIFF
--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -39,13 +39,20 @@ const MediumManualPromo = ({ customFields }) => {
 	if (shouldLazyLoad && isServerSide()) {
 		return null;
 	}
+
+	const availableImageURL = showImage ? imageURL || fallbackImage : null;
+	const headlineText = showHeadline ? headline : null;
+	const descriptionText = showDescription ? description : null;
+
 	return (
 		<LazyLoad enabled={shouldLazyLoad}>
 			<HeadingSection>
 				<article
-					className={`${BLOCK_CLASS_NAME}${showImage ? ` ${BLOCK_CLASS_NAME}--show-image` : ""}`}
+					className={`${BLOCK_CLASS_NAME}${
+						availableImageURL ? ` ${BLOCK_CLASS_NAME}--show-image` : ""
+					}`}
 				>
-					{showImage ? (
+					{availableImageURL ? (
 						<MediaItem {...searchableField("imageURL")} suppressContentEditableWarning>
 							<Conditional
 								component={Link}
@@ -54,12 +61,12 @@ const MediumManualPromo = ({ customFields }) => {
 								openInNewTab={newTab}
 								onClick={registerSuccessEvent}
 							>
-								<Image alt={headline} src={imageURL || fallbackImage} searchableField />
+								<Image alt={headline} src={availableImageURL} searchableField />
 							</Conditional>
 						</MediaItem>
 					) : null}
 
-					{showHeadline && headline ? (
+					{headlineText ? (
 						<Heading>
 							<Conditional
 								component={Link}
@@ -72,7 +79,7 @@ const MediumManualPromo = ({ customFields }) => {
 							</Conditional>
 						</Heading>
 					) : null}
-					{showDescription ? <Paragraph>{description}</Paragraph> : null}
+					{descriptionText ? <Paragraph>{description}</Paragraph> : null}
 				</article>
 			</HeadingSection>
 		</LazyLoad>

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -58,19 +58,18 @@ const MediumManualPromo = ({ customFields }) => {
 							</Conditional>
 						</MediaItem>
 					) : null}
-					{showHeadline ? (
+
+					{showHeadline && headline ? (
 						<Heading>
-							{linkURL ? (
-								<Conditional
-									component={Link}
-									condition={linkURL}
-									href={formatURL(linkURL)}
-									openInNewTab={newTab}
-									onClick={registerSuccessEvent}
-								>
-									{headline}
-								</Conditional>
-							) : null}
+							<Conditional
+								component={Link}
+								condition={linkURL}
+								href={formatURL(linkURL)}
+								openInNewTab={newTab}
+								onClick={registerSuccessEvent}
+							>
+								{headline}
+							</Conditional>
 						</Heading>
 					) : null}
 					{showDescription ? <Paragraph>{description}</Paragraph> : null}

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
@@ -56,7 +56,7 @@ describe("the medium promo feature", () => {
 		);
 	});
 
-	it("does not show iamge", () => {
+	it("does not show image", () => {
 		const noImage = {
 			...customFieldData,
 			showImage: false,
@@ -107,7 +107,7 @@ describe("the medium promo feature", () => {
 		};
 		const wrapper = mount(<MediumManualPromo customFields={noHeadline} />);
 		expect(wrapper.html()).toMatchInlineSnapshot(
-			`"<article class=\\"b-medium-manual-promo b-medium-manual-promo--show-image\\"><figure class=\\"c-media-item\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></figure><h2 class=\\"c-heading\\"></h2><p class=\\"c-paragraph\\">Description</p></article>"`
+			`"<article class=\\"b-medium-manual-promo b-medium-manual-promo--show-image\\"><figure class=\\"c-media-item\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></figure><h2 class=\\"c-heading\\">Headline</h2><p class=\\"c-paragraph\\">Description</p></article>"`
 		);
 	});
 });

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
@@ -105,7 +105,7 @@ describe("the medium promo feature", () => {
 			...customFieldData,
 			linkURL: undefined,
 		};
-		const wrapper = mount(<MediumManualPromo customFields={noImage} />);
+		const wrapper = mount(<MediumManualPromo customFields={noHeadline} />);
 		expect(wrapper.html()).toMatchInlineSnapshot(
 			`"<article class=\\"b-medium-manual-promo b-medium-manual-promo--show-image\\"><figure class=\\"c-media-item\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></figure><h2 class=\\"c-heading\\">Headline</h2><p class=\\"c-paragraph\\">Description</p></article>"`
 		);

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
@@ -105,7 +105,7 @@ describe("the medium promo feature", () => {
 			...customFieldData,
 			linkURL: undefined,
 		};
-		const wrapper = mount(<MediumManualPromo customFields={noHeadline} />);
+		const wrapper = mount(<MediumManualPromo customFields={noImage} />);
 		expect(wrapper.html()).toMatchInlineSnapshot(
 			`"<article class=\\"b-medium-manual-promo b-medium-manual-promo--show-image\\"><figure class=\\"c-media-item\\"><img alt=\\"Headline\\" class=\\"c-image\\" loading=\\"lazy\\" src=\\"image-url.jpg\\"></figure><h2 class=\\"c-heading\\">Headline</h2><p class=\\"c-paragraph\\">Description</p></article>"`
 		);


### PR DESCRIPTION
## Description

### Reported Issue:
The promo headline would not appear if the LinkURL custom field were blank.

### Resolution:
This issue has confirmed and fixed by removing a redundant ternary operator.
Defensive coding was also made more elegant by adding `availableImageURL`, `headlineText`, and `descriptionText` variables.

## Jira Ticket

- [TMEDIA-746](https://arcpublishing.atlassian.net/browse/TMEDIA-746)

## Acceptance Criteria

If a headline custom field has a value, it should appear regardless of the Link URL custom field.

**Example:**


## Test Steps
1. Change local `arc-themes-blocks` repository branch to `TMEDIA-746-medium-manual-promo-block`
2. For safe measure, run `rm -rf node_modules && npm i`.
3. Change local `arc-themes-feature-pack` branch to `news-2.00`.
4. Make certain the `THEMES_BLOCKS_REPO` line in your local feature pack `.env` is the path of your local blocks repo.
5. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/medium-manual-promo-block`
6. Open PageBuilder locally and add a `medium-manual-promo-block` to a page. Fill in the `Headline` custom field but **not** the `Link URL` custom field.

## Effect Of Changes

### Before

The `Headline` value would not render in the block if the `Link URL` custom field were blank.

### After

The `Headline` value will not render in the block regardless of the `Link URL` value.

- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
