### PR TITLE
TBRANDS-98 - Product Content Block

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -350,6 +350,28 @@
 					font-size: var(--body-font-size-small),
 					line-height: var(--body-line-height-small),
 				),
+				details: (
+					display: flex,
+					font-size: var(--body-font-size),
+					gap: var(--global-spacing-4),
+				),
+				details-with-icon-summary: (
+					font-weight: var(--global-font-weight-7),
+					line-height: 1.4,
+					justify-content: space-between,
+				),
+				details-summary: (
+					font-size: var(--body-font-size),
+				),
+				details-summary-icon: (
+					align-items: center,
+					display: flex,
+					height: var(--global-spacing-4),
+					width: var(--global-spacing-4),
+				),
+				details-open-summary-icon: (
+					transform: rotate(180deg),
+				),
 				heading: (
 					font-weight: var(--global-font-weight-7),
 				),
@@ -863,6 +885,9 @@
 				),
 				carousel-track: (
 					gap: var(--global-spacing-6),
+				),
+				details-summary: (
+					font-size: var(--global-font-size-7),
 				),
 			),
 			blocks: (

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -363,7 +363,7 @@
 					justify-content: space-between,
 				),
 				details-summary: (
-					font-size: var(--body-font-size),
+					font-size: var(--global-font-size-5),
 				),
 				details-summary-icon: (
 					align-items: center,

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -353,7 +353,9 @@
 				details: (
 					display: flex,
 					font-size: var(--body-font-size),
-					gap: var(--global-spacing-4),
+				),
+				details-open-summary: (
+					margin-bottom: var(--global-spacing-4),
 				),
 				details-with-icon-summary: (
 					font-weight: var(--global-font-weight-7),

--- a/blocks/product-content-block/README.md
+++ b/blocks/product-content-block/README.md
@@ -1,44 +1,16 @@
-# @wpmedia/product-content-block
+# Product Information Block
 
-_Please provide a 1-2 sentence description of what the @wpmedia/product-content-block is and what it does._
+Used in conjuction with Arc Commerce to give an editor the ability to display Product
+Description and/or Product Details
 
-## Props
+## Custom Fields
 
-| **Prop**          | **Required** | **Type** | **Description** |
-| ----------------- | ------------ | -------- | --------------- |
-| **required prop** | yes          |          |                 |
-| **optional prop** | no           |          |                 |
+| **Custom Field** | **Required** | **Type** | **Description**                                                                        |
+| ---------------- | ------------ | -------- | -------------------------------------------------------------------------------------- |
+| **contentType**  | no           | string   | Choice of which product content item to show                                           |
+| **headline**     | no           | string   | A custom headline to be used in place of the default headline for a given content type |
+| open             | no           | boolean  | Flag to denote if the content panel should be open on intial render                    |
 
-## ANS Schema
+## Data
 
-Outline any schema information requirements necessary to know for ths block
-
-### ANS Fields
-
-- `Add all ANS fields used in the block`
-
-## Internationalization fields
-
-| Phrase key | Default (English)     |
-| ---------- | --------------------- |
-| `key`      | `english translation` |
-
-## Events
-
-Blocks can emit events. The following is a list of events that are emitted by this block.
-
-| **Event Name** | **Description**    |
-| -------------- | ------------------ |
-| **eventName**  | Describe the event |
-
-### Event Listening
-
-Include block specific intructions for event listening.
-
-OR
-
-This block does not emit any events.
-
-## Additional Considerations
-
-_This is optional. Please add an additional context that would be important to know in order to use this block._
+Relies on `globalContent` for data access from Arc Commerce

--- a/blocks/product-content-block/README.md
+++ b/blocks/product-content-block/README.md
@@ -1,0 +1,44 @@
+# @wpmedia/product-content-block
+
+_Please provide a 1-2 sentence description of what the @wpmedia/product-content-block is and what it does._
+
+## Props
+
+| **Prop**          | **Required** | **Type** | **Description** |
+| ----------------- | ------------ | -------- | --------------- |
+| **required prop** | yes          |          |                 |
+| **optional prop** | no           |          |                 |
+
+## ANS Schema
+
+Outline any schema information requirements necessary to know for ths block
+
+### ANS Fields
+
+- `Add all ANS fields used in the block`
+
+## Internationalization fields
+
+| Phrase key | Default (English)     |
+| ---------- | --------------------- |
+| `key`      | `english translation` |
+
+## Events
+
+Blocks can emit events. The following is a list of events that are emitted by this block.
+
+| **Event Name** | **Description**    |
+| -------------- | ------------------ |
+| **eventName**  | Describe the event |
+
+### Event Listening
+
+Include block specific intructions for event listening.
+
+OR
+
+This block does not emit any events.
+
+## Additional Considerations
+
+_This is optional. Please add an additional context that would be important to know in order to use this block._

--- a/blocks/product-content-block/_index.scss
+++ b/blocks/product-content-block/_index.scss
@@ -1,0 +1,5 @@
+@use "@wpmedia/arc-themes-components/scss";
+
+.b-product-content {
+	@include scss.block-properties("product-content");
+}

--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -72,7 +72,7 @@ ProductContent.propTypes = {
 		}),
 		open: PropTypes.boolean.tag({
 			name: "Collapsed on page load",
-			defaultValue: false,
+			defaultValue: true,
 		}),
 	}),
 };

