### PR TITLE
TBRANDS-100 - Update Product Information block to have sale and list price output

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -678,7 +678,20 @@
 							color: var(--text-color),
 							font-size: var(--global-font-size-5),
 							font-weight: var(--global-font-weight-4),
+							gap: var(--global-spacing-1),
 							line-height: var(--global-line-height-4),
+						),
+						price-list: (
+							color: var(--global-neutral-5),
+							text-decoration: line-through,
+						),
+					),
+				),
+				product-information-single-price: (
+					components: (
+						price-list: (
+							color: var(--global-neutral-7),
+							text-decoration: none,
 						),
 					),
 				),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -678,7 +678,7 @@
 							color: var(--text-color),
 							font-size: var(--global-font-size-5),
 							font-weight: var(--global-font-weight-4),
-							gap: var(--global-spacing-1),
+							gap: var(--global-spacing-2),
 							line-height: var(--global-line-height-4),
 						),
 						price-list: (

--- a/blocks/product-information-block/_index.scss
+++ b/blocks/product-information-block/_index.scss
@@ -3,4 +3,9 @@
 .b-product-information {
 	@include scss.block-components("product-information");
 	@include scss.block-properties("product-information");
+
+	&__product-single-price {
+		@include scss.block-properties("product-information-single-price");
+		@include scss.block-components("product-information-single-price");
+	}
 }

--- a/blocks/product-information-block/_index.scss
+++ b/blocks/product-information-block/_index.scss
@@ -1,11 +1,11 @@
 @use "@wpmedia/arc-themes-components/scss";
 
 .b-product-information {
-	@include scss.block-components("product-information");
-	@include scss.block-properties("product-information");
-
 	&__product-single-price {
 		@include scss.block-properties("product-information-single-price");
 		@include scss.block-components("product-information-single-price");
 	}
+
+	@include scss.block-components("product-information");
+	@include scss.block-properties("product-information");
 }

--- a/blocks/product-information-block/features/product-information/default.jsx
+++ b/blocks/product-information-block/features/product-information/default.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { useFusionContext } from "fusion:context";
+import getProperties from "fusion:properties";
+import getTranslatedPhrases from "fusion:intl";
 
 import { Heading, Price, Stack } from "@wpmedia/arc-themes-components";
 
@@ -7,21 +9,45 @@ const BLOCK_CLASS_NAME = "b-product-information";
 
 const getPrice = (type, prices) => (prices && prices.filter((x) => x.type === type)?.[0]) || null;
 
+const priceDisplay = (pricing, item) =>
+	new Intl.NumberFormat(pricing?.currencyLocale, {
+		style: "currency",
+		currency: pricing?.currencyCode,
+		minimumFractionDigits: 2,
+	}).format(item.amount);
+
 export const ProductInformationDisplay = ({ data }) => {
+	const { arcSite } = useFusionContext();
+	const { locale } = getProperties(arcSite);
+	const phrases = getTranslatedPhrases(locale);
+
 	const pricing = (data?.pricing && data?.pricing[0]) || null;
 	const ListPrice = getPrice("List", pricing?.prices);
+	const SalePrice = getPrice("Sale", pricing?.prices);
+	const salePriceAmount = SalePrice?.amount;
+	const listPriceAmount = ListPrice?.amount;
+	const isOnSale = salePriceAmount && salePriceAmount !== listPriceAmount;
 
 	return (
 		<Stack className={`${BLOCK_CLASS_NAME}`}>
 			{data.name ? <Heading>{data.name}</Heading> : null}
 			{ListPrice ? (
-				<Price>
-					<Price.List>
-						{new Intl.NumberFormat(pricing?.currencyLocale, {
-							style: "currency",
-							currency: pricing?.currencyCode,
-							minimumFractionDigits: 2,
-						}).format(ListPrice.amount)}
+				<Price className={`${!isOnSale ? `${BLOCK_CLASS_NAME}__product-single-price` : null}`}>
+					{isOnSale ? (
+						<Price.Sale
+							aria-label={phrases.t("product-information.sale-price", {
+								price: priceDisplay(pricing, SalePrice),
+							})}
+						>
+							{priceDisplay(pricing, SalePrice)}
+						</Price.Sale>
+					) : null}
+					<Price.List
+						aria-label={phrases.t("product-information.list-price", {
+							price: priceDisplay(pricing, ListPrice),
+						})}
+					>
+						{priceDisplay(pricing, ListPrice)}
 					</Price.List>
 				</Price>
 			) : null}

--- a/blocks/product-information-block/features/product-information/default.test.jsx
+++ b/blocks/product-information-block/features/product-information/default.test.jsx
@@ -30,6 +30,30 @@ describe("Product Information", () => {
 		expect(screen.queryByText("Arc Commerce T-Shirt")).toBeInTheDocument();
 	});
 
+	it("should render only list price", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				pricing: [
+					{
+						currencyCode: "USD",
+						currencyDisplayFormat: "symbol",
+						currencyLocale: "en-US",
+						schema: {},
+						prices: [
+							{
+								type: "List",
+								amount: "59.00",
+							},
+						],
+					},
+				],
+			},
+		}));
+		render(<ProductInformation />);
+		expect(screen.queryByText("Arc Commerce T-Shirt")).not.toBeInTheDocument();
+		expect(screen.queryByText("$59.00")).toBeInTheDocument();
+	});
+
 	it("should render product name and list price", () => {
 		useFusionContext.mockImplementation(() => ({
 			globalContent: {
@@ -53,5 +77,67 @@ describe("Product Information", () => {
 		render(<ProductInformation />);
 		expect(screen.queryByText("Arc Commerce T-Shirt")).toBeInTheDocument();
 		expect(screen.queryByText("$59.00")).toBeInTheDocument();
+	});
+
+	it("should render product name, sale price and list price", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				name: "Arc Commerce T-Shirt",
+				pricing: [
+					{
+						currencyCode: "USD",
+						currencyDisplayFormat: "symbol",
+						currencyLocale: "en-US",
+						schema: {},
+						prices: [
+							{
+								type: "List",
+								amount: "59.00",
+							},
+							{
+								type: "Sale",
+								amount: "49.00",
+							},
+						],
+					},
+				],
+			},
+		}));
+		render(<ProductInformation />);
+		expect(screen.queryByText("Arc Commerce T-Shirt")).toBeInTheDocument();
+		expect(screen.queryByText("$59.00")).toBeInTheDocument();
+		expect(screen.getByLabelText("product-information.sale-price")).toBeInTheDocument();
+		expect(screen.queryByText("$49.00")).toBeInTheDocument();
+		expect(screen.getByLabelText("product-information.list-price")).toBeInTheDocument();
+	});
+
+	it("should render product name and sale price if sale and list price are the same", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				name: "Arc Commerce T-Shirt",
+				pricing: [
+					{
+						currencyCode: "USD",
+						currencyDisplayFormat: "symbol",
+						currencyLocale: "en-US",
+						schema: {},
+						prices: [
+							{
+								type: "List",
+								amount: "49.00",
+							},
+							{
+								type: "Sale",
+								amount: "49.00",
+							},
+						],
+					},
+				],
+			},
+		}));
+		render(<ProductInformation />);
+		expect(screen.queryByText("Arc Commerce T-Shirt")).toBeInTheDocument();
+		expect(screen.queryByText("$49.00")).toBeInTheDocument();
+		expect(screen.getByLabelText("product-information.list-price")).toBeInTheDocument();
 	});
 });

