### PR TITLE
TBRANDS-101 : Product Content, Part 2

### DIFF
--- a/blocks/product-content-block/README.md
+++ b/blocks/product-content-block/README.md
@@ -9,8 +9,17 @@ Description and/or Product Details
 | ---------------- | ------------ | -------- | -------------------------------------------------------------------------------------- |
 | **contentType**  | no           | string   | Choice of which product content item to show                                           |
 | **headline**     | no           | string   | A custom headline to be used in place of the default headline for a given content type |
-| open             | no           | boolean  | Flag to denote if the content panel should be open on intial render                    |
+| **open**         | no           | boolean  | Flag to denote if the content panel should be open on intial render                    |
 
 ## Data
 
 Relies on `globalContent` for data access from Arc Commerce
+
+## Internationalization fields
+
+| Phrase Key                         | Default (English)  |
+| ---------------------------------- | ------------------ |
+| product-content.description        | Description        |
+| product-content.details            | Details            |
+| product-content.sizeAndFit         | Size & Fit         |
+| product-content.shippingAndReturns | Shipping & Returns |

--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -12,6 +12,8 @@ const BLOCK_CLASS_NAME = "b-product-content";
 const contentMapping = {
 	description: "description",
 	details: "schema.productDetails",
+	sizeAndFit: "schema.sizeAndFit",
+	shippingAndReturns: "schema.shippingAndReturns",
 };
 
 const getNestedObject = (obj, path) => path.split(".").reduce((value, el) => value[el], obj);