--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -25,7 +25,7 @@ export const ProductContentDisplay = ({ children, summary, open }) => (
 );
 
 const ProductContent = ({ customFields }) => {
-	const { contentType, headline, open } = customFields;
+	const { contentType, headline, collapsed } = customFields;
 	const { arcSite, globalContent = {} } = useFusionContext();
 	const { locale } = getProperties(arcSite);
 	const phrases = getTranslatedPhrases(locale);
@@ -46,7 +46,7 @@ const ProductContent = ({ customFields }) => {
 
 	const data = {
 		summary: headline || phrases.t(`product-content.${contentType}`),
-		open: !open,
+		open: !collapsed,
 		children: contentType === "description" ? productData : productData.value,
 	};
 
@@ -71,7 +71,7 @@ ProductContent.propTypes = {
 			name: "Customize Headline",
 			description: "By adding a custom headline, the default headline will be overridden.",
 		}),
-		open: PropTypes.boolean.tag({
+		collapsed: PropTypes.boolean.tag({
 			name: "Collapsed on page load",
 			defaultValue: true,
 		}),

--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -46,7 +46,7 @@ const ProductContent = ({ customFields }) => {
 
 	const data = {
 		summary: headline || phrases.t(`product-content.${contentType}`),
-		open,
+		open: !open,
 		children: contentType === "description" ? productData : productData.value,
 	};
 

--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import PropTypes from "@arc-fusion/prop-types";
+
+import { useFusionContext } from "fusion:context";
+
+import { Details, Icon } from "@wpmedia/arc-themes-components";
+
+const BLOCK_CLASS_NAME = "b-product-content";
+
+const contentMapping = {
+	description: "description",
+	details: "schema.productDetails",
+};
+
+const getNestedObject = (obj, path) => path.split(".").reduce((value, el) => value[el], obj);
+
+export const ProductContentDisplay = ({ children, summary, open }) => (
+	<div className={`${BLOCK_CLASS_NAME}`}>
+		<Details summary={summary} open={open} icon={<Icon name="ChevronDown" />} childrenHTML>
+			{children}
+		</Details>
+	</div>
+);
+
+const ProductContent = ({ customFields }) => {
+	const { contentType, headline, open } = customFields;
+	const { globalContent = {} } = useFusionContext();
+
+	if (!Object.keys(globalContent).length || contentType === undefined) {
+		return null;
+	}
+
+	const productData = getNestedObject(globalContent, contentMapping[contentType]);
+
+	const data = {
+		summary: headline || productData.label,
+		open,
+		children: productData.value,
+	};
+
+	return <ProductContentDisplay {...data} />;
+};
+
+ProductContent.label = "Product Content – Arc Block";
+
+ProductContent.icon = "shopping-bag-smile";
+
+ProductContent.propTypes = {
+	customFields: PropTypes.shape({
+		contentType: PropTypes.oneOf(["description", "details"]).tag({
+			labels: {
+				description: "Product Description",
+				details: "Product Details",
+			},
+			defaultValue: "description",
+		}),
+		headline: PropTypes.string.tag({
+			name: "Customize Headline",
+			description: "By adding a custom headline, the default headline will be overridden.",
+		}),
+		open: PropTypes.boolean.tag({
+			name: "Collapsed on page load",
+			defaultValue: false,
+		}),
+	}),
+};
+
+export default ProductContent;

--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -60,6 +60,7 @@ ProductContent.icon = "content-browser-edit";
 ProductContent.propTypes = {
 	customFields: PropTypes.shape({
 		contentType: PropTypes.oneOf(["description", "details"]).tag({
+			label: "Product Content",
 			labels: {
 				description: "Product Description",
 				details: "Product Details",

--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -30,7 +30,7 @@ const ProductContent = ({ customFields }) => {
 	const { locale } = getProperties(arcSite);
 	const phrases = getTranslatedPhrases(locale);
 
-	if (!Object.keys(globalContent).length || contentType === undefined) {
+	if (!Object.keys(globalContent).length || !contentType) {
 		return null;
 	}
 
@@ -60,6 +60,7 @@ ProductContent.icon = "content-browser-edit";
 ProductContent.propTypes = {
 	customFields: PropTypes.shape({
 		contentType: PropTypes.oneOf(["description", "details"]).tag({
+			defaultValue: "description",
 			label: "Product Content",
 			labels: {
 				description: "Product Description",

--- a/blocks/product-content-block/features/product-content/default.test.jsx
+++ b/blocks/product-content-block/features/product-content/default.test.jsx
@@ -10,6 +10,7 @@ describe("Product Content", () => {
 		useFusionContext.mockImplementation(() => ({
 			globalContent: {},
 		}));
+
 		const { container } = render(<ProductContent customFields={{}} />);
 		expect(container.firstChild).toBe(null);
 	});
@@ -20,12 +21,12 @@ describe("Product Content", () => {
 		expect(container.firstChild).toBe(null);
 	});
 
-	it("should render product details", () => {
+	it("should render product description", () => {
 		useFusionContext.mockImplementation(() => ({
 			globalContent: {
+				description: "Product Description",
 				schema: {
 					productDetails: {
-						label: "Product Details",
 						value: "Crocker Sandals product",
 						dataType: "string",
 						visible: true,
@@ -34,8 +35,66 @@ describe("Product Content", () => {
 				},
 			},
 		}));
+		render(<ProductContent customFields={{ contentType: "description" }} />);
+		expect(screen.queryByText("product-content.description")).toBeInTheDocument();
+		expect(screen.queryByText("Product Description")).toBeInTheDocument();
+	});
+
+	it("should render product details", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				schema: {
+					productDetails: {
+						value: "Crocker Sandals product",
+						dataType: "string",
+						visible: true,
+						configuration: null,
+					},
+				},
+			},
+		}));
+
 		render(<ProductContent customFields={{ contentType: "details" }} />);
-		expect(screen.queryByText("Product Details")).toBeInTheDocument();
+		expect(screen.queryByText("product-content.details")).toBeInTheDocument();
 		expect(screen.queryByText("Crocker Sandals product")).toBeInTheDocument();
+	});
+
+	it("should render product details", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				schema: {
+					productDetails: {
+						value: "Crocker Sandals product",
+						dataType: "string",
+						configuration: null,
+					},
+				},
+			},
+		}));
+
+		render(<ProductContent customFields={{ contentType: "details" }} />);
+		expect(screen.queryByText("product-content.details")).toBeInTheDocument();
+		expect(screen.queryByText("Crocker Sandals product")).toBeInTheDocument();
+	});
+
+	it("should not render product details if visible flag is false", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				schema: {
+					productDetails: {
+						value: "Crocker Sandals product",
+						dataType: "string",
+						visible: false,
+						configuration: null,
+					},
+				},
+			},
+		}));
+
+		const { container } = render(<ProductContent customFields={{ contentType: "details" }} />);
+
+		expect(container.firstChild).toBe(null);
+		expect(screen.queryByText("product-content.details")).not.toBeInTheDocument();
+		expect(screen.queryByText("Crocker Sandals product")).not.toBeInTheDocument();
 	});
 });

--- a/blocks/product-content-block/features/product-content/default.test.jsx
+++ b/blocks/product-content-block/features/product-content/default.test.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { useFusionContext } from "fusion:context";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+
+import ProductContent from "./default";
+
+describe("Product Content", () => {
+	it("should render null if no global content", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {},
+		}));
+		const { container } = render(<ProductContent customFields={{}} />);
+		expect(container.firstChild).toBe(null);
+	});
+
+	it("should render null if no global content object", () => {
+		useFusionContext.mockImplementation(() => ({}));
+		const { container } = render(<ProductContent customFields={{}} />);
+		expect(container.firstChild).toBe(null);
+	});
+
+	it("should render product details", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				schema: {
+					productDetails: {
+						label: "Product Details",
+						value: "Crocker Sandals product",
+						dataType: "string",
+						visible: true,
+						configuration: null,
+					},
+				},
+			},
+		}));
+		render(<ProductContent customFields={{ contentType: "details" }} />);
+		expect(screen.queryByText("Product Details")).toBeInTheDocument();
+		expect(screen.queryByText("Crocker Sandals product")).toBeInTheDocument();
+	});
+});

