### PR TITLE
TBRANDS-112: Add resizer options to Product Featured Image

### DIFF
--- a/blocks/product-featured-image-block/features/product-featured-image/default.jsx
+++ b/blocks/product-featured-image-block/features/product-featured-image/default.jsx
@@ -1,45 +1,33 @@
 import React from "react";
 
 import { useFusionContext } from "fusion:context";
-import { Image } from "@wpmedia/arc-themes-components";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { imageANSToImageSrc, Image } from "@wpmedia/arc-themes-components";
+import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
 
 const BLOCK_CLASS_NAME = "b-product-featured-image";
 
-export const ProductFeaturedImageDisplay = ({ data, resizerAppVersion }) => {
-	const featuredImageAsset = data.schema?.featuredImage?.value?.assets.find(
-		(asset) => asset.type === "image"
-	);
-
-	if (!featuredImageAsset) {
-		return null;
-	}
-
-	const { url, auth, alt_text: altText } = featuredImageAsset;
-
-	// take in app version that's the public key for the auth object in resizer v2
-	const targetAuth = auth[resizerAppVersion];
-
+export const ProductFeaturedImageDisplay = ({ featuredImage }) => {
+	const { auth, alt_text: altText } = featuredImage;
 	return (
 		<Image
-			src={url}
-			className={BLOCK_CLASS_NAME}
-			resizedOptions={{ auth: targetAuth }}
 			alt={altText}
+			className={BLOCK_CLASS_NAME}
+			height={768}
+			resizedOptions={{ auth: auth[RESIZER_APP_VERSION] }}
+			resizerURL={RESIZER_URL}
+			responsiveImages={[320, 768]}
+			src={imageANSToImageSrc(featuredImage)}
+			width={768}
 		/>
 	);
 };
 
 function ProductFeaturedImage() {
 	const { globalContent = {} } = useFusionContext();
-
-	if (!Object.keys(globalContent).length) {
-		return null;
-	}
-
-	return (
-		<ProductFeaturedImageDisplay resizerAppVersion={RESIZER_APP_VERSION} data={globalContent} />
+	const featuredImage = globalContent?.schema?.featuredImage?.value?.assets.find(
+		({ type }) => type === "image"
 	);
+	return featuredImage ? <ProductFeaturedImageDisplay featuredImage={featuredImage} /> : null;
 }
 
 ProductFeaturedImage.label = "Product Featured Image – Arc Block";

--- a/blocks/product-featured-image-block/features/product-featured-image/default.jsx
+++ b/blocks/product-featured-image-block/features/product-featured-image/default.jsx
@@ -6,15 +6,15 @@ import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
 
 const BLOCK_CLASS_NAME = "b-product-featured-image";
 
-export const ProductFeaturedImageDisplay = ({ featuredImage }) => {
-	const { auth, alt_text: altText } = featuredImage;
+export const ProductFeaturedImageDisplay = ({ featuredImage, resizerAppVersion, resizerURL }) => {
+	const { auth = {}, alt_text: altText } = featuredImage;
 	return (
 		<Image
 			alt={altText}
 			className={BLOCK_CLASS_NAME}
 			height={768}
-			resizedOptions={{ auth: auth[RESIZER_APP_VERSION] }}
-			resizerURL={RESIZER_URL}
+			resizedOptions={{ auth: auth[resizerAppVersion] }}
+			resizerURL={resizerURL}
 			responsiveImages={[320, 768]}
 			src={imageANSToImageSrc(featuredImage)}
 			width={768}
@@ -27,7 +27,13 @@ function ProductFeaturedImage() {
 	const featuredImage = globalContent?.schema?.featuredImage?.value?.assets.find(
 		({ type }) => type === "image"
 	);
-	return featuredImage ? <ProductFeaturedImageDisplay featuredImage={featuredImage} /> : null;
+	return featuredImage ? (
+		<ProductFeaturedImageDisplay
+			featuredImage={featuredImage}
+			resizerAppVersion={RESIZER_APP_VERSION}
+			resizerURL={RESIZER_URL}
+		/>
+	) : null;
 }
 
 ProductFeaturedImage.label = "Product Featured Image – Arc Block";

--- a/blocks/product-featured-image-block/features/product-featured-image/default.test.jsx
+++ b/blocks/product-featured-image-block/features/product-featured-image/default.test.jsx
@@ -88,4 +88,20 @@ describe("Product Featured Image", () => {
 		expect(image).toBeInTheDocument();
 		expect(image).toHaveAttribute("alt", "");
 	});
+	it("should render with no auth", () => {
+		useFusionContext.mockImplementation(() => ({
+			globalContent: {
+				schema: {
+					featuredImage: {
+						value: {
+							assets: [{ ...FEATURED_IMAGE_ASSET, auth: undefined }],
+						},
+					},
+				},
+			},
+		}));
+		render(<ProductFeaturedImage />);
+		const image = screen.getByRole("img");
+		expect(image).toBeInTheDocument();
+	});
 });

--- a/blocks/product-featured-image-block/index.story.jsx
+++ b/blocks/product-featured-image-block/index.story.jsx
@@ -9,26 +9,21 @@ export default {
 };
 
 const mockFeaturedImageData = {
-	schema: {
-		featuredImage: {
-			value: {
-				assets: [
-					{
-						type: "image",
-						url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
-						auth: {
-							1: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
-						},
-						alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
-					},
-				],
-			},
-		},
+	_id: "HY6LDPEW4BBFDLBYD4S3S7LZ3E",
+	type: "image",
+	url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg",
+	auth: {
+		1: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 	},
+	alt_text: "Man smiling posing in front of shelves. (This is alt text.)",
 };
 
 export const displayImage = () => (
-	<ProductFeaturedImageDisplay data={mockFeaturedImageData} resizerAppVersion={1} />
+	<ProductFeaturedImageDisplay
+		featuredImage={mockFeaturedImageData}
+		resizerAppVersion={1}
+		resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
+	/>
 );
 
-export const noImage = () => <ProductFeaturedImageDisplay data={{}} />;
+export const noImage = () => <ProductFeaturedImageDisplay featuredImage={{}} />;


### PR DESCRIPTION
## Description

Adding Resizer Options to the Product Featured Image

## Jira Ticket

- [TBRANDS-112](https://arcpublishing.atlassian.net/browse/TBRANDS-112)

## Acceptance Criteria

1. The Product Featured Image - Arc Block utilizes Resizer v2 for populating images.
2. Image uses a 1:1 aspect ratio
3. Aspect crop feature of resizer v2 is out of scope; all brands photo center images will use a 1:1 ratio to not be distorted

## Test Steps

1. Checkout this branch `git checkout tbrands-112`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/product-featured-image-block`
3. Add the Product Featured image block to a test page and use the `commerce-product` content source and `bounce-running-shoe` sku
4. Check that the image is rendering with the srcset and size options.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
