### PR TITLE
Tmedia 716 update ads other imports

### DIFF
--- a/blocks/ads-block/index.js
+++ b/blocks/ads-block/index.js
@@ -1,7 +1,0 @@
-import ArcAd from "./features/ads/default";
-
-export default ArcAd;
-
-// Once blocks that are using this export have been refactored
-// remove the above export and uncomment the below export
-// module.exports = {};

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -22,7 +22,7 @@ export const GalleryPresentation = ({
 	let AdBlock;
 
 	try {
-		const { default: AdFeature } = require("@wpmedia/ads-block");
+		const { default: AdFeature } = require("@wpmedia/ads-block/features/ads/default");
 		AdBlock = () => (
 			<AdFeature
 				customFields={{

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -78,7 +78,7 @@ class LeadArt extends Component {
 
 		try {
 			/* istanbul ignore next */
-			const { default: AdFeature } = require("@wpmedia/ads-block");
+			const { default: AdFeature } = require("@wpmedia/ads-block/features/ads/default");
 			/* istanbul ignore next */
 			AdBlock = () => (
 				<AdFeature


### PR DESCRIPTION
- Ensure other ads imports are working
- The ads block is needing the import updated

adding other deps to blocks.json
can update cube clicks to validate

```
    "@wpmedia/gallery-block",
    "@wpmedia/lead-art-block",
    "@wpmedia/shared-styles",
    "@wpmedia/placeholder-image-block"
  ],
```

![Screen Shot 2022-08-03 at 10 32 34](https://user-images.githubusercontent.com/5950956/182648707-e7c462a4-a732-4bd3-9019-40726a54aa51.png)
![Screen Shot 2022-08-03 at 10 32 18](https://user-images.githubusercontent.com/5950956/182648709-7151f5b9-7097-4faa-8d30-0fa82659646f.png)

