### PR TITLE
chore: Remove packages from unused block

### DIFF
--- a/blocks/a11y-testing-block/package-lock.json
+++ b/blocks/a11y-testing-block/package-lock.json
@@ -1,20 +1,5 @@
 {
   "name": "@wpmedia/a11y-testing-block",
   "version": "5.14.1",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "axe-core": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
-      "dev": true
-    },
-    "requestidlecallback": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
-      "integrity": "sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=",
-      "dev": true
-    }
-  }
+  "lockfileVersion": 1
 }

--- a/blocks/a11y-testing-block/package.json
+++ b/blocks/a11y-testing-block/package.json
@@ -22,9 +22,5 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "lint": "eslint --ext js --ext jsx features"
   },
-  "devDependencies": {
-    "axe-core": "^3.5.0",
-    "requestidlecallback": "^0.3.0"
-  },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }


### PR DESCRIPTION
- Remove the package from a deprecated block so we don't get package updates #1423 
- Two fewer packages to install if all the blocks package.json's were installed