### PR TITLE
Tmedia 741 video in place fix

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1271,9 +1271,6 @@
 						link: (
 							position: relative,
 						),
-						separator: (
-							margin: 0 var(--global-spacing-2) 0 var(--global-spacing-2),
-						),
 					),
 				),
 				large-promo-icon-label: (
@@ -1315,6 +1312,9 @@
 						),
 						stack: (
 							gap: var(--global-spacing-4),
+						),
+						separator: (
+							margin: 0 var(--global-spacing-2) 0 var(--global-spacing-2),
 						),
 					),
 				),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1268,7 +1268,7 @@
 				large-promo: (
 					gap: var(--global-spacing-4),
 					components: (
-						media-item: (
+						link: (
 							position: relative,
 						),
 						separator: (

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -55,7 +55,6 @@ export const LargePromoPresentation = ({
 	searchableField,
 	translationByText,
 	viewportPercentage,
-	playVideoInPlace,
 }) =>
 	embedMarkup ||
 	contentOverline ||
@@ -82,20 +81,22 @@ export const LargePromoPresentation = ({
 									viewportPercentage={viewportPercentage}
 								/>
 							) : (
-								<Image
-									alt={contentHeadline}
-									src={promoImageURL}
-									width={377}
-									height={283}
-									searchableField
-								/>
+								<>
+									<Image
+										alt={contentHeadline}
+										src={promoImageURL}
+										width={377}
+										height={283}
+										searchableField
+									/>
+									{labelIconName ? (
+										<div className={`${BLOCK_CLASS_NAME}__icon_label`}>
+											<Icon name={labelIconName} />
+											<span className={`${BLOCK_CLASS_NAME}__label`}>{labelIconText}</span>
+										</div>
+									) : null}
+								</>
 							)}
-							{labelIconName && !!playVideoInPlace ? (
-								<div className={`${BLOCK_CLASS_NAME}__icon_label`}>
-									<Icon name={labelIconName} />
-									<span className={`${BLOCK_CLASS_NAME}__label`}>{labelIconText}</span>
-								</div>
-							) : null}
 						</Conditional>
 					</MediaItem>
 				) : null}
@@ -322,7 +323,7 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 	const contentHeadline = content?.headlines?.basic || null;
 	const contentOverline = showOverline ? overlineText : null;
 	const contentUrl = content?.websites?.[arcSite]?.website_url;
-	const embedMarkup = showImage && playVideoInPlace && getVideoFromANS(content);
+	const embedMarkup = playVideoInPlace && getVideoFromANS(content);
 	const imageSearchField = imageOverrideURL ? "imageOverrideURL" : "imageURL";
 	const promoImageURL =
 		showImage && (imageOverrideURL || getImageFromANS(content)?.url || fallbackImage);

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -55,6 +55,7 @@ export const LargePromoPresentation = ({
 	searchableField,
 	translationByText,
 	viewportPercentage,
+	playVideoInPlace,
 }) =>
 	embedMarkup ||
 	contentOverline ||
@@ -89,7 +90,7 @@ export const LargePromoPresentation = ({
 									searchableField
 								/>
 							)}
-							{labelIconName ? (
+							{labelIconName && !playVideoInPlace ? (
 								<div className={`${BLOCK_CLASS_NAME}__icon_label`}>
 									<Icon name={labelIconName} />
 									<span className={`${BLOCK_CLASS_NAME}__label`}>{labelIconText}</span>
@@ -348,6 +349,7 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 			searchableField={searchableField}
 			translationByText={phrases.t("global.by-text")}
 			viewportPercentage={viewportPercentage}
+			playVideoInPlace={playVideoInPlace}
 		/>
 	);
 };

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -90,7 +90,7 @@ export const LargePromoPresentation = ({
 									searchableField
 								/>
 							)}
-							{labelIconName && !playVideoInPlace ? (
+							{labelIconName && !!playVideoInPlace ? (
 								<div className={`${BLOCK_CLASS_NAME}__icon_label`}>
 									<Icon name={labelIconName} />
 									<span className={`${BLOCK_CLASS_NAME}__label`}>{labelIconText}</span>

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -300,7 +300,7 @@ describe("Large Promo", () => {
 				customFields={{
 					showImage: true,
 					showImageOrVideoLabel: true,
-					showVideoLabel: true,
+					playVideoInPlace: false,
 				}}
 			/>
 		);
@@ -312,7 +312,6 @@ describe("Large Promo", () => {
 			<LargePromo
 				customFields={{
 					showImage: true,
-					showVideoLabel: true,
 					playVideoInPlace: true,
 				}}
 			/>

--- a/blocks/large-promo-block/index.story.jsx
+++ b/blocks/large-promo-block/index.story.jsx
@@ -194,22 +194,22 @@ export const withGalleryLabelAndImage = () => (
 export const withVideoLabelAndImage = () => (
 	<LargePromoPresentation
 		aspectRatio={16 / 9}
-		embedMarkup={MOCK_CONTENT.embed_html}
+		promoImageURL={MOCK_CONTENT.promo_items.basic.url}
+		contentUrl="/2019/12/02/baby-panda-born-at-the-zoo/"
 		imageSearchField="imageURL"
 		labelIconName="Play"
 		labelIconText="Video"
 		registerSuccessEvent={() => {}}
 		searchableField={() => {}}
 		viewportPercentage={60}
-		playVideoInPlace={false}
 	/>
 );
 
 export const playVideoInPlaceOfImage = () => (
 	<LargePromoPresentation
-		playVideoInPlace
 		aspectRatio={16 / 9}
 		embedMarkup={MOCK_CONTENT.embed_html}
+		contentUrl="/2019/12/02/baby-panda-born-at-the-zoo/"
 		imageSearchField="imageURL"
 		registerSuccessEvent={() => {}}
 		searchableField={() => {}}

--- a/blocks/large-promo-block/index.story.jsx
+++ b/blocks/large-promo-block/index.story.jsx
@@ -185,6 +185,7 @@ export const withGalleryLabelAndImage = () => (
 		labelIconName="Camera"
 		labelIconText="Gallery"
 		promoImageURL={MOCK_CONTENT.promo_items.basic.url}
+		contentUrl="/2019/12/02/baby-panda-born-at-the-zoo/"
 		registerSuccessEvent={() => {}}
 		searchableField={() => {}}
 		viewportPercentage={60}

--- a/blocks/large-promo-block/index.story.jsx
+++ b/blocks/large-promo-block/index.story.jsx
@@ -201,11 +201,13 @@ export const withVideoLabelAndImage = () => (
 		registerSuccessEvent={() => {}}
 		searchableField={() => {}}
 		viewportPercentage={60}
+		playVideoInPlace={false}
 	/>
 );
 
 export const playVideoInPlaceOfImage = () => (
 	<LargePromoPresentation
+		playVideoInPlace
 		aspectRatio={16 / 9}
 		embedMarkup={MOCK_CONTENT.embed_html}
 		imageSearchField="imageURL"


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description

PlayVideoInPlace should not have video icon and spacing around separator

## Jira Ticket

- [TMEDIA-TMEDIA-741-video-in-place-fix](https://arcpublishing.atlassian.net/browse/TMEDIA-741-video-in-place-fix)

## Acceptance Criteria

PlayVideoInPlace should not have video icon and spacing around separator

## Before
![Screen Shot 2022-08-29 at 9 22 09 AM](https://user-images.githubusercontent.com/83021791/187527340-a177a341-9754-4a2a-8bbc-1fc3b497a875.png)

## After
<img width="1780" alt="Screen Shot 2022-08-30 at 3 35 32 PM" src="https://user-images.githubusercontent.com/83021791/187527502-a63e20c1-6935-4a2f-94fe-dab5ee39fb97.png">

<img width="1782" alt="Screen Shot 2022-08-30 at 3 35 45 PM" src="https://user-images.githubusercontent.com/83021791/187527506-d7b2180b-3310-4eab-b48a-87d575d5af46.png">


## Test Steps

1. Checkout this branch `git checkout TMEDIA-741-play-video-in-place-fix`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/large-promo-block`
3. Configure large-promo Block to use _id : CTAR7XCGLBCAXCHLJ6D5CZEGUA

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