--- a/blocks/product-information-block/index.story.jsx
+++ b/blocks/product-information-block/index.story.jsx
@@ -29,6 +29,36 @@ const mockPrice = {
 		},
 	],
 };
+
+const mockSamePrice = {
+	currencyCode: "USD",
+	currencyDisplayFormat: "symbol",
+	currencyLocale: "en-US",
+	schema: {},
+	prices: [
+		{
+			type: "List",
+			amount: "49.00",
+		},
+		{
+			type: "Sale",
+			amount: "49.00",
+		},
+	],
+};
+
+const mockListPrice = {
+	currencyCode: "USD",
+	currencyDisplayFormat: "symbol",
+	currencyLocale: "en-US",
+	schema: {},
+	prices: [
+		{
+			type: "List",
+			amount: "59.00",
+		},
+	],
+};
 const mockData = {
 	name: "Crocker Sandals",
 	pricing: [mockPrice],
@@ -38,4 +68,10 @@ export const TitleAndPricing = () => <ProductInformationDisplay data={mockData} 
 
 export const TitleOnly = () => <ProductInformationDisplay data={{ name: "Crocker Sandals" }} />;
 
-export const ListsPriceOnly = () => <ProductInformationDisplay data={{ pricing: [mockPrice] }} />;
+export const ListsPriceOnly = () => (
+	<ProductInformationDisplay data={{ pricing: [mockListPrice] }} />
+);
+
+export const saleAndListPriceSame = () => (
+	<ProductInformationDisplay data={{ pricing: [mockSamePrice] }} />
+);

--- a/blocks/product-information-block/intl.json
+++ b/blocks/product-information-block/intl.json
@@ -1,0 +1,24 @@
+{
+	"product-information.sale-price": {
+		"de": "Sale Price %{price}",
+		"en": "Sale Price %{price}",
+		"es": "Sale Price %{price}",
+		"fr": "Sale Price %{price}",
+		"ja": "Sale Price %{price}",
+		"ko": "Sale Price %{price}",
+		"no": "Sale Price %{price}",
+		"pt": "Sale Price %{price}",
+		"sv": "Sale Price %{price}"
+	},
+	"product-information.list-price": {
+		"de": "List Price %{price}",
+		"en": "List Price %{price}",
+		"es": "List Price %{price}",
+		"fr": "List Price %{price}",
+		"ja": "List Price %{price}",
+		"ko": "List Price %{price}",
+		"no": "List Price %{price}",
+		"pt": "List Price %{price}",
+		"sv": "List Price %{price}"
+	}
+}

--- a/blocks/product-information-block/package.json
+++ b/blocks/product-information-block/package.json
@@ -8,7 +8,8 @@
   "main": "",
   "files": [
     "_index.scss",
-    "features"
+    "features",
+	 "intl.json"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/locale/de.json
+++ b/locale/de.json
@@ -447,5 +447,9 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -447,5 +447,9 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -447,5 +447,9 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -447,5 +447,9 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -447,5 +447,9 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -447,5 +447,9 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/no.json
+++ b/locale/no.json
@@ -447,5 +447,9 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -447,5 +447,9 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -447,5 +447,9 @@
 	"product-content-block": {
 		"product-content.description": "Description",
 		"product-content.details": "Details"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }


### PR DESCRIPTION
## Description

Update Product Information block to have Sale and List price output, and also include logic to only show sale price if the product is on sale (a different price)

## Jira Ticket

- [TBRANDS-100](https://arcpublishing.atlassian.net/browse/TBRANDS-100)

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout TBRANDS-100-product-information-updates`
2. Checkout out the Feature Pack PR - `TBRANDS-100-product-information-updates`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/product-information-block`
4. Set up a page to use the Commerce Product Content Source as Global Content
5. Add the Product Information block to the page
6. Verify Sale and List price is shown

For other logic - we can validate via Chromatic and Storybook

## Dependencies or Side Effects

Feature Pack - https://github.com/WPMedia/arc-themes-feature-pack/pull/326

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
