### PR TITLE
TBRANDS 65 carousel thumbnail for product gallery

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -390,9 +390,8 @@
 				),
 				carousel-indicator-thumbnail: (
 					margin: 0 var(--global-spacing-3),
-					height: 50px,
-					width: 50px,
-					padding: var(--global-spacing-1),
+					height: var(--global-spacing-8),
+					width: var(--global-spacing-8),
 					background-color: transparent,
 					opacity: 40%,
 					border: var(--global-border-width-1) var(--global-border-style-1) transparent,
@@ -794,6 +793,11 @@
 							width: 100%,
 						),
 					),
+				),
+				product-gallery-thumbnail: (
+					margin: 3px,
+					height: var(--global-spacing-7),
+					width: var(--global-spacing-7),
 				),
 				product-gallery-featured-slide: (
 					// for featured enabled, this will apply for the desktop growing to expand full width. On mobile, it doesn't hurt.

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -359,6 +359,47 @@
 					max-width: var(--content-scale-width),
 					width: 100%,
 				),
+				carousel-indicator-dots-container: (
+					display: flex,
+					gap: var(--global-spacing-4),
+					padding: var(--global-spacing-4) 0 0 0,
+					justify-content: center,
+					align-items: center,
+				),
+				carousel-indicator-dot: (
+					height: var(--global-spacing-3),
+					width: var(--global-spacing-3),
+					border: var(--global-border-width-1) var(--global-border-style-1) var(--border-color),
+					border-radius: var(--border-radius-circle),
+					background-color: transparent,
+				),
+				carousel-indicator-dot-active: (
+					border: none,
+					height: var(--global-spacing-4),
+					width: var(--global-spacing-4),
+					background-color: var(--global-neutral-4),
+				),
+				carousel-indicator-thumbnails-container: (
+					display: block,
+					padding: var(--global-spacing-4) var(--global-spacing-3) 0 var(--global-spacing-3),
+					width: 100%,
+					overflow-x: auto,
+					overflow-y: hidden,
+					height: var(--global-spacing-11),
+					white-space: nowrap,
+				),
+				carousel-indicator-thumbnail: (
+					margin: 0 var(--global-spacing-3),
+					height: var(--global-spacing-7),
+					width: var(--global-spacing-7),
+					padding: var(--global-spacing-1),
+					background-color: transparent,
+					opacity: 40%,
+				),
+				carousel-indicator-thumbnail-active: (
+					border: var(--global-border-width-1) var(--global-border-style-1) var(--global-black),
+					opacity: 1,
+				),
 				date: (
 					font-size: var(--body-font-size-small),
 					line-height: var(--body-line-height-small),
@@ -1003,6 +1044,12 @@
 						carousel-track: (
 							// slides should flow down rather than be hidden off to the side
 							flex-wrap: wrap,
+						),
+						carousel-indicator-dots-container: (
+							display: none,
+						),
+						carousel-indicator-thumbnails-container: (
+							display: none,
 						),
 					),
 				),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -390,11 +390,12 @@
 				),
 				carousel-indicator-thumbnail: (
 					margin: 0 var(--global-spacing-3),
-					height: var(--global-spacing-8),
-					width: var(--global-spacing-8),
+					height: 50px,
+					width: 50px,
 					padding: var(--global-spacing-1),
 					background-color: transparent,
 					opacity: 40%,
+					border: var(--global-border-width-1) var(--global-border-style-1) transparent,
 				),
 				carousel-indicator-thumbnail-active: (
 					border: var(--global-border-width-1) var(--global-border-style-1) var(--global-black),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -390,8 +390,8 @@
 				),
 				carousel-indicator-thumbnail: (
 					margin: 0 var(--global-spacing-3),
-					height: var(--global-spacing-7),
-					width: var(--global-spacing-7),
+					height: var(--global-spacing-8),
+					width: var(--global-spacing-8),
 					padding: var(--global-spacing-1),
 					background-color: transparent,
 					opacity: 40%,

--- a/blocks/product-gallery-block/README.md
+++ b/blocks/product-gallery-block/README.md
@@ -2,7 +2,7 @@
 
 As a Page Builder user, I want to add the Product Gallery - Arc Block to my PDP page, so that I can merchandise multiple images on my PDP. The Product Gallery uses the Carousel component in Themes Components, along with its indicator type functionality, to show options only available on the mobile viewport.
 
-## Props
+## Custom Fields
 
 | **Prop**               | **Required** | **Type** | **Description**                                            |
 | ---------------------- | ------------ | -------- | ---------------------------------------------------------- |

--- a/blocks/product-gallery-block/README.md
+++ b/blocks/product-gallery-block/README.md
@@ -1,12 +1,13 @@
 # Product Gallery Block
 
-As a Page Builder user, I want to add the Product Gallery - Arc Block to my PDP page, so that I can merchandise multiple images on my PDP.
+As a Page Builder user, I want to add the Product Gallery - Arc Block to my PDP page, so that I can merchandise multiple images on my PDP. The Product Gallery uses the Carousel component in Themes Components, along with its indicator type functionality, to show options only available on the mobile viewport.
 
 ## Props
 
-| **Prop**               | **Required** | **Type** | **Description**                       |
-| ---------------------- | ------------ | -------- | ------------------------------------- |
-| isFeaturedImageEnabled | yes          | boolean  | Display the product’s featured image. |
+| **Prop**               | **Required** | **Type** | **Description**                                            |
+| ---------------------- | ------------ | -------- | ---------------------------------------------------------- |
+| isFeaturedImageEnabled | yes          | boolean  | Display the product’s featured image.                      |
+| indicatorType          | yes          | string   | Type of indicator to be displayed, like thumbnail or dots. |
 
 ## ANS Schema
 

--- a/blocks/product-gallery-block/README.md
+++ b/blocks/product-gallery-block/README.md
@@ -7,7 +7,7 @@ As a Page Builder user, I want to add the Product Gallery - Arc Block to my PDP 
 | **Prop**               | **Required** | **Type** | **Description**                                            |
 | ---------------------- | ------------ | -------- | ---------------------------------------------------------- |
 | isFeaturedImageEnabled | no          | boolean  | Display the product’s featured image.                      |
-| indicatorType          | yes          | string   | Type of indicator to be displayed, like thumbnail or dots. |
+| indicatorType          | no          | string   | Type of indicator to be displayed, like thumbnail or dots. |
 
 ## ANS Schema
 

--- a/blocks/product-gallery-block/README.md
+++ b/blocks/product-gallery-block/README.md
@@ -6,7 +6,7 @@ As a Page Builder user, I want to add the Product Gallery - Arc Block to my PDP 
 
 | **Prop**               | **Required** | **Type** | **Description**                                            |
 | ---------------------- | ------------ | -------- | ---------------------------------------------------------- |
-| isFeaturedImageEnabled | yes          | boolean  | Display the product’s featured image.                      |
+| isFeaturedImageEnabled | no          | boolean  | Display the product’s featured image.                      |
 | indicatorType          | yes          | string   | Type of indicator to be displayed, like thumbnail or dots. |
 
 ## ANS Schema

--- a/blocks/product-gallery-block/_index.scss
+++ b/blocks/product-gallery-block/_index.scss
@@ -5,6 +5,7 @@
 		@include scss.block-components("product-gallery-featured-slide");
 		@include scss.block-properties("product-gallery-featured-slide");
 	}
