### PR TITLE
TMEDIA-706 - Add signing service content source

### DIFF
--- a/blocks/signing-service-content-source-block/README.md
+++ b/blocks/signing-service-content-source-block/README.md
@@ -1,0 +1,24 @@
+# Signing Service Content Source
+
+A Fusion content source for interacting with the Arc Signing Service for generting hashed strings based on an input
+
+## Environment Variables
+
+The sigining content source relies on the following environent variables
+
+| Variable                        | Description                                                                                |
+| ------------------------------- | ------------------------------------------------------------------------------------------ |
+| SIGNING_SERVICE_DEFAULT_APP     | The name of the signing service app that should be used as the default app for API request |
+| SIGNING_SERVICE_DEFAULT_VERSION | The signing service app version that aligns with the default app                           |
+
+## Content Source Params
+
+| Param          | Description                                                                                                           |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| id             | The string to be hashed - this will be passed to the signing service as an encoded string generate a hashed string on |
+| service        | The signing service app to use, by default will use the value from `SIGNING_SERVICE_DEFAULT_APP` environment variable |
+| serviceVersion | The signing service app version to use, by default will use the value from `SIGNING_SERVICE_DEFAULT_VERSION`          |
+
+## TTL
+
+- 365 Days

--- a/blocks/signing-service-content-source-block/README.md
+++ b/blocks/signing-service-content-source-block/README.md
@@ -1,10 +1,10 @@
 # Signing Service Content Source
 
-A Fusion content source for interacting with the Arc Signing Service for generting hashed strings based on an input
+A Fusion content source for interacting with the Arc Signing Service for generating hashed strings based on an input
 
 ## Environment Variables
 
-The sigining content source relies on the following environent variables
+The signing content source relies on the following environment variables
 
 | Variable                        | Description                                                                                |
 | ------------------------------- | ------------------------------------------------------------------------------------------ |

--- a/blocks/signing-service-content-source-block/jest.config.js
+++ b/blocks/signing-service-content-source-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest/jest.config.base");
+
+module.exports = {
+	...base,
+};

--- a/blocks/signing-service-content-source-block/package.json
+++ b/blocks/signing-service-content-source-block/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@wpmedia/signing-service-content-source-block",
+  "version": "0.1.0",
+  "description": "Signing Service Content Source Block",
+  "author": "Arc XP - Themes",
+  "homepage": "https://github.com/WPMedia/arc-themes-blocks",
+  "license": "CC-BY-NC-ND-4.0",
+  "main": "index.js",
+  "files": [
+    "sources"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+    "directory": "blocks/signing-service-content-source-block"
+  },
+  "dependencies": {
+    "axios": "^0.26.0"
+  }
+}

--- a/blocks/signing-service-content-source-block/sources/.npmignore
+++ b/blocks/signing-service-content-source-block/sources/.npmignore
@@ -1,0 +1,3 @@
+*.test.js
+*.test.jsx
+mock*.*

--- a/blocks/signing-service-content-source-block/sources/signing-service.js
+++ b/blocks/signing-service-content-source-block/sources/signing-service.js
@@ -1,0 +1,34 @@
+import axios from "axios";
+import {
+	ARC_ACCESS_TOKEN,
+	CONTENT_BASE,
+	SIGNING_SERVICE_DEFAULT_APP,
+	SIGNING_SERVICE_DEFAULT_VERSION,
+} from "fusion:environment";
+
+const params = {
+	id: "text",
+	service: "text",
+	serviceVersion: "text",
+};
+
+const fetch = ({
+	id,
+	service = SIGNING_SERVICE_DEFAULT_APP,
+	serviceVersion = SIGNING_SERVICE_DEFAULT_VERSION,
+}) =>
+	axios({
+		url: `${CONTENT_BASE}/signing-service/v1/sign/${service}/${serviceVersion}/${encodeURI(id)}`,
+		headers: {
+			"content-type": "application/json",
+			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
+		},
+		method: "GET",
+	}).then(({ data: content }) => content);
+
+export default {
+	fetch,
+	params,
+	// 365 day ttl
+	ttl: 31536000,
+};

--- a/blocks/signing-service-content-source-block/sources/signing-service.test.js
+++ b/blocks/signing-service-content-source-block/sources/signing-service.test.js
@@ -1,0 +1,23 @@
+import contentSource from "./signing-service";
+
+jest.mock("fusion:environment", () => ({
+	CONTENT_BASE: "",
+	SIGNING_SERVICE_DEFAULT_APP: "resizer",
+	SIGNING_SERVICE_DEFAULT_VERSION: 1,
+}));
+
+jest.mock("axios", () => ({
+	__esModule: true,
+	default: jest.fn((data) => Promise.resolve({ data })),
+}));
+
+describe("Test Signing Service content source", () => {
+	it("should build the correct url", async () => {
+		const key = {
+			id: "test-id",
+		};
+		const contentSourceRequest = await contentSource.fetch(key);
+
+		expect(contentSourceRequest.url).toEqual(`/signing-service/v1/sign/resizer/1/test-id`);
+	});
+});

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "@wpmedia/section-title-block": "file:blocks/section-title-block",
     "@wpmedia/share-bar-block": "file:blocks/share-bar-block",
     "@wpmedia/shared-styles": "file:blocks/shared-styles",
+    "@wpmedia/signing-service-content-source-block": "file:blocks/signing-service-content-source-block",
     "@wpmedia/simple-list-block": "file:blocks/simple-list-block",
     "@wpmedia/single-chain-block": "file:blocks/single-chain-block",
     "@wpmedia/single-column-layout-block": "file:blocks/single-column-layout-block",


### PR DESCRIPTION
## Description

Add new content source block - @wpmedia/signing-service-content-source-block

## Jira Ticket

- [TMEDIA-706](https://arcpublishing.atlassian.net/browse/TMEDIA-706)

## Test Steps

Testing with Commerce

**Make sure you set env variables `ARC_ACCESS_TOKEN` and `CONTENT_BASE` to use Commerce**

1. Checkout this branch `git checkout TMEDIA-706-signing-service-content-source`
2. Checkout out the feature pack branch - `TMEDIA-706-signing-service-content-source-commerce`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/signing-service-content-source-block`
4. Go to the local PageBuilder Debugger - http://localhost/pagebuilder/tools/debugger
5. Choose a site
6. Select Content Debugger
7. Validate you see the new content source `signing-service`
8. Enter a value into the id field `3CR76I2B4FFXZLY6P5YAS2AQAU`
9. Validate you get a response back with a hash


Testing with News

**Make sure you set env variables `ARC_ACCESS_TOKEN` and `CONTENT_BASE` to use Themes Internal**

1. Checkout this branch `git checkout TMEDIA-706-signing-service-content-source`
2. Checkout out the feature pack branch - `TMEDIA-706-signing-service-content-source-news`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/signing-service-content-source-block`
4. Go to the local PageBuilder Debugger - http://localhost/pagebuilder/tools/debugger
5. Choose a site
6. Select Content Debugger
7. Validate you see the new content source `signing-service`
8. Enter a value into the id field `3CR76I2B4FFXZLY6P5YAS2AQAU`
9. Validate you get a response back with a hash



## Dependencies or Side Effects

Requires feature pack PR's which include environment variable updates

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
