### PR TITLE
Fix unpopulated extra large manual promo

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -19,9 +19,35 @@ import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 
 const BLOCK_CLASS_NAME = "b-xl-manual-promo";
 
+const PromoHeadline = ({ children, href, openInNewTab }) => (
+	<HeadingSection>
+		<Heading>
+			<Conditional component={Link} condition={href} href={href} openInNewTab={openInNewTab}>
+				{children}
+			</Conditional>
+		</Heading>
+	</HeadingSection>
+);
+
+const PromoImage = ({ alt, href, imageRatio, openInNewTab, src }) => {
+	const { searchableField } = useEditableContent();
+
+	return (
+		<MediaItem {...searchableField("imageURL")} suppressContentEditableWarning>
+			<Conditional component={Link} condition={href} href={href} openInNewTab={openInNewTab}>
+				<Image
+					alt={alt}
+					src={src}
+					searchableField
+					data-aspect-ratio={imageRatio?.replace(":", "/")}
+				/>
+			</Conditional>
+		</MediaItem>
+	);
+};
+
 const ExtraLargeManualPromo = ({ customFields }) => {
 	const { arcSite, isAdmin } = useFusionContext();
-	const { searchableField } = useEditableContent();
 	const { fallbackImage } = getProperties(arcSite);
 	const {
 		description,
@@ -42,44 +68,33 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 	if (shouldLazyLoad && isServerSide()) {
 		return null;
 	}
-	return showOverline || showHeadline || showImage || showDescription ? (
+
+	const availableDescription = showDescription ? description : null;
+	const availableHeadline = showHeadline ? headline : null;
+	const availableImageURL = showImage ? imageURL || fallbackImage : null;
+	const availableOverline = showOverline ? overline : null;
+
+	return availableOverline || availableHeadline || availableImageURL || availableDescription ? (
 		<LazyLoad enabled={shouldLazyLoad}>
 			<article className={BLOCK_CLASS_NAME}>
-				{showOverline ? <Overline href={overlineURL}>{overline}</Overline> : null}
-				{showHeadline || showImage || showDescription ? (
+				{availableOverline ? <Overline href={overlineURL}>{availableOverline}</Overline> : null}
+				{availableHeadline || availableImageURL || availableDescription ? (
 					<Stack>
-						{showHeadline ? (
-							<HeadingSection>
-								<Heading>
-									<Conditional
-										component={Link}
-										condition={linkURL}
-										href={linkURL}
-										openInNewTab={newTab}
-									>
-										{headline}
-									</Conditional>
-								</Heading>
-							</HeadingSection>
+						{availableHeadline ? (
+							<PromoHeadline href={linkURL} openInNewTab={newTab}>
+								{availableHeadline}
+							</PromoHeadline>
 						) : null}
-						{showImage ? (
-							<MediaItem {...searchableField("imageURL")} suppressContentEditableWarning>
-								<Conditional
-									component={Link}
-									condition={linkURL}
-									href={linkURL}
-									openInNewTab={newTab}
-								>
-									<Image
-										alt={headline}
-										src={imageURL || fallbackImage}
-										searchableField
-										data-aspect-ratio={imageRatio?.replace(":", "/")}
-									/>
-								</Conditional>
-							</MediaItem>
+						{availableImageURL ? (
+							<PromoImage
+								alt={headline}
+								href={linkURL}
+								imageRatio={imageRatio}
+								openInNewTab={newTab}
+								src={availableImageURL}
+							/>
 						) : null}
-						{showDescription ? <Paragraph>{description}</Paragraph> : null}
+						{availableDescription ? <Paragraph>{availableDescription}</Paragraph> : null}
 					</Stack>
 				) : null}
 			</article>


### PR DESCRIPTION
## Description

Fix render issue with Extra Large Manual Promo Block

## Jira Ticket

- [TMEDIA-917](https://arcpublishing.atlassian.net/browse/TMEDIA-917)

## Acceptance Criteria

it should show the fallback image, like Small and Medium manual promos do (Daily Intelligencer logo)

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout tmedia-917`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/extra-large-manual-promo-block`
3. Open local host page builder and add the block to the page.

## Effect Of Changes

### Before

![image](https://user-images.githubusercontent.com/2287238/179307714-a2038d9c-fc28-4b17-a112-cc20260d91a4.png)

### After

![image](https://user-images.githubusercontent.com/2287238/179307749-dddb1787-0d26-4c54-a471-5180e9053780.png)

## Dependencies or Side Effects

N/A

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