+
 	&__thumbnail {
 		@include scss.block-components("product-gallery-thumbnail");
 		@include scss.block-properties("product-gallery-thumbnail");

--- a/blocks/product-gallery-block/_index.scss
+++ b/blocks/product-gallery-block/_index.scss
@@ -5,6 +5,10 @@
 		@include scss.block-components("product-gallery-featured-slide");
 		@include scss.block-properties("product-gallery-featured-slide");
 	}
+	&__thumbnail {
+		@include scss.block-components("product-gallery-thumbnail");
+		@include scss.block-properties("product-gallery-thumbnail");
+	}
 
 	@include scss.block-components("product-gallery");
 	@include scss.block-properties("product-gallery");

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -43,10 +43,14 @@ export function ProductGalleryDisplay({
 	return (
 		<Carousel
 			className={BLOCK_CLASS_NAME}
-			key={id}
+			goToSlidePhrase={
+				/* istanbul ignore next */ (slideNumber) =>
+					phrases.t("product-gallery.go-to-slide", { slideNumber })
+			}
 			id={id}
-			label={phrases.t("product-gallery.aria-label")}
 			indicators={indicatorType}
+			key={id}
+			label={phrases.t("product-gallery.aria-label")}
 			thumbnails={thumbnailsArray}
 		>
 			{shortenedCarouselItems?.map((item, carouselIndex) => {

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -30,6 +30,7 @@ export function ProductGalleryDisplay({
 			<Image
 				// used as part of a page design so empty string alt text
 				alt=""
+				className={`${BLOCK_CLASS_NAME}__thumbnail`}
 				height={40}
 				key={itemId}
 				resizedOptions={{ auth: targetAuth }}

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -24,18 +24,19 @@ export function ProductGalleryDisplay({
 	const shortenedCarouselItems = carouselItems.slice(0, isFeaturedImageEnabled ? 9 : 8);
 
 	const thumbnailsArray = shortenedCarouselItems.map((item) => {
-		const { altText, auth, _id: itemId } = item;
+		const { auth, _id: itemId } = item;
 		const targetAuth = auth[resizerAppVersion];
 		return (
 			<Image
-				alt={altText}
-				key={itemId}
-				src={imageANSToImageSrc(item)}
-				resizedOptions={{ auth: targetAuth }}
-				width={40}
+				// used as part of a page design so empty string alt text
+				alt=""
 				height={40}
+				key={itemId}
+				resizedOptions={{ auth: targetAuth }}
 				resizerURL={resizerURL}
 				responsiveImages={[40, 80, 120]}
+				src={imageANSToImageSrc(item)}
+				width={40}
 			/>
 		);
 	});

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -16,11 +16,29 @@ export function ProductGalleryDisplay({
 	isFeaturedImageEnabled,
 	resizerAppVersion,
 	resizerURL,
+	indicatorType,
 }) {
 	const { locale } = getProperties(arcSite);
 	const phrases = getTranslatedPhrases(locale);
 
 	const shortenedCarouselItems = carouselItems.slice(0, isFeaturedImageEnabled ? 9 : 8);
+
+	const thumbnailsArray = shortenedCarouselItems.map((item) => {
+		const { altText, auth, _id: itemId } = item;
+		const targetAuth = auth[resizerAppVersion];
+		return (
+			<Image
+				alt={altText}
+				key={itemId}
+				src={imageANSToImageSrc(item)}
+				resizedOptions={{ auth: targetAuth }}
+				width={40}
+				height={40}
+				resizerURL={resizerURL}
+				responsiveImages={[40, 80, 120]}
+			/>
+		);
+	});
 
 	return (
 		<Carousel
@@ -28,6 +46,8 @@ export function ProductGalleryDisplay({
 			key={id}
 			id={id}
 			label={phrases.t("product-gallery.aria-label")}
+			indicators={indicatorType}
+			thumbnails={thumbnailsArray}
 		>
 			{shortenedCarouselItems?.map((item, carouselIndex) => {
 				const { _id: itemId, auth, alt_text: altText } = item;
@@ -77,7 +97,7 @@ export function ProductGalleryDisplay({
 	);
 }
 function ProductGallery({ customFields }) {
-	const { isFeaturedImageEnabled } = customFields;
+	const { isFeaturedImageEnabled, indicatorType } = customFields;
 	const { id } = useComponentContext();
 
 	const { arcSite, globalContent = {} } = useFusionContext();
@@ -107,6 +127,7 @@ function ProductGallery({ customFields }) {
 			isFeaturedImageEnabled={isFeaturedImageEnabled}
 			resizerAppVersion={RESIZER_APP_VERSION}
 			resizerURL={RESIZER_URL}
+			indicatorType={indicatorType}
 		/>
 	);
 }
@@ -120,6 +141,18 @@ ProductGallery.propTypes = {
 		isFeaturedImageEnabled: PropTypes.boolean.tag({
 			name: "Display the product's featured image",
 			defaultValue: false,
+		}),
+		indicatorType: PropTypes.oneOf(["dots", "thumbnails", "none"]).tag({
+			label: "Indicator Type",
+			defaultValue: "thumbnails",
+			group: "Mobile Layout Options",
+			description:
+				"The type of indicator to use only on mobile screens to show which slide is featured in the carousel. The indicators can also be used for navigating between slides.",
+			labels: {
+				dots: "Carousel Indicators",
+				thumbnails: "Thumbnails",
+				none: "None",
+			},
 		}),
 	}),
 };

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -110,6 +110,7 @@ const MOCK_GLOBAL_CONTENT = {
 
 const DEFAULT_CUSTOM_FIELDS = {
 	isFeaturedImageEnabled: false,
+	indicatorType: "thumbnails",
 };
 
 describe("Product Gallery", () => {

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -10,6 +10,8 @@ jest.mock("fusion:environment", () => ({
 	RESIZER_URL: "https://resizer.com",
 }));
 
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
 const MOCK_ASSET = {
 	_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
 	alt_text: "Man smiling posing in front of shelves. (This is alt text.)",

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -59,6 +59,7 @@ export const defaultFeaturedImageDisabled = () => (
 		arcSite="story-book"
 		id="id"
 		resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
+		indicatorType="thumbnails"
 	/>
 );
 
@@ -70,5 +71,6 @@ export const featuredImageEnabled = () => (
 		id="id"
 		arcSite="story-book"
 		resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
+		indicatorType="thumbnails"
 	/>
 );

--- a/blocks/product-gallery-block/index.story.jsx
+++ b/blocks/product-gallery-block/index.story.jsx
@@ -74,3 +74,39 @@ export const featuredImageEnabled = () => (
 		indicatorType="thumbnails"
 	/>
 );
+
+export const indicatorTypeDotsOnMobile = () => (
+	<ProductGalleryDisplay
+		carouselItems={MOCK_CAROUSEL_ITEMS}
+		isFeaturedImageEnabled={false}
+		resizerAppVersion={2}
+		arcSite="story-book"
+		id="id"
+		resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
+		indicatorType="dots"
+	/>
+);
+
+export const indicatorTypeNoneOnMobile = () => (
+	<ProductGalleryDisplay
+		carouselItems={MOCK_CAROUSEL_ITEMS}
+		isFeaturedImageEnabled={false}
+		resizerAppVersion={2}
+		arcSite="story-book"
+		id="id"
+		resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
+		indicatorType="none"
+	/>
+);
+
+export const indicatorTypeThumbnailsOnMobile = () => (
+	<ProductGalleryDisplay
+		carouselItems={MOCK_CAROUSEL_ITEMS}
+		isFeaturedImageEnabled={false}
+		resizerAppVersion={2}
+		arcSite="story-book"
+		id="id"
+		resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
+		indicatorType="thumbnails"
+	/>
+);

--- a/blocks/product-gallery-block/intl.json
+++ b/blocks/product-gallery-block/intl.json
@@ -10,6 +10,17 @@
 		"pt": "Products",
 		"sv": "Products"
 	},
+	"product-gallery.go-to-slide": {
+		"de": "Go to slide %{slideNumber}",
+		"en": "Go to slide %{slideNumber}",
+		"es": "Go to slide %{slideNumber}",
+		"fr": "Go to slide %{slideNumber}",
+		"ja": "Go to slide %{slideNumber}",
+		"ko": "Go to slide %{slideNumber}",
+		"no": "Go to slide %{slideNumber}",
+		"pt": "Go to slide %{slideNumber}",
+		"sv": "Go to slide %{slideNumber}"
+	},
 	"product-gallery.left-arrow-label": {
 		"de": "Previous",
 		"en": "Previous",

--- a/locale/de.json
+++ b/locale/de.json
@@ -174,6 +174,7 @@
 	},
 	"product-gallery-block": {
 		"product-gallery.aria-label": "Products",
+		"product-gallery.go-to-slide": "Go to slide %{slideNumber}",
 		"product-gallery.left-arrow-label": "Previous",
 		"product-gallery.right-arrow-label": "Next",
 		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"

--- a/locale/en.json
+++ b/locale/en.json
@@ -174,6 +174,7 @@
 	},
 	"product-gallery-block": {
 		"product-gallery.aria-label": "Products",
+		"product-gallery.go-to-slide": "Go to slide %{slideNumber}",
 		"product-gallery.left-arrow-label": "Previous",
 		"product-gallery.right-arrow-label": "Next",
 		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"

--- a/locale/es.json
+++ b/locale/es.json
@@ -174,6 +174,7 @@
 	},
 	"product-gallery-block": {
 		"product-gallery.aria-label": "Products",
+		"product-gallery.go-to-slide": "Go to slide %{slideNumber}",
 		"product-gallery.left-arrow-label": "Previous",
 		"product-gallery.right-arrow-label": "Next",
 		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -174,6 +174,7 @@
 	},
 	"product-gallery-block": {
 		"product-gallery.aria-label": "Products",
+		"product-gallery.go-to-slide": "Go to slide %{slideNumber}",
 		"product-gallery.left-arrow-label": "Previous",
 		"product-gallery.right-arrow-label": "Next",
 		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -174,6 +174,7 @@
 	},
 	"product-gallery-block": {
 		"product-gallery.aria-label": "Products",
+		"product-gallery.go-to-slide": "Go to slide %{slideNumber}",
 		"product-gallery.left-arrow-label": "Previous",
 		"product-gallery.right-arrow-label": "Next",
 		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -174,6 +174,7 @@
 	},
 	"product-gallery-block": {
 		"product-gallery.aria-label": "Products",
+		"product-gallery.go-to-slide": "Go to slide %{slideNumber}",
 		"product-gallery.left-arrow-label": "Previous",
 		"product-gallery.right-arrow-label": "Next",
 		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"

--- a/locale/no.json
+++ b/locale/no.json
@@ -174,6 +174,7 @@
 	},
 	"product-gallery-block": {
 		"product-gallery.aria-label": "Products",
+		"product-gallery.go-to-slide": "Go to slide %{slideNumber}",
 		"product-gallery.left-arrow-label": "Previous",
 		"product-gallery.right-arrow-label": "Next",
 		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -174,6 +174,7 @@
 	},
 	"product-gallery-block": {
 		"product-gallery.aria-label": "Products",
+		"product-gallery.go-to-slide": "Go to slide %{slideNumber}",
 		"product-gallery.left-arrow-label": "Previous",
 		"product-gallery.right-arrow-label": "Next",
 		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -174,6 +174,7 @@
 	},
 	"product-gallery-block": {
 		"product-gallery.aria-label": "Products",
+		"product-gallery.go-to-slide": "Go to slide %{slideNumber}",
 		"product-gallery.left-arrow-label": "Previous",
 		"product-gallery.right-arrow-label": "Next",
 		"product-gallery.slide-indicator": "Slide %{current} of %{maximum}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16669,9 +16669,9 @@
       "version": "file:blocks/alert-bar-content-source-block"
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-2.2",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-2.2/e4d0f5eb46ac76e6c15d0372410e31dc9dfedb58",
-      "integrity": "sha512-Oimqy1ej6b4NxExjsOj6glw3m4FDHRO9Lzp9CdgwDVFY+TKG898hCv26P6zrwuQNKMPzLxCRQSKptHzHxohTTQ==",
+      "version": "0.0.4-arc-themes-release-version-2-0-2.8",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-2.8/4376947aec896d9e735f1d23afd1eff65d3fa4c0",
+      "integrity": "sha512-jnJuZngcdv1IHwzUa1uE/EHlp/LQeRMz/m3WI/jLu/SO0ohMdREK54SQWzHmh4HWEDYlYjQ1JrrOqFj3gRu8uQ==",
       "dev": true,
       "requires": {
         "react-oembed-container": "^1.0.1",


### PR DESCRIPTION
## Description

Update the product gallery to use the carousel thumbnail 

As a PageBuilder Editor user, I want to provide consumer users on mobile devices a more dynamic Product Gallery experience, so that they can easily navigate the Product Gallery images. 

## Jira Ticket

- [TBRANDS-65](https://arcpublishing.atlassian.net/jira/software/c/projects/TMEDIA/boards/875?modal=detail&selectedIssue=TBRANDS-65&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria

A PageBuilder Editor user can configure the layout for the mobile Product Gallery by selecting the following from a dropdown custom field - New custom field called “Mobile Layout Options”:

Options are:

Thumbnails (Default)

A consumer user would see a horizontally scrollable carousel of thumbnail images that they can click on a thumbnail and advance to that specific image.

A consumer user who scrolls horizontally on the main image, the thumbnail of that image should be highlighted.

Carousel Indicators:

A consumer user would see a set of dots (carousel indicator) corresponding to the number of images in the Product Gallery.

A consumer user who scrolls horizontally on the main image, the carousel indicator of that image should be highlighted.

None:

A consumer user would see no thumbnails or carousel indicators below the product gallery. 

## Test Steps

1. Checkout this branch `git checkout TBRANDS-65-carousel-thumbnails` in blocks. 
2. `git checkout TBRANDS-65-carousel-thumbnails` in feature pack
3. `git checkout TBRANDS-65-carousel-thumbnails` in the themes components -> components have been merged, unnecessary
4. Set to the dev commerce .env
5. Link the themes components repo in .env with branch (until merged)  -> components have been merged, unnecessary
6. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/product-gallery-block`
7. Create a page for product gallery block
8. Add a gallery block 
9. Set the global content to 
![Screen Shot 2022-09-13 at 17 22 48](https://user-images.githubusercontent.com/5950956/190019806-14893b8b-83bc-4946-95bc-dc6fd1f53193.png)
10. Test changing the indicator type to the thumbnail or dots or none. See the effect in published page
11. Publish page. And click the eye emoji to see the preview 
12. Notice seeing no indicators on the desktop if you've elected for "Carousel Indicators" or "Thumbnails"

![Screen Shot 2022-09-13 at 17 23 47](https://user-images.githubusercontent.com/5950956/190019950-8c229f81-c166-4b54-82f2-ce11ec22d5a3.png)
13. Go to mobile viewport. See the thumbnail displayed. 
![Screen Shot 2022-09-13 at 17 24 40](https://user-images.githubusercontent.com/5950956/190020034-56c522a5-427a-426f-aa6d-b3b51062f247.png)
14. Screen can be shrinked to see the effect of the items. Can work on finding a commerce product with more images 
![Screen Shot 2022-09-13 at 17 25 38](https://user-images.githubusercontent.com/5950956/190020192-8a936954-ad27-48be-b8a2-b644615ae176.png)

## Effect Of Changes

### Before

- No indicator functionality seen on mobile or any viewport

### After

- Show the indicator type 

<img width="312" alt="Screen Shot 2022-09-13 at 16 46 15" src="https://user-images.githubusercontent.com/5950956/190020266-eae2ba93-c3d8-4a40-86b9-35af583edcf7.png">
![Screen Shot 2022-09-13 at 17 27 06](https://user-images.githubusercontent.com/5950956/190020288-18645885-b0b1-49f0-b561-5844089ea414.png)


## Dependencies or Side Effects

- Components pr https://github.com/WPMedia/arc-themes-components/pull/142
- Feature pack pr https://github.com/WPMedia/arc-themes-feature-pack/pull/351

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files  -> without testing the internals of the lib, this is tough in rtl with the current tests. Also need to actually merge components first
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.

--

Todo: 

- [ ] Add tests -> without testing the internals of the lib, this is tough in rtl with the current tests. Also need to actually merge components first
- [x] Add translations 
- [x] Update the doc to show functionality