### PR TITLE
TMEDIA-743 QA Issue - Fix for custom image to render

### DIFF
--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -20,7 +20,7 @@ import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 const BLOCK_CLASS_NAME = "b-small-promo";
 
 const SmallPromo = ({ customFields }) => {
-	const { imagePosition, lazyLoad, showHeadline, showImage } = customFields;
+	const { imagePosition, lazyLoad, showHeadline, showImage, imageOverrideURL } = customFields;
 	const { registerSuccessEvent } = useComponentContext();
 	const { arcSite, isAdmin } = useFusionContext();
 	const shouldLazyLoad = lazyLoad && !isAdmin;
@@ -100,7 +100,7 @@ const SmallPromo = ({ customFields }) => {
 
 	const PromoImage = () => {
 		const { fallbackImage } = getProperties(arcSite);
-		const availableImage = imageURL || fallbackImage;
+		const availableImage = imageOverrideURL || imageURL || fallbackImage;
 		return showImage && availableImage ? (
 			<Conditional
 				component={Link}


### PR DESCRIPTION
## Description

Fixes the custom image issue found in QA testing where the custom image was not being applied.

## Jira Ticket

- This is an extention to https://arcpublishing.atlassian.net/browse/TMEDIA-743 that came out of QA testing

## Acceptance Criteria

Ensure a custom image selection in Page Builder is applied to the small promo on the page

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout small-promo-custom-image-fix`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/small-promo-block`
3. Add a small promo to a page and link it to a story to see the related image for that story render.
4. Select an alternative image in the `Image URL` PG field and ensure that image replaces the image related to the story.

