### PR TITLE
fix: Remove article body unused engine theme sdk prop. The value is hidden anyway.

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -3,7 +3,7 @@ import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
 import getTranslatedPhrases from "fusion:intl";
-import { LazyLoad, isServerSide, videoPlayerCustomFields } from "@wpmedia/engine-theme-sdk";
+import { LazyLoad, isServerSide } from "@wpmedia/engine-theme-sdk";
 
 import {
 	formatCredits,
@@ -386,7 +386,6 @@ ArticleBodyChain.propTypes = {
 			description:
 				"Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.",
 		}),
-		...videoPlayerCustomFields(),
 		hideImageTitle: PropTypes.bool.tag({
 			description: "This display option applies to all Images in the Article Body.",
 			label: "Hide Title",

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -12,8 +12,6 @@ jest.mock("fusion:properties", () =>
 );
 
 jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	Image: () => <div />,
-	ImageMetadata: () => <div />,
 	LazyLoad: ({ children }) => <>{children}</>,
 	isServerSide: jest.fn(),
 }));

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -2221,4 +2221,106 @@ describe("article-body chain", () => {
 			expect(wrapper.find("Video").length).toEqual(1);
 		});
 	});
+
+	describe("Render gallery type", () => {
+		it("should render gallery type", () => {
+			// add match media for carousel matchmedia check mocking
+			window.matchMedia = jest.fn();
+
+			useFusionContext.mockImplementation(() => ({
+				globalContent: {
+					_id: "gallery_id",
+					content_elements: [
+						{
+							_id: "gallery_id",
+							content_elements: [
+								{
+									_id: "image_id1",
+									alt_text: "Image Alt Text 1",
+									caption: "Image Caption 1",
+									credits: {
+										affiliation: [{ name: "Affiliation 1", type: "author" }],
+										by: [
+											{
+												byline: "Custom Credit 1",
+												name: "Smith Smitherson",
+												type: "author",
+											},
+										],
+									},
+									vanity_credits: {
+										by: [
+											{
+												type: "author",
+												name: "Here's my vanity photographer",
+											},
+										],
+										affiliation: [
+											{
+												type: "author",
+												name: "Here's my vanity credit",
+											},
+										],
+									},
+									height: 3744,
+									resized_params: {
+										"274x0": "--al0lnFNBcEFSRnjIDaqW3hEXs=filters:format(jpg):quality(70)/",
+										"400x0": "D1TuuuNZJiX29k5IcHROrI-y1zI=filters:format(jpg):quality(70)/",
+										"768x0": "C6NNPZQgZICy5VMk-jLjNpbg_vw=filters:format(jpg):quality(70)/",
+										"800x0": "SFAi-Aks2Fy99PkwQ9LLvd2Jxl4=filters:format(jpg):quality(70)/",
+										"1024x0": "LSihqkSkpwAFfD0qsLDFuLw08P8=filters:format(jpg):quality(70)/",
+										"1440x0": "mnOhSZmQiFynETHFN7BAYI5-Pzg=filters:format(jpg):quality(70)/",
+									},
+									subtitle: "Image Subtitle 1",
+									type: "image",
+									url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg",
+									width: 5616,
+								},
+								{
+									_id: "image_id2",
+									alt_text: "Image Alt Text 2",
+									caption: "Image Caption 2",
+									credits: {
+										affiliation: [{ name: "Affiliation 2", type: "author" }],
+										by: [
+											{
+												byline: "Custom Credit 2",
+												name: "Smith Smitherson",
+												type: "author",
+											},
+										],
+									},
+									height: 3744,
+									resized_params: {
+										"274x0": "--al0lnFNBcEFSRnjIDaqW3hEXs=filters:format(jpg):quality(70)/",
+										"400x0": "D1TuuuNZJiX29k5IcHROrI-y1zI=filters:format(jpg):quality(70)/",
+										"768x0": "C6NNPZQgZICy5VMk-jLjNpbg_vw=filters:format(jpg):quality(70)/",
+										"800x0": "SFAi-Aks2Fy99PkwQ9LLvd2Jxl4=filters:format(jpg):quality(70)/",
+										"1024x0": "LSihqkSkpwAFfD0qsLDFuLw08P8=filters:format(jpg):quality(70)/",
+										"1440x0": "mnOhSZmQiFynETHFN7BAYI5-Pzg=filters:format(jpg):quality(70)/",
+									},
+									subtitle: "Image Subtitle 2",
+									type: "image",
+									url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG",
+									width: 5616,
+								},
+							],
+							headlines: {
+								basic: "Gallery Headline",
+							},
+							type: "gallery",
+						},
+					],
+					headlines: {
+						basic: "Gallery Headline",
+					},
+					type: "story",
+				},
+			}));
+
+			const wrapper = mount(<ArticleBodyChain />);
+
+			expect(wrapper.find("Carousel").length).toEqual(1);
+		});
+	});
 });


### PR DESCRIPTION
How to test: 

- `npx fusion start -f -l @wpmedia/article-body-block`
- Should not show group of unused inputs for video 
- Look at the code. Make sure not unnecessary engine theme sdk props are being used

-----

- The video props sdk helper should not be being used. Was causing an error without the lib in engine theme sdk. I've been testing without these https://github.com/WPMedia/engine-theme-sdk/pull/686

![Screen Shot 2022-08-04 at 09 44 31](https://user-images.githubusercontent.com/5950956/182881403-3179bd6b-5848-4cc3-9217-9207c1706e49.png)

# Before 

cc 

video settings is hidden anyway

![Screen Shot 2022-08-04 at 10 01 54](https://user-images.githubusercontent.com/5950956/182881640-2b670765-3328-4cf8-b944-8884881035b3.png)

# After 
![Screen Shot 2022-08-04 at 10 07 02](https://user-images.githubusercontent.com/5950956/182881763-fb259ec8-1ade-492f-9a0b-b472dcf2fd6a.png)

no error on the page around missing the import
![Screen Shot 2022-08-04 at 10 07 15](https://user-images.githubusercontent.com/5950956/182881809-c2f6a064-92f7-4551-9728-7ded38a5b2ac.png)


---- 

- Follows the checklist around removing engine theme sdk conversion 