--- a/blocks/product-content-block/index.story.jsx
+++ b/blocks/product-content-block/index.story.jsx
@@ -5,6 +5,9 @@ export default {
 	title: "Blocks/Product Content",
 	parameters: {
 		chromatic: { viewports: [320, 1200] },
+		cssVariables: {
+			theme: "commerce",
+		},
 	},
 };
 

--- a/blocks/product-content-block/index.story.jsx
+++ b/blocks/product-content-block/index.story.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { ProductContentDisplay } from "./features/product-content/default";
+
+export default {
+	title: "Blocks/Product Content",
+	parameters: {
+		chromatic: { viewports: [320, 1200] },
+	},
+};
+
+const mockData = {
+	schema: {
+		productDetails: {
+			label: "Product Details",
+			value: "Crocker Sandals<br />product",
+			dataType: "string",
+			visible: true,
+			configuration: null,
+		},
+	},
+};
+
+export const TitleAndContent = () => (
+	<ProductContentDisplay summary="Product Details">
+		{mockData.schema.productDetails.value}
+	</ProductContentDisplay>
+);

--- a/blocks/product-content-block/intl.json
+++ b/blocks/product-content-block/intl.json
@@ -1,13 +1,24 @@
 {
-	"product-content-block.hello-text": {
-		"de": "Hallo",
-		"en": "Hello World",
-		"es": "Hola Mundo",
-		"fr": "Bonjour le monde",
-		"ja": "こんにちは世界",
-		"ko": "안녕하세요 세계",
-		"no": "Hei Verden",
-		"pt": "Olá Mundo",
-		"sv": "Hej Verden"
+	"product-content.description": {
+		"de": "Description",
+		"en": "Description",
+		"es": "Description",
+		"fr": "Description",
+		"ja": "Description",
+		"ko": "Description",
+		"no": "Description",
+		"pt": "Description",
+		"sv": "Description"
+	},
+	"product-content.details": {
+		"de": "Details",
+		"en": "Details",
+		"es": "Details",
+		"fr": "Details",
+		"ja": "Details",
+		"ko": "Details",
+		"no": "Details",
+		"pt": "Details",
+		"sv": "Details"
 	}
 }

--- a/blocks/product-content-block/intl.json
+++ b/blocks/product-content-block/intl.json
@@ -1,0 +1,13 @@
+{
+	"product-content-block.hello-text": {
+		"de": "Hallo",
+		"en": "Hello World",
+		"es": "Hola Mundo",
+		"fr": "Bonjour le monde",
+		"ja": "こんにちは世界",
+		"ko": "안녕하세요 세계",
+		"no": "Hei Verden",
+		"pt": "Olá Mundo",
+		"sv": "Hej Verden"
+	}
+}

--- a/blocks/product-content-block/jest.config.js
+++ b/blocks/product-content-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest/jest.config.base");
+
+module.exports = {
+	...base,
+};

--- a/blocks/product-content-block/package.json
+++ b/blocks/product-content-block/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@wpmedia/product-content-block",
+  "version": "0.1.0",
+  "description": "Product Content Block",
+  "author": "Arc XP - Themes",
+  "homepage": "https://github.com/WPMedia/arc-themes-blocks",
+  "license": "CC-BY-NC-ND-4.0",
+  "main": "",
+  "files": [
+    "_index.scss",
+    "features",
+    "intl.json"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+    "directory": "blocks/product-content-block"
+  },
+  "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
+    "@wpmedia/arc-themes-components": "*"
+  }
+}

