### PR TITLE
Tmedia 962 update large image size

### DIFF
--- a/blocks/resizer-image-block/ratiosFor.js
+++ b/blocks/resizer-image-block/ratiosFor.js
@@ -11,7 +11,7 @@ const sizes = {
 		options: [
 			{ kind: "small", width: 600 },
 			{ kind: "medium", width: 800 },
-			{ kind: "large", width: 377 },
+			{ kind: "large", width: 600 },
 		],
 		defaultRatio: "4:3",
 	},

--- a/blocks/resizer-image-block/ratiosFor.test.js
+++ b/blocks/resizer-image-block/ratiosFor.test.js
@@ -50,8 +50,8 @@ describe("validates arithmatic for ratios", () => {
 			expect(ratios.smallHeight).toMatchInlineSnapshot("450");
 			expect(ratios.mediumWidth).toMatchInlineSnapshot("800");
 			expect(ratios.mediumHeight).toMatchInlineSnapshot("600");
-			expect(ratios.largeWidth).toMatchInlineSnapshot("377");
-			expect(ratios.largeHeight).toMatchInlineSnapshot("283");
+			expect(ratios.largeWidth).toMatchInlineSnapshot("600");
+			expect(ratios.largeHeight).toMatchInlineSnapshot("450");
 		});
 
 		it("default values for MD", () => {
@@ -110,8 +110,8 @@ describe("validates arithmatic for ratios", () => {
 			expect(ratios.smallHeight).toMatchInlineSnapshot("338");
 			expect(ratios.smallWidth).toMatchInlineSnapshot("600");
 			expect(ratios.smallHeight).toMatchInlineSnapshot("338");
-			expect(ratios.largeWidth).toMatchInlineSnapshot("377");
-			expect(ratios.largeHeight).toMatchInlineSnapshot("212");
+			expect(ratios.largeWidth).toMatchInlineSnapshot("600");
+			expect(ratios.largeHeight).toMatchInlineSnapshot(`338`);
 		});
 		it("LG on 4:3", () => {
 			const ratios = ratiosFor("LG", "4:3");
@@ -119,8 +119,8 @@ describe("validates arithmatic for ratios", () => {
 			expect(ratios.smallHeight).toMatchInlineSnapshot("450");
 			expect(ratios.mediumWidth).toMatchInlineSnapshot("800");
 			expect(ratios.mediumHeight).toMatchInlineSnapshot("600");
-			expect(ratios.largeWidth).toMatchInlineSnapshot("377");
-			expect(ratios.largeHeight).toMatchInlineSnapshot("283");
+			expect(ratios.largeWidth).toMatchInlineSnapshot("600");
+			expect(ratios.largeHeight).toMatchInlineSnapshot("450");
 		});
 		it("LG on 3:2", () => {
 			const ratios = ratiosFor("LG", "3:2");
@@ -128,8 +128,8 @@ describe("validates arithmatic for ratios", () => {
 			expect(ratios.smallHeight).toMatchInlineSnapshot("400");
 			expect(ratios.mediumWidth).toMatchInlineSnapshot("800");
 			expect(ratios.mediumHeight).toMatchInlineSnapshot("533");
-			expect(ratios.largeWidth).toMatchInlineSnapshot("377");
-			expect(ratios.largeHeight).toMatchInlineSnapshot("251");
+			expect(ratios.largeWidth).toMatchInlineSnapshot("600");
+			expect(ratios.largeHeight).toMatchInlineSnapshot(`400`);
 		});
 
 		it("MD on 16:9", () => {

--- a/blocks/resizer-image-block/ratiosFor.test.js
+++ b/blocks/resizer-image-block/ratiosFor.test.js
@@ -1,6 +1,6 @@
 import ratiosFor from "./ratiosFor";
 
-describe("validates arithmatic for ratios", () => {
+describe("validates arithmetic for ratios", () => {
 	describe("validate parameters", () => {
 		it("if size is missing, must use XL", () => {
 			const ratios = ratiosFor();


### PR DESCRIPTION
## Description

Change large ratio size 

## Jira Ticket

- [TMEDIA-962](https://arcpublishing.atlassian.net/browse/TMEDIA-962)

## Acceptance Criteria

I am expecting that when I use the Top Table List and set it to display a Large item that it will display the image with a clear version. 

Right now it looks like it's using a resizer URL with a 377x212 image size, but the Large image is larger than that so it's blowing out the image on the website. 

via Jenae comment: Let’s go with 600 to start, check it out in QA; if for any reason we need to go bigger, we could do 800, but we’re thinking 600 will suffice. https://arcpublishing.atlassian.net/browse/TMEDIA-962?focusedCommentId=816895

## Test Steps

- Inspect the chromatic for a block like top table list that uses large ratio
- Ensure that the 377 is not used as the width, instead 600
- Look at top table list and inspect the snapshot to ensure that at large breakpoint 600 width  
https://5f91e4721ccaba0022a10782-pkpjutwjaw.chromatic.com/?path=/story/blocks-top-table-list--one-large

![Screen Shot 2022-10-07 at 15 58 04](https://user-images.githubusercontent.com/5950956/194651439-89aabcda-42b7-468b-97e4-6aef5d01d2c2.png)
![Screen Shot 2022-10-07 at 15 59 58](https://user-images.githubusercontent.com/5950956/194651644-b3c38dbd-eaf7-490c-9e20-cac62b9a3abf.png)


## Effect Of Changes

### Before

- Image was being stretched for its spot for a client 
![Screen Shot 2022-10-07 at 16 00 43](https://user-images.githubusercontent.com/5950956/194651744-1b8dd617-9a7a-4726-ab18-b29e1df31bf6.png)
https://5f91e4721ccaba0022a10782-fufibgqxby.chromatic.com/?id=blocks-top-table-list--one-large&viewMode=story

### After

![Screen Shot 2022-10-07 at 16 02 05](https://user-images.githubusercontent.com/5950956/194651941-34da9017-04b1-4f4c-92c2-37028462cb88.png)

https://5f91e4721ccaba0022a10782-pkpjutwjaw.chromatic.com/?path=/story/blocks-top-table-list--one-large
- Image may not be as stretched depending on position

## Dependencies or Side Effects

- None 

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block. -> don't think this is necessary 
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added. -> not relevant

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
