### PR TITLE
Tmedia 934

### DIFF
--- a/.storybook/alias/environment.js
+++ b/.storybook/alias/environment.js
@@ -1,3 +1,2 @@
 export const RESIZER_APP_VERSION = 2;
-export const RESIZER_URL =
-	"https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/";
+export const RESIZER_URL = "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/";

--- a/.storybook/alias/environment.js
+++ b/.storybook/alias/environment.js
@@ -1,2 +1,3 @@
 export const RESIZER_APP_VERSION = 2;
-export const RESIZER_URL = "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/";
+export const RESIZER_URL =
+	"https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/";

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -49,13 +49,13 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 	switch (type) {
 		case "text": {
 			return content && content.length > 0 ? (
-				<Paragraph key={`${type}_${key}`} dangerouslySetInnerHTML={{ __html: content }} />
+				<Paragraph key={`${type}_${index}_${key}`} dangerouslySetInnerHTML={{ __html: content }} />
 			) : null;
 		}
 		case "copyright": {
 			return content && content.length > 0 ? (
 				<Paragraph
-					key={`${type}_${key}`}
+					key={`${type}_${index}_${key}`}
 					className={`${BLOCK_CLASS_NAME}__copyright`}
 					dangerouslySetInnerHTML={{ __html: content }}
 				/>
@@ -63,7 +63,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		}
 
 		case "divider": {
-			return <hr className={`${BLOCK_CLASS_NAME}__divider`} key={`${type}_${key}`} />;
+			return <hr className={`${BLOCK_CLASS_NAME}__divider`} key={`${type}_${index}_${key}`} />;
 		}
 
 		case "image": {
@@ -89,7 +89,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 				const formattedCredits = formatCredits(vanityCredits || credits);
 				return (
 					<MediaItem
-						key={`${type}_${key}`}
+						key={`${type}_${index}_${key}`}
 						className={figureImageClassName}
 						caption={!hideImageCaption ? caption : null}
 						credit={!hideImageCredits ? formattedCredits : null}
@@ -119,7 +119,10 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 			const afterContent = "&nbsp;]";
 
 			return (
-				<Paragraph key={`${type}_${key}`} className={`${BLOCK_CLASS_NAME}__interstitial-link`}>
+				<Paragraph
+					key={`${type}_${index}_${key}`}
+					className={`${BLOCK_CLASS_NAME}__interstitial-link`}
+				>
 					<span dangerouslySetInnerHTML={{ __html: beforeContent }} />
 					<Link
 						href={url}
@@ -135,7 +138,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		case "raw_html": {
 			return content && content.length > 0 ? (
 				<HTML
-					key={`${type}_${key}`}
+					key={`${type}_${index}_${key}`}
 					id={key}
 					className={`${BLOCK_CLASS_NAME}__html`}
 					content={content}
@@ -147,7 +150,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 			const { _id: listId = "", list_type: listType, items: listItems } = item;
 			// eslint-disable-next-line arrow-body-style
 			return listItems && listItems.length > 0 ? (
-				<List key={`${type}_${listId}_${key}`} listType={listType} listItems={listItems} />
+				<List key={`${type}_${index}_${listId}_${key}`} listType={listType} listItems={listItems} />
 			) : null;
 		}
 
@@ -160,7 +163,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 					: phrases.t("article-body-block.correction");
 
 			return item.text && item.text.length > 0 ? (
-				<section className={`${BLOCK_CLASS_NAME}__correction`} key={`${type}_${key}`}>
+				<section className={`${BLOCK_CLASS_NAME}__correction`} key={`${type}_${index}_${key}`}>
 					<HeadingSection>
 						<Heading>{labelText}</Heading>
 						<Paragraph>{item.text}</Paragraph>
@@ -171,18 +174,18 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 
 		case "header":
 			return item.content && item.content.length > 0 ? (
-				<Header key={`${type}_${key}`} classPrefix={BLOCK_CLASS_NAME} element={item} />
+				<Header key={`${type}_${index}_${key}`} classPrefix={BLOCK_CLASS_NAME} element={item} />
 			) : null;
 
 		case "oembed_response": {
 			return item.raw_oembed ? (
-				<Oembed key={`${type}_${key}`} classPrefix={BLOCK_CLASS_NAME} element={item} />
+				<Oembed key={`${type}_${index}_${key}`} classPrefix={BLOCK_CLASS_NAME} element={item} />
 			) : null;
 		}
 
 		case "table": {
 			return item.rows ? (
-				<Table key={`${type}_${key}`} element={item} classPrefix={BLOCK_CLASS_NAME} />
+				<Table key={`${type}_${index}_${key}`} element={item} classPrefix={BLOCK_CLASS_NAME} />
 			) : null;
 		}
 
@@ -191,7 +194,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 				case "pullquote":
 					return (
 						<Quote
-							key={`${type}_${key}`}
+							key={`${type}_${index}_${key}`}
 							element={item}
 							classPrefix={BLOCK_CLASS_NAME}
 							type="pullquote"
@@ -200,13 +203,15 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 
 				case "blockquote":
 				default:
-					return <Quote key={`${type}_${key}`} element={item} classPrefix={BLOCK_CLASS_NAME} />;
+					return (
+						<Quote key={`${type}_${index}_${key}`} element={item} classPrefix={BLOCK_CLASS_NAME} />
+					);
 			}
 
 		case "video":
 			return (
 				<MediaItem
-					key={`${type}_${key}`}
+					key={`${type}_${index}_${key}`}
 					caption={!hideVideoCaption ? item?.description?.basic : null}
 					credit={!hideVideoCredits ? formatCredits(item.credits) : null}
 					title={!hideVideoTitle ? item?.headlines?.basic : null}
@@ -217,7 +222,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		case "gallery": {
 			const total = item.content_elements.length;
 			return (
-				<section key={`${type}_${key}`}>
+				<section key={`${type}_${index}_${key}`}>
 					<Carousel
 						id={key}
 						className={`${BLOCK_CLASS_NAME}__gallery`}

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -1,15 +1,20 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext } from "fusion:context";
-import { LazyLoad, isServerSide } from "@wpmedia/engine-theme-sdk";
+import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
+
+import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 
 import {
 	Carousel,
+	Conditional,
 	formatCredits,
 	Heading,
 	HeadingSection,
 	Icon,
 	Image,
+	imageANSToImageSrc,
+	isServerSide,
 	Link,
 	MediaItem,
 	Paragraph,
@@ -44,13 +49,13 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 	switch (type) {
 		case "text": {
 			return content && content.length > 0 ? (
-				<Paragraph key={key} dangerouslySetInnerHTML={{ __html: content }} />
+				<Paragraph key={`${type}_${key}`} dangerouslySetInnerHTML={{ __html: content }} />
 			) : null;
 		}
 		case "copyright": {
 			return content && content.length > 0 ? (
 				<Paragraph
-					key={key}
+					key={`${type}_${key}`}
 					className={`${BLOCK_CLASS_NAME}__copyright`}
 					dangerouslySetInnerHTML={{ __html: content }}
 				/>
@@ -58,69 +63,51 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		}
 
 		case "divider": {
-			return <hr className={`${BLOCK_CLASS_NAME}__divider`} key={key} />;
+			return <hr className={`${BLOCK_CLASS_NAME}__divider`} key={`${type}_${key}`} />;
 		}
 
 		case "image": {
 			const {
-				url,
-				subtitle,
-				caption,
-				credits,
-				alt_text: altText,
-				vanity_credits: vanityCredits,
+				additional_properties: { link = "" } = {},
 				// alignment not always present
 				alignment = "",
-				additional_properties: additionalProperties = {},
+				alt_text: altText,
+				auth,
+				caption,
+				credits,
+				subtitle,
+				url,
+				vanity_credits: vanityCredits,
 			} = item;
-
-			// link url set in composer
-			const { link = "" } = additionalProperties;
 
 			// only left and right float supported
 			const allowedFloatValue = alignment === "left" || alignment === "right" ? alignment : "";
-
-			let figureImageClassName = `${BLOCK_CLASS_NAME}__image`;
-
-			if (allowedFloatValue) {
-				// add space after initial string ' '
-				figureImageClassName +=
-					allowedFloatValue === "left"
-						? ` ${BLOCK_CLASS_NAME}__image-float-left`
-						: ` ${BLOCK_CLASS_NAME}__image-float-right`;
-			}
+			const figureImageClassName = `${BLOCK_CLASS_NAME}__image${
+				allowedFloatValue ? ` ${BLOCK_CLASS_NAME}__image-float-${allowedFloatValue}` : ""
+			}`;
 
 			if (url) {
-				const ArticleBodyImage = () => <Image src={url} alt={altText} />;
 				const formattedCredits = formatCredits(vanityCredits || credits);
-
-				const ArticleBodyImageContainer = ({ children }) => (
+				return (
 					<MediaItem
-						key={key}
+						key={`${type}_${key}`}
 						className={figureImageClassName}
 						caption={!hideImageCaption ? caption : null}
 						credit={!hideImageCredits ? formattedCredits : null}
 						title={!hideImageTitle ? subtitle : null}
 					>
-						{children}
+						<Conditional component={Link} condition={link} href={link}>
+							<Image
+								src={imageANSToImageSrc(item)}
+								alt={altText}
+								resizerURL={RESIZER_URL}
+								resizedOptions={{ auth: auth[RESIZER_APP_VERSION] }}
+								width={item.width}
+								height={item.height}
+								responsiveImages={[274, 400, 768, 1024, 1440]}
+							/>
+						</Conditional>
 					</MediaItem>
-				);
-
-				// if link url then make entire image clickable
-				if (link) {
-					return (
-						<ArticleBodyImageContainer key={key}>
-							<Link href={link}>
-								<ArticleBodyImage />
-							</Link>
-						</ArticleBodyImageContainer>
-					);
-				}
-
-				return (
-					<ArticleBodyImageContainer key={key}>
-						<ArticleBodyImage />
-					</ArticleBodyImageContainer>
 				);
 			}
 			return null;
@@ -134,7 +121,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 			const afterContent = "&nbsp;]";
 
 			return (
-				<Paragraph key={key} className={`${BLOCK_CLASS_NAME}__interstitial-link`}>
+				<Paragraph key={`${type}_${key}`} className={`${BLOCK_CLASS_NAME}__interstitial-link`}>
 					<span dangerouslySetInnerHTML={{ __html: beforeContent }} />
 					<Link
 						href={url}
@@ -149,15 +136,20 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 
 		case "raw_html": {
 			return content && content.length > 0 ? (
-				<HTML key={key} id={key} className={`${BLOCK_CLASS_NAME}__html`} content={content} />
+				<HTML
+					key={`${type}_${key}`}
+					id={key}
+					className={`${BLOCK_CLASS_NAME}__html`}
+					content={content}
+				/>
 			) : null;
 		}
 
 		case "list": {
-			const { list_type: listType, items: listItems } = item;
+			const { _id: listId = "", list_type: listType, items: listItems } = item;
 			// eslint-disable-next-line arrow-body-style
 			return listItems && listItems.length > 0 ? (
-				<List key={key} listType={listType} listItems={listItems} />
+				<List key={`${type}_${listId}_${key}`} listType={listType} listItems={listItems} />
 			) : null;
 		}
 
@@ -170,7 +162,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 					: phrases.t("article-body-block.correction");
 
 			return item.text && item.text.length > 0 ? (
-				<section className={`${BLOCK_CLASS_NAME}__correction`} key={key}>
+				<section className={`${BLOCK_CLASS_NAME}__correction`} key={`${type}_${key}`}>
 					<HeadingSection>
 						<Heading>{labelText}</Heading>
 						<Paragraph>{item.text}</Paragraph>
@@ -181,33 +173,42 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 
 		case "header":
 			return item.content && item.content.length > 0 ? (
-				<Header key={key} classPrefix={BLOCK_CLASS_NAME} element={item} />
+				<Header key={`${type}_${key}`} classPrefix={BLOCK_CLASS_NAME} element={item} />
 			) : null;
 
 		case "oembed_response": {
 			return item.raw_oembed ? (
-				<Oembed key={key} classPrefix={BLOCK_CLASS_NAME} element={item} />
+				<Oembed key={`${type}_${key}`} classPrefix={BLOCK_CLASS_NAME} element={item} />
 			) : null;
 		}
 
 		case "table": {
-			return item.rows ? <Table key={key} element={item} classPrefix={BLOCK_CLASS_NAME} /> : null;
+			return item.rows ? (
+				<Table key={`${type}_${key}`} element={item} classPrefix={BLOCK_CLASS_NAME} />
+			) : null;
 		}
 
 		case "quote":
 			switch (item.subtype) {
 				case "pullquote":
-					return <Quote key={key} element={item} classPrefix={BLOCK_CLASS_NAME} type="pullquote" />;
+					return (
+						<Quote
+							key={`${type}_${key}`}
+							element={item}
+							classPrefix={BLOCK_CLASS_NAME}
+							type="pullquote"
+						/>
+					);
 
 				case "blockquote":
 				default:
-					return <Quote key={key} element={item} classPrefix={BLOCK_CLASS_NAME} />;
+					return <Quote key={`${type}_${key}`} element={item} classPrefix={BLOCK_CLASS_NAME} />;
 			}
 
 		case "video":
 			return (
 				<MediaItem
-					key={key}
+					key={`${type}_${key}`}
 					caption={!hideVideoCaption ? item?.description?.basic : null}
 					credit={!hideVideoCredits ? formatCredits(item.credits) : null}
 					title={!hideVideoTitle ? item?.headlines?.basic : null}
@@ -218,7 +219,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		case "gallery": {
 			const total = item.content_elements.length;
 			return (
-				<section key={key}>
+				<section key={`${type}_${key}`}>
 					<Carousel
 						id={key}
 						className={`${BLOCK_CLASS_NAME}__gallery`}

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext } from "fusion:context";
-import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
 
 import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 
@@ -13,7 +12,6 @@ import {
 	HeadingSection,
 	Icon,
 	Image,
-	imageANSToImageSrc,
 	isServerSide,
 	Link,
 	MediaItem,
@@ -21,6 +19,8 @@ import {
 	usePhrases,
 	Video,
 } from "@wpmedia/arc-themes-components";
+
+import getResizeParamsFromANSImage from "./shared/get-resize-params-from-ans-image";
 
 import Header from "./_children/heading";
 import HTML from "./_children/html";
@@ -72,7 +72,6 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 				// alignment not always present
 				alignment = "",
 				alt_text: altText,
-				auth,
 				caption,
 				credits,
 				subtitle,
@@ -98,13 +97,12 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 					>
 						<Conditional component={Link} condition={link} href={link}>
 							<Image
-								src={imageANSToImageSrc(item)}
+								{...getResizeParamsFromANSImage(
+									item,
+									allowedFloatValue ? 400 : 800,
+									[274, 400, 768, 1024, 1440].map((w) => (allowedFloatValue ? w / 2 : w))
+								)}
 								alt={altText}
-								resizerURL={RESIZER_URL}
-								resizedOptions={{ auth: auth[RESIZER_APP_VERSION] }}
-								width={item.width}
-								height={item.height}
-								responsiveImages={[274, 400, 768, 1024, 1440]}
 							/>
 						</Conditional>
 					</MediaItem>
@@ -275,7 +273,10 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 									title={!hideGalleryTitle ? i.subtitle : null}
 								>
 									<div className={`${BLOCK_CLASS_NAME}__image-wrapper`}>
-										<Image src={i.url} alt={i.alt_text} width={800} />
+										<Image
+											{...getResizeParamsFromANSImage(i, 800, [400, 600, 800, 1600])}
+											alt={i.alt_text}
+										/>
 									</div>
 								</MediaItem>
 							</Carousel.Item>

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -90,7 +90,6 @@ describe("article-body chain", () => {
 					<span>3</span>
 				</ArticleBodyChain>
 			);
-			//
 			expect(wrapper.find("article")).toHaveLength(1);
 			expect(wrapper.find("article").find("div")).toHaveLength(2);
 		});

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -1,9 +1,14 @@
 import React from "react";
 import { mount } from "enzyme";
 import { useFusionContext } from "fusion:context";
-import { isServerSide } from "@wpmedia/engine-theme-sdk";
+import { isServerSide } from "@wpmedia/arc-themes-components";
 
 import ArticleBodyChain from "./default";
+
+jest.mock("fusion:environment", () => ({
+	RESIZER_APP_VERSION: 2,
+	RESIZER_URL: "http://some.url",
+}));
 
 jest.mock("fusion:properties", () =>
 	jest.fn(() => ({
@@ -13,6 +18,10 @@ jest.mock("fusion:properties", () =>
 
 jest.mock("@wpmedia/engine-theme-sdk", () => ({
 	LazyLoad: ({ children }) => <>{children}</>,
+}));
+
+jest.mock("@wpmedia/arc-themes-components", () => ({
+	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(),
 }));
 
@@ -81,7 +90,7 @@ describe("article-body chain", () => {
 					<span>3</span>
 				</ArticleBodyChain>
 			);
-
+			//
 			expect(wrapper.find("article")).toHaveLength(1);
 			expect(wrapper.find("article").find("div")).toHaveLength(2);
 		});
@@ -1244,6 +1253,9 @@ describe("article-body chain", () => {
 			},
 			address: {},
 			alt_text: "A person walks down a path with their surfboard towards the ocean.",
+			auth: {
+				2: "RESIZER_AUTH_KEY",
+			},
 			caption:
 				"Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break. ",
 			created_date: "2019-07-09T22:26:02Z",
@@ -1288,7 +1300,6 @@ describe("article-body chain", () => {
 			url: "https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg",
 			version: "0.9.0",
 			width: 5616,
-			resized_params: { "1440x0": "" },
 		};
 
 		it("should render image with figcaption and author", () => {
@@ -1368,6 +1379,9 @@ describe("article-body chain", () => {
 							},
 							address: {},
 							alt_text: "A person walks down a path with their surfboard towards the ocean.",
+							auth: {
+								2: "RESIZER_AUTH_KEY",
+							},
 							caption:
 								"Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break. ",
 							created_date: "2019-07-09T22:26:02Z",
@@ -1472,6 +1486,9 @@ describe("article-body chain", () => {
 							},
 							address: {},
 							alt_text: "A person walks down a path with their surfboard towards the ocean.",
+							auth: {
+								2: "RESIZER_AUTH_KEY",
+							},
 							caption:
 								"Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break. ",
 							created_date: "2019-07-09T22:26:02Z",
@@ -1521,7 +1538,6 @@ describe("article-body chain", () => {
 							url: "https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg",
 							version: "0.9.0",
 							width: 5616,
-							resized_params: { "1440x0": "" },
 						},
 					],
 				},
@@ -1593,6 +1609,9 @@ describe("article-body chain", () => {
 							},
 							address: {},
 							alt_text: "A person walks down a path with their surfboard towards the ocean.",
+							auth: {
+								2: "RESIZER_AUTH_KEY",
+							},
 							caption:
 								"Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break. ",
 							created_date: "2019-07-09T22:26:02Z",
@@ -1652,7 +1671,6 @@ describe("article-body chain", () => {
 							url: "https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg",
 							version: "0.9.0",
 							width: 5616,
-							resized_params: { "1440x0": "" },
 						},
 					],
 				},
@@ -1720,6 +1738,9 @@ describe("article-body chain", () => {
 							},
 							address: {},
 							alt_text: "A person walks down a path with their surfboard towards the ocean.",
+							auth: {
+								2: "RESIZER_AUTH_KEY",
+							},
 							caption:
 								"Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break. ",
 							created_date: "2019-07-09T22:26:02Z",
@@ -1779,7 +1800,6 @@ describe("article-body chain", () => {
 							url: "https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg",
 							version: "0.9.0",
 							width: 5616,
-							resized_params: { "1440x0": "" },
 						},
 					],
 				},
@@ -1840,6 +1860,9 @@ describe("article-body chain", () => {
 							},
 							address: {},
 							alt_text: "A person walks down a path with their surfboard towards the ocean.",
+							auth: {
+								2: "RESIZER_AUTH_KEY",
+							},
 							caption:
 								"Australia's great ocean road is home to the kind of stuff you see in magazines and always wish you could visit one day: Twelve Apostles, Koalas, Kangaroos, surf towns, Bells Beach and Point Break. ",
 							created_date: "2019-07-09T22:26:02Z",
@@ -1899,7 +1922,6 @@ describe("article-body chain", () => {
 							url: "https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg",
 							version: "0.9.0",
 							width: 5616,
-							resized_params: { "1440x0": "" },
 						},
 					],
 				},
@@ -2000,6 +2022,9 @@ describe("article-body chain", () => {
 								comments: [],
 								inline_comments: [],
 							},
+							auth: {
+								2: "RESIZER_AUTH_KEY",
+							},
 							content: "This story has a divider below this paragraph",
 						},
 						{
@@ -2017,6 +2042,9 @@ describe("article-body chain", () => {
 								comments: [],
 								inline_comments: [],
 							},
+							auth: {
+								2: "RESIZER_AUTH_KEY",
+							},
 							content:
 								"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mi elit, varius quis dui nec, bibendum accumsan nisl. Cras et efficitur ex. Maecenas tempor pellentesque sem, ac interdum felis mollis ac. Sed at tristique felis. Morbi a dictum sapien, quis lacinia nulla. Vestibulum sagittis mauris vitae faucibus sodales. Nunc porttitor sollicitudin leo, ut varius metus condimentum sit amet. Nam ipsum ante, vestibulum vitae rutrum at, viverra sed neque. In non imperdiet risus. Duis maximus lectus a sollicitudin pulvinar. Curabitur non fermentum neque. In sed lacus in leo venenatis luctus. Cras mollis et mi at pretium.",
 						},
@@ -2027,6 +2055,9 @@ describe("article-body chain", () => {
 								comments: [],
 								inline_comments: [],
 							},
+							auth: {
+								2: "RESIZER_AUTH_KEY",
+							},
 							content:
 								"Suspendisse sollicitudin nulla nisi, sed accumsan leo interdum a. Mauris sit amet fermentum dolor, non sollicitudin tortor. Cras enim ante, consectetur sed sapien ac, blandit dictum ex. Suspendisse lacinia ligula at mauris fermentum viverra. Duis facilisis sit amet risus quis blandit. Suspendisse eget nulla quam. Etiam facilisis purus ac interdum convallis. Nunc vel ultrices ante, eget lacinia est. Etiam sollicitudin, mi quis gravida tempor, lorem sem ultricies massa, nec blandit purus nunc vitae metus. Suspendisse potenti. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Phasellus imperdiet ullamcorper facilisis.",
 						},
@@ -2036,6 +2067,9 @@ describe("article-body chain", () => {
 							additional_properties: {
 								comments: [],
 								inline_comments: [],
+							},
+							auth: {
+								2: "RESIZER_AUTH_KEY",
 							},
 							content: "There is another divider below this paragraph",
 						},
@@ -2053,6 +2087,9 @@ describe("article-body chain", () => {
 							additional_properties: {
 								comments: [],
 								inline_comments: [],
+							},
+							auth: {
+								2: "RESIZER_AUTH_KEY",
 							},
 							content:
 								"Vivamus scelerisque vestibulum pharetra. Nullam erat elit, suscipit ac eros nec, faucibus dapibus diam. Curabitur venenatis orci sit amet massa suscipit, non cursus diam consequat. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec sollicitudin, justo ac tristique blandit, felis dolor lobortis turpis, a facilisis diam lectus id nisi. Ut quis accumsan felis. Praesent nec condimentum eros, sed faucibus tortor. Nullam at commodo purus.",
@@ -2089,6 +2126,9 @@ describe("article-body chain", () => {
 								comments: [],
 								inline_comments: [],
 							},
+							auth: {
+								2: "RESIZER_AUTH_KEY",
+							},
 							content: "Paragraph with Copyright Following",
 						},
 					],
@@ -2121,6 +2161,9 @@ describe("article-body chain", () => {
 							additional_properties: {
 								comments: [],
 								inline_comments: [],
+							},
+							auth: {
+								2: "RESIZER_AUTH_KEY",
 							},
 							content: "",
 						},
@@ -2155,6 +2198,9 @@ describe("article-body chain", () => {
 								comments: [],
 								inline_comments: [],
 							},
+							auth: {
+								2: "RESIZER_AUTH_KEY",
+							},
 							content: "Paragraph with Copyright Following",
 						},
 					],
@@ -2179,6 +2225,9 @@ describe("article-body chain", () => {
 							additional_properties: {
 								comments: [],
 								inline_comments: [],
+							},
+							auth: {
+								2: "RESIZER_AUTH_KEY",
 							},
 							content: "",
 						},
@@ -2237,6 +2286,9 @@ describe("article-body chain", () => {
 								{
 									_id: "image_id1",
 									alt_text: "Image Alt Text 1",
+									auth: {
+										2: "RESIZER_AUTH_KEY",
+									},
 									caption: "Image Caption 1",
 									credits: {
 										affiliation: [{ name: "Affiliation 1", type: "author" }],
@@ -2263,14 +2315,6 @@ describe("article-body chain", () => {
 										],
 									},
 									height: 3744,
-									resized_params: {
-										"274x0": "--al0lnFNBcEFSRnjIDaqW3hEXs=filters:format(jpg):quality(70)/",
-										"400x0": "D1TuuuNZJiX29k5IcHROrI-y1zI=filters:format(jpg):quality(70)/",
-										"768x0": "C6NNPZQgZICy5VMk-jLjNpbg_vw=filters:format(jpg):quality(70)/",
-										"800x0": "SFAi-Aks2Fy99PkwQ9LLvd2Jxl4=filters:format(jpg):quality(70)/",
-										"1024x0": "LSihqkSkpwAFfD0qsLDFuLw08P8=filters:format(jpg):quality(70)/",
-										"1440x0": "mnOhSZmQiFynETHFN7BAYI5-Pzg=filters:format(jpg):quality(70)/",
-									},
 									subtitle: "Image Subtitle 1",
 									type: "image",
 									url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg",
@@ -2279,6 +2323,9 @@ describe("article-body chain", () => {
 								{
 									_id: "image_id2",
 									alt_text: "Image Alt Text 2",
+									auth: {
+										2: "RESIZER_AUTH_KEY",
+									},
 									caption: "Image Caption 2",
 									credits: {
 										affiliation: [{ name: "Affiliation 2", type: "author" }],
@@ -2291,14 +2338,6 @@ describe("article-body chain", () => {
 										],
 									},
 									height: 3744,
-									resized_params: {
-										"274x0": "--al0lnFNBcEFSRnjIDaqW3hEXs=filters:format(jpg):quality(70)/",
-										"400x0": "D1TuuuNZJiX29k5IcHROrI-y1zI=filters:format(jpg):quality(70)/",
-										"768x0": "C6NNPZQgZICy5VMk-jLjNpbg_vw=filters:format(jpg):quality(70)/",
-										"800x0": "SFAi-Aks2Fy99PkwQ9LLvd2Jxl4=filters:format(jpg):quality(70)/",
-										"1024x0": "LSihqkSkpwAFfD0qsLDFuLw08P8=filters:format(jpg):quality(70)/",
-										"1440x0": "mnOhSZmQiFynETHFN7BAYI5-Pzg=filters:format(jpg):quality(70)/",
-									},
 									subtitle: "Image Subtitle 2",
 									type: "image",
 									url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG",

--- a/blocks/article-body-block/chains/article-body/shared/get-resize-params-from-ans-image.js
+++ b/blocks/article-body-block/chains/article-body/shared/get-resize-params-from-ans-image.js
@@ -1,0 +1,13 @@
+import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
+import { imageANSToImageSrc } from "@wpmedia/arc-themes-components";
+
+const getResizeParamsFromANSImage = (ansImageItem, defaultWidth, responsiveWidths = []) => ({
+	height: Math.floor((ansImageItem.height / ansImageItem.width) * defaultWidth),
+	resizerURL: RESIZER_URL,
+	resizedOptions: { auth: ansImageItem.auth[RESIZER_APP_VERSION] },
+	...(responsiveWidths.length ? { responsiveImages: responsiveWidths } : {}),
+	src: imageANSToImageSrc(ansImageItem),
+	width: defaultWidth,
+});
+
+export default getResizeParamsFromANSImage;

--- a/blocks/article-body-block/chains/article-body/shared/get-resize-params-from-ans-image.test.js
+++ b/blocks/article-body-block/chains/article-body/shared/get-resize-params-from-ans-image.test.js
@@ -1,0 +1,56 @@
+import getResizeParamsFromANSImage from "./get-resize-params-from-ans-image";
+
+jest.mock("fusion:environment", () => ({
+	RESIZER_APP_VERSION: 2,
+	RESIZER_URL: "https://image.url",
+}));
+
+describe("get-resize-params-from-ans-image", () => {
+	it("should return an object with appropriate resizer parameters for the Image component", () => {
+		expect(
+			getResizeParamsFromANSImage(
+				{
+					_id: "IMAGE_ID",
+					auth: { 2: "AUTH_TOKEN" },
+					height: 15000,
+					url: "https://unresized.img/IMAGE_FILE_NAME.jpg",
+					width: 10000,
+				},
+				500,
+				[100, 200, 300, 400, 500]
+			)
+		).toEqual(
+			expect.objectContaining({
+				height: 750,
+				resizedOptions: { auth: "AUTH_TOKEN" },
+				resizerURL: "https://image.url",
+				responsiveImages: [100, 200, 300, 400, 500],
+				src: "IMAGE_ID.jpg",
+				width: 500,
+			})
+		);
+	});
+
+	it("should return an object with appropriate resizer parameters without the resizer width array", () => {
+		expect(
+			getResizeParamsFromANSImage(
+				{
+					_id: "IMAGE_ID",
+					auth: { 2: "AUTH_TOKEN" },
+					height: 15000,
+					url: "https://unresized.img/IMAGE_FILE_NAME.jpg",
+					width: 10000,
+				},
+				800
+			)
+		).toEqual(
+			expect.objectContaining({
+				height: 1200,
+				resizedOptions: { auth: "AUTH_TOKEN" },
+				resizerURL: "https://image.url",
+				src: "IMAGE_ID.jpg",
+				width: 800,
+			})
+		);
+	});
+});

--- a/blocks/article-body-block/index.story.jsx
+++ b/blocks/article-body-block/index.story.jsx
@@ -56,6 +56,9 @@ const mockGallery = {
 		{
 			_id: "image_id1",
 			alt_text: "Image Alt Text 1",
+			auth: {
+				2: "RESIZER_AUTH_KEY",
+			},
 			caption: "Image Caption 1",
 			credits: {
 				affiliation: [{ name: "Affiliation 1", type: "author" }],
@@ -98,6 +101,9 @@ const mockGallery = {
 		{
 			_id: "image_id2",
 			alt_text: "Image Alt Text 2",
+			auth: {
+				2: "RESIZER_AUTH_KEY",
+			},
 			caption: "Image Caption 2",
 			credits: {
 				affiliation: [{ name: "Affiliation 2", type: "author" }],
@@ -154,6 +160,9 @@ const mockHeader4 = {
 const mockImage = {
 	_id: "image_id",
 	alt_text: "Image Alt Text",
+	auth: {
+		2: "RESIZER_AUTH_KEY",
+	},
 	caption: "Image Caption",
 	credits: {
 		affiliation: [{ name: "Affiliation", type: "author" }],

--- a/blocks/article-body-block/index.story.jsx
+++ b/blocks/article-body-block/index.story.jsx
@@ -54,10 +54,10 @@ const mockGallery = {
 	_id: "gallery_id",
 	content_elements: [
 		{
-			_id: "CITIAYX2ERDOPP2TPJGEUV7SNQ",
+			_id: "EM5DTGYGABDJZODV7YVFOC2DOM",
 			alt_text: "Image Alt Text 1",
 			auth: {
-				2: "RESIZER_AUTH_KEY",
+				2: "75f6b4c64c7889dc8eadf6a328999d522be2e2397c7b9a5a0704f6d9afa60fcf",
 			},
 			caption: "Image Caption 1",
 			credits: {
@@ -95,14 +95,14 @@ const mockGallery = {
 			},
 			subtitle: "Image Subtitle 1",
 			type: "image",
-			url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg",
+			url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/EM5DTGYGABDJZODV7YVFOC2DOM.jpeg",
 			width: 5616,
 		},
 		{
-			_id: "4PUA6PJWEBEELOHMHMUUUB2WSM",
+			_id: "2KCJNN2JM5ECLEZDNHBWJQZKYQ",
 			alt_text: "Image Alt Text 2",
 			auth: {
-				2: "RESIZER_AUTH_KEY",
+				2: "1d2390c4cc8df2265924631d707ead2490865f17830bfbb52c8541b8696bf573",
 			},
 			caption: "Image Caption 2",
 			credits: {
@@ -126,7 +126,7 @@ const mockGallery = {
 			},
 			subtitle: "Image Subtitle 2",
 			type: "image",
-			url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG",
+			url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/2KCJNN2JM5ECLEZDNHBWJQZKYQ.jpg",
 			width: 5616,
 		},
 	],
@@ -158,10 +158,10 @@ const mockHeader4 = {
 };
 
 const mockImage = {
-	_id: "CITIAYX2ERDOPP2TPJGEUV7SNQ",
+	_id: "EM5DTGYGABDJZODV7YVFOC2DOM",
 	alt_text: "Image Alt Text",
 	auth: {
-		2: "RESIZER_AUTH_KEY",
+		2: "75f6b4c64c7889dc8eadf6a328999d522be2e2397c7b9a5a0704f6d9afa60fcf",
 	},
 	caption: "Image Caption",
 	credits: {
@@ -171,7 +171,7 @@ const mockImage = {
 	height: 3744,
 	subtitle: "Image Subtitle",
 	type: "image",
-	url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg",
+	url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/EM5DTGYGABDJZODV7YVFOC2DOM.jpeg",
 	width: 5616,
 };
 

--- a/blocks/article-body-block/index.story.jsx
+++ b/blocks/article-body-block/index.story.jsx
@@ -54,7 +54,7 @@ const mockGallery = {
 	_id: "gallery_id",
 	content_elements: [
 		{
-			_id: "image_id1",
+			_id: "CITIAYX2ERDOPP2TPJGEUV7SNQ",
 			alt_text: "Image Alt Text 1",
 			auth: {
 				2: "RESIZER_AUTH_KEY",
@@ -99,7 +99,7 @@ const mockGallery = {
 			width: 5616,
 		},
 		{
-			_id: "image_id2",
+			_id: "4PUA6PJWEBEELOHMHMUUUB2WSM",
 			alt_text: "Image Alt Text 2",
 			auth: {
 				2: "RESIZER_AUTH_KEY",
@@ -158,7 +158,7 @@ const mockHeader4 = {
 };
 
 const mockImage = {
-	_id: "image_id",
+	_id: "CITIAYX2ERDOPP2TPJGEUV7SNQ",
 	alt_text: "Image Alt Text",
 	auth: {
 		2: "RESIZER_AUTH_KEY",
@@ -169,14 +169,6 @@ const mockImage = {
 		by: [{ byline: "Custom Credit", name: "Smith Smitherson", type: "author" }],
 	},
 	height: 3744,
-	resized_params: {
-		"274x0": "--al0lnFNBcEFSRnjIDaqW3hEXs=filters:format(jpg):quality(70)/",
-		"400x0": "D1TuuuNZJiX29k5IcHROrI-y1zI=filters:format(jpg):quality(70)/",
-		"768x0": "C6NNPZQgZICy5VMk-jLjNpbg_vw=filters:format(jpg):quality(70)/",
-		"800x0": "SFAi-Aks2Fy99PkwQ9LLvd2Jxl4=filters:format(jpg):quality(70)/",
-		"1024x0": "LSihqkSkpwAFfD0qsLDFuLw08P8=filters:format(jpg):quality(70)/",
-		"1440x0": "mnOhSZmQiFynETHFN7BAYI5-Pzg=filters:format(jpg):quality(70)/",
-	},
 	subtitle: "Image Subtitle",
 	type: "image",
 	url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/CITIAYX2ERDOPP2TPJGEUV7SNQ.jpg",

--- a/blocks/content-api-source-block/sources/content-api.js
+++ b/blocks/content-api-source-block/sources/content-api.js
@@ -9,11 +9,10 @@ const params = {
 	website_url: "text",
 };
 
-const fetch = ({ _id, "arc-site": site, website_url: websiteUrl }, { cachedCall }) => {
+const fetch = ({ _id, "arc-site": website, website_url: websiteUrl }, { cachedCall }) => {
 	const urlSearch = new URLSearchParams({
-		_id,
-		...(site ? { website: site } : {}),
-		website_url: websiteUrl,
+		...(_id ? { _id } : { website_url: websiteUrl }),
+		...(website ? { website } : {}),
 	});
 
 	return axios({

--- a/blocks/content-api-source-block/sources/content-api.test.js
+++ b/blocks/content-api-source-block/sources/content-api.test.js
@@ -103,7 +103,6 @@ describe("the content api source block", () => {
 			expect(contentSourceFetch.request.url.searchObject).toEqual(
 				expect.objectContaining({
 					_id: "myid",
-					website_url: "/aaaa/eeeeee/",
 				})
 			);
 		});


### PR DESCRIPTION
## Description

Convert `article-body-block` to image resizer.
Also fix condition in `content-api` that I missed.

## Jira Ticket

- [TMEDIA-934](https://arcpublishing.atlassian.net/browse/TMEDIA-934)

## Acceptance Criteria

Article Body block is using image resizer v2

## Test Steps

1. Checkout this branch `git checkout tmedia-934`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/article-body-block`
3. Open the Article Body Chain test page and use content-api countent source with id:  `PKFVHJKBBVHZRIHJEMQGGREWIE`
4. Check that the appropriately sized image is loaded and that the markup is as below (in the After section)

## Effect Of Changes

### Before

![image](https://user-images.githubusercontent.com/2287238/197884863-a1dc1e70-0a18-414d-b310-62c9f1270456.png)

### After

![image](https://user-images.githubusercontent.com/2287238/197884534-23f9211a-9fb5-4e64-abd8-db532f44da2e.png)

## Dependencies or Side Effects

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
