### PR TITLE
Tbrands 100 width fix

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -685,6 +685,8 @@
 					),
 				),
 				product-information: (
+					// padding is overridden on desktop
+					padding: 0 var(--global-spacing-5),
 					components: (
 						heading: (
 							color: var(--global-black),
@@ -705,7 +707,7 @@
 						price-list: (
 							color: var(--global-neutral-5),
 							text-decoration: line-through,
-						),
+						)
 					),
 				),
 				product-information-single-price: (
@@ -987,6 +989,10 @@
 							flex-wrap: wrap,
 						),
 					),
+				),
+				product-information: (
+					// we don't want padding on desktop
+					padding: initial,
 				),
 				quilted-image: (
 					max-width: var(--content-scale-width),

--- a/blocks/product-information-block/features/product-information/default.jsx
+++ b/blocks/product-information-block/features/product-information/default.jsx
@@ -32,7 +32,7 @@ export const ProductInformationDisplay = ({ data }) => {
 		<Stack className={`${BLOCK_CLASS_NAME}`}>
 			{data.name ? <Heading>{data.name}</Heading> : null}
 			{ListPrice ? (
-				<Price className={`${!isOnSale ? `${BLOCK_CLASS_NAME}__product-single-price` : null}`}>
+				<Price className={`${!isOnSale ? `${BLOCK_CLASS_NAME}__product-single-price` : ""}`}>
 					{isOnSale ? (
 						<Price.Sale
 							aria-label={phrases.t("product-information.sale-price", {


### PR DESCRIPTION
## Description

Hard-code padding into mobile, per design request

## Jira Ticket

- [TBRANDS-100](https://arcpublishing.atlassian.net/browse/TBRANDS-100)

## Acceptance Criteria

Use block styles instead of layout styles to style this block on mobile 

## Test Steps

### Storybook

- Go to mobile breakpoint. 
- See horizontal padding left and right 
<img width="1436" alt="Screen Shot 2022-08-15 at 10 29 45" src="https://user-images.githubusercontent.com/5950956/184665605-dd4e7d90-f28c-41e4-821c-f260ad2bd6f0.png">

## Effect Of Changes

### Before

- No padding on block 
<img width="258" alt="Screen Shot 2022-08-15 at 10 30 39" src="https://user-images.githubusercontent.com/5950956/184665738-89e0da14-d69a-4e03-ab8c-50210ad30133.png">

### After

- Padding on mobile block 
<img width="252" alt="Screen Shot 2022-08-15 at 10 30 23" src="https://user-images.githubusercontent.com/5950956/184665682-2c520bde-67b8-4a41-8401-08f689f92ae0.png">

## Dependencies or Side Effects

- This adds a new paradigm of adding padding around our blocks 
- Also fixed an instance where null was being rendered as a classname 

before 
![Screen Shot 2022-08-15 at 10 13 35](https://user-images.githubusercontent.com/5950956/184665910-335e05f8-6e1c-46a1-92a4-0533431d8515.png)

after
![Screen Shot 2022-08-15 at 10 26 41](https://user-images.githubusercontent.com/5950956/184665892-1226b622-219b-4883-ad1a-23acca9b4b5c.png)

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block. -> not necessary
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