--- a/blocks/product-information-block/features/product-information/default.jsx
+++ b/blocks/product-information-block/features/product-information/default.jsx
@@ -39,7 +39,7 @@ const ProductInformation = () => {
 	return <ProductInformationDisplay data={globalContent} />;
 };
 
-ProductInformation.label = "Product Infomration - Arc Block";
+ProductInformation.label = "Product Information - Arc Block";
 
 ProductInformation.icon = "cursor-information";
 

--- a/locale/de.json
+++ b/locale/de.json
@@ -443,5 +443,9 @@
 		"product-assortment-carousel.right-arrow-label": "Next",
 		"product-assortment-carousel.left-arrow-label": "Previous",
 		"product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+	},
+	"product-content-block": {
+		"product-content.description": "Description",
+		"product-content.details": "Details"
 	}
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -443,5 +443,9 @@
 		"product-assortment-carousel.right-arrow-label": "Next",
 		"product-assortment-carousel.left-arrow-label": "Previous",
 		"product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+	},
+	"product-content-block": {
+		"product-content.description": "Description",
+		"product-content.details": "Details"
 	}
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -443,5 +443,9 @@
 		"product-assortment-carousel.right-arrow-label": "Next",
 		"product-assortment-carousel.left-arrow-label": "Previous",
 		"product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+	},
