### PR TITLE
Tbrands 99 product gallery

### DIFF
--- a/.storybook/alias/context.js
+++ b/.storybook/alias/context.js
@@ -188,6 +188,7 @@ export const useFusionContext = () => ({
 
 export const useComponentContext = () => ({
 	registerSuccessEvent: () => ({}),
+	id: "unique-id-via-use-component-context",
 });
 
 export default () => {};

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -705,7 +705,8 @@
 							--slide-width: 100%,
 						),
 						carousel-actions: (
-							display: flex,
+							// hide the actions on desktop and mobile
+							display: none,
 						),
 						carousel-track: (
 							gap: var(--global-spacing-4),
@@ -997,10 +998,6 @@
 							// will be 50% accounting for the gap
 							--slides: 2,
 							--slide-width: 50%,
-						),
-						carousel-actions: (
-							// hide the actions on desktop
-							display: none,
 						),
 						carousel-track: (
 							// slides should flow down rather than be hidden off to the side

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -676,6 +676,9 @@
 				),
 				product-gallery: (
 					components: (
+						image: (
+							width: auto,
+						),
 						carousel: (
 							--slides: 1,
 							--slide-width: 100%,

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -674,6 +674,26 @@
 						),
 					),
 				),
+				product-gallery: (
+					components: (
+						carousel: (
+							--slides: 1,
+							--slide-width: 100%,
+						),
+						carousel-actions: (
+							display: flex,
+						),
+						carousel-track: (
+							gap: var(--global-spacing-4),
+							max-width: 100%,
+							width: 100%,
+						),
+					),
+				),
+				product-gallery-featured-image-enabled-first-child: (
+					// for featured enabled, this will apply for the desktop growing to expand full width. On mobile, it doesn't hurt.
+					flex-basis: 100%,
+				),
 				quilted-image: (
 					margin-left: auto,
 					margin-right: auto,
@@ -947,6 +967,24 @@
 						),
 						price: (
 							font-size: var(--global-font-size-7),
+						),
+					),
+				),
+				product-gallery: (
+					components: (
+						carousel: (
+							// the slides that are not featured are half the width of the screen
+							// will be 50% accounting for the gap
+							--slides: 2,
+							--slide-width: 50%,
+						),
+						carousel-actions: (
+							// hide the actions on desktop
+							display: none,
+						),
+						carousel-track: (
+							// slides should flow down rather than be hidden off to the side
+							flex-wrap: wrap,
 						),
 					),
 				),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -1041,6 +1041,7 @@
 @use "../../blocks/category-carousel-block";
 @use "../../blocks/hero-block";
 @use "../../blocks/product-featured-image-block";
+@use "../../blocks/product-gallery-block";
 @use "../../blocks/product-information-block";
 @use "../../blocks/quilted-image-block";
 @use "../../blocks/story-carousel-block";

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -723,7 +723,7 @@
 						),
 						carousel: (
 							--slides: 1,
-							--slide-width: 100%,
+							--carousel-slide-width: 100%,
 						),
 						carousel-actions: (
 							// hide the actions on desktop and mobile
@@ -980,7 +980,7 @@
 							// the slides that are not featured are half the width of the screen
 							// will be 50% accounting for the gap
 							--slides: 2,
-							--slide-width: 50%,
+							--carousel-slide-width: 50%,
 						),
 						carousel-track: (
 							// slides should flow down rather than be hidden off to the side

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -714,7 +714,7 @@
 						),
 					),
 				),
