### PR TITLE
TMEDIA-907: Convert more source blocks to use new resizer

### DIFF
--- a/blocks/story-feed-author-content-source-block/index.js
+++ b/blocks/story-feed-author-content-source-block/index.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/blocks/story-feed-author-content-source-block/package.json
+++ b/blocks/story-feed-author-content-source-block/package.json
@@ -5,7 +5,7 @@
 	"author": "Arc XP - Themes",
 	"homepage": "https://github.com/WPMedia/arc-themes-blocks",
 	"license": "CC-BY-NC-ND-4.0",
-	"main": "index.js",
+	"main": "",
 	"files": [
 		"sources"
 	],
@@ -18,10 +18,9 @@
 		"url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
 		"directory": "blocks/story-feed-author-content-source-block"
 	},
-	"gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95",
 	"peerDependencies": {
-		"@wpmedia/resizer-image-block": "*",
 		"@wpmedia/arc-themes-components": "*",
 		"@wpmedia/signing-service-content-source-block": "*"
-	}
+	},
+	"gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/story-feed-author-content-source-block/package.json
+++ b/blocks/story-feed-author-content-source-block/package.json
@@ -1,29 +1,27 @@
 {
-  "name": "@wpmedia/story-feed-author-content-source-block",
-  "version": "5.14.1",
-  "description": "Content source block for story feed queries by author",
-  "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/arc-themes-blocks",
-  "license": "CC-BY-NC-ND-4.0",
-  "main": "index.js",
-  "files": [
-    "sources"
-  ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
-    "directory": "blocks/story-feed-author-content-source-block"
-  },
-  "scripts": {
-    "test": "echo \"Error: run tests from root\" && exit 1",
-    "lint": "eslint --ext js --ext jsx sources"
-  },
-  "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95",
-  "peerDependencies": {
-    "@wpmedia/resizer-image-block": "*"
-  }
+	"name": "@wpmedia/story-feed-author-content-source-block",
+	"version": "5.14.1",
+	"description": "Content source block for story feed queries by author",
+	"author": "Arc XP - Themes",
+	"homepage": "https://github.com/WPMedia/arc-themes-blocks",
+	"license": "CC-BY-NC-ND-4.0",
+	"main": "index.js",
+	"files": [
+		"sources"
+	],
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com/",
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+		"directory": "blocks/story-feed-author-content-source-block"
+	},
+	"gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95",
+	"peerDependencies": {
+		"@wpmedia/resizer-image-block": "*",
+		"@wpmedia/arc-themes-components": "*",
+		"@wpmedia/signing-service-content-source-block": "*"
+	}
 }

--- a/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
+++ b/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
@@ -1,14 +1,41 @@
-import getResizedImageData from "@wpmedia/resizer-image-block";
+import axios from "axios";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:environment";
+
+import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
+import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
+
+const params = {
+	authorSlug: "text",
+	feedOffset: "number",
+	feedSize: "number",
+};
+
+const fetch = (
+	{ authorSlug, feedOffset: from = 0, feedSize: size = 8, "arc-site": website },
+	{ cachedCall }
+) => {
+	const urlSearch = new URLSearchParams({
+		from,
+		q: `credits.by.slug:"${authorSlug}"`,
+		sort: "display_date:desc",
+		size,
+		website,
+	});
+
+	return axios({
+		url: `${CONTENT_BASE}/content/v4/search/published?${urlSearch.toString()}`,
+		headers: {
+			"content-type": "application/json",
+			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
+		},
+		method: "GET",
+	})
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(({ data }) => data);
+};
 
 export default {
-	resolve: ({ authorSlug, feedSize = 8, feedOffset = 0, "arc-site": website }) =>
-		`/content/v4/search/published?q=credits.by.slug:"${authorSlug}"&size=${feedSize}&from=${feedOffset}&sort=display_date:desc&website=${website}`,
+	fetch,
+	params,
 	schemaName: "ans-feed",
-	params: {
-		authorSlug: "text",
-		feedSize: "number",
-		feedOffset: "number",
-	},
-	// other options null use default functionality, such as filter quality
-	transform: (data, query) => getResizedImageData(data, null, null, null, query["arc-site"]),
 };

