### PR TITLE
Add additional logic to check product data value

### DIFF
--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -42,7 +42,7 @@ const ProductContent = ({ customFields }) => {
 			? productData?.visible
 			: true;
 
-	if (!visible) {
+	if (!visible || (typeof productData === "object" && !productData?.value)) {
 		return null;
 	}
 

--- a/blocks/product-content-block/features/product-content/default.jsx
+++ b/blocks/product-content-block/features/product-content/default.jsx
@@ -36,7 +36,7 @@ const ProductContent = ({ customFields }) => {
 		return null;
 	}
 
-	const productData = getNestedObject(globalContent, contentMapping[contentType]);
+	const productData = getNestedObject(globalContent, contentMapping[contentType]) || {};
 	const visible =
 		typeof productData === "object" && Object.prototype.hasOwnProperty.call(productData, "visible")
 			? productData?.visible

--- a/blocks/product-content-block/features/product-content/default.test.jsx
+++ b/blocks/product-content-block/features/product-content/default.test.jsx
@@ -21,12 +21,25 @@ describe("Product Content", () => {
 		expect(container.firstChild).toBe(null);
 	});
 
-	it("should render null schema item has no value", () => {
+	it("should render null if schema item has no value", () => {
 		useFusionContext.mockImplementation(() => ({
 			globalContent: {
 				description: "Product Description",
 				schema: {
 					productDetails: {},
+				},
+			},
+		}));
+		const { container } = render(<ProductContent customFields={{ contentType: "details" }} />);
+		expect(container.firstChild).toBe(null);
+	});
+
+	it("should render null if schema item is not pressent", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				description: "Product Description",
+				schema: {
+					sizeAndFit: {},
 				},
 			},
 		}));

--- a/blocks/product-content-block/features/product-content/default.test.jsx
+++ b/blocks/product-content-block/features/product-content/default.test.jsx
@@ -21,6 +21,19 @@ describe("Product Content", () => {
 		expect(container.firstChild).toBe(null);
 	});
 
+	it("should render null schema item has no value", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				description: "Product Description",
+				schema: {
+					productDetails: {},
+				},
+			},
+		}));
+		const { container } = render(<ProductContent customFields={{ contentType: "details" }} />);
+		expect(container.firstChild).toBe(null);
+	});
+
 	it("should render product description", () => {
 		useFusionContext.mockImplementation(() => ({
 			globalContent: {


### PR DESCRIPTION
## Description

When testing commerce APIs I came across the following scenarios

1. `value` isn't returned
2. Not all products have all schema items, for templates we need to account for the block being put on the page and products not returning all the same schema fields

## Test Steps

Unit tests added to account for additional logic


## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