-				product-gallery-featured-image-enabled-first-child: (
+				product-gallery-featured-slide: (
 					// for featured enabled, this will apply for the desktop growing to expand full width. On mobile, it doesn't hurt.
 					flex-basis: 100%,
 				),

--- a/blocks/commerce-product-content-source-block/sources/mock-data.js
+++ b/blocks/commerce-product-content-source-block/sources/mock-data.js
@@ -1,3 +1,92 @@
+const PRODUCT_GALLERY_ITEM = {
+	_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+	alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+	additional_properties: {
+		fullSizeResizeUrl:
+			"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		galleries: [],
+		ingestionMethod: "manual",
+		iptc_source: "Digital Vision",
+		iptc_title: "Contributor",
+		keywords: [""],
+		mime_type: "image/jpeg",
+		originalName: "iStock-669887798.jpg",
+		originalUrl:
+			"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		owner: "matthew.roach@washpost.com",
+		proxyUrl:
+			"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		published: true,
+		resizeUrl:
+			"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		restricted: false,
+		takenOn: "2016-09-24T00:00:00Z",
+		thumbnailResizeUrl:
+			"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		usage_instructions: "Model and Property Released (MR&PR) ",
+		version: 0,
+		template_id: 1184,
+	},
+	address: {
+		locality: "Barcelona",
+	},
+	auth: {
+		2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
+	},
+	caption:
+		"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+	copyright: "Abel Mitja Varela",
+	created_date: "2022-06-10T16:37:52Z",
+	credits: {
+		affiliation: [
+			{
+				name: "Getty Images",
+				type: "author",
+			},
+		],
+		by: [
+			{
+				byline: "Morsa Images",
+				name: "Morsa Images",
+				type: "author",
+			},
+		],
+	},
+	height: 2576,
+	image_type: "photograph",
+	last_updated_date: "2022-06-10T16:37:52Z",
+	licensable: false,
+	owner: {
+		id: "sandbox.themesinternal",
+		sponsored: false,
+	},
+	slug: "669887798",
+	source: {
+		additional_properties: {
+			editor: "photo center",
+		},
+		edit_url: "https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+		system: "photo center",
+	},
+	subtitle: "Executive with arms crossed against rolled fabric",
+	taxonomy: {
+		associated_tasks: [],
+	},
+	type: "image",
+	url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+	version: "0.10.3",
+	width: 3864,
+	syndication: {},
+	creditIPTC: "Getty Images",
+};
+const PRODUCT_GALLERY_MOCK = [
+	...Array(10)
+		.fill(PRODUCT_GALLERY_ITEM)
+		.map((item, index) => ({
+			...item,
+			_id: `${item._id}${index}`,
+		})),
+];
 // eslint-disable-next-line import/prefer-default-export
 export const mockProductData = {
 	id: 7551398322245086,
@@ -123,254 +212,7 @@ export const mockProductData = {
 		productGallery: {
 			label: "Gallery",
 			value: {
-				assets: [
-					{
-						_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-						additional_properties: {
-							fullSizeResizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							galleries: [],
-							ingestionMethod: "manual",
-							iptc_source: "Digital Vision",
-							iptc_title: "Contributor",
-							keywords: [""],
-							mime_type: "image/jpeg",
-							originalName: "iStock-669887798.jpg",
-							originalUrl:
-								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							owner: "matthew.roach@washpost.com",
-							proxyUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							published: true,
-							resizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							restricted: false,
-							takenOn: "2016-09-24T00:00:00Z",
-							thumbnailResizeUrl:
-								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							usage_instructions: "Model and Property Released (MR&PR) ",
-							version: 0,
-							template_id: 1184,
-						},
-						address: {
-							locality: "Barcelona",
-						},
-						auth: {
-							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
-						},
-						caption:
-							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-						copyright: "Abel Mitja Varela",
-						created_date: "2022-06-10T16:37:52Z",
-						credits: {
-							affiliation: [
-								{
-									name: "Getty Images",
-									type: "author",
-								},
-							],
-							by: [
-								{
-									byline: "Morsa Images",
-									name: "Morsa Images",
-									type: "author",
-								},
-							],
-						},
-						height: 2576,
-						image_type: "photograph",
-						last_updated_date: "2022-06-10T16:37:52Z",
-						licensable: false,
-						owner: {
-							id: "sandbox.themesinternal",
-							sponsored: false,
-						},
-						slug: "669887798",
-						source: {
-							additional_properties: {
-								editor: "photo center",
-							},
-							edit_url:
-								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-							system: "photo center",
-						},
-						subtitle: "Executive with arms crossed against rolled fabric",
-						taxonomy: {
-							associated_tasks: [],
-						},
-						type: "image",
-						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-						version: "0.10.3",
-						width: 3864,
-						syndication: {},
-						creditIPTC: "Getty Images",
-					},
-					{
-						_id: "HY6LDPEW4BBFDLBYD4Szzzzz",
-						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-						additional_properties: {
-							fullSizeResizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							galleries: [],
-							ingestionMethod: "manual",
-							iptc_source: "Digital Vision",
-							iptc_title: "Contributor",
-							keywords: [""],
-							mime_type: "image/jpeg",
-							originalName: "iStock-669887798.jpg",
-							originalUrl:
-								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							owner: "matthew.roach@washpost.com",
-							proxyUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							published: true,
-							resizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							restricted: false,
-							takenOn: "2016-09-24T00:00:00Z",
-							thumbnailResizeUrl:
-								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							usage_instructions: "Model and Property Released (MR&PR) ",
-							version: 0,
-							template_id: 1184,
-						},
-						address: {
-							locality: "Barcelona",
-						},
-						auth: {
-							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
-						},
-						caption:
-							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-						copyright: "Abel Mitja Varela",
-						created_date: "2022-06-10T16:37:52Z",
-						credits: {
-							affiliation: [
-								{
-									name: "Getty Images",
-									type: "author",
-								},
-							],
-							by: [
-								{
-									byline: "Morsa Images",
-									name: "Morsa Images",
-									type: "author",
-								},
-							],
-						},
-						height: 2576,
-						image_type: "photograph",
-						last_updated_date: "2022-06-10T16:37:52Z",
-						licensable: false,
-						owner: {
-							id: "sandbox.themesinternal",
-							sponsored: false,
-						},
-						slug: "669887798",
-						source: {
-							additional_properties: {
-								editor: "photo center",
-							},
-							edit_url:
-								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-							system: "photo center",
-						},
-						subtitle: "Executive with arms crossed against rolled fabric",
-						taxonomy: {
-							associated_tasks: [],
-						},
-						type: "image",
-						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-						version: "0.10.3",
-						width: 3864,
-						syndication: {},
-						creditIPTC: "Getty Images",
-					},
-					{
-						_id: "HY6LDPEW4BBFDLBYfff",
-						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-						additional_properties: {
-							fullSizeResizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							galleries: [],
-							ingestionMethod: "manual",
-							iptc_source: "Digital Vision",
-							iptc_title: "Contributor",
-							keywords: [""],
-							mime_type: "image/jpeg",
-							originalName: "iStock-669887798.jpg",
-							originalUrl:
-								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							owner: "matthew.roach@washpost.com",
-							proxyUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							published: true,
-							resizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							restricted: false,
-							takenOn: "2016-09-24T00:00:00Z",
-							thumbnailResizeUrl:
-								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							usage_instructions: "Model and Property Released (MR&PR) ",
-							version: 0,
-							template_id: 1184,
-						},
-						address: {
-							locality: "Barcelona",
-						},
-						auth: {
-							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
-						},
-						caption:
-							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-						copyright: "Abel Mitja Varela",
-						created_date: "2022-06-10T16:37:52Z",
-						credits: {
-							affiliation: [
-								{
-									name: "Getty Images",
-									type: "author",
-								},
-							],
-							by: [
-								{
-									byline: "Morsa Images",
-									name: "Morsa Images",
-									type: "author",
-								},
-							],
-						},
-						height: 2576,
-						image_type: "photograph",
-						last_updated_date: "2022-06-10T16:37:52Z",
-						licensable: false,
-						owner: {
-							id: "sandbox.themesinternal",
-							sponsored: false,
-						},
-						slug: "669887798",
-						source: {
-							additional_properties: {
-								editor: "photo center",
-							},
-							edit_url:
-								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-							system: "photo center",
-						},
-						subtitle: "Executive with arms crossed against rolled fabric",
-						taxonomy: {
-							associated_tasks: [],
-						},
-						type: "image",
-						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-						version: "0.10.3",
-						width: 3864,
-						syndication: {},
-						creditIPTC: "Getty Images",
-					},
-				],
+				assets: PRODUCT_GALLERY_MOCK,
 			},
 		},
 		productDetails: {

--- a/blocks/commerce-product-content-source-block/sources/mock-data.js
+++ b/blocks/commerce-product-content-source-block/sources/mock-data.js
@@ -157,7 +157,171 @@ export const mockProductData = {
 							locality: "Barcelona",
 						},
 						auth: {
-							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
+						},
+						caption:
+							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+						copyright: "Abel Mitja Varela",
+						created_date: "2022-06-10T16:37:52Z",
+						credits: {
+							affiliation: [
+								{
+									name: "Getty Images",
+									type: "author",
+								},
+							],
+							by: [
+								{
+									byline: "Morsa Images",
+									name: "Morsa Images",
+									type: "author",
+								},
+							],
+						},
+						height: 2576,
+						image_type: "photograph",
+						last_updated_date: "2022-06-10T16:37:52Z",
+						licensable: false,
+						owner: {
+							id: "sandbox.themesinternal",
+							sponsored: false,
+						},
+						slug: "669887798",
+						source: {
+							additional_properties: {
+								editor: "photo center",
+							},
+							edit_url:
+								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+							system: "photo center",
+						},
+						subtitle: "Executive with arms crossed against rolled fabric",
+						taxonomy: {
+							associated_tasks: [],
+						},
+						type: "image",
+						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+						version: "0.10.3",
+						width: 3864,
+						syndication: {},
+						creditIPTC: "Getty Images",
+					},
+					{
+						_id: "HY6LDPEW4BBFDLBYD4Szzzzz",
+						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+						additional_properties: {
+							fullSizeResizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							galleries: [],
+							ingestionMethod: "manual",
+							iptc_source: "Digital Vision",
+							iptc_title: "Contributor",
+							keywords: [""],
+							mime_type: "image/jpeg",
+							originalName: "iStock-669887798.jpg",
+							originalUrl:
+								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							owner: "matthew.roach@washpost.com",
+							proxyUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							published: true,
+							resizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							restricted: false,
+							takenOn: "2016-09-24T00:00:00Z",
+							thumbnailResizeUrl:
+								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							usage_instructions: "Model and Property Released (MR&PR) ",
+							version: 0,
+							template_id: 1184,
+						},
+						address: {
+							locality: "Barcelona",
+						},
+						auth: {
+							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
+						},
+						caption:
+							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+						copyright: "Abel Mitja Varela",
+						created_date: "2022-06-10T16:37:52Z",
+						credits: {
+							affiliation: [
+								{
+									name: "Getty Images",
+									type: "author",
+								},
+							],
+							by: [
+								{
+									byline: "Morsa Images",
+									name: "Morsa Images",
+									type: "author",
+								},
+							],
+						},
+						height: 2576,
+						image_type: "photograph",
+						last_updated_date: "2022-06-10T16:37:52Z",
+						licensable: false,
+						owner: {
+							id: "sandbox.themesinternal",
+							sponsored: false,
+						},
+						slug: "669887798",
+						source: {
+							additional_properties: {
+								editor: "photo center",
+							},
+							edit_url:
+								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+							system: "photo center",
+						},
+						subtitle: "Executive with arms crossed against rolled fabric",
+						taxonomy: {
+							associated_tasks: [],
+						},
+						type: "image",
+						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+						version: "0.10.3",
+						width: 3864,
+						syndication: {},
+						creditIPTC: "Getty Images",
+					},
+					{
+						_id: "HY6LDPEW4BBFDLBYfff",
+						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+						additional_properties: {
+							fullSizeResizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							galleries: [],
+							ingestionMethod: "manual",
+							iptc_source: "Digital Vision",
+							iptc_title: "Contributor",
+							keywords: [""],
+							mime_type: "image/jpeg",
+							originalName: "iStock-669887798.jpg",
+							originalUrl:
+								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							owner: "matthew.roach@washpost.com",
+							proxyUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							published: true,
+							resizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							restricted: false,
+							takenOn: "2016-09-24T00:00:00Z",
+							thumbnailResizeUrl:
+								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							usage_instructions: "Model and Property Released (MR&PR) ",
+							version: 0,
+							template_id: 1184,
+						},
+						address: {
+							locality: "Barcelona",
+						},
+						auth: {
+							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
 						},
 						caption:
 							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",

--- a/blocks/product-gallery-block/README.md
+++ b/blocks/product-gallery-block/README.md
@@ -1,0 +1,19 @@
+# Product Gallery Block
+
+As a Page Builder user, I want to add the Product Gallery - Arc Block to my PDP page, so that I can merchandise multiple images on my PDP.
+
+## Props
+
+| **Prop**               | **Required** | **Type** | **Description**                       |
+| ---------------------- | ------------ | -------- | ------------------------------------- |
+| isFeaturedImageEnabled | yes          | boolean  | Display the product’s featured image. |
+
+## ANS Schema
+
+Arc Commerce Content Source is used.
+
+### ANS Fields
+
+- `schema.productGallery`
+
+## Additional Considerations

--- a/blocks/product-gallery-block/_index.scss
+++ b/blocks/product-gallery-block/_index.scss
@@ -1,14 +1,11 @@
 @use "@wpmedia/arc-themes-components/scss";
 
 .b-product-gallery {
-	&--featured-image-enabled {
-		.c-carousel__slide:first-child {
-			@include scss.block-components("product-gallery-featured-image-enabled-first-child");
-			@include scss.block-properties("product-gallery-featured-image-enabled-first-child");
-		}
-		@include scss.block-components("product-gallery-featured-image-enabled");
-		@include scss.block-properties("product-gallery-featured-image-enabled");
+	&__featured-slide {
+		@include scss.block-components("product-gallery-featured-slide");
+		@include scss.block-properties("product-gallery-featured-slide");
 	}
+
 	@include scss.block-components("product-gallery");
 	@include scss.block-properties("product-gallery");
 }

--- a/blocks/product-gallery-block/_index.scss
+++ b/blocks/product-gallery-block/_index.scss
@@ -4,6 +4,10 @@
 	&--featured-image-enabled {
 		@include scss.block-components("product-gallery-featured-image-enabled");
 		@include scss.block-properties("product-gallery-featured-image-enabled");
+		.c-carousel__slide:first-child {
+			@include scss.block-components("product-gallery-featured-image-enabled-first-child");
+			@include scss.block-properties("product-gallery-featured-image-enabled-first-child");
+		}
 	}
 	@include scss.block-components("product-gallery");
 	@include scss.block-properties("product-gallery");

--- a/blocks/product-gallery-block/_index.scss
+++ b/blocks/product-gallery-block/_index.scss
@@ -2,12 +2,12 @@
 
 .b-product-gallery {
 	&--featured-image-enabled {
-		@include scss.block-components("product-gallery-featured-image-enabled");
-		@include scss.block-properties("product-gallery-featured-image-enabled");
 		.c-carousel__slide:first-child {
 			@include scss.block-components("product-gallery-featured-image-enabled-first-child");
 			@include scss.block-properties("product-gallery-featured-image-enabled-first-child");
 		}
+		@include scss.block-components("product-gallery-featured-image-enabled");
+		@include scss.block-properties("product-gallery-featured-image-enabled");
 	}
 	@include scss.block-components("product-gallery");
 	@include scss.block-properties("product-gallery");

--- a/blocks/product-gallery-block/_index.scss
+++ b/blocks/product-gallery-block/_index.scss
@@ -2,12 +2,8 @@
 
 .b-product-gallery {
 	&--featured-image-enabled {
-		@include scss.block-components("product-gallery-feature-image-enabled");
-		@include scss.block-properties("product-gallery-feature-image-enabled");
-	}
-	&--featured-image-disabled {
-		@include scss.block-components("product-gallery-feature-image-disabled");
-		@include scss.block-properties("product-gallery-feature-image-disabled");
+		@include scss.block-components("product-gallery-featured-image-enabled");
+		@include scss.block-properties("product-gallery-featured-image-enabled");
 	}
 	@include scss.block-components("product-gallery");
 	@include scss.block-properties("product-gallery");

--- a/blocks/product-gallery-block/_index.scss
+++ b/blocks/product-gallery-block/_index.scss
@@ -1,0 +1,14 @@
+@use "@wpmedia/arc-themes-components/scss";
+
+.b-product-gallery {
+	&--featured-image-enabled {
+		@include scss.block-components("product-gallery-feature-image-enabled");
+		@include scss.block-properties("product-gallery-feature-image-enabled");
+	}
+	&--featured-image-disabled {
+		@include scss.block-components("product-gallery-feature-image-disabled");
+		@include scss.block-properties("product-gallery-feature-image-disabled");
+	}
+	@include scss.block-components("product-gallery");
+	@include scss.block-properties("product-gallery");
+}

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -11,9 +11,9 @@ const BLOCK_CLASS_NAME = "b-product-gallery";
 
 export function ProductGalleryDisplay(props) {
 	const { data, id, label, isFeaturedImageEnabled, resizerAppVersion } = props;
-	const carouselItems = data?.schema?.productGallery?.value?.assets.filter(
-		(asset) => asset.type === "image"
-	);
+	const carouselItems = data?.schema?.productGallery?.value?.assets
+		.filter((asset) => asset.type === "image")
+		.slice(0, isFeaturedImageEnabled ? 9 : 8);
 
 	return (
 		<Carousel

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext } from "fusion:context";
+import { Carousel } from "@wpmedia/arc-themes-components";
 
 const BLOCK_CLASS_NAME = "b-product-gallery";
 
@@ -14,7 +15,7 @@ function ProductGallery({ customFields }) {
 	}
 
 	return (
-		<div
+		<Carousel
 			className={`${BLOCK_CLASS_NAME} ${BLOCK_CLASS_NAME}--featured-image-${
 				isFeaturedImageEnabled ? `enabled` : `disabled`
 			}`}

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -1,12 +1,14 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
-import { useFusionContext } from "fusion:context";
+import { useFusionContext, useComponentContext } from "fusion:context";
+// import getProperties from "fusion:properties";
 import { Carousel } from "@wpmedia/arc-themes-components";
 
 const BLOCK_CLASS_NAME = "b-product-gallery";
 
 function ProductGallery({ customFields }) {
 	const { isFeaturedImageEnabled } = customFields;
+	const { id } = useComponentContext();
 
 	const { globalContent = {} } = useFusionContext();
 
@@ -19,6 +21,8 @@ function ProductGallery({ customFields }) {
 			className={`${BLOCK_CLASS_NAME}${
 				isFeaturedImageEnabled ? ` ${BLOCK_CLASS_NAME}--featured-image-enabled` : ""
 			}`}
+			id={id}
+			label={label}
 		/>
 	);
 }

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -10,7 +10,7 @@ import { Carousel, Icon, Image } from "@wpmedia/arc-themes-components";
 const BLOCK_CLASS_NAME = "b-product-gallery";
 
 export function ProductGalleryDisplay(props) {
-	const { arcSite, data, id, isFeaturedImageEnabled, resizerAppVersion } = props;
+	const { arcSite, data, id, isFeaturedImageEnabled, resizerAppVersion, resizerURL } = props;
 
 	const { locale } = getProperties(arcSite);
 	const phrases = getTranslatedPhrases(locale);
@@ -40,6 +40,9 @@ export function ProductGalleryDisplay(props) {
 			{carouselItems?.map((item, carouselIndex) => {
 				const { url, auth, alt_text: altText, _id: itemId } = item;
 
+				// is this a featured image?
+				const isFeaturedImage = isFeaturedImageEnabled && carouselIndex === 0;
+
 				// take in app version that's the public key for the auth object in resizer v2
 				const targetAuth = auth[resizerAppVersion];
 				return (
@@ -50,7 +53,25 @@ export function ProductGalleryDisplay(props) {
 							maximum: carouselItems.length,
 						})}`}
 					>
-						<Image alt={altText} src={url} resizedOptions={{ auth: targetAuth }} />
+						<Image
+							alt={altText}
+							src={url}
+							resizedOptions={{ auth: targetAuth }}
+							width={372}
+							height={279}
+							responsiveImages={[150, 372, 500, 1500, 2000]}
+							resizerURL={resizerURL}
+							sizes={[
+								{
+									isDefault: true,
+									sourceSizeValue: "100vw",
+								},
+								{
+									sourceSizeValue: isFeaturedImage ? "50vw" : "25vw",
+									mediaCondition: "(min-width: 48rem)",
+								},
+							]}
+						/>
 					</Carousel.Item>
 				);
 			})}

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -1,10 +1,17 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
+import { useFusionContext } from "fusion:context";
 
 const BLOCK_CLASS_NAME = "b-product-gallery";
 
 function ProductGallery({ customFields }) {
 	const { isFeaturedImageEnabled } = customFields;
+
+	const { globalContent = {} } = useFusionContext();
+
+	if (!Object.keys(globalContent).length) {
+		return null;
+	}
 
 	return (
 		<div

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -22,9 +22,7 @@ export function ProductGalleryDisplay({
 
 	return (
 		<Carousel
-			className={`${BLOCK_CLASS_NAME}${
-				isFeaturedImageEnabled ? ` ${BLOCK_CLASS_NAME}--featured-image-enabled` : ""
-			}`}
+			className={BLOCK_CLASS_NAME}
 			key={id}
 			id={id}
 			label={phrases.t("product-gallery.aria-label")}
@@ -50,6 +48,7 @@ export function ProductGalleryDisplay({
 				return (
 					<Carousel.Item
 						key={itemId}
+						className={isFeaturedImage ? `${BLOCK_CLASS_NAME}__featured-slide` : ""}
 						label={`${phrases.t("product-gallery.slide-indicator", {
 							current: carouselIndex + 1,
 							maximum: carouselItems.length,

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -9,8 +9,7 @@ import { Carousel, Icon, Image } from "@wpmedia/arc-themes-components";
 
 const BLOCK_CLASS_NAME = "b-product-gallery";
 
-export function ProductGalleryDisplay(props) {
-	const { arcSite, data, id, isFeaturedImageEnabled, resizerAppVersion, resizerURL } = props;
+export function ProductGalleryDisplay({ arcSite, data, id, isFeaturedImageEnabled, resizerAppVersion, resizerURL }) {
 
 	const { locale } = getProperties(arcSite);
 	const phrases = getTranslatedPhrases(locale);

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -63,11 +63,12 @@ export function ProductGalleryDisplay(props) {
 							resizerURL={resizerURL}
 							sizes={[
 								{
+									// featured image should take up full width of the screen on mobile and desktop
 									isDefault: true,
 									sourceSizeValue: "100vw",
 								},
-								{
-									sourceSizeValue: isFeaturedImage ? "50vw" : "25vw",
+								isFeaturedImage || {
+									sourceSizeValue: "50vw",
 									mediaCondition: "(min-width: 48rem)",
 								},
 							]}

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -59,8 +59,8 @@ export function ProductGalleryDisplay({
 							alt={altText}
 							src={url}
 							resizedOptions={{ auth: targetAuth }}
-							width={372}
-							height={279}
+							width={375}
+							height={375}
 							responsiveImages={[150, 372, 500, 1500, 2000]}
 							resizerURL={resizerURL}
 							sizes={[
@@ -69,10 +69,14 @@ export function ProductGalleryDisplay({
 									isDefault: true,
 									sourceSizeValue: "100vw",
 								},
-								isFeaturedImage || {
-									sourceSizeValue: "50vw",
-									mediaCondition: "(min-width: 48rem)",
-								},
+								...(isFeaturedImage
+									? []
+									: [
+											{
+												sourceSizeValue: "50vw",
+												mediaCondition: "(min-width: 48rem)",
+											},
+									  ]),
 							]}
 						/>
 					</Carousel.Item>

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -20,6 +20,8 @@ export function ProductGalleryDisplay({
 	const { locale } = getProperties(arcSite);
 	const phrases = getTranslatedPhrases(locale);
 
+	const shortenedCarouselItems = carouselItems.slice(0, isFeaturedImageEnabled ? 9 : 8);
+
 	return (
 		<Carousel
 			className={BLOCK_CLASS_NAME}
@@ -37,7 +39,7 @@ export function ProductGalleryDisplay({
 				</Carousel.Button>
 			}
 		>
-			{carouselItems?.map((item, carouselIndex) => {
+			{shortenedCarouselItems?.map((item, carouselIndex) => {
 				const { url, auth, alt_text: altText, _id: itemId } = item;
 
 				// is this a featured image?
@@ -95,9 +97,9 @@ function ProductGallery({ customFields }) {
 	}
 
 	const carouselItems =
-		globalContent?.schema?.productGallery?.value?.assets
-			.filter((asset) => asset.type === "image")
-			.slice(0, isFeaturedImageEnabled ? 9 : 8) || [];
+		globalContent?.schema?.productGallery?.value?.assets.filter(
+			(asset) => asset.type === "image"
+		) || [];
 
 	if (carouselItems.length === 0) {
 		return null;

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -24,7 +24,7 @@ export function ProductGalleryDisplay(props) {
 			id={id}
 			label={label}
 		>
-			{carouselItems.map((item) => {
+			{carouselItems?.map((item) => {
 				const { url, auth, alt_text: altText, _id: itemId } = item;
 
 				// take in app version that's the public key for the auth object in resizer v2

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext, useComponentContext } from "fusion:context";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
 import getProperties from "fusion:properties";
 import getTranslatedPhrases from "fusion:intl";
 
@@ -95,6 +95,7 @@ function ProductGallery({ customFields }) {
 			id={id}
 			isFeaturedImageEnabled={isFeaturedImageEnabled}
 			resizerAppVersion={RESIZER_APP_VERSION}
+			resizerURL={RESIZER_URL}
 		/>
 	);
 }

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -2,15 +2,18 @@ import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext, useComponentContext } from "fusion:context";
 import { RESIZER_APP_VERSION } from "fusion:environment";
-// import getProperties from "fusion:properties";
-// import getTranslatedPhrases from "fusion:intl";
+import getProperties from "fusion:properties";
+import getTranslatedPhrases from "fusion:intl";
 
-import { Carousel, Image } from "@wpmedia/arc-themes-components";
+import { Carousel, Icon, Image } from "@wpmedia/arc-themes-components";
 
 const BLOCK_CLASS_NAME = "b-product-gallery";
 
 export function ProductGalleryDisplay(props) {
-	const { data, id, label, isFeaturedImageEnabled, resizerAppVersion } = props;
+	const { arcSite, data, id, isFeaturedImageEnabled, resizerAppVersion } = props;
+
+	const { locale } = getProperties(arcSite);
+	const phrases = getTranslatedPhrases(locale);
 	const carouselItems = data?.schema?.productGallery?.value?.assets
 		.filter((asset) => asset.type === "image")
 		.slice(0, isFeaturedImageEnabled ? 9 : 8);
@@ -22,9 +25,19 @@ export function ProductGalleryDisplay(props) {
 			}`}
 			key={id}
 			id={id}
-			label={label}
+			label={phrases.t("product-gallery.aria-label")}
+			nextButton={
+				<Carousel.Button id={id} label={phrases.t("product-gallery.right-arrow-label")}>
+					<Icon name="ChevronRight" />
+				</Carousel.Button>
+			}
+			previousButton={
+				<Carousel.Button id={id} label={phrases.t("product-gallery.left-arrow-label")}>
+					<Icon name="ChevronLeft" />
+				</Carousel.Button>
+			}
 		>
-			{carouselItems?.map((item) => {
+			{carouselItems?.map((item, carouselIndex) => {
 				const { url, auth, alt_text: altText, _id: itemId } = item;
 
 				// take in app version that's the public key for the auth object in resizer v2
@@ -32,9 +45,10 @@ export function ProductGalleryDisplay(props) {
 				return (
 					<Carousel.Item
 						key={itemId}
-						// todo: add a label to the item
-						// need to update the item to take in classes
-						// className={`${index === 0 ? `${BLOCK_CLASS_NAME}__first-item` : ""}`}
+						label={`${phrases.t("product-gallery.slide-indicator", {
+							current: carouselIndex + 1,
+							maximum: carouselItems.length,
+						})}`}
 					>
 						<Image alt={altText} src={url} resizedOptions={{ auth: targetAuth }} />
 					</Carousel.Item>
@@ -47,23 +61,18 @@ function ProductGallery({ customFields }) {
 	const { isFeaturedImageEnabled } = customFields;
 	const { id } = useComponentContext();
 
-	const { /* arcSite , */ globalContent = {} } = useFusionContext();
+	const { arcSite, globalContent = {} } = useFusionContext();
 
 	if (!Object.keys(globalContent).length) {
 		return null;
 	}
 
-	// will get label from phrases
-	// const { locale } = getProperties(arcSite);
-	// const phrases = getTranslatedPhrases(locale);
-	const label = "label";
-
 	return (
 		<ProductGalleryDisplay
+			arcSite={arcSite}
 			data={globalContent}
 			id={id}
 			isFeaturedImageEnabled={isFeaturedImageEnabled}
-			label={label}
 			resizerAppVersion={RESIZER_APP_VERSION}
 		/>
 	);

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -24,8 +24,7 @@ function ProductGallery({ customFields }) {
 
 ProductGallery.label = "Product Gallery – Arc Block";
 
-// todo: update icon based on Matt Nash discussion
-ProductGallery.icon = "shopping-bag-smile";
+ProductGallery.icon = "picture-polaroid-four";
 
 ProductGallery.propTypes = {
 	customFields: PropTypes.shape({

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -30,7 +30,12 @@ export function ProductGalleryDisplay(props) {
 				// take in app version that's the public key for the auth object in resizer v2
 				const targetAuth = auth[resizerAppVersion];
 				return (
-					<Carousel.Item key={itemId}>
+					<Carousel.Item
+						key={itemId}
+						// todo: add a label to the item
+						// need to update the item to take in classes
+						// className={`${index === 0 ? `${BLOCK_CLASS_NAME}__first-item` : ""}`}
+					>
 						<Image alt={altText} src={url} resizedOptions={{ auth: targetAuth }} />
 					</Carousel.Item>
 				);

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import PropTypes from "@arc-fusion/prop-types";
+
+const BLOCK_CLASS_NAME = "b-product-gallery";
+
+function ProductGallery({ customFields }) {
+	const { isFeaturedImageEnabled } = customFields;
+
+	return (
+		<div
+			className={`${BLOCK_CLASS_NAME} ${BLOCK_CLASS_NAME}--featured-image-${
+				isFeaturedImageEnabled ? `enabled` : `disabled`
+			}`}
+		/>
+	);
+}
+
+ProductGallery.label = "Product Gallery – Arc Block";
+
+// todo: update icon based on Matt Nash discussion
+ProductGallery.icon = "shopping-bag-smile";
+
+ProductGallery.propTypes = {
+	customFields: PropTypes.shape({
+		isFeaturedImageEnabled: PropTypes.boolean.tag({
+			name: "Display the product's featured image",
+			defaultValue: false,
+		}),
+	}),
+};
+
+export default ProductGallery;

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -1,28 +1,65 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext, useComponentContext } from "fusion:context";
+import { RESIZER_APP_VERSION } from "fusion:environment";
 // import getProperties from "fusion:properties";
-import { Carousel } from "@wpmedia/arc-themes-components";
+// import getTranslatedPhrases from "fusion:intl";
+
+import { Carousel, Image } from "@wpmedia/arc-themes-components";
 
 const BLOCK_CLASS_NAME = "b-product-gallery";
 
-function ProductGallery({ customFields }) {
-	const { isFeaturedImageEnabled } = customFields;
-	const { id } = useComponentContext();
-
-	const { globalContent = {} } = useFusionContext();
-
-	if (!Object.keys(globalContent).length) {
-		return null;
-	}
+export function ProductGalleryDisplay(props) {
+	const { data, id, label, isFeaturedImageEnabled, resizerAppVersion } = props;
+	const carouselItems = data?.schema?.productGallery?.value?.assets.filter(
+		(asset) => asset.type === "image"
+	);
 
 	return (
 		<Carousel
 			className={`${BLOCK_CLASS_NAME}${
 				isFeaturedImageEnabled ? ` ${BLOCK_CLASS_NAME}--featured-image-enabled` : ""
 			}`}
+			key={id}
 			id={id}
 			label={label}
+		>
+			{carouselItems.map((item) => {
+				const { url, auth, alt_text: altText, _id: itemId } = item;
+
+				// take in app version that's the public key for the auth object in resizer v2
+				const targetAuth = auth[resizerAppVersion];
+				return (
+					<Carousel.Item key={itemId}>
+						<Image alt={altText} src={url} resizedOptions={{ auth: targetAuth }} />
+					</Carousel.Item>
+				);
+			})}
+		</Carousel>
+	);
+}
+function ProductGallery({ customFields }) {
+	const { isFeaturedImageEnabled } = customFields;
+	const { id } = useComponentContext();
+
+	const { /* arcSite , */ globalContent = {} } = useFusionContext();
+
+	if (!Object.keys(globalContent).length) {
+		return null;
+	}
+
+	// will get label from phrases
+	// const { locale } = getProperties(arcSite);
+	// const phrases = getTranslatedPhrases(locale);
+	const label = "label";
+
+	return (
+		<ProductGalleryDisplay
+			data={globalContent}
+			id={id}
+			isFeaturedImageEnabled={isFeaturedImageEnabled}
+			label={label}
+			resizerAppVersion={RESIZER_APP_VERSION}
 		/>
 	);
 }

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -10,13 +10,11 @@ import { Carousel, Icon, Image } from "@wpmedia/arc-themes-components";
 const BLOCK_CLASS_NAME = "b-product-gallery";
 
 export function ProductGalleryDisplay(props) {
-	const { arcSite, data, id, isFeaturedImageEnabled, resizerAppVersion, resizerURL } = props;
+	const { arcSite, carouselItems, id, isFeaturedImageEnabled, resizerAppVersion, resizerURL } =
+		props;
 
 	const { locale } = getProperties(arcSite);
 	const phrases = getTranslatedPhrases(locale);
-	const carouselItems = data?.schema?.productGallery?.value?.assets
-		.filter((asset) => asset.type === "image")
-		.slice(0, isFeaturedImageEnabled ? 9 : 8);
 
 	return (
 		<Carousel
@@ -89,10 +87,19 @@ function ProductGallery({ customFields }) {
 		return null;
 	}
 
+	const carouselItems =
+		globalContent?.schema?.productGallery?.value?.assets
+			.filter((asset) => asset.type === "image")
+			.slice(0, isFeaturedImageEnabled ? 9 : 8) || [];
+
+	if (carouselItems.length === 0) {
+		return null;
+	}
+
 	return (
 		<ProductGalleryDisplay
 			arcSite={arcSite}
-			data={globalContent}
+			carouselItems={carouselItems}
 			id={id}
 			isFeaturedImageEnabled={isFeaturedImageEnabled}
 			resizerAppVersion={RESIZER_APP_VERSION}

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -5,7 +5,7 @@ import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
 import getProperties from "fusion:properties";
 import getTranslatedPhrases from "fusion:intl";
 
-import { Carousel, Icon, Image } from "@wpmedia/arc-themes-components";
+import { Carousel, Image } from "@wpmedia/arc-themes-components";
 
 const BLOCK_CLASS_NAME = "b-product-gallery";
 
@@ -28,16 +28,6 @@ export function ProductGalleryDisplay({
 			key={id}
 			id={id}
 			label={phrases.t("product-gallery.aria-label")}
-			nextButton={
-				<Carousel.Button id={id} label={phrases.t("product-gallery.right-arrow-label")}>
-					<Icon name="ChevronRight" />
-				</Carousel.Button>
-			}
-			previousButton={
-				<Carousel.Button id={id} label={phrases.t("product-gallery.left-arrow-label")}>
-					<Icon name="ChevronLeft" />
-				</Carousel.Button>
-			}
 		>
 			{shortenedCarouselItems?.map((item, carouselIndex) => {
 				const { url, auth, alt_text: altText, _id: itemId } = item;

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -61,7 +61,7 @@ export function ProductGalleryDisplay({
 							resizedOptions={{ auth: targetAuth }}
 							width={375}
 							height={375}
-							responsiveImages={[150, 372, 500, 1500, 2000]}
+							responsiveImages={[150, 375, 500, 1500, 2000]}
 							resizerURL={resizerURL}
 							sizes={[
 								{

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -16,8 +16,8 @@ function ProductGallery({ customFields }) {
 
 	return (
 		<Carousel
-			className={`${BLOCK_CLASS_NAME} ${BLOCK_CLASS_NAME}--featured-image-${
-				isFeaturedImageEnabled ? `enabled` : `disabled`
+			className={`${BLOCK_CLASS_NAME}${
+				isFeaturedImageEnabled ? ` ${BLOCK_CLASS_NAME}--featured-image-enabled` : ""
 			}`}
 		/>
 	);

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -116,14 +116,12 @@ describe("Product Gallery", () => {
 		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
 		expect(container.firstChild).toBeNull();
 	});
-	it("renders with default disabled classname modifier", () => {
+	it("renders with default classname without featured image enabled modifier", () => {
 		useFusionContext.mockImplementation(() => ({
 			globalContent: MOCK_GLOBAL_CONTENT,
 		}));
 		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
-		expect(container.querySelectorAll(".b-product-gallery--featured-image-disabled").length).toBe(
-			1
-		);
+		expect(container.querySelectorAll(".b-product-gallery").length).toBe(1);
 		expect(container.querySelectorAll(".b-product-gallery--featured-image-enabled").length).toBe(0);
 	});
 	it("featured image enabled will add featured image enabled classname modifier", () => {
@@ -133,7 +131,7 @@ describe("Product Gallery", () => {
 		const { container } = render(
 			<ProductGallery customFields={{ ...DEFAULT_CUSTOM_FIELDS, isFeaturedImageEnabled: true }} />
 		);
-
+		expect(container.querySelectorAll(".b-product-gallery").length).toBe(1);
 		expect(container.querySelectorAll(".b-product-gallery--featured-image-enabled").length).toBe(1);
 	});
 });

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -1,11 +1,125 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
+import { useFusionContext } from "fusion:context";
 
 import ProductGallery from "./default";
 
+const MOCK_DATA = {
+	schema: {
+		productGallery: {
+			label: "Gallery",
+			value: {
+				assets: [
+					{
+						_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+						additional_properties: {
+							fullSizeResizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							galleries: [],
+							ingestionMethod: "manual",
+							iptc_source: "Digital Vision",
+							iptc_title: "Contributor",
+							keywords: [""],
+							mime_type: "image/jpeg",
+							originalName: "iStock-669887798.jpg",
+							originalUrl:
+								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							owner: "matthew.roach@washpost.com",
+							proxyUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							published: true,
+							resizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							restricted: false,
+							takenOn: "2016-09-24T00:00:00Z",
+							thumbnailResizeUrl:
+								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							usage_instructions: "Model and Property Released (MR&PR) ",
+							version: 0,
+							template_id: 1184,
+						},
+						address: {
+							locality: "Barcelona",
+						},
+						auth: {
+							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+						},
+						caption:
+							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+						copyright: "Abel Mitja Varela",
+						created_date: "2022-06-10T16:37:52Z",
+						credits: {
+							affiliation: [
+								{
+									name: "Getty Images",
+									type: "author",
+								},
+							],
+							by: [
+								{
+									byline: "Morsa Images",
+									name: "Morsa Images",
+									type: "author",
+								},
+							],
+						},
+						height: 2576,
+						image_type: "photograph",
+						last_updated_date: "2022-06-10T16:37:52Z",
+						licensable: false,
+						owner: {
+							id: "sandbox.themesinternal",
+							sponsored: false,
+						},
+						slug: "669887798",
+						source: {
+							additional_properties: {
+								editor: "photo center",
+							},
+							edit_url:
+								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+							system: "photo center",
+						},
+						subtitle: "Executive with arms crossed against rolled fabric",
+						taxonomy: {
+							associated_tasks: [],
+						},
+						type: "image",
+						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+						version: "0.10.3",
+						width: 3864,
+						syndication: {},
+						creditIPTC: "Getty Images",
+					},
+				],
+			},
+		},
+	},
+};
+
 describe("Product Gallery", () => {
+	it("renders null if global content is not set", () => {
+		useFusionContext.mockImplementation(() => ({}));
+		const { container } = render(
+			<ProductGallery customFields={{ isFeaturedImageEnabled: false }} />
+		);
+		expect(container.firstChild).toBeNull();
+	});
+	it("renders null if no global content provided", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {},
+		}));
+		const { container } = render(
+			<ProductGallery customFields={{ isFeaturedImageEnabled: false }} />
+		);
+		expect(container.firstChild).toBeNull();
+	});
 	it("renders with default disabled classname modifier", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: MOCK_DATA,
+		}));
 		const { container } = render(
 			<ProductGallery customFields={{ isFeaturedImageEnabled: false }} />
 		);
@@ -15,6 +129,9 @@ describe("Product Gallery", () => {
 		expect(container.querySelectorAll(".b-product-gallery--featured-image-enabled").length).toBe(0);
 	});
 	it("featured image enabled will add featured image enabled classname modifier", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: MOCK_DATA,
+		}));
 		const { container } = render(
 			<ProductGallery customFields={{ isFeaturedImageEnabled: true }} />
 		);

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -5,175 +5,102 @@ import { useFusionContext } from "fusion:context";
 
 import ProductGallery from "./default";
 
+jest.mock("fusion:environment", () => ({
+	RESIZER_APP_VERSION: 2,
+}));
+
+const MOCK_ASSET = {
+	_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+	alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+	additional_properties: {
+		fullSizeResizeUrl:
+			"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		galleries: [],
+		ingestionMethod: "manual",
+		iptc_source: "Digital Vision",
+		iptc_title: "Contributor",
+		keywords: [""],
+		mime_type: "image/jpeg",
+		originalName: "iStock-669887798.jpg",
+		originalUrl:
+			"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		owner: "matthew.roach@washpost.com",
+		proxyUrl:
+			"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		published: true,
+		resizeUrl:
+			"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		restricted: false,
+		takenOn: "2016-09-24T00:00:00Z",
+		thumbnailResizeUrl:
+			"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		usage_instructions: "Model and Property Released (MR&PR) ",
+		version: 0,
+		template_id: 1184,
+	},
+	address: {
+		locality: "Barcelona",
+	},
+	auth: {
+		2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+	},
+	caption:
+		"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+	copyright: "Abel Mitja Varela",
+	created_date: "2022-06-10T16:37:52Z",
+	credits: {
+		affiliation: [
+			{
+				name: "Getty Images",
+				type: "author",
+			},
+		],
+		by: [
+			{
+				byline: "Morsa Images",
+				name: "Morsa Images",
+				type: "author",
+			},
+		],
+	},
+	height: 2576,
+	image_type: "photograph",
+	last_updated_date: "2022-06-10T16:37:52Z",
+	licensable: false,
+	owner: {
+		id: "sandbox.themesinternal",
+		sponsored: false,
+	},
+	slug: "669887798",
+	source: {
+		additional_properties: {
+			editor: "photo center",
+		},
+		edit_url: "https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+		system: "photo center",
+	},
+	subtitle: "Executive with arms crossed against rolled fabric",
+	taxonomy: {
+		associated_tasks: [],
+	},
+	type: "image",
+	url: "https://fake-img.jpg",
+	version: "0.10.3",
+	width: 3864,
+	syndication: {},
+	creditIPTC: "Getty Images",
+};
+
 const MOCK_GLOBAL_CONTENT = {
 	schema: {
 		productGallery: {
 			label: "Gallery",
 			value: {
 				assets: [
+					MOCK_ASSET,
 					{
-						_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-						additional_properties: {
-							fullSizeResizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							galleries: [],
-							ingestionMethod: "manual",
-							iptc_source: "Digital Vision",
-							iptc_title: "Contributor",
-							keywords: [""],
-							mime_type: "image/jpeg",
-							originalName: "iStock-669887798.jpg",
-							originalUrl:
-								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							owner: "matthew.roach@washpost.com",
-							proxyUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							published: true,
-							resizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							restricted: false,
-							takenOn: "2016-09-24T00:00:00Z",
-							thumbnailResizeUrl:
-								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							usage_instructions: "Model and Property Released (MR&PR) ",
-							version: 0,
-							template_id: 1184,
-						},
-						address: {
-							locality: "Barcelona",
-						},
-						auth: {
-							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
-						},
-						caption:
-							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-						copyright: "Abel Mitja Varela",
-						created_date: "2022-06-10T16:37:52Z",
-						credits: {
-							affiliation: [
-								{
-									name: "Getty Images",
-									type: "author",
-								},
-							],
-							by: [
-								{
-									byline: "Morsa Images",
-									name: "Morsa Images",
-									type: "author",
-								},
-							],
-						},
-						height: 2576,
-						image_type: "photograph",
-						last_updated_date: "2022-06-10T16:37:52Z",
-						licensable: false,
-						owner: {
-							id: "sandbox.themesinternal",
-							sponsored: false,
-						},
-						slug: "669887798",
-						source: {
-							additional_properties: {
-								editor: "photo center",
-							},
-							edit_url:
-								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-							system: "photo center",
-						},
-						subtitle: "Executive with arms crossed against rolled fabric",
-						taxonomy: {
-							associated_tasks: [],
-						},
-						type: "image",
-						url: "https://fake-img.jpg",
-						version: "0.10.3",
-						width: 3864,
-						syndication: {},
-						creditIPTC: "Getty Images",
-					},
-					{
-						_id: "HY6LDPEW4BBFfff",
-						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-						additional_properties: {
-							fullSizeResizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							galleries: [],
-							ingestionMethod: "manual",
-							iptc_source: "Digital Vision",
-							iptc_title: "Contributor",
-							keywords: [""],
-							mime_type: "image/jpeg",
-							originalName: "iStock-669887798.jpg",
-							originalUrl:
-								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							owner: "matthew.roach@washpost.com",
-							proxyUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							published: true,
-							resizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							restricted: false,
-							takenOn: "2016-09-24T00:00:00Z",
-							thumbnailResizeUrl:
-								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							usage_instructions: "Model and Property Released (MR&PR) ",
-							version: 0,
-							template_id: 1184,
-						},
-						address: {
-							locality: "Barcelona",
-						},
-						auth: {
-							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
-						},
-						caption:
-							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-						copyright: "Abel Mitja Varela",
-						created_date: "2022-06-10T16:37:52Z",
-						credits: {
-							affiliation: [
-								{
-									name: "Getty Images",
-									type: "author",
-								},
-							],
-							by: [
-								{
-									byline: "Morsa Images",
-									name: "Morsa Images",
-									type: "author",
-								},
-							],
-						},
-						height: 2576,
-						image_type: "photograph",
-						last_updated_date: "2022-06-10T16:37:52Z",
-						licensable: false,
-						owner: {
-							id: "sandbox.themesinternal",
-							sponsored: false,
-						},
-						slug: "669887798",
-						source: {
-							additional_properties: {
-								editor: "photo center",
-							},
-							edit_url:
-								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-							system: "photo center",
-						},
-						subtitle: "Executive with arms crossed against rolled fabric",
-						taxonomy: {
-							associated_tasks: [],
-						},
-						type: "image",
-						url: "https://fake-img.jpg",
-						version: "0.10.3",
-						width: 3864,
-						syndication: {},
-						creditIPTC: "Getty Images",
+						...MOCK_ASSET,
+						_id: "HY6LDPEW4BBFDLBfff",
 					},
 				],
 			},
@@ -223,7 +150,49 @@ describe("Product Gallery", () => {
 		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
 
 		expect(container.querySelectorAll(".c-carousel").length).toBe(1);
-		// rendering two images
+		// rendering two images from mock data
 		expect(container.querySelectorAll(".c-carousel__slide").length).toBe(2);
+	});
+	it("only renders 9 items for featured image enabled with more than 9 passed in", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				...MOCK_GLOBAL_CONTENT,
+				schema: {
+					...MOCK_GLOBAL_CONTENT.schema,
+					productGallery: {
+						...MOCK_GLOBAL_CONTENT.schema.productGallery,
+						value: {
+							...MOCK_GLOBAL_CONTENT.schema.productGallery.value,
+							assets: Array.from({ length: 10 }, (_, i) => ({ ...MOCK_ASSET, _id: i })),
+						},
+					},
+				},
+			},
+		}));
+		const { container } = render(
+			<ProductGallery customFields={{ ...DEFAULT_CUSTOM_FIELDS, isFeaturedImageEnabled: true }} />
+		);
+		expect(container.querySelectorAll(".c-carousel__slide").length).toBe(9);
+	});
+	it("only renders 8 items for featured image disabled with more than 8 passed in", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				...MOCK_GLOBAL_CONTENT,
+				schema: {
+					...MOCK_GLOBAL_CONTENT.schema,
+					productGallery: {
+						...MOCK_GLOBAL_CONTENT.schema.productGallery,
+						value: {
+							...MOCK_GLOBAL_CONTENT.schema.productGallery.value,
+							assets: Array.from({ length: 10 }, (_, i) => ({ ...MOCK_ASSET, _id: i })),
+						},
+					},
+				},
+			},
+		}));
+		const { container } = render(
+			<ProductGallery customFields={{ ...DEFAULT_CUSTOM_FIELDS, isFeaturedImageEnabled: false }} />
+		);
+		expect(container.querySelectorAll(".c-carousel__slide").length).toBe(8);
 	});
 });

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+
+import ProductGallery from "./default";
+
+describe("Product Gallery", () => {
+	it("renders with default disabled classname modifier", () => {
+		const { container } = render(
+			<ProductGallery customFields={{ isFeaturedImageEnabled: false }} />
+		);
+		expect(container.querySelectorAll(".b-product-gallery--featured-image-disabled").length).toBe(
+			1
+		);
+		expect(container.querySelectorAll(".b-product-gallery--featured-image-enabled").length).toBe(0);
+	});
+	it("featured image enabled will add featured image enabled classname modifier", () => {
+		const { container } = render(
+			<ProductGallery customFields={{ isFeaturedImageEnabled: true }} />
+		);
+
+		expect(container.querySelectorAll(".b-product-gallery--featured-image-enabled").length).toBe(1);
+	});
+});

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -7,6 +7,7 @@ import ProductGallery from "./default";
 
 jest.mock("fusion:environment", () => ({
 	RESIZER_APP_VERSION: 2,
+	RESIZER_URL: "https://resizer.com",
 }));
 
 const MOCK_ASSET = {
@@ -125,6 +126,33 @@ describe("Product Gallery", () => {
 		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
 		expect(container.firstChild).toBeNull();
 	});
+	it("returns null without a carousel if no items", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				schema: {
+					productGallery: {
+						value: {
+							assets: [],
+						},
+					},
+				},
+			},
+		}));
+		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
+		expect(container.querySelectorAll(".b-product-gallery").length).toBe(0);
+		expect(container.firstChild).toBeNull();
+	});
+	it("returns null without a product gallery", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				schema: {},
+			},
+		}));
+		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
+		expect(container.querySelectorAll(".b-product-gallery").length).toBe(0);
+		expect(container.firstChild).toBeNull();
+	});
+
 	it("renders with default classname without featured image enabled modifier", () => {
 		useFusionContext.mockImplementation(() => ({
 			globalContent: MOCK_GLOBAL_CONTENT,

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -5,7 +5,7 @@ import { useFusionContext } from "fusion:context";
 
 import ProductGallery from "./default";
 
-const MOCK_DATA = {
+const MOCK_GLOBAL_CONTENT = {
 	schema: {
 		productGallery: {
 			label: "Gallery",
@@ -118,7 +118,7 @@ describe("Product Gallery", () => {
 	});
 	it("renders with default disabled classname modifier", () => {
 		useFusionContext.mockImplementation(() => ({
-			globalContent: MOCK_DATA,
+			globalContent: MOCK_GLOBAL_CONTENT,
 		}));
 		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
 		expect(container.querySelectorAll(".b-product-gallery--featured-image-disabled").length).toBe(
@@ -128,7 +128,7 @@ describe("Product Gallery", () => {
 	});
 	it("featured image enabled will add featured image enabled classname modifier", () => {
 		useFusionContext.mockImplementation(() => ({
-			globalContent: MOCK_DATA,
+			globalContent: MOCK_GLOBAL_CONTENT,
 		}));
 		const { container } = render(
 			<ProductGallery customFields={{ ...DEFAULT_CUSTOM_FIELDS, isFeaturedImageEnabled: true }} />

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -153,23 +153,12 @@ describe("Product Gallery", () => {
 		expect(container.firstChild).toBeNull();
 	});
 
-	it("renders with default classname without featured image enabled modifier", () => {
+	it("renders with default classname for gallery", () => {
 		useFusionContext.mockImplementation(() => ({
 			globalContent: MOCK_GLOBAL_CONTENT,
 		}));
 		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
 		expect(container.querySelectorAll(".b-product-gallery").length).toBe(1);
-		expect(container.querySelectorAll(".b-product-gallery--featured-image-enabled").length).toBe(0);
-	});
-	it("featured image enabled will add featured image enabled classname modifier", () => {
-		useFusionContext.mockImplementation(() => ({
-			globalContent: MOCK_GLOBAL_CONTENT,
-		}));
-		const { container } = render(
-			<ProductGallery customFields={{ ...DEFAULT_CUSTOM_FIELDS, isFeaturedImageEnabled: true }} />
-		);
-		expect(container.querySelectorAll(".b-product-gallery").length).toBe(1);
-		expect(container.querySelectorAll(".b-product-gallery--featured-image-enabled").length).toBe(1);
 	});
 	it("renders carousel and items", () => {
 		useFusionContext.mockImplementation(() => ({

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -87,7 +87,89 @@ const MOCK_GLOBAL_CONTENT = {
 							associated_tasks: [],
 						},
 						type: "image",
-						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+						url: "https://fake-img.jpg",
+						version: "0.10.3",
+						width: 3864,
+						syndication: {},
+						creditIPTC: "Getty Images",
+					},
+					{
+						_id: "HY6LDPEW4BBFfff",
+						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+						additional_properties: {
+							fullSizeResizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							galleries: [],
+							ingestionMethod: "manual",
+							iptc_source: "Digital Vision",
+							iptc_title: "Contributor",
+							keywords: [""],
+							mime_type: "image/jpeg",
+							originalName: "iStock-669887798.jpg",
+							originalUrl:
+								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							owner: "matthew.roach@washpost.com",
+							proxyUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							published: true,
+							resizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							restricted: false,
+							takenOn: "2016-09-24T00:00:00Z",
+							thumbnailResizeUrl:
+								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							usage_instructions: "Model and Property Released (MR&PR) ",
+							version: 0,
+							template_id: 1184,
+						},
+						address: {
+							locality: "Barcelona",
+						},
+						auth: {
+							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+						},
+						caption:
+							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+						copyright: "Abel Mitja Varela",
+						created_date: "2022-06-10T16:37:52Z",
+						credits: {
+							affiliation: [
+								{
+									name: "Getty Images",
+									type: "author",
+								},
+							],
+							by: [
+								{
+									byline: "Morsa Images",
+									name: "Morsa Images",
+									type: "author",
+								},
+							],
+						},
+						height: 2576,
+						image_type: "photograph",
+						last_updated_date: "2022-06-10T16:37:52Z",
+						licensable: false,
+						owner: {
+							id: "sandbox.themesinternal",
+							sponsored: false,
+						},
+						slug: "669887798",
+						source: {
+							additional_properties: {
+								editor: "photo center",
+							},
+							edit_url:
+								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+							system: "photo center",
+						},
+						subtitle: "Executive with arms crossed against rolled fabric",
+						taxonomy: {
+							associated_tasks: [],
+						},
+						type: "image",
+						url: "https://fake-img.jpg",
 						version: "0.10.3",
 						width: 3864,
 						syndication: {},
@@ -133,5 +215,15 @@ describe("Product Gallery", () => {
 		);
 		expect(container.querySelectorAll(".b-product-gallery").length).toBe(1);
 		expect(container.querySelectorAll(".b-product-gallery--featured-image-enabled").length).toBe(1);
+	});
+	it("renders carousel and items", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: MOCK_GLOBAL_CONTENT,
+		}));
+		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
+
+		expect(container.querySelectorAll(".c-carousel").length).toBe(1);
+		// rendering two images
+		expect(container.querySelectorAll(".c-carousel__slide").length).toBe(2);
 	});
 });

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -99,30 +99,28 @@ const MOCK_DATA = {
 	},
 };
 
+const DEFAULT_CUSTOM_FIELDS = {
+	isFeaturedImageEnabled: false,
+};
+
 describe("Product Gallery", () => {
 	it("renders null if global content is not set", () => {
 		useFusionContext.mockImplementation(() => ({}));
-		const { container } = render(
-			<ProductGallery customFields={{ isFeaturedImageEnabled: false }} />
-		);
+		const { container } = render(<ProductGallery customFields={DEFAULT_CUSTOM_FIELDS} />);
 		expect(container.firstChild).toBeNull();
 	});
 	it("renders null if no global content provided", () => {
 		useFusionContext.mockImplementation(() => ({
 			globalContent: {},
 		}));
-		const { container } = render(
-			<ProductGallery customFields={{ isFeaturedImageEnabled: false }} />
-		);
+		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
 		expect(container.firstChild).toBeNull();
 	});
 	it("renders with default disabled classname modifier", () => {
 		useFusionContext.mockImplementation(() => ({
 			globalContent: MOCK_DATA,
 		}));
-		const { container } = render(
-			<ProductGallery customFields={{ isFeaturedImageEnabled: false }} />
-		);
+		const { container } = render(<ProductGallery customFields={{ DEFAULT_CUSTOM_FIELDS }} />);
 		expect(container.querySelectorAll(".b-product-gallery--featured-image-disabled").length).toBe(
 			1
 		);
@@ -133,7 +131,7 @@ describe("Product Gallery", () => {
 			globalContent: MOCK_DATA,
 		}));
 		const { container } = render(
-			<ProductGallery customFields={{ isFeaturedImageEnabled: true }} />
+			<ProductGallery customFields={{ ...DEFAULT_CUSTOM_FIELDS, isFeaturedImageEnabled: true }} />
 		);
 
 		expect(container.querySelectorAll(".b-product-gallery--featured-image-enabled").length).toBe(1);

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -5,9 +5,9 @@ export default {
 	title: "Blocks/Product Gallery",
 	parameters: {
 		chromatic: { viewports: [320, 1200] },
-	},
-	cssVariables: {
-		theme: "commerce",
+		cssVariables: {
+			theme: "commerce",
+		},
 	},
 };
 

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -271,7 +271,7 @@ export const defaultFeaturedImageDisabled = () => (
 		data={MOCK_GLOBAL_CONTENT}
 		isFeaturedImageEnabled={false}
 		resizerAppVersion={2}
-		label="label"
+		arcSite="story-book"
 		id="id"
 	/>
 );
@@ -281,7 +281,7 @@ export const featuredImageEnabled = () => (
 		data={MOCK_GLOBAL_CONTENT}
 		isFeaturedImageEnabled
 		resizerAppVersion={2}
-		label="label"
 		id="id"
+		arcSite="story-book"
 	/>
 );

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import ProductGallery from "./features/product-gallery/default";
+
+export default {
+	title: "Blocks/Product Gallery",
+	parameters: {
+		chromatic: { viewports: [320, 1200] },
+	},
+};
+
+const CUSTOM_FIELDS_DEFAULTS = {
+	isFeaturedImageEnabled: false,
+};
+
+// featured image is disabled via custom field
+// default behavior
+export const featuredImageDisabled = () => <ProductGallery customFields={CUSTOM_FIELDS_DEFAULTS} />;
+
+// featured image enabled
+export const featuredImageEnabled = () => (
+	<ProductGallery customFields={{ ...CUSTOM_FIELDS_DEFAULTS, isFeaturedImageEnabled: true }} />
+);

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ProductGallery from "./features/product-gallery/default";
+import { ProductGalleryDisplay } from "./features/product-gallery/default";
 
 export default {
 	title: "Blocks/Product Gallery",
@@ -8,15 +8,186 @@ export default {
 	},
 };
 
-const CUSTOM_FIELDS_DEFAULTS = {
-	isFeaturedImageEnabled: false,
+const MOCK_GLOBAL_CONTENT = {
+	schema: {
+		productGallery: {
+			label: "Gallery",
+			value: {
+				assets: [
+					{
+						_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+						additional_properties: {
+							fullSizeResizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							galleries: [],
+							ingestionMethod: "manual",
+							iptc_source: "Digital Vision",
+							iptc_title: "Contributor",
+							keywords: [""],
+							mime_type: "image/jpeg",
+							originalName: "iStock-669887798.jpg",
+							originalUrl:
+								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							owner: "matthew.roach@washpost.com",
+							proxyUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							published: true,
+							resizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							restricted: false,
+							takenOn: "2016-09-24T00:00:00Z",
+							thumbnailResizeUrl:
+								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							usage_instructions: "Model and Property Released (MR&PR) ",
+							version: 0,
+							template_id: 1184,
+						},
+						address: {
+							locality: "Barcelona",
+						},
+						auth: {
+							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+						},
+						caption:
+							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+						copyright: "Abel Mitja Varela",
+						created_date: "2022-06-10T16:37:52Z",
+						credits: {
+							affiliation: [
+								{
+									name: "Getty Images",
+									type: "author",
+								},
+							],
+							by: [
+								{
+									byline: "Morsa Images",
+									name: "Morsa Images",
+									type: "author",
+								},
+							],
+						},
+						height: 2576,
+						image_type: "photograph",
+						last_updated_date: "2022-06-10T16:37:52Z",
+						licensable: false,
+						owner: {
+							id: "sandbox.themesinternal",
+							sponsored: false,
+						},
+						slug: "669887798",
+						source: {
+							additional_properties: {
+								editor: "photo center",
+							},
+							edit_url:
+								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+							system: "photo center",
+						},
+						subtitle: "Executive with arms crossed against rolled fabric",
+						taxonomy: {
+							associated_tasks: [],
+						},
+						type: "image",
+						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+						version: "0.10.3",
+						width: 3864,
+						syndication: {},
+						creditIPTC: "Getty Images",
+					},
+					{
+						_id: "HY6LDPEW4BBFfff",
+						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+						additional_properties: {
+							fullSizeResizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							galleries: [],
+							ingestionMethod: "manual",
+							iptc_source: "Digital Vision",
+							iptc_title: "Contributor",
+							keywords: [""],
+							mime_type: "image/jpeg",
+							originalName: "iStock-669887798.jpg",
+							originalUrl:
+								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							owner: "matthew.roach@washpost.com",
+							proxyUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							published: true,
+							resizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							restricted: false,
+							takenOn: "2016-09-24T00:00:00Z",
+							thumbnailResizeUrl:
+								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							usage_instructions: "Model and Property Released (MR&PR) ",
+							version: 0,
+							template_id: 1184,
+						},
+						address: {
+							locality: "Barcelona",
+						},
+						auth: {
+							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+						},
+						caption:
+							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+						copyright: "Abel Mitja Varela",
+						created_date: "2022-06-10T16:37:52Z",
+						credits: {
+							affiliation: [
+								{
+									name: "Getty Images",
+									type: "author",
+								},
+							],
+							by: [
+								{
+									byline: "Morsa Images",
+									name: "Morsa Images",
+									type: "author",
+								},
+							],
+						},
+						height: 2576,
+						image_type: "photograph",
+						last_updated_date: "2022-06-10T16:37:52Z",
+						licensable: false,
+						owner: {
+							id: "sandbox.themesinternal",
+							sponsored: false,
+						},
+						slug: "669887798",
+						source: {
+							additional_properties: {
+								editor: "photo center",
+							},
+							edit_url:
+								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+							system: "photo center",
+						},
+						subtitle: "Executive with arms crossed against rolled fabric",
+						taxonomy: {
+							associated_tasks: [],
+						},
+						type: "image",
+						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+						version: "0.10.3",
+						width: 3864,
+						syndication: {},
+						creditIPTC: "Getty Images",
+					},
+				],
+			},
+		},
+	},
 };
 
-// featured image is disabled via custom field
-// default behavior
-export const featuredImageDisabled = () => <ProductGallery customFields={CUSTOM_FIELDS_DEFAULTS} />;
+export const defaultFeaturedImageDisabled = () => (
+	<ProductGalleryDisplay data={MOCK_GLOBAL_CONTENT} isFeaturedImageEnabled={false} />
+);
 
-// featured image enabled
 export const featuredImageEnabled = () => (
-	<ProductGallery customFields={{ ...CUSTOM_FIELDS_DEFAULTS, isFeaturedImageEnabled: true }} />
+	<ProductGalleryDisplay data={MOCK_GLOBAL_CONTENT} isFeaturedImageEnabled />
 );

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -8,267 +8,255 @@ export default {
 	},
 };
 
-const MOCK_GLOBAL_CONTENT = {
-	schema: {
-		productGallery: {
-			label: "Gallery",
-			value: {
-				assets: [
-					{
-						_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-						additional_properties: {
-							fullSizeResizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							galleries: [],
-							ingestionMethod: "manual",
-							iptc_source: "Digital Vision",
-							iptc_title: "Contributor",
-							keywords: [""],
-							mime_type: "image/jpeg",
-							originalName: "iStock-669887798.jpg",
-							originalUrl:
-								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							owner: "matthew.roach@washpost.com",
-							proxyUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							published: true,
-							resizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							restricted: false,
-							takenOn: "2016-09-24T00:00:00Z",
-							thumbnailResizeUrl:
-								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							usage_instructions: "Model and Property Released (MR&PR) ",
-							version: 0,
-							template_id: 1184,
-						},
-						address: {
-							locality: "Barcelona",
-						},
-						auth: {
-							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
-						},
-						caption:
-							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-						copyright: "Abel Mitja Varela",
-						created_date: "2022-06-10T16:37:52Z",
-						credits: {
-							affiliation: [
-								{
-									name: "Getty Images",
-									type: "author",
-								},
-							],
-							by: [
-								{
-									byline: "Morsa Images",
-									name: "Morsa Images",
-									type: "author",
-								},
-							],
-						},
-						height: 2576,
-						image_type: "photograph",
-						last_updated_date: "2022-06-10T16:37:52Z",
-						licensable: false,
-						owner: {
-							id: "sandbox.themesinternal",
-							sponsored: false,
-						},
-						slug: "669887798",
-						source: {
-							additional_properties: {
-								editor: "photo center",
-							},
-							edit_url:
-								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-							system: "photo center",
-						},
-						subtitle: "Executive with arms crossed against rolled fabric",
-						taxonomy: {
-							associated_tasks: [],
-						},
-						type: "image",
-						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-						version: "0.10.3",
-						width: 3864,
-						syndication: {},
-						creditIPTC: "Getty Images",
-					},
-					{
-						_id: "HY6LDPEW4BBFfff",
-						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-						additional_properties: {
-							fullSizeResizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							galleries: [],
-							ingestionMethod: "manual",
-							iptc_source: "Digital Vision",
-							iptc_title: "Contributor",
-							keywords: [""],
-							mime_type: "image/jpeg",
-							originalName: "iStock-669887798.jpg",
-							originalUrl:
-								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							owner: "matthew.roach@washpost.com",
-							proxyUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							published: true,
-							resizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							restricted: false,
-							takenOn: "2016-09-24T00:00:00Z",
-							thumbnailResizeUrl:
-								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							usage_instructions: "Model and Property Released (MR&PR) ",
-							version: 0,
-							template_id: 1184,
-						},
-						address: {
-							locality: "Barcelona",
-						},
-						auth: {
-							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
-						},
-						caption:
-							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-						copyright: "Abel Mitja Varela",
-						created_date: "2022-06-10T16:37:52Z",
-						credits: {
-							affiliation: [
-								{
-									name: "Getty Images",
-									type: "author",
-								},
-							],
-							by: [
-								{
-									byline: "Morsa Images",
-									name: "Morsa Images",
-									type: "author",
-								},
-							],
-						},
-						height: 2576,
-						image_type: "photograph",
-						last_updated_date: "2022-06-10T16:37:52Z",
-						licensable: false,
-						owner: {
-							id: "sandbox.themesinternal",
-							sponsored: false,
-						},
-						slug: "669887798",
-						source: {
-							additional_properties: {
-								editor: "photo center",
-							},
-							edit_url:
-								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-							system: "photo center",
-						},
-						subtitle: "Executive with arms crossed against rolled fabric",
-						taxonomy: {
-							associated_tasks: [],
-						},
-						type: "image",
-						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-						version: "0.10.3",
-						width: 3864,
-						syndication: {},
-						creditIPTC: "Getty Images",
-					},
-					{
-						_id: "HY6LDPEW4BBFzzz",
-						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-						additional_properties: {
-							fullSizeResizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							galleries: [],
-							ingestionMethod: "manual",
-							iptc_source: "Digital Vision",
-							iptc_title: "Contributor",
-							keywords: [""],
-							mime_type: "image/jpeg",
-							originalName: "iStock-669887798.jpg",
-							originalUrl:
-								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							owner: "matthew.roach@washpost.com",
-							proxyUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							published: true,
-							resizeUrl:
-								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							restricted: false,
-							takenOn: "2016-09-24T00:00:00Z",
-							thumbnailResizeUrl:
-								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-							usage_instructions: "Model and Property Released (MR&PR) ",
-							version: 0,
-							template_id: 1184,
-						},
-						address: {
-							locality: "Barcelona",
-						},
-						auth: {
-							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
-						},
-						caption:
-							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-						copyright: "Abel Mitja Varela",
-						created_date: "2022-06-10T16:37:52Z",
-						credits: {
-							affiliation: [
-								{
-									name: "Getty Images",
-									type: "author",
-								},
-							],
-							by: [
-								{
-									byline: "Morsa Images",
-									name: "Morsa Images",
-									type: "author",
-								},
-							],
-						},
-						height: 2576,
-						image_type: "photograph",
-						last_updated_date: "2022-06-10T16:37:52Z",
-						licensable: false,
-						owner: {
-							id: "sandbox.themesinternal",
-							sponsored: false,
-						},
-						slug: "669887798",
-						source: {
-							additional_properties: {
-								editor: "photo center",
-							},
-							edit_url:
-								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-							system: "photo center",
-						},
-						subtitle: "Executive with arms crossed against rolled fabric",
-						taxonomy: {
-							associated_tasks: [],
-						},
-						type: "image",
-						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-						version: "0.10.3",
-						width: 3864,
-						syndication: {},
-						creditIPTC: "Getty Images",
-					},
-				],
-			},
+const MOCK_CAROUSEL_ITEMS = [
+	{
+		_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+		alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+		additional_properties: {
+			fullSizeResizeUrl:
+				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			galleries: [],
+			ingestionMethod: "manual",
+			iptc_source: "Digital Vision",
+			iptc_title: "Contributor",
+			keywords: [""],
+			mime_type: "image/jpeg",
+			originalName: "iStock-669887798.jpg",
+			originalUrl:
+				"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			owner: "matthew.roach@washpost.com",
+			proxyUrl:
+				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			published: true,
+			resizeUrl:
+				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			restricted: false,
+			takenOn: "2016-09-24T00:00:00Z",
+			thumbnailResizeUrl:
+				"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			usage_instructions: "Model and Property Released (MR&PR) ",
+			version: 0,
+			template_id: 1184,
 		},
+		address: {
+			locality: "Barcelona",
+		},
+		auth: {
+			2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
+		},
+		caption:
+			"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+		copyright: "Abel Mitja Varela",
+		created_date: "2022-06-10T16:37:52Z",
+		credits: {
+			affiliation: [
+				{
+					name: "Getty Images",
+					type: "author",
+				},
+			],
+			by: [
+				{
+					byline: "Morsa Images",
+					name: "Morsa Images",
+					type: "author",
+				},
+			],
+		},
+		height: 2576,
+		image_type: "photograph",
+		last_updated_date: "2022-06-10T16:37:52Z",
+		licensable: false,
+		owner: {
+			id: "sandbox.themesinternal",
+			sponsored: false,
+		},
+		slug: "669887798",
+		source: {
+			additional_properties: {
+				editor: "photo center",
+			},
+			edit_url: "https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+			system: "photo center",
+		},
+		subtitle: "Executive with arms crossed against rolled fabric",
+		taxonomy: {
+			associated_tasks: [],
+		},
+		type: "image",
+		url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		version: "0.10.3",
+		width: 3864,
+		syndication: {},
+		creditIPTC: "Getty Images",
 	},
-};
+	{
+		_id: "HY6LDPEW4BBFfff",
+		alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+		additional_properties: {
+			fullSizeResizeUrl:
+				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			galleries: [],
+			ingestionMethod: "manual",
+			iptc_source: "Digital Vision",
+			iptc_title: "Contributor",
+			keywords: [""],
+			mime_type: "image/jpeg",
+			originalName: "iStock-669887798.jpg",
+			originalUrl:
+				"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			owner: "matthew.roach@washpost.com",
+			proxyUrl:
+				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			published: true,
+			resizeUrl:
+				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			restricted: false,
+			takenOn: "2016-09-24T00:00:00Z",
+			thumbnailResizeUrl:
+				"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			usage_instructions: "Model and Property Released (MR&PR) ",
+			version: 0,
+			template_id: 1184,
+		},
+		address: {
+			locality: "Barcelona",
+		},
+		auth: {
+			2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
+		},
+		caption:
+			"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+		copyright: "Abel Mitja Varela",
+		created_date: "2022-06-10T16:37:52Z",
+		credits: {
+			affiliation: [
+				{
+					name: "Getty Images",
+					type: "author",
+				},
+			],
+			by: [
+				{
+					byline: "Morsa Images",
+					name: "Morsa Images",
+					type: "author",
+				},
+			],
+		},
+		height: 2576,
+		image_type: "photograph",
+		last_updated_date: "2022-06-10T16:37:52Z",
+		licensable: false,
+		owner: {
+			id: "sandbox.themesinternal",
+			sponsored: false,
+		},
+		slug: "669887798",
+		source: {
+			additional_properties: {
+				editor: "photo center",
+			},
+			edit_url: "https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+			system: "photo center",
+		},
+		subtitle: "Executive with arms crossed against rolled fabric",
+		taxonomy: {
+			associated_tasks: [],
+		},
+		type: "image",
+		url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		version: "0.10.3",
+		width: 3864,
+		syndication: {},
+		creditIPTC: "Getty Images",
+	},
+	{
+		_id: "HY6LDPEW4BBFzzz",
+		alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+		additional_properties: {
+			fullSizeResizeUrl:
+				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			galleries: [],
+			ingestionMethod: "manual",
+			iptc_source: "Digital Vision",
+			iptc_title: "Contributor",
+			keywords: [""],
+			mime_type: "image/jpeg",
+			originalName: "iStock-669887798.jpg",
+			originalUrl:
+				"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			owner: "matthew.roach@washpost.com",
+			proxyUrl:
+				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			published: true,
+			resizeUrl:
+				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			restricted: false,
+			takenOn: "2016-09-24T00:00:00Z",
+			thumbnailResizeUrl:
+				"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+			usage_instructions: "Model and Property Released (MR&PR) ",
+			version: 0,
+			template_id: 1184,
+		},
+		address: {
+			locality: "Barcelona",
+		},
+		auth: {
+			2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
+		},
+		caption:
+			"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+		copyright: "Abel Mitja Varela",
+		created_date: "2022-06-10T16:37:52Z",
+		credits: {
+			affiliation: [
+				{
+					name: "Getty Images",
+					type: "author",
+				},
+			],
+			by: [
+				{
+					byline: "Morsa Images",
+					name: "Morsa Images",
+					type: "author",
+				},
+			],
+		},
+		height: 2576,
+		image_type: "photograph",
+		last_updated_date: "2022-06-10T16:37:52Z",
+		licensable: false,
+		owner: {
+			id: "sandbox.themesinternal",
+			sponsored: false,
+		},
+		slug: "669887798",
+		source: {
+			additional_properties: {
+				editor: "photo center",
+			},
+			edit_url: "https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+			system: "photo center",
+		},
+		subtitle: "Executive with arms crossed against rolled fabric",
+		taxonomy: {
+			associated_tasks: [],
+		},
+		type: "image",
+		url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		version: "0.10.3",
+		width: 3864,
+		syndication: {},
+		creditIPTC: "Getty Images",
+	},
+];
 
 export const defaultFeaturedImageDisabled = () => (
 	<ProductGalleryDisplay
-		data={MOCK_GLOBAL_CONTENT}
+		carouselItems={MOCK_CAROUSEL_ITEMS}
 		isFeaturedImageEnabled={false}
 		resizerAppVersion={2}
 		arcSite="story-book"
@@ -279,7 +267,7 @@ export const defaultFeaturedImageDisabled = () => (
 
 export const featuredImageEnabled = () => (
 	<ProductGalleryDisplay
-		data={MOCK_GLOBAL_CONTENT}
+		carouselItems={MOCK_CAROUSEL_ITEMS}
 		isFeaturedImageEnabled
 		resizerAppVersion={2}
 		id="id"

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -6,6 +6,9 @@ export default {
 	parameters: {
 		chromatic: { viewports: [320, 1200] },
 	},
+	cssVariables: {
+		theme: "commerce",
+	},
 };
 
 const MOCK_ITEM = {

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -8,250 +8,95 @@ export default {
 	},
 };
 
+const MOCK_ITEM = {
+	_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+	alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+	additional_properties: {
+		fullSizeResizeUrl:
+			"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		galleries: [],
+		ingestionMethod: "manual",
+		iptc_source: "Digital Vision",
+		iptc_title: "Contributor",
+		keywords: [""],
+		mime_type: "image/jpeg",
+		originalName: "iStock-669887798.jpg",
+		originalUrl:
+			"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		owner: "matthew.roach@washpost.com",
+		proxyUrl:
+			"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		published: true,
+		resizeUrl:
+			"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		restricted: false,
+		takenOn: "2016-09-24T00:00:00Z",
+		thumbnailResizeUrl:
+			"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+		usage_instructions: "Model and Property Released (MR&PR) ",
+		version: 0,
+		template_id: 1184,
+	},
+	address: {
+		locality: "Barcelona",
+	},
+	auth: {
+		2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
+	},
+	caption:
+		"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+	copyright: "Abel Mitja Varela",
+	created_date: "2022-06-10T16:37:52Z",
+	credits: {
+		affiliation: [
+			{
+				name: "Getty Images",
+				type: "author",
+			},
+		],
+		by: [
+			{
+				byline: "Morsa Images",
+				name: "Morsa Images",
+				type: "author",
+			},
+		],
+	},
+	height: 2576,
+	image_type: "photograph",
+	last_updated_date: "2022-06-10T16:37:52Z",
+	licensable: false,
+	owner: {
+		id: "sandbox.themesinternal",
+		sponsored: false,
+	},
+	slug: "669887798",
+	source: {
+		additional_properties: {
+			editor: "photo center",
+		},
+		edit_url: "https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+		system: "photo center",
+	},
+	subtitle: "Executive with arms crossed against rolled fabric",
+	taxonomy: {
+		associated_tasks: [],
+	},
+	type: "image",
+	url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+	version: "0.10.3",
+	width: 3864,
+	syndication: {},
+	creditIPTC: "Getty Images",
+};
+
 const MOCK_CAROUSEL_ITEMS = [
-	{
-		_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-		alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-		additional_properties: {
-			fullSizeResizeUrl:
-				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			galleries: [],
-			ingestionMethod: "manual",
-			iptc_source: "Digital Vision",
-			iptc_title: "Contributor",
-			keywords: [""],
-			mime_type: "image/jpeg",
-			originalName: "iStock-669887798.jpg",
-			originalUrl:
-				"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			owner: "matthew.roach@washpost.com",
-			proxyUrl:
-				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			published: true,
-			resizeUrl:
-				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			restricted: false,
-			takenOn: "2016-09-24T00:00:00Z",
-			thumbnailResizeUrl:
-				"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			usage_instructions: "Model and Property Released (MR&PR) ",
-			version: 0,
-			template_id: 1184,
-		},
-		address: {
-			locality: "Barcelona",
-		},
-		auth: {
-			2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
-		},
-		caption:
-			"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-		copyright: "Abel Mitja Varela",
-		created_date: "2022-06-10T16:37:52Z",
-		credits: {
-			affiliation: [
-				{
-					name: "Getty Images",
-					type: "author",
-				},
-			],
-			by: [
-				{
-					byline: "Morsa Images",
-					name: "Morsa Images",
-					type: "author",
-				},
-			],
-		},
-		height: 2576,
-		image_type: "photograph",
-		last_updated_date: "2022-06-10T16:37:52Z",
-		licensable: false,
-		owner: {
-			id: "sandbox.themesinternal",
-			sponsored: false,
-		},
-		slug: "669887798",
-		source: {
-			additional_properties: {
-				editor: "photo center",
-			},
-			edit_url: "https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-			system: "photo center",
-		},
-		subtitle: "Executive with arms crossed against rolled fabric",
-		taxonomy: {
-			associated_tasks: [],
-		},
-		type: "image",
-		url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-		version: "0.10.3",
-		width: 3864,
-		syndication: {},
-		creditIPTC: "Getty Images",
-	},
-	{
-		_id: "HY6LDPEW4BBFfff",
-		alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-		additional_properties: {
-			fullSizeResizeUrl:
-				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			galleries: [],
-			ingestionMethod: "manual",
-			iptc_source: "Digital Vision",
-			iptc_title: "Contributor",
-			keywords: [""],
-			mime_type: "image/jpeg",
-			originalName: "iStock-669887798.jpg",
-			originalUrl:
-				"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			owner: "matthew.roach@washpost.com",
-			proxyUrl:
-				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			published: true,
-			resizeUrl:
-				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			restricted: false,
-			takenOn: "2016-09-24T00:00:00Z",
-			thumbnailResizeUrl:
-				"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			usage_instructions: "Model and Property Released (MR&PR) ",
-			version: 0,
-			template_id: 1184,
-		},
-		address: {
-			locality: "Barcelona",
-		},
-		auth: {
-			2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
-		},
-		caption:
-			"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-		copyright: "Abel Mitja Varela",
-		created_date: "2022-06-10T16:37:52Z",
-		credits: {
-			affiliation: [
-				{
-					name: "Getty Images",
-					type: "author",
-				},
-			],
-			by: [
-				{
-					byline: "Morsa Images",
-					name: "Morsa Images",
-					type: "author",
-				},
-			],
-		},
-		height: 2576,
-		image_type: "photograph",
-		last_updated_date: "2022-06-10T16:37:52Z",
-		licensable: false,
-		owner: {
-			id: "sandbox.themesinternal",
-			sponsored: false,
-		},
-		slug: "669887798",
-		source: {
-			additional_properties: {
-				editor: "photo center",
-			},
-			edit_url: "https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-			system: "photo center",
-		},
-		subtitle: "Executive with arms crossed against rolled fabric",
-		taxonomy: {
-			associated_tasks: [],
-		},
-		type: "image",
-		url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-		version: "0.10.3",
-		width: 3864,
-		syndication: {},
-		creditIPTC: "Getty Images",
-	},
-	{
-		_id: "HY6LDPEW4BBFzzz",
-		alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-		additional_properties: {
-			fullSizeResizeUrl:
-				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			galleries: [],
-			ingestionMethod: "manual",
-			iptc_source: "Digital Vision",
-			iptc_title: "Contributor",
-			keywords: [""],
-			mime_type: "image/jpeg",
-			originalName: "iStock-669887798.jpg",
-			originalUrl:
-				"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			owner: "matthew.roach@washpost.com",
-			proxyUrl:
-				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			published: true,
-			resizeUrl:
-				"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			restricted: false,
-			takenOn: "2016-09-24T00:00:00Z",
-			thumbnailResizeUrl:
-				"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-			usage_instructions: "Model and Property Released (MR&PR) ",
-			version: 0,
-			template_id: 1184,
-		},
-		address: {
-			locality: "Barcelona",
-		},
-		auth: {
-			2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
-		},
-		caption:
-			"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
-		copyright: "Abel Mitja Varela",
-		created_date: "2022-06-10T16:37:52Z",
-		credits: {
-			affiliation: [
-				{
-					name: "Getty Images",
-					type: "author",
-				},
-			],
-			by: [
-				{
-					byline: "Morsa Images",
-					name: "Morsa Images",
-					type: "author",
-				},
-			],
-		},
-		height: 2576,
-		image_type: "photograph",
-		last_updated_date: "2022-06-10T16:37:52Z",
-		licensable: false,
-		owner: {
-			id: "sandbox.themesinternal",
-			sponsored: false,
-		},
-		slug: "669887798",
-		source: {
-			additional_properties: {
-				editor: "photo center",
-			},
-			edit_url: "https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
-			system: "photo center",
-		},
-		subtitle: "Executive with arms crossed against rolled fabric",
-		taxonomy: {
-			associated_tasks: [],
-		},
-		type: "image",
-		url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-		version: "0.10.3",
-		width: 3864,
-		syndication: {},
-		creditIPTC: "Getty Images",
-	},
+	...Array(10)
+		.fill(MOCK_ITEM)
+		.map((item, index) => ({
+			...item,
+			_id: `${item._id}${index}`,
+		})),
 ];
 
 export const defaultFeaturedImageDisabled = () => (

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -178,6 +178,88 @@ const MOCK_GLOBAL_CONTENT = {
 						syndication: {},
 						creditIPTC: "Getty Images",
 					},
+					{
+						_id: "HY6LDPEW4BBFzzz",
+						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
+						additional_properties: {
+							fullSizeResizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							galleries: [],
+							ingestionMethod: "manual",
+							iptc_source: "Digital Vision",
+							iptc_title: "Contributor",
+							keywords: [""],
+							mime_type: "image/jpeg",
+							originalName: "iStock-669887798.jpg",
+							originalUrl:
+								"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							owner: "matthew.roach@washpost.com",
+							proxyUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							published: true,
+							resizeUrl:
+								"/resizer/vNkSDXlCXlGHlHfBlHN5zIlCKFQ=/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							restricted: false,
+							takenOn: "2016-09-24T00:00:00Z",
+							thumbnailResizeUrl:
+								"/resizer/FSBpqd6Pj-OHgF0XkRsw3eqlq3Q=/300x0/arc-photo-themesinternal/arc2-sandbox/public/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+							usage_instructions: "Model and Property Released (MR&PR) ",
+							version: 0,
+							template_id: 1184,
+						},
+						address: {
+							locality: "Barcelona",
+						},
+						auth: {
+							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+						},
+						caption:
+							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
+						copyright: "Abel Mitja Varela",
+						created_date: "2022-06-10T16:37:52Z",
+						credits: {
+							affiliation: [
+								{
+									name: "Getty Images",
+									type: "author",
+								},
+							],
+							by: [
+								{
+									byline: "Morsa Images",
+									name: "Morsa Images",
+									type: "author",
+								},
+							],
+						},
+						height: 2576,
+						image_type: "photograph",
+						last_updated_date: "2022-06-10T16:37:52Z",
+						licensable: false,
+						owner: {
+							id: "sandbox.themesinternal",
+							sponsored: false,
+						},
+						slug: "669887798",
+						source: {
+							additional_properties: {
+								editor: "photo center",
+							},
+							edit_url:
+								"https://sandbox.themesinternal.arcpublishing.com/photo/HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+							system: "photo center",
+						},
+						subtitle: "Executive with arms crossed against rolled fabric",
+						taxonomy: {
+							associated_tasks: [],
+						},
+						type: "image",
+						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+						version: "0.10.3",
+						width: 3864,
+						syndication: {},
+						creditIPTC: "Getty Images",
+					},
 				],
 			},
 		},
@@ -185,9 +267,21 @@ const MOCK_GLOBAL_CONTENT = {
 };
 
 export const defaultFeaturedImageDisabled = () => (
-	<ProductGalleryDisplay data={MOCK_GLOBAL_CONTENT} isFeaturedImageEnabled={false} />
+	<ProductGalleryDisplay
+		data={MOCK_GLOBAL_CONTENT}
+		isFeaturedImageEnabled={false}
+		resizerAppVersion={2}
+		label="label"
+		id="id"
+	/>
 );
 
 export const featuredImageEnabled = () => (
-	<ProductGalleryDisplay data={MOCK_GLOBAL_CONTENT} isFeaturedImageEnabled />
+	<ProductGalleryDisplay
+		data={MOCK_GLOBAL_CONTENT}
+		isFeaturedImageEnabled
+		resizerAppVersion={2}
+		label="label"
+		id="id"
+	/>
 );

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -47,7 +47,7 @@ const MOCK_GLOBAL_CONTENT = {
 							locality: "Barcelona",
 						},
 						auth: {
-							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
 						},
 						caption:
 							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
@@ -129,7 +129,7 @@ const MOCK_GLOBAL_CONTENT = {
 							locality: "Barcelona",
 						},
 						auth: {
-							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
 						},
 						caption:
 							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
@@ -211,7 +211,7 @@ const MOCK_GLOBAL_CONTENT = {
 							locality: "Barcelona",
 						},
 						auth: {
-							2: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+							2: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
 						},
 						caption:
 							"Portrait of confident businessman with arms crossed against rolled fabric. Executive is smiling while standing against shelves. He is wearing smart casuals in textile factory.",
@@ -273,6 +273,7 @@ export const defaultFeaturedImageDisabled = () => (
 		resizerAppVersion={2}
 		arcSite="story-book"
 		id="id"
+		resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 	/>
 );
 
@@ -283,5 +284,6 @@ export const featuredImageEnabled = () => (
 		resizerAppVersion={2}
 		id="id"
 		arcSite="story-book"
+		resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 	/>
 );

--- a/blocks/product-gallery-block/intl.json
+++ b/blocks/product-gallery-block/intl.json
@@ -10,28 +10,6 @@
 		"pt": "Products",
 		"sv": "Products"
 	},
-	"product-gallery.right-arrow-label": {
-		"de": "Next",
-		"en": "Next",
-		"es": "Next",
-		"fr": "Next",
-		"ja": "Next",
-		"ko": "Next",
-		"no": "Next",
-		"pt": "Next",
-		"sv": "Next"
-	},
-	"product-gallery.left-arrow-label": {
-		"de": "Previous",
-		"en": "Previous",
-		"es": "Previous",
-		"fr": "Previous",
-		"ja": "Previous",
-		"ko": "Previous",
-		"no": "Previous",
-		"pt": "Previous",
-		"sv": "Previous"
-	},
 	"product-gallery.slide-indicator": {
 		"de": "Slide %{current} of %{maximum}",
 		"en": "Slide %{current} of %{maximum}",

--- a/blocks/product-gallery-block/intl.json
+++ b/blocks/product-gallery-block/intl.json
@@ -1,0 +1,46 @@
+{
+	"product-gallery.aria-label": {
+		"de": "Products",
+		"en": "Products",
+		"es": "Products",
+		"fr": "Products",
+		"ja": "Products",
+		"ko": "Products",
+		"no": "Products",
+		"pt": "Products",
+		"sv": "Products"
+	},
+	"product-gallery.right-arrow-label": {
+		"de": "Next",
+		"en": "Next",
+		"es": "Next",
+		"fr": "Next",
+		"ja": "Next",
+		"ko": "Next",
+		"no": "Next",
+		"pt": "Next",
+		"sv": "Next"
+	},
+	"product-gallery.left-arrow-label": {
+		"de": "Previous",
+		"en": "Previous",
+		"es": "Previous",
+		"fr": "Previous",
+		"ja": "Previous",
+		"ko": "Previous",
+		"no": "Previous",
+		"pt": "Previous",
+		"sv": "Previous"
+	},
+	"product-gallery.slide-indicator": {
+		"de": "Slide %{current} of %{maximum}",
+		"en": "Slide %{current} of %{maximum}",
+		"es": "Slide %{current} of %{maximum}",
+		"fr": "Slide %{current} of %{maximum}",
+		"ja": "Slide %{current} of %{maximum}",
+		"ko": "Slide %{current} of %{maximum}",
+		"no": "Slide %{current} of %{maximum}",
+		"pt": "Slide %{current} of %{maximum}",
+		"sv": "Slide %{current} of %{maximum}"
+	}
+}

--- a/blocks/product-gallery-block/jest.config.js
+++ b/blocks/product-gallery-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest/jest.config.base");
+
+module.exports = {
+	...base,
+};

--- a/blocks/product-gallery-block/package.json
+++ b/blocks/product-gallery-block/package.json
@@ -8,7 +8,8 @@
   "main": "",
   "files": [
     "_index.scss",
-    "features"
+    "features",
+    "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/blocks/product-gallery-block/package.json
+++ b/blocks/product-gallery-block/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@wpmedia/product-gallery-block",
+  "version": "0.1.0",
+  "description": "Product Gallery Block",
+  "author": "Arc XP - Themes",
+  "homepage": "https://github.com/WPMedia/arc-themes-blocks",
+  "license": "CC-BY-NC-ND-4.0",
+  "main": "",
+  "files": [
+    "_index.scss",
+    "features"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+    "directory": "blocks/product-gallery-block"
+  },
+  "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
+    "@wpmedia/arc-themes-components": "*"
+  }
+}

--- a/jest/mocks/context.js
+++ b/jest/mocks/context.js
@@ -1,3 +1,5 @@
-export const useComponentContext = jest.fn(() => ({}));
+export const useComponentContext = jest.fn(() => ({
+	id: "id-app-context-jest-mock",
+}));
 export const useAppContext = jest.fn(() => ({}));
 export const useFusionContext = jest.fn(() => ({}));

--- a/locale/de.json
+++ b/locale/de.json
@@ -447,5 +447,11 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-gallery-block": {
+		"product-gallery.aria-label": "Products",
+		"product-gallery.right-arrow-label": "Next",
+		"product-gallery.left-arrow-label": "Previous",
+		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"
 	}
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -447,5 +447,11 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-gallery-block": {
+		"product-gallery.aria-label": "Products",
+		"product-gallery.right-arrow-label": "Next",
+		"product-gallery.left-arrow-label": "Previous",
+		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"
 	}
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -447,5 +447,11 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-gallery-block": {
+		"product-gallery.aria-label": "Products",
+		"product-gallery.right-arrow-label": "Next",
+		"product-gallery.left-arrow-label": "Previous",
+		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"
 	}
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -447,5 +447,11 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-gallery-block": {
+		"product-gallery.aria-label": "Products",
+		"product-gallery.right-arrow-label": "Next",
+		"product-gallery.left-arrow-label": "Previous",
+		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"
 	}
 }

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -447,5 +447,11 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-gallery-block": {
+		"product-gallery.aria-label": "Products",
+		"product-gallery.right-arrow-label": "Next",
+		"product-gallery.left-arrow-label": "Previous",
+		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"
 	}
 }

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -447,5 +447,11 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-gallery-block": {
+		"product-gallery.aria-label": "Products",
+		"product-gallery.right-arrow-label": "Next",
+		"product-gallery.left-arrow-label": "Previous",
+		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"
 	}
 }

--- a/locale/no.json
+++ b/locale/no.json
@@ -447,5 +447,11 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-gallery-block": {
+		"product-gallery.aria-label": "Products",
+		"product-gallery.right-arrow-label": "Next",
+		"product-gallery.left-arrow-label": "Previous",
+		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"
 	}
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -447,5 +447,11 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-gallery-block": {
+		"product-gallery.aria-label": "Products",
+		"product-gallery.right-arrow-label": "Next",
+		"product-gallery.left-arrow-label": "Previous",
+		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"
 	}
 }

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -447,5 +447,11 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-gallery-block": {
+		"product-gallery.aria-label": "Products",
+		"product-gallery.right-arrow-label": "Next",
+		"product-gallery.left-arrow-label": "Previous",
+		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16669,9 +16669,9 @@
       "version": "file:blocks/alert-bar-content-source-block"
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-1.34",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-1.34/678b546393ed0f7dee906d2107fbc37ca7de4e4a",
-      "integrity": "sha512-NknjuNVCS417E0BZFHz1T0epVoOkEbV96vtp6XOs46aXXDoEvj95effGtihO6OpYSl2stWv0Fj9t9RNZBGOTFg==",
+      "version": "0.0.4-arc-themes-release-version-2-0-1.35",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-1.35/b9d75d2e6e6872ebd0c1c46f1257f42e54befc8c",
+      "integrity": "sha512-7IhtifQIl3DxW6jr/DHKwYdfGjM71quS0TqN5Kz8ApCDWwfpJKrAJb1onBObxxmmu89qLqRMKyTr3ucXxBtoKA==",
       "dev": true,
       "requires": {
         "react-oembed-container": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5859,6 +5859,7 @@
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
       "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -5866,7 +5867,8 @@
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
         }
       }
     },
@@ -16654,8 +16656,7 @@
     "@wpmedia/ads-block": {
       "version": "file:blocks/ads-block",
       "requires": {
-        "arcads": "6.1.1",
-        "lazy-child": "^0.2.0"
+        "arcads": "6.1.1"
       }
     },
     "@wpmedia/alert-bar-block": {
@@ -16668,9 +16669,9 @@
       "version": "file:blocks/alert-bar-content-source-block"
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-1.32",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-1.32/8780493e7dec28b513afcf04a909550ff24c42f0f81198646462a718f5c16d2f",
-      "integrity": "sha512-5lrzgZPy+EPAwcKNaHWAzE1rSu6MCNZ9yRLf7IZB2s6cSeL9b15eYpXmyf0VP+neeJCkqmZ/QLWmMviya/zt7Q==",
+      "version": "0.0.4-arc-themes-release-version-2-0-1.34",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-1.34/678b546393ed0f7dee906d2107fbc37ca7de4e4a",
+      "integrity": "sha512-NknjuNVCS417E0BZFHz1T0epVoOkEbV96vtp6XOs46aXXDoEvj95effGtihO6OpYSl2stWv0Fj9t9RNZBGOTFg==",
       "dev": true,
       "requires": {
         "react-oembed-container": "^1.0.1",
@@ -16754,9 +16755,9 @@
       "version": "file:blocks/double-chain-block"
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.13.2-arc-themes-release-version-1-22.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/engine-theme-sdk/2.13.2-arc-themes-release-version-1-22.0/67c3f939a1ae3067162f91c7d154aa5b63f4ca28b1b44445c957bd86f1e12c97",
-      "integrity": "sha512-NMfeJoJJ2GlMnvzlXMqSB5tN+jCfokng5GzOOh0rpRhW4UVhb2e4I/wB4egPZpj6JHzTfwH4RDQYJARSwekZfQ==",
+      "version": "2.13.2-arc-themes-release-version-1-23.0",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/engine-theme-sdk/2.13.2-arc-themes-release-version-1-23.0/fbdbe4c62842d3d0a77fd9e6bfd4bd8534aac150",
+      "integrity": "sha512-wh3Mf/o1jTnLpcP41MIsdnlWSu9qqL9opcKRVY6P0pWZbnkxMAgR192nmTGVbIqxOdDhIKeAwWASNkHoI5K/IQ==",
       "dev": true,
       "requires": {
         "@arc-fusion/prop-types": "^0.1.5",
@@ -16876,7 +16877,7 @@
     },
     "@wpmedia/news-theme-css": {
       "version": "4.3.1-stable.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/news-theme-css/4.3.1-stable.0/b9bd2b0a246deff98e4d4621b32ac90c2ce3ff72b03aad561dacbf122935b100",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/news-theme-css/4.3.1-stable.0/44b712ac7e92b0c873c8844d8b4b4c283a6336b9",
       "integrity": "sha512-pFdWkoEtXaNLNRQt6MOYuMIR6jgXhAIWEWBebxu0Cm5dElnLX0bDKvv4zyCuyPAeS5olYhSWqvV8Hrr2ZzF4fQ==",
       "dev": true
     },
@@ -16997,7 +16998,7 @@
     },
     "@wpmedia/timezone": {
       "version": "1.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/timezone/1.1.1/0ad6c48a887bc2b122d141a1eb5fb9a81b5f2ee7195d0d81f38aab7366919c2b",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/timezone/1.1.1/bdcfc9fe46beecfe4ec5e5cf71095dae7e2588f3",
       "integrity": "sha512-nN6M2q8cyJELhihJ65t4CVFWr7QgZSnO+aAEXVFdh/k9RpQJd7EtGVLjZyd8HzAFwhiGv+O4Iz7nclbOnNXEWg==",
       "dev": true
     },
@@ -30349,15 +30350,6 @@
         "language-subtag-registry": "~0.3.2"
       }
     },
-    "lazy-child": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/lazy-child/-/lazy-child-0.2.0.tgz",
-      "integrity": "sha512-QOlhECVjMLIS2FNujfZqPXnWBYpd54sv0k4YDgwuPb16CZMMPC5QxNfN/rH0SpfSe3sktK0l6qrOgtScV7eqWQ==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "react-peekaboo": "^0.3.0"
-      }
-    },
     "lazy-universal-dotenv": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lazy-universal-dotenv/-/lazy-universal-dotenv-3.0.1.tgz",
@@ -31278,7 +31270,8 @@
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+      "dev": true
     },
     "lodash.toarray": {
       "version": "4.4.0",
@@ -35006,15 +34999,6 @@
       "integrity": "sha512-wU7s2Ql6LZp7bTbf7Hloy7ONDCSb+44iM4Ezdk36qqsVSxOefvN70DBuqf3Z/c7zQdYVwODHryMYawq6sxmG+A==",
       "requires": {
         "prop-types": "^15.6.0"
-      }
-    },
-    "react-peekaboo": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/react-peekaboo/-/react-peekaboo-0.3.0.tgz",
-      "integrity": "sha512-Vae3BZ6aBCqAD4F7nWwX0Q8GWHb15p8hgfLiKtp3XF8/iyWhx+9na4Kz15lvoOR12+V7sdYv3BCNv3rG5gK2uA==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "lodash.throttle": "^4.1.1"
       }
     },
     "react-popper": {


### PR DESCRIPTION
## Description

Add product gallery that highlights the first image if toggled on

## Jira Ticket

- [TBRANDS-99](https://arcpublishing.atlassian.net/jira/software/c/projects/TMEDIA/boards/875?modal=detail&selectedIssue=TBRANDS-99&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria

Product Gallery - Arc Block is available within PageBuilder Editor and can be used to create a PDP.

Product images are available for display from the Arc Commerce Content Source. API data field - schema.productGallery

Product Gallery - Arc Block will have 2 display states which will be configured within PageBuilder Editor:

Featured Image disabled:

This is the default state.

Featured Image enabled:

A user can override the default state (Featured Image disabled) by selecting a radio button that says: Display the product’s featured image.

When Feature Image enabled:

Desktop: a single column large image will populate the first image position of the gallery.

Mobile: the featured image will populate the first position of the gallery.

Product Gallery - Display Logic:

Featured Image disabled:

Maximum of 8 images will display.

Desktop:

Images will display as a 2 column grid.

Even number of images: Renders a 2 column grid

Odd number of images: Renders a 2 column grid. Last image will nest as the last item in the left column. 

Mobile:

Images will appear in a gallery carousel.

Gallery navigation will have a forward button which when clicked will unveil the next image.

Gallery navigation will have a back button which when clicked will unveil the previous image.

Users can horizontally navigate the gallery by swiping from:

right to left which will unveil the next image.

left to right which will unveil the previous image.

On page load:

The forward button is the only button to display.

If a user engages with the forward button or swipes from right to left and unveils the 2nd image, the back button will also display.

If user reaches the last image of the gallery, the forward button will disappear and only the back button will display.

Featured Image enabled:

Maximum of 9 images will display (featured image + up to 8 other product images).

Desktop:

Images will display:

Position #1: a single column large image

Position #2 - #9: will display beneath the single column large image as a 2 column grid.

Even number of images: Renders a 2 column grid

Odd number of images: Renders a 2 column grid. Last image will nest as the last item in the left column. 

Mobile:

Images will appear in a gallery carousel.

The featured image will populate the 1st position of the gallery.

Gallery navigation will have a forward button which when clicked will unveil the next image.

Gallery navigation will have a back button which when clicked will unveil the previous image.

Users can horizontally navigate the gallery by swiping from:

right to left which will unveil the next image.

left to right which will unveil the previous image.

On page load:

The forward button is the only button to display.

If a user engages with the forward button or swipes from right to left and unveils the 2nd image, the back button will also display.

If user reaches the last image of the gallery, the forward button will disappear and only the back button will display.

## Test Steps

### Fusion 

1. Checkout this branch `git checkout TBRANDS-99-product-gallery` for feature pack as well
2. Make sure to link themes components pr as well https://github.com/WPMedia/arc-themes-components/pull/132 -> make sure to reinstall dependencies for themes components for sb
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/product-gallery-block,@wpmedia/commerce-product-content-source-block`
4. Create a new page
5. Use the right rail layout
6. Add the product gallery to the main section
7. Toggle the featured image on and off to see the first image displayed at various widths 

desktop
<img width="1437" alt="Screen Shot 2022-08-09 at 15 12 41" src="https://user-images.githubusercontent.com/5950956/183751772-820d078b-3c31-48ff-8c5a-db33a012e2d4.png">
<img width="1440" alt="Screen Shot 2022-08-09 at 15 12 33" src="https://user-images.githubusercontent.com/5950956/183751781-e992aa65-5359-4d12-95eb-25e2bdf4e7bf.png">

mobile

- edge to edge
- I also used the other gallery styles because we weren't following the dots mock

<img width="547" alt="Screen Shot 2022-08-09 at 15 14 53" src="https://user-images.githubusercontent.com/5950956/183752874-407a7338-8fca-4419-a8db-7c144a764fbe.png">
<img width="544" alt="Screen Shot 2022-08-09 at 15 14 58" src="https://user-images.githubusercontent.com/5950956/183752771-b1505590-2153-4649-b028-66d78f160560.png">

### Storybook

1. Look at chromatic at the various breakpoints 
2. You'll notice that the images are being set to be 25vw for non-featured image on desktop.
3. The featured image will be 50vw per the mocks on the screen for desktop
4. The mobile is edge to edge based on the designs 

## Dependencies or Side Effects

- Feature pack pr https://github.com/WPMedia/arc-themes-feature-pack/pull/327
- I updated the mock auth data to make sure that the external url token is being used here in the gallery
- merge themes components pr https://github.com/WPMedia/arc-themes-components/pull/132

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


# question: 

- What are the dimensions of the designs in the images? will it always be a height and width for the image? or will we use whatever native resolution of the images (may result in one some odd spacing)? -> always 4:3 based on Matt Nash answer
- show dots based on mocks? -> no
- Reuse carousel translation like next slide form product-assortment-carousel into global phrases. Should "products" be a global phrase? is "next" and "previous" ok as global phrases? 
- Can product.item take in a classname? currently I'm selecting the first instance of its class but that item doesn't take in additional classnames
- I used the styling for the other commerce carousels with the icon buttons to make sure that the styling made sense if we were not going to use dots. Is this ok from a design perspective? 

# todos

- [x] Remove the non-modifier from the bem naming of `--disabled` for the top level block. add the base bem name `b-block-name`. Update tests
- [x] Take in id from global data like component context done in other carousel
- [x] Display images within mock data on sb and on the test
- [x] Style the two modifiers for enhanced styles in the theme file for featured image enabled custom setting logic. Make sure the first element styles apply on both breakpoints -- default and desktop. The first element in the list will need a modifier like first-item. (This could be done with a :first or something for css I think but let's make sure it's following other v2 styles precedent if there is one.)  
- [x] Cutoff render of max of 8 items are available to be toggled to or seen with featured disabled, regardless of breakpoint
- [x] Cutoff render of max of 9 items to be toggled or seen with featured enabled, regardless of breakpoint
- [x] Take in label, other translations for carousel from block translations like other blocks
- [x] Localize some like a fallback aria label for Products? 
- [x] Add some basic responsive image widths for resizing with 4:3 aspect ratio
- [x] Investigate passing in a class into the carousel item