--- a/blocks/story-feed-author-content-source-block/sources/story-feed-author.test.jsx
+++ b/blocks/story-feed-author-content-source-block/sources/story-feed-author.test.jsx
@@ -1,4 +1,4 @@
-import contentSource from "./story-feed-query";
+import contentSource from "./story-feed-author";
 
 jest.mock("fusion:environment", () => ({
 	CONTENT_BASE: "https://content.base",
@@ -28,18 +28,18 @@ jest.mock("axios", () => ({
 describe("story-feed-author-content-source-block", () => {
 	it("should use the proper param types", () => {
 		expect(contentSource.params).toEqual({
-			query: "text",
-			size: "number",
-			offset: "number",
+			authorSlug: "text",
+			feedOffset: "number",
+			feedSize: "number",
 		});
 	});
 
 	it("should build the correct url", async () => {
 		const contentSourceFetch = await contentSource.fetch(
 			{
-				query: "slug",
-				offset: 4,
-				size: 3,
+				authorSlug: "slug",
+				feedOffset: 4,
+				feedSize: 3,
 				"arc-site": "the-site",
 			},
 			{ cachedCall: () => {} }
@@ -50,7 +50,7 @@ describe("story-feed-author-content-source-block", () => {
 		expect(contentSourceFetch.request.url.searchObject).toEqual(
 			expect.objectContaining({
 				from: "4",
-				q: "slug",
+				q: 'credits.by.slug:"slug"',
 				sort: "display_date:desc",
 				size: "3",
 				website: "the-site",
@@ -58,9 +58,10 @@ describe("story-feed-author-content-source-block", () => {
 		);
 	});
 
-	it("should default query to * size to 8 and offset to 0", async () => {
+	it("should default size to 8 and offset to 0", async () => {
 		const contentSourceFetch = await contentSource.fetch(
 			{
+				authorSlug: "slug",
 				"arc-site": "the-site",
 			},
 			{ cachedCall: () => {} }
@@ -69,7 +70,7 @@ describe("story-feed-author-content-source-block", () => {
 		expect(contentSourceFetch.request.url.searchObject).toEqual(
 			expect.objectContaining({
 				from: "0",
-				q: "*",
+				q: 'credits.by.slug:"slug"',
 				sort: "display_date:desc",
 				size: "8",
 				website: "the-site",

--- a/blocks/story-feed-query-content-source-block/index.js
+++ b/blocks/story-feed-query-content-source-block/index.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/blocks/story-feed-query-content-source-block/package.json
+++ b/blocks/story-feed-query-content-source-block/package.json
@@ -1,29 +1,27 @@
 {
-  "name": "@wpmedia/story-feed-query-content-source-block",
-  "version": "5.14.1",
-  "description": "Content source block for story feed queries by Elasticsearch queries",
-  "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/arc-themes-blocks",
-  "license": "CC-BY-NC-ND-4.0",
-  "main": "index.js",
-  "files": [
-    "sources"
-  ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
-    "directory": "blocks/story-feed-query-content-source-block"
-  },
-  "scripts": {
-    "test": "echo \"Error: run tests from root\" && exit 1",
-    "lint": "eslint --ext js --ext jsx sources"
-  },
-  "peerDependencies": {
-    "@wpmedia/resizer-image-block": "*"
-  },
-  "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
+	"name": "@wpmedia/story-feed-query-content-source-block",
+	"version": "5.14.1",
+	"description": "Content source block for story feed queries by Elasticsearch queries",
+	"author": "Arc XP - Themes",
+	"homepage": "https://github.com/WPMedia/arc-themes-blocks",
+	"license": "CC-BY-NC-ND-4.0",
+	"main": "index.js",
+	"files": [
+		"sources"
+	],
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com/",
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+		"directory": "blocks/story-feed-query-content-source-block"
+	},
+	"peerDependencies": {
+		"@wpmedia/resizer-image-block": "*",
+		"@wpmedia/arc-themes-components": "*",
+		"@wpmedia/signing-service-content-source-block": "*"
+	},
+	"gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/story-feed-query-content-source-block/package.json
+++ b/blocks/story-feed-query-content-source-block/package.json
@@ -5,7 +5,7 @@
 	"author": "Arc XP - Themes",
 	"homepage": "https://github.com/WPMedia/arc-themes-blocks",
 	"license": "CC-BY-NC-ND-4.0",
-	"main": "index.js",
+	"main": "",
 	"files": [
 		"sources"
 	],
@@ -19,7 +19,6 @@
 		"directory": "blocks/story-feed-query-content-source-block"
 	},
 	"peerDependencies": {
-		"@wpmedia/resizer-image-block": "*",
 		"@wpmedia/arc-themes-components": "*",
 		"@wpmedia/signing-service-content-source-block": "*"
 	},

--- a/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
+++ b/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
@@ -1,16 +1,41 @@
-import getResizedImageData from "@wpmedia/resizer-image-block";
+import axios from "axios";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:environment";
+
+import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
+import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
+
+const params = {
+	offset: "number",
+	query: "text",
+	size: "number",
+};
+
+const fetch = (
+	{ query: q = "*", size = 8, offset: from = 0, "arc-site": website },
+	{ cachedCall }
+) => {
+	const urlSearch = new URLSearchParams({
+		from,
+		q,
+		size,
+		sort: "display_date:desc",
+		website,
+	});
+
+	return axios({
+		url: `${CONTENT_BASE}/content/v4/search/published?${urlSearch.toString()}`,
+		headers: {
+			"content-type": "application/json",
+			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
+		},
+		method: "GET",
+	})
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(({ data }) => data);
+};
 
 export default {
-	resolve: (params) =>
-		`/content/v4/search/published?q=${params.query || "*"}&website=${params["arc-site"]}&size=${
-			params.size || 8
-		}&from=${params.offset || 0}&sort=display_date:desc`,
+	fetch,
+	params,
 	schemaName: "ans-feed",
-	params: {
-		query: "text",
-		size: "number",
-		offset: "number",
-	},
-	// other options null use default functionality, such as filter quality
-	transform: (data, query) => getResizedImageData(data, null, null, null, query["arc-site"]),
 };

--- a/blocks/story-feed-sections-content-source-block/index.js
+++ b/blocks/story-feed-sections-content-source-block/index.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/blocks/story-feed-sections-content-source-block/package.json
+++ b/blocks/story-feed-sections-content-source-block/package.json
@@ -1,29 +1,27 @@
 {
-  "name": "@wpmedia/story-feed-sections-content-source-block",
-  "version": "5.15.0",
-  "description": "Content source block for story feed queries by section",
-  "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/arc-themes-blocks",
-  "license": "CC-BY-NC-ND-4.0",
-  "main": "index.js",
-  "files": [
-    "sources"
-  ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
-    "directory": "blocks/story-feed-sections-content-source-block"
-  },
-  "scripts": {
-    "test": "echo \"Error: run tests from root\" && exit 1",
-    "lint": "eslint --ext js --ext jsx sources"
-  },
-  "peerDependencies": {
-    "@wpmedia/resizer-image-block": "*"
-  },
-  "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
+	"name": "@wpmedia/story-feed-sections-content-source-block",
+	"version": "5.15.0",
+	"description": "Content source block for story feed queries by section",
+	"author": "Arc XP - Themes",
+	"homepage": "https://github.com/WPMedia/arc-themes-blocks",
+	"license": "CC-BY-NC-ND-4.0",
+	"main": "index.js",
+	"files": [
+		"sources"
+	],
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com/",
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+		"directory": "blocks/story-feed-sections-content-source-block"
+	},
+	"peerDependencies": {
+		"@wpmedia/resizer-image-block": "*",
+		"@wpmedia/arc-themes-components": "*",
+		"@wpmedia/signing-service-content-source-block": "*"
+	},
+	"gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/story-feed-sections-content-source-block/package.json
+++ b/blocks/story-feed-sections-content-source-block/package.json
@@ -5,7 +5,7 @@
 	"author": "Arc XP - Themes",
 	"homepage": "https://github.com/WPMedia/arc-themes-blocks",
 	"license": "CC-BY-NC-ND-4.0",
-	"main": "index.js",
+	"main": "",
 	"files": [
 		"sources"
 	],
@@ -19,7 +19,6 @@
 		"directory": "blocks/story-feed-sections-content-source-block"
 	},
 	"peerDependencies": {
-		"@wpmedia/resizer-image-block": "*",
 		"@wpmedia/arc-themes-components": "*",
 		"@wpmedia/signing-service-content-source-block": "*"
 	},

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
@@ -92,7 +92,7 @@ const fetch = (
 	};
 
 	const urlSearch = new URLSearchParams({
-		body: encodeURI(JSON.stringify(body)),
+		body: JSON.stringify(body),
 		from,
 		size,
 		sort: "display_date:desc",

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.test.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.test.js
@@ -110,7 +110,7 @@ describe("story-feed-author-content-source-block", () => {
 		expect(contentSourceFetch.request.url.searchObject).toEqual(
 			expect.objectContaining({
 				from: "4",
-				body: encodeURI(JSON.stringify(body)),
+				body: JSON.stringify(body),
 				sort: "display_date:desc",
 				size: "3",
 				website: "the-site",
@@ -131,7 +131,7 @@ describe("story-feed-author-content-source-block", () => {
 		expect(contentSourceFetch.request.url.searchObject).toEqual(
 			expect.objectContaining({
 				from: "0",
-				body: encodeURI(JSON.stringify(body)),
+				body: JSON.stringify(body),
 				sort: "display_date:desc",
 				size: "10",
 				website: "the-site",
@@ -164,38 +164,36 @@ describe("story-feed-author-content-source-block", () => {
 		expect(contentSourceFetch.request.url.searchObject).toEqual(
 			expect.objectContaining({
 				from: "0",
-				body: encodeURI(
-					JSON.stringify({
-						...body,
-						query: {
-							...body.query,
-							bool: {
-								...body.query.bool,
-								must_not: [
-									{
-										nested: {
-											...body.query.bool.must_not[0].nested,
-											query: {
-												...body.query.bool.must_not[0].nested.query,
-												bool: {
-													...body.query.bool.must_not[0].nested.query.bool,
-													must: [
-														{
-															terms: { "taxonomy.sections._id": [""] },
-														},
-														{
-															term: { "taxonomy.sections._website": "the-site" },
-														},
-													],
-												},
+				body: JSON.stringify({
+					...body,
+					query: {
+						...body.query,
+						bool: {
+							...body.query.bool,
+							must_not: [
+								{
+									nested: {
+										...body.query.bool.must_not[0].nested,
+										query: {
+											...body.query.bool.must_not[0].nested.query,
+											bool: {
+												...body.query.bool.must_not[0].nested.query.bool,
+												must: [
+													{
+														terms: { "taxonomy.sections._id": [""] },
+													},
+													{
+														term: { "taxonomy.sections._website": "the-site" },
+													},
+												],
 											},
 										},
 									},
-								],
-							},
+								},
+							],
 						},
-					})
-				),
+					},
+				}),
 				sort: "display_date:desc",
 				size: "10",
 				website: "the-site",

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.test.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.test.js
@@ -1,118 +1,205 @@
-import storyFeedSections from "./story-feed-sections";
+import contentSource from "./story-feed-sections";
 
-describe("storyFeedSections.resolve function", () => {
-	const key = {
-		"arc-site": "test-site",
-		includeSections: "/my-sections-to-include,/another-section-to-include",
-		excludeSections: "/my-sections-to-exclude,/another-section-to-exclude",
-		feedSize: 5,
-		feedOffset: 0,
-	};
+jest.mock("fusion:environment", () => ({
+	CONTENT_BASE: "https://content.base",
+}));
 
-	const body = {
-		query: {
-			bool: {
-				must: [
-					{
-						term: {
-							"revision.published": "true",
-						},
-					},
-					{
-						nested: {
-							path: "taxonomy.sections",
-							query: {
-								bool: {
-									must: [
-										{
-											terms: {
-												"taxonomy.sections._id": [
-													"/my-sections-to-include",
-													"/another-section-to-include",
-												],
-											},
-										},
-										{
-											term: {
-												"taxonomy.sections._website": "test-site",
-											},
-										},
-									],
-								},
-							},
-						},
-					},
-				],
-				must_not: [
-					{
-						nested: {
-							path: "taxonomy.sections",
-							query: {
-								bool: {
-									must: [
-										{
-											terms: {
-												"taxonomy.sections._id": [
-													"/my-sections-to-exclude",
-													"/another-section-to-exclude",
-												],
-											},
-										},
-										{
-											term: {
-												"taxonomy.sections._website": "test-site",
-											},
-										},
-									],
-								},
-							},
-						},
-					},
-				],
+jest.mock("axios", () => ({
+	__esModule: true,
+	default: jest.fn((request) => {
+		const requestUrl = new URL(request.url);
+		const url = {
+			hostname: requestUrl.hostname,
+			pathname: requestUrl.pathname,
+			searchObject: Object.fromEntries(requestUrl.searchParams),
+		};
+		return Promise.resolve({
+			data: {
+				content_elements: [{ url }],
+				request: {
+					...request,
+					url,
+				},
 			},
+		});
+	}),
+}));
+
+const body = {
+	query: {
+		bool: {
+			must: [
+				{
+					term: {
+						"revision.published": "true",
+					},
+				},
+				{
+					nested: {
+						path: "taxonomy.sections",
+						query: {
+							bool: {
+								must: [
+									{
+										terms: {
+											"taxonomy.sections._id": ["3", "4"],
+										},
+									},
+									{
+										term: {
+											"taxonomy.sections._website": "the-site",
+										},
+									},
+								],
+							},
+						},
+					},
+				},
+			],
+			must_not: [
+				{
+					nested: {
+						path: "taxonomy.sections",
+						query: {
+							bool: {
+								must: [
+									{
+										terms: {
+											"taxonomy.sections._id": ["1", "2"],
+										},
+									},
+									{
+										term: {
+											"taxonomy.sections._website": "the-site",
+										},
+									},
+								],
+							},
+						},
+					},
+				},
+			],
 		},
-	};
+	},
+};
 
-	it("Checks that storyFeedSections.resolve returns the right pattern from the key", () => {
-		const { feedOffset, feedSize } = key;
-		const website = key["arc-site"];
-		const encodedBody = encodeURI(JSON.stringify(body));
-		const endpoint = `/content/v4/search/published?body=${encodedBody}&website=${website}&size=${feedSize}&from=${feedOffset}&sort=display_date:desc`;
-		expect(storyFeedSections.resolve(key)).toBe(endpoint);
+describe("story-feed-author-content-source-block", () => {
+	it("should use the proper param types", () => {
+		expect(contentSource.params).toEqual({
+			excludeSections: "text",
+			feedOffset: "number",
+			feedSize: "number",
+			includeSections: "text",
+		});
 	});
 
-	it("Checks that includeSections return correctly", () => {
-		const endcodedSectionsArray = ["/my-sections-to-include", "/another-section-to-include"];
-		expect(
-			storyFeedSections.resolve(key).includes(encodeURI(JSON.stringify(endcodedSectionsArray)))
-		).toBe(true);
-	});
+	it("should build the correct url", async () => {
+		const contentSourceFetch = await contentSource.fetch(
+			{
+				excludeSections: "1,2",
+				feedOffset: 4,
+				feedSize: 3,
+				includeSections: "3, 4",
+				"arc-site": "the-site",
+			},
+			{ cachedCall: () => {} }
+		);
 
-	it("uses the default feedSize and feedOffset", () => {
-		const options = {
-			"arc-site": "test-site",
-			includeSections: "/my-sections-to-include,/another-section-to-include",
-		};
-
-		expect(storyFeedSections.resolve(options)).toBe(
-			"/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22revision.published%22:%22true%22%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/my-sections-to-include%22,%22/another-section-to-include%22%5D%7D%7D,%7B%22term%22:%7B%22taxonomy.sections._website%22:%22test-site%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22%22%5D%7D%7D,%7B%22term%22:%7B%22taxonomy.sections._website%22:%22test-site%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=test-site&size=10&from=0&sort=display_date:desc"
+		expect(contentSourceFetch.request.url.hostname).toEqual("content.base");
+		expect(contentSourceFetch.request.url.pathname).toEqual("/content/v4/search/published");
+		expect(contentSourceFetch.request.url.searchObject).toEqual(
+			expect.objectContaining({
+				from: "4",
+				body: encodeURI(JSON.stringify(body)),
+				sort: "display_date:desc",
+				size: "3",
+				website: "the-site",
+			})
 		);
 	});
 
-	it("Allows excludeSection to be not passed", () => {
-		const options = {
-			"arc-site": "test-site",
-			includeSections: "/my-sections-to-include,/another-section-to-include",
-			feedSize: 5,
-			feedOffset: 0,
-		};
+	it("should default size to 10 and offset to 0", async () => {
+		const contentSourceFetch = await contentSource.fetch(
+			{
+				excludeSections: "1,2",
+				includeSections: "3, 4",
+				"arc-site": "the-site",
+			},
+			{ cachedCall: () => {} }
+		);
 
-		expect(storyFeedSections.resolve(options)).toBe(
-			"/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22revision.published%22:%22true%22%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/my-sections-to-include%22,%22/another-section-to-include%22%5D%7D%7D,%7B%22term%22:%7B%22taxonomy.sections._website%22:%22test-site%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22%22%5D%7D%7D,%7B%22term%22:%7B%22taxonomy.sections._website%22:%22test-site%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=test-site&size=5&from=0&sort=display_date:desc"
+		expect(contentSourceFetch.request.url.searchObject).toEqual(
+			expect.objectContaining({
+				from: "0",
+				body: encodeURI(JSON.stringify(body)),
+				sort: "display_date:desc",
+				size: "10",
+				website: "the-site",
+			})
 		);
 	});
 
-	it("Returns error if no params", () => {
-		expect(() => storyFeedSections.resolve()).toThrow("includeSections parameter is required");
+	it("should fail if includeSections is not passed in", async () => {
+		const contentSourceFetch = await contentSource
+			.fetch(
+				{
+					"arc-site": "the-site",
+				},
+				{ cachedCall: () => {} }
+			)
+			.catch((e) => expect(e).not.toBeNull());
+
+		expect(contentSourceFetch).not.toBeDefined();
+	});
+
+	it("should succeed if excludeSections is not passed in", async () => {
+		const contentSourceFetch = await contentSource.fetch(
+			{
+				includeSections: "3, 4",
+				"arc-site": "the-site",
+			},
+			{ cachedCall: () => {} }
+		);
+
+		expect(contentSourceFetch.request.url.searchObject).toEqual(
+			expect.objectContaining({
+				from: "0",
+				body: encodeURI(
+					JSON.stringify({
+						...body,
+						query: {
+							...body.query,
+							bool: {
+								...body.query.bool,
+								must_not: [
+									{
+										nested: {
+											...body.query.bool.must_not[0].nested,
+											query: {
+												...body.query.bool.must_not[0].nested.query,
+												bool: {
+													...body.query.bool.must_not[0].nested.query.bool,
+													must: [
+														{
+															terms: { "taxonomy.sections._id": [""] },
+														},
+														{
+															term: { "taxonomy.sections._website": "the-site" },
+														},
+													],
+												},
+											},
+										},
+									},
+								],
+							},
+						},
+					})
+				),
+				sort: "display_date:desc",
+				size: "10",
+				website: "the-site",
+			})
+		);
 	});
 });

--- a/blocks/story-feed-tag-content-source-block/index.js
+++ b/blocks/story-feed-tag-content-source-block/index.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -1,29 +1,27 @@
 {
-  "name": "@wpmedia/story-feed-tag-content-source-block",
-  "version": "5.15.0",
-  "description": "Content source block for story feed queries by tag",
-  "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/arc-themes-blocks",
-  "license": "CC-BY-NC-ND-4.0",
-  "main": "index.js",
-  "files": [
-    "sources"
-  ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
-    "directory": "blocks/story-feed-tag-content-source-block"
-  },
-  "scripts": {
-    "test": "echo \"Error: run tests from root\" && exit 1",
-    "lint": "eslint --ext js --ext jsx sources"
-  },
-  "peerDependencies": {
-    "@wpmedia/resizer-image-block": "*"
-  },
-  "gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
+	"name": "@wpmedia/story-feed-tag-content-source-block",
+	"version": "5.15.0",
+	"description": "Content source block for story feed queries by tag",
+	"author": "Arc XP - Themes",
+	"homepage": "https://github.com/WPMedia/arc-themes-blocks",
+	"license": "CC-BY-NC-ND-4.0",
+	"main": "index.js",
+	"files": [
+		"sources"
+	],
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com/",
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+		"directory": "blocks/story-feed-tag-content-source-block"
+	},
+	"peerDependencies": {
+		"@wpmedia/resizer-image-block": "*",
+		"@wpmedia/arc-themes-components": "*",
+		"@wpmedia/signing-service-content-source-block": "*"
+	},
+	"gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
 }

--- a/blocks/story-feed-tag-content-source-block/package.json
+++ b/blocks/story-feed-tag-content-source-block/package.json
@@ -5,7 +5,7 @@
 	"author": "Arc XP - Themes",
 	"homepage": "https://github.com/WPMedia/arc-themes-blocks",
 	"license": "CC-BY-NC-ND-4.0",
-	"main": "index.js",
+	"main": "",
 	"files": [
 		"sources"
 	],
@@ -19,7 +19,6 @@
 		"directory": "blocks/story-feed-tag-content-source-block"
 	},
 	"peerDependencies": {
-		"@wpmedia/resizer-image-block": "*",
 		"@wpmedia/arc-themes-components": "*",
 		"@wpmedia/signing-service-content-source-block": "*"
 	},


### PR DESCRIPTION
## Description

Convert the following content sources to use image resizer V2:
* story-feed-author-content-source-block
* story-feed-query-content-source-block
* story-feed-sections-content-source-block
* story-feed-tag-content-source-block

## Jira Ticket

- [TMEDIA-907](https://arcpublishing.atlassian.net/browse/TMEDIA-907)

## Acceptance Criteria

Convert the following content sources to use image resizer V2:
* story-feed-author-content-source-block
* story-feed-query-content-source-block
* story-feed-sections-content-source-block
* story-feed-tag-content-source-block

## Test Steps

1. Checkout this branch `git checkout tmedia-907`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/story-feed-author-content-source-block,@wpmedia/story-feed-query-content-source-block,@wpmedia/story-feed-sections-content-source-block,@wpmedia/story-feed-tag-content-source-block`
3. http://localhost/pagebuilder/tools/debugger?_website=themesinternal&type=content-debugger&source=story-feed-author&config={%22authorSlug%22:%22tariq-alshwaiki%22}
4. Inspect the data for `auth-tokens` (content-elements[0].content-elements[4])
5. http://localhost/pagebuilder/tools/debugger?_website=themesinternal&type=content-debugger&source=story-feed-sections&config={%22excludeSections%22:%22%22,%22includeSections%22:%22/demo%22}
6. http://localhost/pagebuilder/tools/debugger?_website=themesinternal&type=content-debugger&source=story-feed-tag&config={%22tagSlug%22:%22dogs%22}
7. http://localhost/pagebuilder/tools/debugger?_website=themesinternal&type=content-debugger&source=story-feed-query

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
