### PR TITLE
TBRANDS 116: Right rail brands max width pattern

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -806,7 +806,6 @@
 				right-rail-main: (
 					display: grid,
 					gap: var(--global-spacing-5),
-					max-width: calc(var(--content-max-width) * 1px),
 					width: 100%,
 					components: (
 						stack: (
@@ -819,7 +818,7 @@
 					grid-template-rows: 1fr,
 					gap: var(--global-spacing-5),
 					margin: auto,
-					max-width: initial,
+					max-width: calc(var(--content-max-width) * 1px),
 					width: var(--content-scale-width),
 				),
 				right-rail-main-right-rail: (

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -806,7 +806,9 @@
 				right-rail-main: (
 					display: grid,
 					gap: var(--global-spacing-6),
-					width: 100%,
+					max-width: calc(var(--content-max-width) * 1px),
+					width: var(--content-scale-width),
+					margin: auto,
 					components: (
 						stack: (
 							gap: var(--global-spacing-5),
@@ -1020,8 +1022,6 @@
 					gap: var(--global-spacing-10),
 				),
 				right-rail-rail-container: (
-					max-width: calc(var(--content-max-width) * 1px),
-					width: var(--content-scale-width),
 					margin: auto,
 					grid-template-columns: repeat(12, 1fr),
 					gap: var(--global-spacing-6),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -795,7 +795,7 @@
 				),
 				right-rail: (
 					display: grid,
-					gap: var(--global-spacing-6),
+					gap: var(--global-spacing-5),
 				),
 				right-rail-navigation: (
 					position: sticky,
@@ -805,10 +805,9 @@
 				),
 				right-rail-main: (
 					display: grid,
-					gap: var(--global-spacing-6),
+					gap: var(--global-spacing-5),
 					max-width: calc(var(--content-max-width) * 1px),
-					width: var(--content-scale-width),
-					margin: auto,
+					width: 100%,
 					components: (
 						stack: (
 							gap: var(--global-spacing-5),
@@ -816,12 +815,12 @@
 					),
 				),
 				right-rail-rail-container: (
-					max-width: initial,
-					width: 100%,
-					margin: auto,
 					grid-template-columns: initial,
 					grid-template-rows: 1fr,
 					gap: var(--global-spacing-5),
+					margin: auto,
+					max-width: initial,
+					width: var(--content-scale-width),
 				),
 				right-rail-main-right-rail: (
 					grid-column: 1,
@@ -1017,6 +1016,9 @@
 					grid-template-areas: "top top" "bottom bottom",
 					max-width: var(--content-scale-width),
 					width: 100%,
+				),
+				right-rail: (
+					gap: var(--global-spacing-6),
 				),
 				right-rail-main: (
 					gap: var(--global-spacing-10),

--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
@@ -42,7 +42,6 @@ const RightRailAdvancedLayout = ({ children }) => {
 				{fullwidth1 ? (
 					<Stack className={`${LAYOUT_CLASS_NAME}__full-width-1`}>{fullwidth1}</Stack>
 				) : null}
-
 				<Grid className={`${LAYOUT_CLASS_NAME}__rail-container`}>
 					<Stack className={`${LAYOUT_CLASS_NAME}__main-interior-item`}>
 						<Stack className={`${LAYOUT_CLASS_NAME}__main-interior-item-1`}>{main}</Stack>
@@ -59,7 +58,7 @@ const RightRailAdvancedLayout = ({ children }) => {
 					</Stack>
 				</Grid>
 				{featureList["7"] > 0 ? (
-					<div className={`${LAYOUT_CLASS_NAME}__full-width-2`}>{fullWidth2}</div>
+					<Stack className={`${LAYOUT_CLASS_NAME}__full-width-2`}>{fullWidth2}</Stack>
 				) : null}
 			</section>
 			{footer ? (


### PR DESCRIPTION
## Description

Follow same patterns as news around responsive layout (not using padding) 

## Jira Ticket

- [TBRANDS-116](https://arcpublishing.atlassian.net/browse/TBRANDS-116)

## Acceptance Criteria

Product info, for instance, should not be edge to edge when put into right rail main

## Test Steps

1. Checkout this branch `git checkout TBRANDS-932-right-rail-width`
2. Go to feature pack `TBRANDS-116-update-commerce-max-width`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/right-rail-block,@wpmedia/product-information-block`
4. Create a new page
5. Add right rail layout 
6. Add product info in main area 
7. See the space around the product info horizontally on mobile 
![image](https://user-images.githubusercontent.com/5950956/184677951-da49d8c9-9dba-4a27-a3b9-6d985b33d71a.png)

### Storybook

- See effect with environment commerce

## Effect Of Changes

### Before

edge to edge on main area

### After

use max width on mobile 

## Dependencies or Side Effects

- Merge https://github.com/WPMedia/arc-themes-feature-pack/pull/334 feature pack

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
