### PR TITLE
TMEDIA 734 related: Image gallery on article Match the max height on the image wrapper

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -728,7 +728,7 @@
 					components: (
 						image: (
 							height: auto,
-							max-height: 100%,
+							max-height: 75vh,
 							max-width: 100%,
 						),
 					),


### PR DESCRIPTION
# Before 

- Carousel image was overflowing onto the carousel controls 

# After 

- Carousel image no longer overflowing


feature pack pr: https://github.com/WPMedia/arc-themes-feature-pack/pull/343