### PR TITLE
Tbrands 110 product assortment algolia

### DIFF
--- a/.storybook/mock-content/algoliaProduct.js
+++ b/.storybook/mock-content/algoliaProduct.js
@@ -8,7 +8,6 @@ const PRICING_ARRAY_ONLY_LIST = [
 		currencyLocale: "en-US",
 		prices: [
 			{
-				id: 70076,
 				type: "List",
 				amount: 26,
 			},
@@ -25,12 +24,10 @@ const PRICING_ARRAY_SAME_LIST_SALE = [
 		currencyLocale: "en-US",
 		prices: [
 			{
-				id: 70076,
 				type: "List",
 				amount: 26,
 			},
 			{
-				id: 70076,
 				type: "Sale",
 				amount: 26,
 			},
@@ -47,12 +44,10 @@ const PRICING_ARRAY_DIFFERENT_LIST_SALE = [
 		currencyLocale: "en-US",
 		prices: [
 			{
-				id: 70076,
 				type: "List",
 				amount: 26,
 			},
 			{
-				id: 70076,
 				type: "Sale",
 				amount: 16,
 			},

--- a/.storybook/mock-content/algoliaProduct.js
+++ b/.storybook/mock-content/algoliaProduct.js
@@ -1,19 +1,73 @@
 import testImageURL from "../../resources/camera.jpg";
 
+const PRICING_ARRAY_ONLY_LIST = [
+	{
+		id: null,
+		currencyCode: "USD",
+		currencyDisplayFormat: "symbol",
+		currencyLocale: "en-US",
+		prices: [
+			{
+				id: 70076,
+				type: "List",
+				amount: 26,
+			},
+		],
+		schema: {},
+	},
+];
+
+const PRICING_ARRAY_SAME_LIST_SALE = [
+	{
+		id: null,
+		currencyCode: "USD",
+		currencyDisplayFormat: "symbol",
+		currencyLocale: "en-US",
+		prices: [
+			{
+				id: 70076,
+				type: "List",
+				amount: 26,
+			},
+			{
+				id: 70076,
+				type: "Sale",
+				amount: 26,
+			},
+		],
+		schema: {},
+	},
+];
+
+const PRICING_ARRAY_DIFFERENT_LIST_SALE = [
+	{
+		id: null,
+		currencyCode: "USD",
+		currencyDisplayFormat: "symbol",
+		currencyLocale: "en-US",
+		prices: [
+			{
+				id: 70076,
+				type: "List",
+				amount: 26,
+			},
+			{
+				id: 70076,
+				type: "Sale",
+				amount: 16,
+			},
+		],
+		schema: {},
+	},
+];
+
 // eslint-disable-next-line import/prefer-default-export
 export const algoliaProductMock = [
 	{
 		name: "Item 1",
 		image: testImageURL,
 		sku: "sku-1",
-		prices: [
-			{
-				amount: 26,
-				type: "List",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-		],
+		pricing: PRICING_ARRAY_ONLY_LIST,
 		attributes: [
 			{
 				name: "product_url",
@@ -25,75 +79,28 @@ export const algoliaProductMock = [
 		name: "Item 2",
 		image: testImageURL,
 		sku: "sku-2",
-		prices: [
-			{
-				amount: 16,
-				type: "Sale",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-			{
-				amount: 26,
-				type: "List",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-		],
+		pricing: PRICING_ARRAY_DIFFERENT_LIST_SALE,
 	},
 	{
 		name: "Item 3",
 		image: testImageURL,
 		sku: "sku-3",
-		prices: [
-			{
-				amount: 26,
-				type: "List",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-		],
+		pricing: PRICING_ARRAY_ONLY_LIST,
 	},
 	{
 		image: testImageURL,
 		sku: "sku-4",
-		prices: [
-			{
-				amount: 26,
-				type: "List",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-		],
+		pricing: PRICING_ARRAY_ONLY_LIST,
 	},
 	{
 		image: testImageURL,
 		sku: "sku-5",
-		prices: [
-			{
-				amount: 26,
-				type: "List",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-		],
+		pricing: PRICING_ARRAY_ONLY_LIST,
 	},
 	{
 		name: "Item 6",
 		image: testImageURL,
 		sku: "sku-6",
-		prices: [
-			{
-				amount: 26,
-				type: "Sale",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-			{
-				amount: 26,
-				type: "List",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-		],
+		pricing: PRICING_ARRAY_SAME_LIST_SALE,
 	},
 ];

--- a/blocks/product-assortment-carousel-block/README.md
+++ b/blocks/product-assortment-carousel-block/README.md
@@ -35,7 +35,6 @@ The block relies on Algolia data to render the products in the carousel. The fie
       - For each price object
         - `type` - `Sale` or `List`
         - `amount`
-        - `id`
 
 ## Internationalization fields
 

--- a/blocks/product-assortment-carousel-block/README.md
+++ b/blocks/product-assortment-carousel-block/README.md
@@ -26,14 +26,16 @@ The block relies on Algolia data to render the products in the carousel. The fie
 - Image
 - Attributes - array of objects
   - `name = product_url`
-- Prices - array of object
-  - `type = List`
-  - `type = Sale`
-  - For each price
+- Pricing - array of object
+  - For each pricing object
     - `currencyLocale`
     - `currencyCode`
-    - `amount`
-    - `type`
+    - `currencyDisplayFormat`
+    - Prices - array of object
+      - For each price object
+        - `type` - `Sale` or `List`
+        - `amount`
+        - `id`
 
 ## Internationalization fields
 

--- a/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
+++ b/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
@@ -125,8 +125,40 @@ function ProductAssortmentCarousel({ customFields = {} }) {
 					}
 				>
 					{content.map((item, carouselIndex) => {
-						const SalePrice = getPrice("Sale", item.prices);
-						const ListPrice = getPrice("List", item.prices);
+						/*
+							incoming data is both: 
+						1)
+							{
+								pricing: [
+									{
+										prices: [
+											{
+												type: "Sale"
+											}
+										]
+									}
+								]
+							}
+
+						2)
+
+							{
+								prices: [
+									{
+										prices: [
+											{
+												type: "Sale"
+											}
+										]
+									}
+								]
+							}
+
+							should I handle both or is this an algolia issue?
+						*/
+						const SalePrice = getPrice("Sale", item.prices[0].prices);
+						const ListPrice = getPrice("List", item.prices[0].prices);
+
 						const salePriceAmount = SalePrice?.amount;
 						const listPriceAmount = ListPrice?.amount;
 						const isOnSale = salePriceAmount && salePriceAmount !== listPriceAmount;

--- a/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
+++ b/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
@@ -156,8 +156,8 @@ function ProductAssortmentCarousel({ customFields = {} }) {
 
 							should I handle both or is this an algolia issue?
 						*/
-						const SalePrice = getPrice("Sale", item.prices[0].prices);
-						const ListPrice = getPrice("List", item.prices[0].prices);
+						const SalePrice = getPrice("Sale", item.prices?.[0].prices || item.pricing[0].prices);
+						const ListPrice = getPrice("List", item.prices?.[0].prices || item.pricing[0].prices);
 
 						const salePriceAmount = SalePrice?.amount;
 						const listPriceAmount = ListPrice?.amount;
@@ -192,6 +192,26 @@ function ProductAssortmentCarousel({ customFields = {} }) {
 												<Price.Sale>
 													{new Intl.NumberFormat(SalePrice.currencyLocale, {
 														style: "currency",
+														// does not have a currency code on the item
+														/*
+															would expect the item to look like this 
+															
+															{
+																amount: 26,
+																type: "List",
+																currencyLocale: "en-US",
+																currencyCode: "USD",
+															},
+
+															instead 
+
+																{
+																	amount: 139.99,
+																	id: 70059,
+																	type: "Sale"
+																}
+
+														*/
 														currency: SalePrice.currencyCode,
 														minimumFractionDigits: 2,
 													}).format(salePriceAmount)}

--- a/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
+++ b/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
@@ -125,39 +125,9 @@ function ProductAssortmentCarousel({ customFields = {} }) {
 					}
 				>
 					{content.map((item, carouselIndex) => {
-						/*
-							incoming data is both: 
-						1)
-							{
-								pricing: [
-									{
-										prices: [
-											{
-												type: "Sale"
-											}
-										]
-									}
-								]
-							}
-
-						2)
-
-							{
-								prices: [
-									{
-										prices: [
-											{
-												type: "Sale"
-											}
-										]
-									}
-								]
-							}
-
-							should I handle both or is this an algolia issue?
-						*/
-						const SalePrice = getPrice("Sale", item.prices?.[0].prices || item.pricing[0].prices);
-						const ListPrice = getPrice("List", item.prices?.[0].prices || item.pricing[0].prices);
+						const pricing = item.pricing[0];
+						const SalePrice = getPrice("Sale", pricing.prices);
+						const ListPrice = getPrice("List", pricing.prices);
 
 						const salePriceAmount = SalePrice?.amount;
 						const listPriceAmount = ListPrice?.amount;
@@ -190,37 +160,17 @@ function ProductAssortmentCarousel({ customFields = {} }) {
 										>
 											{isOnSale ? (
 												<Price.Sale>
-													{new Intl.NumberFormat(SalePrice.currencyLocale, {
+													{new Intl.NumberFormat(pricing.currencyLocale, {
 														style: "currency",
-														// does not have a currency code on the item
-														/*
-															would expect the item to look like this 
-															
-															{
-																amount: 26,
-																type: "List",
-																currencyLocale: "en-US",
-																currencyCode: "USD",
-															},
-
-															instead 
-
-																{
-																	amount: 139.99,
-																	id: 70059,
-																	type: "Sale"
-																}
-
-														*/
-														currency: SalePrice.currencyCode,
+														currency: pricing.currencyCode,
 														minimumFractionDigits: 2,
 													}).format(salePriceAmount)}
 												</Price.Sale>
 											) : null}
 											<Price.List>
-												{new Intl.NumberFormat(ListPrice.currencyLocale, {
+												{new Intl.NumberFormat(pricing.currencyLocale, {
 													style: "currency",
-													currency: ListPrice.currencyCode,
+													currency: pricing.currencyCode,
 													minimumFractionDigits: 2,
 												}).format(listPriceAmount)}
 											</Price.List>

--- a/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.test.jsx
+++ b/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.test.jsx
@@ -6,19 +6,73 @@ import { useFusionContext } from "fusion:context";
 
 import ProductAssortmentCarousel from "./default";
 
+const PRICING_ARRAY_ONLY_LIST = [
+	{
+		id: null,
+		currencyCode: "USD",
+		currencyDisplayFormat: "symbol",
+		currencyLocale: "en-US",
+		prices: [
+			{
+				id: 70076,
+				type: "List",
+				amount: 26,
+			},
+		],
+		schema: {},
+	},
+];
+
+const PRICING_ARRAY_DIFFERENT_LIST_SALE = [
+	{
+		id: null,
+		currencyCode: "USD",
+		currencyDisplayFormat: "symbol",
+		currencyLocale: "en-US",
+		prices: [
+			{
+				id: 70076,
+				type: "List",
+				amount: 26,
+			},
+			{
+				id: 70076,
+				type: "Sale",
+				amount: 16,
+			},
+		],
+		schema: {},
+	},
+];
+
+const PRICING_ARRAY_SAME_LIST_SALE = [
+	{
+		id: null,
+		currencyCode: "USD",
+		currencyDisplayFormat: "symbol",
+		currencyLocale: "en-US",
+		prices: [
+			{
+				id: 70076,
+				type: "List",
+				amount: 26,
+			},
+			{
+				id: 70076,
+				type: "Sale",
+				amount: 26,
+			},
+		],
+		schema: {},
+	},
+];
+
 const mockContent = [
 	{
 		name: "Item 1",
 		image: "image-url",
 		sku: "sku-1",
-		prices: [
-			{
-				amount: 26,
-				type: "List",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-		],
+		pricing: PRICING_ARRAY_ONLY_LIST,
 		attributes: [
 			{
 				name: "product_url",
@@ -30,45 +84,18 @@ const mockContent = [
 		name: "Item 2",
 		image: "image-url",
 		sku: "sku-2",
-		prices: [
-			{
-				amount: 16,
-				type: "Sale",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-			{
-				amount: 26,
-				type: "List",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-		],
+		pricing: PRICING_ARRAY_DIFFERENT_LIST_SALE,
 	},
 	{
 		name: "Item 3",
 		image: "image-url",
 		sku: "sku-3",
-		prices: [
-			{
-				amount: 26,
-				type: "List",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-		],
+		pricing: PRICING_ARRAY_ONLY_LIST,
 	},
 	{
 		image: "image-url",
 		sku: "sku-4",
-		prices: [
-			{
-				amount: 26,
-				type: "List",
-				currencyLocale: "en-US",
-				currencyCode: "USD",
-			},
-		],
+		pricing: PRICING_ARRAY_ONLY_LIST,
 	},
 ];
 
@@ -136,14 +163,7 @@ describe("Product Assortment Carousel", () => {
 				name: "List Price Render",
 				image: "image-url",
 				sku: "sku-mock",
-				prices: [
-					{
-						amount: 26,
-						type: "List",
-						currencyLocale: "en-US",
-						currencyCode: "USD",
-					},
-				],
+				pricing: PRICING_ARRAY_ONLY_LIST,
 				attributes: [
 					{
 						name: "product_url",
@@ -169,20 +189,7 @@ describe("Product Assortment Carousel", () => {
 				name: "List + Sale Price Render",
 				image: "image-url",
 				sku: "sku-mock",
-				prices: [
-					{
-						amount: 16,
-						type: "Sale",
-						currencyLocale: "en-US",
-						currencyCode: "USD",
-					},
-					{
-						amount: 26,
-						type: "List",
-						currencyLocale: "en-US",
-						currencyCode: "USD",
-					},
-				],
+				pricing: PRICING_ARRAY_DIFFERENT_LIST_SALE,
 			},
 			...mockContent,
 		]);
@@ -202,20 +209,7 @@ describe("Product Assortment Carousel", () => {
 				name: "List Price Render",
 				image: "image-url",
 				sku: "sku-mock",
-				prices: [
-					{
-						amount: 26,
-						type: "Sale",
-						currencyLocale: "en-US",
-						currencyCode: "USD",
-					},
-					{
-						amount: 26,
-						type: "List",
-						currencyLocale: "en-US",
-						currencyCode: "USD",
-					},
-				],
+				pricing: PRICING_ARRAY_SAME_LIST_SALE,
 				attributes: [
 					{
 						name: "product_url",
@@ -242,14 +236,7 @@ describe("Product Assortment Carousel", () => {
 				name: "Has product_url attribute",
 				image: "image-url",
 				sku: "sku-1",
-				prices: [
-					{
-						amount: 26,
-						type: "List",
-						currencyLocale: "en-US",
-						currencyCode: "USD",
-					},
-				],
+				pricing: PRICING_ARRAY_ONLY_LIST,
 				attributes: [
 					{
 						name: "product_url",
@@ -261,14 +248,7 @@ describe("Product Assortment Carousel", () => {
 				name: "Has no product_url attribute",
 				image: "image-url",
 				sku: "sku-2",
-				prices: [
-					{
-						amount: 26,
-						type: "List",
-						currencyLocale: "en-US",
-						currencyCode: "USD",
-					},
-				],
+				pricing: PRICING_ARRAY_ONLY_LIST,
 				attributes: [
 					{
 						name: "unrelated_field",
@@ -280,28 +260,14 @@ describe("Product Assortment Carousel", () => {
 				name: "Has empty attribute array",
 				image: "image-url",
 				sku: "sku-3",
-				prices: [
-					{
-						amount: 26,
-						type: "List",
-						currencyLocale: "en-US",
-						currencyCode: "USD",
-					},
-				],
+				pricing: PRICING_ARRAY_ONLY_LIST,
 				attributes: [],
 			},
 			{
 				name: "Has no attribute key",
 				image: "image-url",
 				sku: "sku-4",
-				prices: [
-					{
-						amount: 26,
-						type: "List",
-						currencyLocale: "en-US",
-						currencyCode: "USD",
-					},
-				],
+				pricing: PRICING_ARRAY_ONLY_LIST,
 			},
 		]);
 		const { container } = render(

--- a/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.test.jsx
+++ b/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.test.jsx
@@ -14,7 +14,6 @@ const PRICING_ARRAY_ONLY_LIST = [
 		currencyLocale: "en-US",
 		prices: [
 			{
-				id: 70076,
 				type: "List",
 				amount: 26,
 			},
@@ -31,12 +30,10 @@ const PRICING_ARRAY_DIFFERENT_LIST_SALE = [
 		currencyLocale: "en-US",
 		prices: [
 			{
-				id: 70076,
 				type: "List",
 				amount: 26,
 			},
 			{
-				id: 70076,
 				type: "Sale",
 				amount: 16,
 			},
@@ -53,12 +50,10 @@ const PRICING_ARRAY_SAME_LIST_SALE = [
 		currencyLocale: "en-US",
 		prices: [
 			{
-				id: 70076,
 				type: "List",
 				amount: 26,
 			},
 			{
-				id: 70076,
 				type: "Sale",
 				amount: 26,
 			},


### PR DESCRIPTION
## Description

Update assortment data handling 

## Jira Ticket

- [TBRANDS-110](https://arcpublishing.atlassian.net/browse/TBRANDS-110)

## Acceptance Criteria

Product Assortment - Arc Block has been updated to correctly render the update Algolia data.

Product Assortment - Arc Block renders the data as expected.

## Test Steps

1. Checkout this branch `git checkout TBRANDS-110-product-assortment-algolia`
2. Make sure you're using commerce feature pack with an all-access algolia token
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/product-assortment-carousel-block`
4. Add a product assortment carousel 
5. Click the icon to update the algolia data 
6. Algolia Index to use arccommerce-product-commerceqa
7. One rule has been set up - Product Assortment Testing
8. See the sale and list prices

## Effect Of Changes

### Before

- Different data structure 

### After

- new data structure, same output

## Dependencies or Side Effects

- None

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


---

Two questions: 
- Should I handle keys of both prices and pricing? Is this expected? Based on investigating the other block, it is not expected. Issue with algolia data? I can get around it with optional keys but this doesn't seem optimal. -> was given wrong data, updated
- Shouldn't the sale price, for instance, have currency code. It does not. Based on investigating the other block, I see the same issue. I can try to hack this one if we assume usd, but i wasn't sure where we could assume this. Or how to change the currency target -- theme setting? -> no this is expected, similar to product assortment

put q in ticket as well https://arcpublishing.atlassian.net/browse/TBRANDS-110?focusedCommentId=818782