### PR TITLE
TMEDIA-724 - Update logo alignment issues and right placement items

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -930,11 +930,9 @@
 				header-nav-chain-top-layout: (
 					align-items: center,
 					display: flex,
+					justify-content: space-between,
 					width: 100%,
 					gap: var(--global-spacing-5),
-				),
-				header-nav-chain-top-layout-center-logo: (
-					justify-content: space-between,
 				),
 				header-nav-chain-top-layout-last-child: (
 					margin-right: 0,
@@ -958,6 +956,12 @@
 					align-items: center,
 					display: none,
 					gap: var(--global-spacing-2),
+				),
+				header-nav-chain-logo: (
+					margin-right: auto,
+				),
+				header-nav-chain-logo-center: (
+					margin-right: 0,
 				),
 				header-nav-chain-logo-hidden: (
 					opacity: 0,
@@ -1014,7 +1018,7 @@
 					display: none,
 					gap: var(--global-spacing-2),
 					height: var(--global-spacing-5),
-					flex: 0 3 auto,
+					flex: 1 1 auto,
 					overflow: hidden,
 					text-align: left,
 					width: auto,

--- a/blocks/header-nav-chain-block/_index.scss
+++ b/blocks/header-nav-chain-block/_index.scss
@@ -158,16 +158,16 @@
 	}
 
 	&__top-layout {
-		&--center-logo {
-			@include scss.block-components("header-nav-chain-top-layout-center-logo");
-			@include scss.block-properties("header-nav-chain-top-layout-center-logo");
-		}
-
 		@include scss.block-components("header-nav-chain-top-layout");
 		@include scss.block-properties("header-nav-chain-top-layout");
 	}
 
 	&__logo {
+		&--center {
+			@include scss.block-components("header-nav-chain-logo-center");
+			@include scss.block-properties("header-nav-chain-logo-center");
+		}
+
 		&.nav-logo-show {
 			@include scss.block-components("header-nav-chain-logo-show");
 			@include scss.block-properties("header-nav-chain-logo-show");

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
@@ -4,7 +4,7 @@ import { useDebouncedCallback } from "use-debounce";
 
 const showLogoAbove = 768;
 
-const NavLogo = ({ imageAltText, imageSource, blockClassName }) => {
+const NavLogo = ({ imageAltText, imageSource, blockClassName, logoAlignment }) => {
 	const [isLogoVisible, setLogoVisibility] = useState(false);
 
 	// istanbul ignore next
@@ -71,9 +71,9 @@ const NavLogo = ({ imageAltText, imageSource, blockClassName }) => {
 		<Link
 			href="/"
 			title={imageAltText}
-			className={`${blockClassName}__logo  ${isLogoVisible ? "nav-logo-show" : "nav-logo-hidden"} ${
-				isLogoSVG ? "svg-logo" : ""
-			}`}
+			className={`${blockClassName}__logo ${
+				logoAlignment === "center" ? `${blockClassName}__logo--center` : ``
+			} ${isLogoVisible ? "nav-logo-show" : "nav-logo-hidden"} ${isLogoSVG ? "svg-logo" : ""}`}
 			assistiveHidden={!isLogoVisible}
 		>
 			{imageSource ? <img src={imageSource} alt={imageAltText || ""} /> : null}

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -43,11 +43,7 @@ export function PresentationalNav(props) {
 			className={`${BLOCK_CLASS_NAME} ${isScrolled ? `${BLOCK_CLASS_NAME}--scrolled` : ``}`}
 			aria-label={sectionAriaLabel}
 		>
-			<div
-				className={`${BLOCK_CLASS_NAME}__top-layout ${
-					logoAlignment === "center" ? `${BLOCK_CLASS_NAME}__top-layout--center-logo` : ``
-				}`}
-			>
+			<div className={`${BLOCK_CLASS_NAME}__top-layout`}>
 				<NavSection
 					blockClassName={BLOCK_CLASS_NAME}
 					customFields={customFields}
@@ -59,6 +55,7 @@ export function PresentationalNav(props) {
 				</NavSection>
 				<NavLogo
 					blockClassName={BLOCK_CLASS_NAME}
+					logoAlignment={logoAlignment}
 					imageSource={primaryLogoPath}
 					imageAltText={primaryLogoAlt}
 				/>

--- a/blocks/header-nav-chain-block/index.story.jsx
+++ b/blocks/header-nav-chain-block/index.story.jsx
@@ -153,6 +153,27 @@ export const leftLogoWithLinks = () => (
 	/>
 );
 
+export const leftLogoWithRightItems = () => (
+	<PresentationalNav
+		closeDrawer={() => {}}
+		customFields={{
+			...CUSTOM_FIELDS_BASE,
+			rightComponentDesktop1: "search",
+		}}
+		displayLinks
+		isAdmin={false}
+		isSectionDrawerOpen={false}
+		logoAlignment="left"
+		menuButtonClickAction={() => {}}
+		sectionAriaLabel="Menu des sections"
+		sections={[]}
+		showDotSeparators
+		signInOrder={1}
+		primaryLogoPath="https://place-hold.it/86x36"
+		primaryLogoAlt="Shows dimensions of 86 by 36."
+	/>
+);
+
 export const leftLogoWithLinksAndSearch = () => (
 	<PresentationalNav
 		closeDrawer={() => {}}
@@ -163,7 +184,7 @@ export const leftLogoWithLinksAndSearch = () => (
 			leftComponentMobile1: "menu",
 		}}
 		displayLinks
-		horizontalLinksHierarchy="horizontal-links"
+		horizontalLinksHierarchy="tenLinks"
 		isAdmin={false}
 		logoAlignment="left"
 		menuButtonClickAction={() => {}}


### PR DESCRIPTION
## Description

Update Logo and right navigation items being in the correct location as per testing feedback

## Jira Ticket

- [TMEDIA-724](https://arcpublishing.atlassian.net/browse/TMEDIA-724)


## Test Steps

1. Checkout this branch `git checkout TMEDIA-724-testing-feedback`
2. Checkout branch on Feature pack `TMEDIA-724-testing-feedback`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
4. Test Header Nav Chain on Page with different logo placements (Left & Center)
5. Test with right components on desktop via Custom Fields

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
