### PR TITLE
tmedia 942: Update from helper image getter for image url 

### DIFF
--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -165,6 +165,8 @@ const CardListItems = (props) => {
 	}
 	// End Overline data
 
+	const imageUrl = getImageFromANS(sourceContent)?.url;
+
 	return contentItems.length > 0 ? (
 		<HeadingSection>
 			<Stack className={BLOCK_CLASS_NAME}>
@@ -175,13 +177,8 @@ const CardListItems = (props) => {
 						className={`${BLOCK_CLASS_NAME}__main-item-image-link`}
 						href={sourceContent.websites[arcSite].website_url}
 					>
-						{getImageFromANS(sourceContent) ? (
-							<Image
-								width={377}
-								height={283}
-								src={getImageFromANS(sourceContent)}
-								alt={sourceContent.headlines.basic}
-							/>
+						{imageUrl ? (
+							<Image width={377} height={283} src={imageUrl} alt={sourceContent.headlines.basic} />
 						) : (
 							<Image
 								width={377}
@@ -219,7 +216,7 @@ const CardListItems = (props) => {
 						</Stack>
 						{contentItems.slice(1).map((element) => {
 							const { headlines: { basic: headlineText } = {} } = element;
-							const imageURL = getImageFromANS(element);
+							const imageURL = getImageFromANS(element).url;
 							const itemUrl = element.websites[arcSite]?.website_url;
 							if (!itemUrl) {
 								return null;

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -216,7 +216,7 @@ const CardListItems = (props) => {
 						</Stack>
 						{contentItems.slice(1).map((element) => {
 							const { headlines: { basic: headlineText } = {} } = element;
-							const imageURL = getImageFromANS(element).url;
+							const imageURL = getImageFromANS(element)?.url;
 							const itemUrl = element.websites[arcSite]?.website_url;
 							if (!itemUrl) {
 								return null;

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -187,7 +187,7 @@ const ExtraLargePromo = ({ customFields }) => {
 	const embedMarkup = playVideoInPlace && getVideoFromANS(content);
 	const hasAuthors = showByline && content?.credits?.by.length > 0;
 	const imageSearchField = imageOverrideURL ? "imageOverrideURL" : "imageURL";
-	const promoImageURL = imageOverrideURL || getImageFromANS(content);
+	const promoImageURL = imageOverrideURL || getImageFromANS(content)?.url;
 
 	const MediaImage = () =>
 		showImage ? (

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -324,7 +324,7 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 	const embedMarkup = showImage && playVideoInPlace && getVideoFromANS(content);
 	const imageSearchField = imageOverrideURL ? "imageOverrideURL" : "imageURL";
 	const promoImageURL =
-		showImage && (imageOverrideURL || getImageFromANS(content) || fallbackImage);
+		showImage && (imageOverrideURL || getImageFromANS(content)?.url || fallbackImage);
 
 	return (
 		<LargePromoPresentation

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -95,7 +95,7 @@ const NumberedList = (props) => {
 						{contentElements.length
 							? contentElements.map((element, i) => {
 									const { headlines: { basic: headlineText = "" } = {}, websites } = element;
-									const imageURL = getImageFromANS(element);
+									const imageURL = getImageFromANS(element)?.url;
 
 									if (!websites[arcSite]) {
 										return null;

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -21,7 +21,7 @@ const unserializeStory = (arcSite) => (acc, storyObject) => {
 		return acc.concat({
 			id: storyObject._id,
 			itemTitle: storyObject.headlines.basic,
-			imageURL: getImageFromANS(storyObject) || "",
+			imageURL: getImageFromANS(storyObject)?.url || "",
 			websiteURL: storyObject.websites[arcSite].website_url || "",
 		});
 	}

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -95,7 +95,7 @@ const SmallPromo = ({ customFields }) => {
 	}
 
 	const linkURL = content?.websites?.[arcSite]?.website_url;
-	const imageURL = getImageFromANS(content);
+	const imageURL = getImageFromANS(content)?.url;
 	const headline = content?.headlines?.basic;
 
 	const PromoImage = () => {

--- a/blocks/story-carousel-block/features/story-carousel/default.jsx
+++ b/blocks/story-carousel-block/features/story-carousel/default.jsx
@@ -109,7 +109,7 @@ const StoryCarousel = ({
 							description: { basic: descriptionText = null } = {},
 							websites,
 						} = item;
-						const imageURL = getImageFromANS(item);
+						const imageURL = getImageFromANS(item)?.url;
 
 						if (!websites[arcSite]) {
 							return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16669,9 +16669,9 @@
       "version": "file:blocks/alert-bar-content-source-block"
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-1.35",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-1.35/b9d75d2e6e6872ebd0c1c46f1257f42e54befc8c",
-      "integrity": "sha512-7IhtifQIl3DxW6jr/DHKwYdfGjM71quS0TqN5Kz8ApCDWwfpJKrAJb1onBObxxmmu89qLqRMKyTr3ucXxBtoKA==",
+      "version": "0.0.4-arc-themes-release-version-2-0-1.37",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-1.37/718dccd2dafa76eeaf5fdeba3d2f32020d066a02",
+      "integrity": "sha512-xwNrS1zWC6go8G+GkY6mgvEht5Iio0JHoezBISfml4XI39bDoYw1dV7zEct72Gn4GRJG6kJGs0z0bVpKGii2ZA==",
       "dev": true,
       "requires": {
         "react-oembed-container": "^1.0.1",
@@ -16918,6 +16918,27 @@
     },
     "@wpmedia/shared-styles": {
       "version": "file:blocks/shared-styles"
+    },
+    "@wpmedia/signing-service-content-source-block": {
+      "version": "file:blocks/signing-service-content-source-block",
+      "requires": {
+        "axios": "^0.26.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+          "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+        }
+      }
     },
     "@wpmedia/simple-list-block": {
       "version": "file:blocks/simple-list-block"


### PR DESCRIPTION
## Description

Update the response to the get image function

## Jira Ticket

- [TMEDIA-942](https://arcpublishing.atlassian.net/browse/TMEDIA-942)

## Acceptance Criteria

Change [getImageFromANS](https://github.com/WPMedia/arc-themes-components/blob/arc-themes-release-version-2.0.1/src/utils/get-image-from-ans/index.js) function to return all image data for an ANS story.

Edit blocks using getImageFromANS to instead use getImageFromANS.url, including:

Card List

Extra Large Promo

Large Promo

Medium Promo

Small Promo

Numbered List

Simple List

Story Carousel

## Test Steps

1. Link the relevant theme components branch https://github.com/WPMedia/arc-themes-components/pull/135
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/story-carousel-block` to test with the commerce theme pack. Or `npx fusion start -f -l @wpmedia/card-list-block,@wpmedia/extra-large-promo-block,@wpmedia/large-promo-block,@wpmedia/numbered-list-block,@wpmedia/simple-list-block,@wpmedia/small-promo-block` to test all of the news ones. 
A new page may be needed to added if we don't have all of the blocks in a page for the news blocks
4. See the images rendered. Looking at homepage for news themes internal sandbox

commerce
<img width="1430" alt="Screen Shot 2022-08-24 at 16 23 20" src="https://user-images.githubusercontent.com/5950956/186529036-f7621fcd-782c-4d79-a755-bd199cd29639.png">

news 
![Screen Shot 2022-08-24 at 16 45 20](https://user-images.githubusercontent.com/5950956/186529201-d8c9d86b-dc31-4ce1-8a04-11867d916c46.png)

## Effect Of Changes

### Before

- Couldn't easily get the auth token 

### After

- No visual change
- Make it easier to get the auth token 

## Dependencies or Side Effects

- Update to the image url helper is merged https://github.com/WPMedia/arc-themes-components/pull/135
- Could update the auth token if we need to validate that here 

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
