### PR TITLE
TBRANDS-95 - Add gap to main

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -715,7 +715,7 @@
 					width: 100%,
 					components: (
 						stack: (
-							gap: var(--global-spacing-6),
+							gap: var(--global-spacing-5),
 						),
 					),
 				),
@@ -952,11 +952,6 @@
 				),
 				right-rail-main: (
 					gap: var(--global-spacing-10),
-					components: (
-						stack: (
-							gap: var(--global-spacing-10),
-						),
-					),
 				),
 				right-rail-rail-container: (
 					max-width: calc(var(--content-max-width) * 1px),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -713,6 +713,11 @@
 					display: grid,
 					gap: var(--global-spacing-6),
 					width: 100%,
+					components: (
+						stack: (
+							gap: var(--global-spacing-6),
+						),
+					),
 				),
 				right-rail-rail-container: (
 					max-width: initial,
@@ -947,6 +952,11 @@
 				),
 				right-rail-main: (
 					gap: var(--global-spacing-10),
+					components: (
+						stack: (
+							gap: var(--global-spacing-10),
+						),
+					),
 				),
 				right-rail-rail-container: (
 					max-width: calc(var(--content-max-width) * 1px),


### PR DESCRIPTION
## Description

Add `gap` value for right rail main to ensure there is a gap between blocks within the main and right rail layout sections

## Jira Ticket

- [TBRANDS-95](https://arcpublishing.atlassian.net/browse/TBRANDS-95)

## Test Steps

1. Checkout this branch `git checkout TBRANDS-95-gap-update`
2. Checkout this branch for the Feature Pack `git checkout TBRANDS-95-gap-update`
3. Run fusion repo with linked blocks `npx fusion start -f`
4. Create a new page with right rail layout
5. Add multiple blocks to the `main` and `rightrail` sections
6. Verify there is a gap between blocks

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