@@ -59,12 +61,19 @@ ProductContent.icon = "content-browser-edit";
 
 ProductContent.propTypes = {
 	customFields: PropTypes.shape({
-		contentType: PropTypes.oneOf(["description", "details"]).tag({
+		contentType: PropTypes.oneOf([
+			"description",
+			"details",
+			"sizeAndFit",
+			"shippingAndReturns",
+		]).tag({
 			defaultValue: "description",
 			label: "Product Content",
 			labels: {
 				description: "Product Description",
 				details: "Product Details",
+				sizeAndFit: "Size & Fit",
+				shippingAndReturns: "shipping & Returns",
 			},
 		}),
 		headline: PropTypes.string.tag({

--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -73,7 +73,7 @@ ProductContent.propTypes = {
 				description: "Product Description",
 				details: "Product Details",
 				sizeAndFit: "Size & Fit",
-				shippingAndReturns: "shipping & Returns",
+				shippingAndReturns: "Shipping & Returns",
 			},
 		}),
 		headline: PropTypes.string.tag({

--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -12,8 +12,8 @@ const BLOCK_CLASS_NAME = "b-product-content";
 const contentMapping = {
 	description: "description",
 	details: "schema.productDetails",
-	sizeAndFit: "schema.sizeAndFit",
-	shippingAndReturns: "schema.shippingAndReturns",
+	"size-and-fit": "schema.sizeAndFit",
+	"shipping-and-returns": "schema.shippingAndReturns",
 };
 
 const getNestedObject = (obj, path) => path.split(".").reduce((value, el) => value[el], obj);
@@ -64,16 +64,16 @@ ProductContent.propTypes = {
 		contentType: PropTypes.oneOf([
 			"description",
 			"details",
-			"sizeAndFit",
-			"shippingAndReturns",
+			"size-and-fit",
+			"shipping-and-returns",
 		]).tag({
 			defaultValue: "description",
 			label: "Product Content",
 			labels: {
 				description: "Product Description",
 				details: "Product Details",
-				sizeAndFit: "Size & Fit",
-				shippingAndReturns: "Shipping & Returns",
+				"size-and-fit": "Size & Fit",
+				"shipping-and-returns": "Shipping & Returns",
 			},
 		}),
 		headline: PropTypes.string.tag({

--- a/blocks/product-content-block/index.story.jsx
+++ b/blocks/product-content-block/index.story.jsx
@@ -24,7 +24,7 @@ const mockData = {
 };
 
 export const TitleAndContent = () => (
-	<ProductContentDisplay summary="Product Details">
+	<ProductContentDisplay summary={mockData.schema.productDetails.label}>
 		{mockData.schema.productDetails.value}
 	</ProductContentDisplay>
 );

--- a/blocks/product-content-block/intl.json
+++ b/blocks/product-content-block/intl.json
@@ -21,7 +21,7 @@
 		"pt": "Details",
 		"sv": "Details"
 	},
-	"product-content.sizeAndFit": {
+	"product-content.size-and-fit": {
 		"de": "Size & Fit",
 		"en": "Size & Fit",
 		"es": "Size & Fit",
@@ -32,7 +32,7 @@
 		"pt": "Size & Fit",
 		"sv": "Size & Fit"
 	},
-	"product-content.shippingAndReturns": {
+	"product-content.shipping-and-returns": {
 		"de": "Shipping & Returns",
 		"en": "Shipping & Returns",
 		"es": "Shipping & Returns",

--- a/blocks/product-content-block/intl.json
+++ b/blocks/product-content-block/intl.json
@@ -20,5 +20,27 @@
 		"no": "Details",
 		"pt": "Details",
 		"sv": "Details"
+	},
+	"product-content.sizeAndFit": {
+		"de": "Size & Fit",
+		"en": "Size & Fit",
+		"es": "Size & Fit",
+		"fr": "Size & Fit",
+		"ja": "Size & Fit",
+		"ko": "Size & Fit",
+		"no": "Size & Fit",
+		"pt": "Size & Fit",
+		"sv": "Size & Fit"
+	},
+	"product-content.shippingAndReturns": {
+		"de": "Shipping & Returns",
+		"en": "Shipping & Returns",
+		"es": "Shipping & Returns",
+		"fr": "Shipping & Returns",
+		"ja": "Shipping & Returns",
+		"ko": "Shipping & Returns",
+		"no": "Shipping & Returns",
+		"pt": "Shipping & Returns",
+		"sv": "Shipping & Returns"
 	}
 }

--- a/locale/de.json
+++ b/locale/de.json
@@ -446,6 +446,12 @@
 	},
 	"product-content-block": {
 		"product-content.description": "Description",
-		"product-content.details": "Details"
+		"product-content.details": "Details",
+		"product-content.size-and-fit": "Size & Fit",
+		"product-content.shipping-and-returns": "Shipping & Returns"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/de.json
+++ b/locale/de.json
@@ -449,9 +449,5 @@
 		"product-content.details": "Details",
 		"product-content.size-and-fit": "Size & Fit",
 		"product-content.shipping-and-returns": "Shipping & Returns"
-	},
-	"product-information-block": {
-		"product-information.sale-price": "Sale Price %{price}",
-		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -446,6 +446,12 @@
 	},
 	"product-content-block": {
 		"product-content.description": "Description",
-		"product-content.details": "Details"
+		"product-content.details": "Details",
+		"product-content.size-and-fit": "Size & Fit",
+		"product-content.shipping-and-returns": "Shipping & Returns"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -449,9 +449,5 @@
 		"product-content.details": "Details",
 		"product-content.size-and-fit": "Size & Fit",
 		"product-content.shipping-and-returns": "Shipping & Returns"
-	},
-	"product-information-block": {
-		"product-information.sale-price": "Sale Price %{price}",
-		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -446,6 +446,12 @@
 	},
 	"product-content-block": {
 		"product-content.description": "Description",
-		"product-content.details": "Details"
+		"product-content.details": "Details",
+		"product-content.size-and-fit": "Size & Fit",
+		"product-content.shipping-and-returns": "Shipping & Returns"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -449,9 +449,5 @@
 		"product-content.details": "Details",
 		"product-content.size-and-fit": "Size & Fit",
 		"product-content.shipping-and-returns": "Shipping & Returns"
-	},
-	"product-information-block": {
-		"product-information.sale-price": "Sale Price %{price}",
-		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -446,6 +446,12 @@
 	},
 	"product-content-block": {
 		"product-content.description": "Description",
-		"product-content.details": "Details"
+		"product-content.details": "Details",
+		"product-content.size-and-fit": "Size & Fit",
+		"product-content.shipping-and-returns": "Shipping & Returns"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -449,9 +449,5 @@
 		"product-content.details": "Details",
 		"product-content.size-and-fit": "Size & Fit",
 		"product-content.shipping-and-returns": "Shipping & Returns"
-	},
-	"product-information-block": {
-		"product-information.sale-price": "Sale Price %{price}",
-		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -446,6 +446,12 @@
 	},
 	"product-content-block": {
 		"product-content.description": "Description",
-		"product-content.details": "Details"
+		"product-content.details": "Details",
+		"product-content.size-and-fit": "Size & Fit",
+		"product-content.shipping-and-returns": "Shipping & Returns"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -449,9 +449,5 @@
 		"product-content.details": "Details",
 		"product-content.size-and-fit": "Size & Fit",
 		"product-content.shipping-and-returns": "Shipping & Returns"
-	},
-	"product-information-block": {
-		"product-information.sale-price": "Sale Price %{price}",
-		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -446,6 +446,12 @@
 	},
 	"product-content-block": {
 		"product-content.description": "Description",
-		"product-content.details": "Details"
+		"product-content.details": "Details",
+		"product-content.size-and-fit": "Size & Fit",
+		"product-content.shipping-and-returns": "Shipping & Returns"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -449,9 +449,5 @@
 		"product-content.details": "Details",
 		"product-content.size-and-fit": "Size & Fit",
 		"product-content.shipping-and-returns": "Shipping & Returns"
-	},
-	"product-information-block": {
-		"product-information.sale-price": "Sale Price %{price}",
-		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/no.json
+++ b/locale/no.json
@@ -446,6 +446,12 @@
 	},
 	"product-content-block": {
 		"product-content.description": "Description",
-		"product-content.details": "Details"
+		"product-content.details": "Details",
+		"product-content.size-and-fit": "Size & Fit",
+		"product-content.shipping-and-returns": "Shipping & Returns"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/no.json
+++ b/locale/no.json
@@ -449,9 +449,5 @@
 		"product-content.details": "Details",
 		"product-content.size-and-fit": "Size & Fit",
 		"product-content.shipping-and-returns": "Shipping & Returns"
-	},
-	"product-information-block": {
-		"product-information.sale-price": "Sale Price %{price}",
-		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -446,6 +446,12 @@
 	},
 	"product-content-block": {
 		"product-content.description": "Description",
-		"product-content.details": "Details"
+		"product-content.details": "Details",
+		"product-content.size-and-fit": "Size & Fit",
+		"product-content.shipping-and-returns": "Shipping & Returns"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -449,9 +449,5 @@
 		"product-content.details": "Details",
 		"product-content.size-and-fit": "Size & Fit",
 		"product-content.shipping-and-returns": "Shipping & Returns"
-	},
-	"product-information-block": {
-		"product-information.sale-price": "Sale Price %{price}",
-		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -446,6 +446,12 @@
 	},
 	"product-content-block": {
 		"product-content.description": "Description",
-		"product-content.details": "Details"
+		"product-content.details": "Details",
+		"product-content.size-and-fit": "Size & Fit",
+		"product-content.shipping-and-returns": "Shipping & Returns"
+	},
+	"product-information-block": {
+		"product-information.sale-price": "Sale Price %{price}",
+		"product-information.list-price": "List Price %{price}"
 	}
 }

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -449,9 +449,5 @@
 		"product-content.details": "Details",
 		"product-content.size-and-fit": "Size & Fit",
 		"product-content.shipping-and-returns": "Shipping & Returns"
-	},
-	"product-information-block": {
-		"product-information.sale-price": "Sale Price %{price}",
-		"product-information.list-price": "List Price %{price}"
 	}
 }


### PR DESCRIPTION
## Description

Add "Size & Fit" and "Shipping & Returns" options as Product Content titles.

## Jira Ticket

- [TMEDIA-101](https://arcpublishing.atlassian.net/browse/TBRANDS-101)

## Acceptance Criteria

1. Product Content - Arc Block is available to be added to a page in Page Builder Editor.
2. The following types of Product Content are available for display from the Arc Commerce Content Source:
     a. Size & Fit - API Field - schema.sizeAndFit
     b. Shipping & Returns - API Field - schema.shippingAndReturns
3. A user within Page Builder can select the type of content to display. A user has the can select one of the following content types:
     a. Size & Fit
     b. Shipping & Returns
4. If a user selects the Size & Fit content type, the headline will display as Size & Fit
5. If a user selects the Shipping & Returns content type, the headline will display as Shipping & Returns
6. A user can override the headline by utilizing a custom field names Customize Headline.
     a. A tool tip exists and when a user clicks on it, it unveils the following message:
          i. By adding a custom headline, the default headline will be overridden.
7. As a user I can select if I want the Product Content - Arc Block to be expanded of collapsed on page load by utilizing a custom field/radio button that says: Collapsed on page load.
8. Product Content - Arc Block display and styling match designs.
9. Product Content - Arc Block is responsive and works across all device types.

## Test Steps

1. Checkout this branch for the blocks repo: `git checkout {TBRANDS-101-product-content}`
2. Run fusion feature pack with linked block `npx fusion start -f -l @wpmedia/product-content-block`
3. Create a new page in PageBuilder Editor using the "Right Rail" layout. Set the page Global Content with the following options:
     a. Content Source: `commerce-product`
     b. slug: `crocker-sandals`  
4. Add two instances of the "Product Content" Arc Block to the page in the `rightrail` section.
     a. Set the "Product Content" custom field of one to "Size & Fit"
     b. Set the "Product Content" custom field of the other to "Shipping & Returns"

## Effect Of Changes

You should see the following for the page using the above steps.
<img width="1544" alt="image" src="https://user-images.githubusercontent.com/452134/183725173-3f5d9723-6287-4fd4-8b7c-1ada7e9e0e6a.png">
If the "Collapsed on Page Load" custom field is set to false for each block, the following will be seen:
<img width="1543" alt="image" src="https://user-images.githubusercontent.com/452134/183725384-f7f58e5d-f65a-49c3-ac0a-f4ff93c9aea5.png">

### Before
The block's "Product Content" custom field did not have the option for "Size & Fit" or "Shipping & Returns".

### After
The block's "Product Content" custom field now has those two options. Content will be displayed from the respective schema fields for each option.

## Dependencies or Side Effects

Two phrases were added to the block's `intl.json` file in this pull request. Language-specific files in `/locale/` have been updated to reflect this.

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [X] Confirmed all the test steps a reviewer will follow above are working.
- [X] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [X] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [X] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [X] Confirmed this PR has unit test files _(no additional tests were needed for changes in this ticket.)_.
  - [X] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
