### PR TITLE
TBRANDS-95 - Add Commerce right rail layout styles

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -696,7 +696,6 @@
 				right-rail-rail-container: (
 					margin: 0 auto var(--global-spacing-6) auto,
 					max-width: calc(var(--content-max-width) * 1px),
-					width: var(--content-scale-width),
 					components: (
 						grid: (
 							template-columns: 1fr,

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -680,6 +680,36 @@
 						),
 					),
 				),
+				right-rail-navigation: (
+					position: sticky,
+					top: 0,
+					width: 100%,
+					z-index: 9,
+					margin-bottom: var(--global-spacing-6),
+				),
+				right-rail-full-width-1: (
+					margin-bottom: var(--global-spacing-6),
+				),
+				right-rail-full-width-2: (
+					margin-bottom: var(--global-spacing-6),
+				),
+				right-rail-rail-container: (
+					margin: 0 auto var(--global-spacing-6) auto,
+					max-width: calc(var(--content-max-width) * 1px),
+					width: var(--content-scale-width),
+					components: (
+						grid: (
+							template-columns: 1fr,
+							gap: var(--global-spacing-6),
+						),
+					),
+				),
+				right-rail-main-interior-item: (
+					grid-column: 1,
+				),
+				right-rail-main-right-rail: (
+					grid-column: 1,
+				),
 				single-column-regular-main: (
 					components: (
 						stack: (
@@ -897,6 +927,29 @@
 							margin-top: -7rem,
 						),
 					),
+				),
+				right-rail-navigation: (
+					margin-bottom: var(--global-spacing-10),
+				),
+				right-rail-full-width-1: (
+					margin-bottom: var(--global-spacing-10),
+				),
+				right-rail-full-width-2: (
+					margin-bottom: var(--global-spacing-10),
+				),
+				right-rail-rail-container: (
+					margin: 0 auto var(--global-spacing-10) auto,
+					components: (
+						grid: (
+							template-columns: repeat(12, 1fr),
+						),
+					),
+				),
+				right-rail-main-interior-item: (
+					grid-column: span 7,
+				),
+				right-rail-main-right-rail: (
+					grid-column: span 5,
 				),
 				story-carousel-title: (
 					font-size: var(--global-font-size-11),

--- a/blocks/right-rail-block/index.story.jsx
+++ b/blocks/right-rail-block/index.story.jsx
@@ -45,3 +45,14 @@ export const basic = () => (
 		<RightRailBlock children={layoutAreas.map((name) => layoutItem(name))} />
 	</div>
 );
+
+export const commerce = () => (
+	<div id="fusion-app" className="layout-section">
+		<RightRailBlock children={layoutAreas.map((name) => layoutItem(name))} />
+	</div>
+);
+commerce.parameters = {
+	cssVariables: {
+		theme: "commerce",
+	},
+};


### PR DESCRIPTION
## Description

Concept PR to test rendering a story with a given theme via parameters in storybook to allow chromatic to give us snapshots for a story in a given theme

Update story to render commerce theme for commerce story of the right rail layout

## Jira Ticket

- [TBRANDS-95](https://arcpublishing.atlassian.net/browse/TBRANDS-95)

## Test Steps

Use Chromatic and local for testing

1. Checkout this branch `git checkout TBRANDS-95-commerce-right-rail-layout`
2. Run storybook `npm run storybook`
3. Check out Right Rail Stories

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
