### PR TITLE
TMEDIA-707 - Change content api content source back to ans-item schema name

### DIFF
--- a/blocks/content-api-source-block/sources/content-api.js
+++ b/blocks/content-api-source-block/sources/content-api.js
@@ -30,5 +30,5 @@ const fetch = ({ _id, "arc-site": website, website_url: websiteUrl }, { cachedCa
 export default {
 	fetch,
 	params,
-	schemaName: "ans-feed",
+	schemaName: "ans-item",
 };


### PR DESCRIPTION
## Description

The Content API schema name was changed in a recent PR (https://github.com/WPMedia/arc-themes-blocks/pull/1536) which stops blocks that are set to use `ans-item` for their content config being able to select a content source

## Jira Ticket

- [TMEDIA-707](https://arcpublishing.atlassian.net/browse/TMEDIA-707)

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout content-api-schema-name-change`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/content-api-source-block`
3. Validate you are now able to select the content-api content source when using Promo Blocks

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
