### PR TITLE
TMEDIA-724 - header nav adjustments

### DIFF
--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -38,113 +38,116 @@ export function PresentationalNav(props) {
 	} = props;
 
 	return (
-		<nav
-			id="main-nav"
-			className={`${BLOCK_CLASS_NAME} ${isScrolled ? `${BLOCK_CLASS_NAME}--scrolled` : ``}`}
-			aria-label={sectionAriaLabel}
-		>
-			<div className={`${BLOCK_CLASS_NAME}__top-layout`}>
-				<NavSection
-					blockClassName={BLOCK_CLASS_NAME}
-					customFields={customFields}
-					menuButtonClickAction={menuButtonClickAction}
-					side="left"
-					signInOrder={signInOrder}
-				>
-					{children}
-				</NavSection>
-				<NavLogo
-					blockClassName={BLOCK_CLASS_NAME}
-					logoAlignment={logoAlignment}
-					imageSource={primaryLogoPath}
-					imageAltText={primaryLogoAlt}
-				/>
-				{displayLinks ? (
-					<NavLinksBar
-						hierarchy={horizontalLinksHierarchy}
-						showHorizontalSeperatorDots={showDotSeparators}
-						ariaLabel={ariaLabelLink}
-						blockClassName={BLOCK_CLASS_NAME}
-					/>
-				) : null}
-				<NavSection
-					blockClassName={BLOCK_CLASS_NAME}
-					customFields={customFields}
-					menuButtonClickAction={menuButtonClickAction}
-					side="right"
-					signInOrder={signInOrder}
-				>
-					{children}
-				</NavSection>
-			</div>
-			<Stack
-				id="flyout-overlay"
-				className={`${BLOCK_CLASS_NAME}__flyout-overlay ${isSectionDrawerOpen ? "open" : "closed"}`}
-				direction="vertical"
-				justification="start"
-				onClick={closeDrawer}
+		<>
+			<nav
+				id="main-nav"
+				className={`${BLOCK_CLASS_NAME} ${isScrolled ? `${BLOCK_CLASS_NAME}--scrolled` : ``}`}
+				aria-label={sectionAriaLabel}
 			>
-				<FocusTrap
-					active={isSectionDrawerOpen}
-					focusTrapOptions={{
-						allowOutsideClick: true,
-						returnFocusOnDeactivate: true,
-						onDeactivate: /* istanbul ignore next */ () => {
-							// Focus the next focusable element in the navbar
-							// Workaround for issue where 'nav-sections-btn' wont programmatically focus
-							const focusElement = document.querySelector(`
+				<div className={`${BLOCK_CLASS_NAME}__top-layout`}>
+					<NavSection
+						blockClassName={BLOCK_CLASS_NAME}
+						customFields={customFields}
+						menuButtonClickAction={menuButtonClickAction}
+						side="left"
+						signInOrder={signInOrder}
+					>
+						{children}
+					</NavSection>
+					<NavLogo
+						blockClassName={BLOCK_CLASS_NAME}
+						logoAlignment={logoAlignment}
+						imageSource={primaryLogoPath}
+						imageAltText={primaryLogoAlt}
+					/>
+					{displayLinks ? (
+						<NavLinksBar
+							hierarchy={horizontalLinksHierarchy}
+							showHorizontalSeperatorDots={showDotSeparators}
+							ariaLabel={ariaLabelLink}
+							blockClassName={BLOCK_CLASS_NAME}
+						/>
+					) : null}
+					<NavSection
+						blockClassName={BLOCK_CLASS_NAME}
+						customFields={customFields}
+						menuButtonClickAction={menuButtonClickAction}
+						side="right"
+						signInOrder={signInOrder}
+					>
+						{children}
+					</NavSection>
+				</div>
+				<Stack
+					id="flyout-overlay"
+					className={`${BLOCK_CLASS_NAME}__flyout-overlay ${
+						isSectionDrawerOpen ? "open" : "closed"
+					}`}
+					direction="vertical"
+					justification="start"
+					onClick={closeDrawer}
+				>
+					<FocusTrap
+						active={isSectionDrawerOpen}
+						focusTrapOptions={{
+							allowOutsideClick: true,
+							returnFocusOnDeactivate: true,
+							onDeactivate: /* istanbul ignore next */ () => {
+								// Focus the next focusable element in the navbar
+								// Workaround for issue where 'nav-sections-btn' wont programmatically focus
+								const focusElement = document.querySelector(`
                 #main-nav a:not(.nav-sections-btn),
                 #main-nav button:not(.nav-sections-btn)
               `);
-							// istanbul ignore next
-							if (focusElement) {
-								focusElement.focus();
-								focusElement.blur();
-							}
-						},
-						fallbackFocus: /* istanbul ignore next */ () =>
-							document.getElementById("flyout-overlay"),
-					}}
-				>
-					{/**
-					 * Need to disable tabindex lint as this is a fallback for when section menu
-					 * has no items and FocusTrap requires at least one tabable element
-					 * which would be the follow container that's used with `fallbackFocus`
-					 *
-					 * Div needed as Stack does not forward Ref - this causes Focus Trap
-					 * library to throw errors without the div
-					 */}
-					<div>
-						<Stack
-							className={`${BLOCK_CLASS_NAME}__flyout-nav-wrapper ${
-								isSectionDrawerOpen ? "open" : "closed"
-							}`}
-							direction="vertical"
-							justification="start"
-							// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-							tabIndex={!sections.length ? "-1" : null}
-						>
-							<SectionNav
-								blockClassName={BLOCK_CLASS_NAME}
-								sections={sections}
-								isHidden={!isSectionDrawerOpen}
+								// istanbul ignore next
+								if (focusElement) {
+									focusElement.focus();
+									focusElement.blur();
+								}
+							},
+							fallbackFocus: /* istanbul ignore next */ () =>
+								document.getElementById("flyout-overlay"),
+						}}
+					>
+						{/**
+						 * Need to disable tabindex lint as this is a fallback for when section menu
+						 * has no items and FocusTrap requires at least one tabable element
+						 * which would be the follow container that's used with `fallbackFocus`
+						 *
+						 * Div needed as Stack does not forward Ref - this causes Focus Trap
+						 * library to throw errors without the div
+						 */}
+						<div>
+							<Stack
+								className={`${BLOCK_CLASS_NAME}__flyout-nav-wrapper ${
+									isSectionDrawerOpen ? "open" : "closed"
+								}`}
+								direction="vertical"
+								justification="start"
+								// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+								tabIndex={!sections.length ? "-1" : null}
 							>
-								<MenuWidgets
-									customFields={customFields}
-									menuButtonClickAction={menuButtonClickAction}
+								<SectionNav
+									blockClassName={BLOCK_CLASS_NAME}
+									sections={sections}
+									isHidden={!isSectionDrawerOpen}
 								>
-									{children}
-								</MenuWidgets>
-							</SectionNav>
-						</Stack>
-					</div>
-				</FocusTrap>
-			</Stack>
-
+									<MenuWidgets
+										customFields={customFields}
+										menuButtonClickAction={menuButtonClickAction}
+									>
+										{children}
+									</MenuWidgets>
+								</SectionNav>
+							</Stack>
+						</div>
+					</FocusTrap>
+				</Stack>
+			</nav>
 			{horizontalLinksHierarchy && logoAlignment !== "left" && isAdmin ? (
 				<Stack>In order to render horizontal links, the logo must be aligned to the left.</Stack>
 			) : null}
-		</nav>
+		</>
 	);
 }
 /* Main Component */
@@ -167,7 +170,7 @@ const Nav = (props) => {
 	const {
 		hierarchy,
 		signInOrder,
-		logoAlignment = "center",
+		logoAlignment,
 		horizontalLinksHierarchy,
 		showHorizontalSeperatorDots,
 		ariaLabel,
@@ -265,7 +268,7 @@ const Nav = (props) => {
 			horizontalLinksHierarchy={horizontalLinksHierarchy}
 			isAdmin={isAdmin}
 			isSectionDrawerOpen={isSectionDrawerOpen}
-			logoAlignment={logoAlignment}
+			logoAlignment={logoAlignment || "center"}
 			menuButtonClickAction={menuButtonClickAction}
 			isScrolled={isScrolled}
 			sectionAriaLabel={sectionAriaLabel}

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -241,6 +241,7 @@ const Nav = (props) => {
 		};
 	}, []);
 
+	// istanbul ignore next
 	const handleScroll = () => {
 		setIsScrolled(window.pageYOffset > 0);
 	};


### PR DESCRIPTION
## Description

Move admin message below `nav` to avoid it rendering within the nav
Move default value for logo to be within the property as PageBuilder is giving a `null` when user selects `---` as the custom field value 

## Jira Ticket

- [TMEDIA-724](https://arcpublishing.atlassian.net/browse/TMEDIA-724)

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TMEDIA-724-header-nav-adjustments`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Validate in PageBuilder when logo is set to `---` image is center aligned
4. Validate when you have logo center aligned and Horizontal Links hierarchy is set there is an admin message shown below nav

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