+	"product-content-block": {
+		"product-content.description": "Description",
+		"product-content.details": "Details"
 	}
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -443,5 +443,9 @@
 		"product-assortment-carousel.right-arrow-label": "Next",
 		"product-assortment-carousel.left-arrow-label": "Previous",
 		"product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+	},
+	"product-content-block": {
+		"product-content.description": "Description",
+		"product-content.details": "Details"
 	}
 }

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -443,5 +443,9 @@
 		"product-assortment-carousel.right-arrow-label": "Next",
 		"product-assortment-carousel.left-arrow-label": "Previous",
 		"product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+	},
+	"product-content-block": {
+		"product-content.description": "Description",
+		"product-content.details": "Details"
 	}
 }

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -443,5 +443,9 @@
 		"product-assortment-carousel.right-arrow-label": "Next",
 		"product-assortment-carousel.left-arrow-label": "Previous",
 		"product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+	},
+	"product-content-block": {
+		"product-content.description": "Description",
+		"product-content.details": "Details"
 	}
 }

--- a/locale/no.json
+++ b/locale/no.json
@@ -443,5 +443,9 @@
 		"product-assortment-carousel.right-arrow-label": "Next",
 		"product-assortment-carousel.left-arrow-label": "Previous",
 		"product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+	},
+	"product-content-block": {
+		"product-content.description": "Description",
+		"product-content.details": "Details"
 	}
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -443,5 +443,9 @@
 		"product-assortment-carousel.right-arrow-label": "Next",
 		"product-assortment-carousel.left-arrow-label": "Previous",
 		"product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+	},
