### PR TITLE
Add missing block-components to feature generator scss

### DIFF
--- a/_templates/feature/new/scss-entry.ejs.t
+++ b/_templates/feature/new/scss-entry.ejs.t
@@ -5,5 +5,6 @@ to: blocks/<%= h.inflection.dasherize(block_name) %>-block/_index.scss
 @use "@wpmedia/arc-themes-components/scss";
 
 .b-<%= h.inflection.dasherize(block_name) %> {
-	@include scss.block-properties('<%= h.inflection.dasherize(block_name) %>');
+	@include scss.block-components("<%= h.inflection.dasherize(block_name) %>");
+	@include scss.block-properties("<%= h.inflection.dasherize(block_name) %>");
 }


### PR DESCRIPTION
## Description

Add missing Sass library include for block-components to the feature generator code

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