+	"product-content-block": {
+		"product-content.description": "Description",
+		"product-content.details": "Details"
 	}
 }

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -443,5 +443,9 @@
 		"product-assortment-carousel.right-arrow-label": "Next",
 		"product-assortment-carousel.left-arrow-label": "Previous",
 		"product-assortment-carousel.slide-indicator": "Slide %{current} of %{maximum}"
+	},
+	"product-content-block": {
+		"product-content.description": "Description",
+		"product-content.details": "Details"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16668,9 +16668,9 @@
       "version": "file:blocks/alert-bar-content-source-block"
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-1.31",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-1.31/baf65145bcf6230af0ffd4766e2bdf531d9fd20619b1e3042a8c958734c0ab47",
-      "integrity": "sha512-0zemsrFPPr9oUt4PIFH1jMtiQMOOZKebwNuDwBWAvTSCXuw0jDG36+nbeQr4SfnJnKSWZN1GtafqDHqmGpBUDQ==",
+      "version": "0.0.4-arc-themes-release-version-2-0-1.32",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-1.32/8780493e7dec28b513afcf04a909550ff24c42f0f81198646462a718f5c16d2f",
+      "integrity": "sha512-5lrzgZPy+EPAwcKNaHWAzE1rSu6MCNZ9yRLf7IZB2s6cSeL9b15eYpXmyf0VP+neeJCkqmZ/QLWmMviya/zt7Q==",
       "dev": true,
       "requires": {
         "react-oembed-container": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16892,6 +16892,9 @@
     "@wpmedia/product-assortment-carousel-block": {
       "version": "file:blocks/product-assortment-carousel-block"
     },
+    "@wpmedia/product-content-block": {
+      "version": "file:blocks/product-content-block"
+    },
     "@wpmedia/product-information-block": {
       "version": "file:blocks/product-information-block"
     },

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "@wpmedia/overline-block": "file:blocks/overline-block",
     "@wpmedia/placeholder-image-block": "file:blocks/placeholder-image-block",
     "@wpmedia/product-assortment-carousel-block": "file:blocks/product-assortment-carousel-block",
+    "@wpmedia/product-content-block": "file:blocks/product-content-block",
     "@wpmedia/product-information-block": "file:blocks/product-information-block",
     "@wpmedia/quad-chain-block": "file:blocks/quad-chain-block",
     "@wpmedia/quilted-image-block": "file:blocks/quilted-image-block",


### PR DESCRIPTION
## Description

Add new block - Product Content Block.

Display's either product description or product details depending on the option picked via PageBuilder Custom fields, - relies on global content from Arc Commerce APIs

## Jira Ticket

- [TBRANDS-98](https://arcpublishing.atlassian.net/browse/TBRANDS-98)

## Test Steps

1. Checkout this branch `git checkout TBRANDS-98-product-content-block`
2. Checkout out the following branch on Feature Pack `TBRANDS-98-product-content-block`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/product-content-block`
4. Create a new page in PageBuilder
5. Set the page to have global content using the content source `commerce-product`
6. Add the **Product Content - Arc Block** to a section of the page
7. Validate the custom fields work as intended
8. Picking a content type displays the correct content

## Dependencies or Side Effects

Feature Pack PR - https://github.com/WPMedia/arc-themes-feature-pack/pull/315

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
