### PR TITLE
TMEDIA-938 - Extra large promo image updates

### DIFF
--- a/.storybook/mock-content/extraLargePromo.js
+++ b/.storybook/mock-content/extraLargePromo.js
@@ -35,19 +35,11 @@ export const extraLargePromo = {
 	},
 	promo_items: {
 		basic: {
-			resized_params: {
-				"400x225": "Ajb8uwIAZ0XSQ8IPqWGLLW7NifQ=filters:format(jpg):quality(70)/",
-				"400x267": "_iFZPwsbU19A0A9D1xRlPLhVx8A=filters:format(jpg):quality(70)/",
-				"400x300": "i-eI-H-xOkI6EyCk-Ph98hBjjRg=filters:format(jpg):quality(70)/",
-				"600x338": "cwoIRHNCzgkrRQCiW3SogwZS1AY=filters:format(jpg):quality(70)/",
-				"600x400": "WxcB_Wff18LDqZt1wd3JH8vPTZI=filters:format(jpg):quality(70)/",
-				"600x450": "LRgGYobwJDQZyfeEhtalyrn3Ad0=filters:format(jpg):quality(70)/",
-				"800x450": "vvQrhtG0ck1TcO519Mo2dZQCRTE=filters:format(jpg):quality(70)/",
-				"800x533": "LQ2EhhmbD5brfMTBNwl_PT8Tkdg=filters:format(jpg):quality(70)/",
-				"800x600": "AjVgpLNL9WYSLNei-Ks_kwDEa7Q=filters:format(jpg):quality(70)/",
+			auth: {
+				2: "75f6b4c64c7889dc8eadf6a328999d522be2e2397c7b9a5a0704f6d9afa60fcf",
 			},
 			type: "image",
-			url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/RYNL5SXYCVDH7LCJPXAHYF3DJI.JPG",
+			url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/EM5DTGYGABDJZODV7YVFOC2DOM.jpeg",
 		},
 	},
 	type: "story",

--- a/.storybook/mock-content/extraLargePromo.js
+++ b/.storybook/mock-content/extraLargePromo.js
@@ -35,6 +35,7 @@ export const extraLargePromo = {
 	},
 	promo_items: {
 		basic: {
+			_id: "EM5DTGYGABDJZODV7YVFOC2DOM",
 			auth: {
 				2: "75f6b4c64c7889dc8eadf6a328999d522be2e2397c7b9a5a0704f6d9afa60fcf",
 			},

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -184,7 +184,7 @@ const ExtraLargePromo = ({ customFields }) => {
 						? {
 								_id: imageOverrideId,
 								url: imageOverrideURL,
-								auth: imageOverrideAuth ? JSON.parse(imageOverrideAuth) : null,
+								auth: imageOverrideAuth ? JSON.parse(imageOverrideAuth) : {},
 						  }
 						: getImageFromANS(content),
 					alt: content?.headlines?.basic || "",

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { RESIZER_APP_VERSION } from "fusion:environment";
 import { useContent, useEditableContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
@@ -44,7 +45,9 @@ const ExtraLargePromo = ({ customFields }) => {
 	} = getProperties(arcSite);
 	const phrases = usePhrases();
 	const {
+		imageOverrideAuth,
 		imageOverrideURL,
+		imageOverrideId,
 		imageRatio,
 		itemContentConfig,
 		lazyLoad,
@@ -107,35 +110,21 @@ const ExtraLargePromo = ({ customFields }) => {
 						type
 						promo_items {
 							basic {
+								_id
 								type
 								url
-								resized_params {
-									800x600
-									800x533
-									800x450
-									600x450
-									600x400
-									600x338
-									400x300
-									400x267
-									400x225
+								auth {
+									${RESIZER_APP_VERSION}
 								}
 							}
 						}
 					}
 					basic {
+						_id
 						type
 						url
-						resized_params {
-							800x600
-							800x533
-							800x450
-							600x450
-							600x400
-							600x338
-							400x300
-							400x267
-							400x225
+						auth {
+							${RESIZER_APP_VERSION}
 						}
 					}
 				}
@@ -185,18 +174,27 @@ const ExtraLargePromo = ({ customFields }) => {
 	const contentUrl = content?.websites?.[arcSite]?.website_url;
 	const embedMarkup = playVideoInPlace && getVideoFromANS(content);
 	const hasAuthors = showByline && content?.credits?.by.length > 0;
-	const promoImageURL = imageOverrideURL || getImageFromANS(content)?.url;
-
-	const MediaImage = () =>
-		showImage ? (
-			<Conditional component={Link} condition={contentUrl} href={contentUrl}>
-				<Image
-					alt={content?.headlines?.basic}
-					src={promoImageURL || fallbackImage}
-					data-aspect-ratio={imageRatio?.replace(":", "/")}
-				/>
-			</Conditional>
-		) : null;
+	const imageParams =
+		imageOverrideURL || content
+			? {
+					ansImage: imageOverrideURL
+						? {
+								_id: imageOverrideId,
+								url: imageOverrideURL,
+								auth: JSON.parse(imageOverrideAuth),
+						  }
+						: getImageFromANS(content),
+					alt: content?.headlines?.basic || "",
+					aspectRatio: imageRatio,
+					resizedOptions: {
+						smart: true,
+					},
+					responsiveImages: [400, 600, 800, 1200],
+					width: 800,
+			  }
+			: {
+					src: fallbackImage,
+			  };
 
 	return showOverline ||
 		contentHeading ||
@@ -219,8 +217,26 @@ const ExtraLargePromo = ({ customFields }) => {
 							</HeadingSection>
 						) : null}
 						{embedMarkup || showImage ? (
-							<MediaItem {...searchableField("imageOverrideURL")} suppressContentEditableWarning>
-								{embedMarkup ? <Video embedMarkup={embedMarkup} /> : <MediaImage />}
+							<MediaItem
+								{...searchableField({
+									imageOverrideURL: "url",
+									imageOverrideId: "_id",
+									imageOverrideAuth: "auth",
+								})}
+								suppressContentEditableWarning
+							>
+								{embedMarkup ? (
+									<Video embedMarkup={embedMarkup} />
+								) : (
+									<Conditional
+										component={Link}
+										condition={contentUrl}
+										href={contentUrl}
+										assistiveHidden
+									>
+										<Image {...imageParams} />
+									</Conditional>
+								)}
 							</MediaItem>
 						) : null}
 						{contentDescription ? <Paragraph>{contentDescription}</Paragraph> : null}
@@ -282,10 +298,18 @@ ExtraLargePromo.propTypes = {
 			group: "Show promo elements",
 			label: "Show date",
 		}),
+		imageOverrideAuth: PropTypes.string.tag({
+			group: "Image",
+			hidden: true,
+		}),
 		imageOverrideURL: PropTypes.string.tag({
 			group: "Image",
 			label: "Image URL",
 			searchable: "image",
+		}),
+		imageOverrideId: PropTypes.string.tag({
+			group: "Image",
+			hidden: true,
 		}),
 		imageRatio: PropTypes.oneOf(["16:9", "3:2", "4:3"]).tag({
 			defaultValue: "4:3",

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -151,6 +151,7 @@ const ExtraLargePromo = ({ customFields }) => {
 	const formattedDate = Date.parse(displayDate)
 		? localizeDateTime(new Date(displayDate), dateTimeFormat, language, timeZone)
 		: "";
+	const hasDate = showDate && formattedDate;
 
 	const { display: labelDisplay, url: labelUrl, text: labelText } = content?.label?.basic || {};
 
@@ -169,6 +170,8 @@ const ExtraLargePromo = ({ customFields }) => {
 		[overlineText, overlineUrl] = [labelText, labelUrl];
 	}
 
+	const hasOverline = showOverline && overlineText;
+
 	const contentDescription = showDescription ? content?.description?.basic : null;
 	const contentHeading = showHeadline ? content?.headlines?.basic : null;
 	const contentUrl = content?.websites?.[arcSite]?.website_url;
@@ -181,7 +184,7 @@ const ExtraLargePromo = ({ customFields }) => {
 						? {
 								_id: imageOverrideId,
 								url: imageOverrideURL,
-								auth: JSON.parse(imageOverrideAuth),
+								auth: imageOverrideAuth ? JSON.parse(imageOverrideAuth) : null,
 						  }
 						: getImageFromANS(content),
 					alt: content?.headlines?.basic || "",
@@ -196,16 +199,16 @@ const ExtraLargePromo = ({ customFields }) => {
 					src: fallbackImage,
 			  };
 
-	return showOverline ||
+	return hasOverline ||
 		contentHeading ||
 		showImage ||
 		contentDescription ||
 		hasAuthors ||
-		showDate ? (
+		hasDate ? (
 		<LazyLoad enabled={shouldLazyLoad}>
 			<article className={BLOCK_CLASS_NAME}>
-				{showOverline ? <Overline href={overlineUrl}>{overlineText}</Overline> : null}
-				{contentHeading || showImage || contentDescription || hasAuthors || showDate ? (
+				{hasOverline ? <Overline href={overlineUrl}>{overlineText}</Overline> : null}
+				{contentHeading || showImage || contentDescription || hasAuthors || hasDate ? (
 					<Stack>
 						{contentHeading ? (
 							<HeadingSection>
@@ -240,7 +243,7 @@ const ExtraLargePromo = ({ customFields }) => {
 							</MediaItem>
 						) : null}
 						{contentDescription ? <Paragraph>{contentDescription}</Paragraph> : null}
-						{hasAuthors || showDate ? (
+						{hasAuthors || hasDate ? (
 							<Attribution>
 								<Join separator={Separator}>
 									{hasAuthors ? (
@@ -249,7 +252,7 @@ const ExtraLargePromo = ({ customFields }) => {
 											{formatAuthors(content?.credits?.by, phrases.t("global.and-text"))}
 										</Join>
 									) : null}
-									{showDate ? (
+									{hasDate ? (
 										<DateComponent dateTime={displayDate} dateString={formattedDate} />
 									) : null}
 								</Join>

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -67,7 +67,7 @@ describe("the extra large promo feature", () => {
 		expect(screen.queryByRole("img", { name: config.headline })).not.toBeNull();
 	});
 
-	it("should return a fallback image if showImage is trueand imageUrl is not valid", () => {
+	it("should return a fallback image if showImage is true and imageUrl is not valid", () => {
 		const config = {
 			imageRatio: "4:3",
 			showImage: true,

--- a/blocks/extra-large-promo-block/features/extra-large-promo/mock-data.js
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/mock-data.js
@@ -6,96 +6,80 @@ export default {
 		{
 			_id: "L6RMSXTS7RB5XFKZPPAZKXGRF4",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				"No, August isn’t the District’s hottest month, not quite. It’s actually July. But as the area is in the thick of yet another heat wave, August surely feels like it.",
 		},
 		{
 			_id: "BQ3NJWT6UBDCJNDONKJW7E3I2E",
 			type: "text",
-			additional_properties: [Object],
 			content: "Here’s why such feelings can be deceptive.",
 		},
 		{
 			_id: "QYR6VILSJBEJNI45LOBXYIUWNA",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				"The numbers plainly show that July’s heat reigns supreme. The table below displays 30-year “normal” or average temperatures for July and August at Washington’s Reagan National Airport (DCA) from 1981 to 2010 as well as the records from 1871 to the present.",
 		},
 		{
 			_id: "3J4YJHWBLVEXXEQW5O2724TTVY",
 			type: "table",
-			header: [Array],
-			additional_properties: [Object],
-			rows: [Array],
 		},
 		{
 			_id: "SQQV7L2A3BCCPHUVMFNUWLAJJY",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				"*The “mean maximum” and “mean minimum” are the averages over the period of the highest and lowest temperature recorded during the month.",
 		},
 		{
 			_id: "6FNU7LJLBVDGLMEGSWEZHAS2E4",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				"If July and August seem hotter than the above averages to you, you might be right: As the climate warms, the 30-year normal temperatures have steadily increased. But, in any case, you can see that July beats August in every temperature category except the record-high temperature, and in that category, the two months are coequal champions. July also edges August in humidity (based on average dew point).",
 		},
 		{
 			_id: "PHQ7QRFGAJBQPOOV42EV56YWIE",
 			type: "text",
-			additional_properties: [Object],
 			content: "So why does August <i>seem </i>hotter? I think it comes from weariness.",
 		},
 		{
 			_id: "RDWPXSNECRDQNOT5UFZYXMQVTI",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				'By the time August rolls around, we’ve just lived through July: hot, humid, July. By mid-August, most people are tired of the heat. Certainly the Capital Weather Gang’s <a href="https://www.washingtonpost.com/weather/2019/08/19/dc-area-forecast-several-days-sweltering-heat-before-we-find-relief/">narrative forecasts</a> this month have made clear that the CWG is getting tired of the heat!',
 		},
 		{
 			_id: "MCDFYGVX3NG65LUH6XOQLIHQSU",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				'In addition, most D.C.-area summers feature <a href="https://www.washingtonpost.com/weather/2019/08/06/strange-true-dc-area-could-really-use-some-rain/">browning lawns and other signs of plants experiencing stress</a>. Plant stress tends to increase as the summer progresses, and by August, many plants that haven’t been well watered are showing the strain. I think a similar effect can be seen in winter in many locations, where February seems like the coldest month, even though January averages colder.',
 		},
 		{
 			_id: "OMLLHJQ7ZNBJ7IC4AKYVHGYDSA",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				"But it is interesting to ask why August, which is so close to fall in the Northern Hemisphere, is even nearly as hot as July. Look out the window today. The sun is not as high at noon as it was at the beginning of July, or even three weeks ago; your shadow never gets as short now as it did then. The sun in D.C. now sets before 8 p.m., instead of 8.37 pm in early July.",
 		},
 		{
 			_id: "RWKSCBHFP5FUXPTVOTFNFFRXKM",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				"Sunrise has got later, as well, and we’ve lost a full hour of daylight. That means there’s less time for the sun to heat us up, and it’s less effective than before because of the lower sun angle; and there’s more time for nighttime cooling. Yet average temperatures in Washington don’t really start to dip until the last 10 days of August. Why?",
 		},
 		{
 			_id: "ACZ7AO2DQRHNFHJC5BM7EBL5XI",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				"The main reason is that the ocean (and, to some extent, the ground) continues to warm at least until the end of August, which counteracts the decreased daytime heating and increased opportunity for nighttime cooling. There are some places in the country where June is neck and neck with July for the hottest month, which is what you’d predict from the sun’s angle and day length alone.",
 		},
 		{
 			_id: "36V64M5IOBHO3HDGG4GVUXNOGA",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				"In Tucson, the average high temperature in June is 100.3, while in July it’s “only” 99.7. The highest temperature ever recorded in Tucson was 117 in June; in July, the highest was “only” 114. The reason for all of this is the summer monsoon. Tucson averages 0.20 inches of rain in June and 2.25 inches in July. The rain reduces sunshine and provides a break from the heat, and the water that falls has to be turned into steam for it to get excessively hot, which takes energy. August is slightly wetter and cooler than July.",
 		},
 		{
 			_id: "BSBXLQICK5EWHFM6G2QVE64ZZI",
 			type: "text",
-			additional_properties: [Object],
 			content:
 				"So for the short term, take heart. The worst of D.C.’s summer heat is almost behind us. By mid-September, heat waves are fairly unlikely. For the medium and longer term, I am not so sanguine. The combination of global warming caused by human activities and local warming caused by the increasing footprint of the urban heat island promise ever hotter and longer summers in the area over the coming years. Brace yourselves.",
 		},
@@ -103,7 +87,6 @@ export default {
 			_id: "PJYLLGASWBCBHN3KFINPDURGGM",
 			type: "correction",
 			correction_type: "correction",
-			additional_properties: [Object],
 			text: "Update: We initially compared average relative humidity between July and August, for which August had a slightly higher value. But, at the recommendation of readers, we compared average dew point, which is an absolute measurement of humidity, and found July’s had a higher average. This article has been updated using the dew point information.",
 		},
 	],
@@ -148,9 +131,7 @@ export default {
 		source_type: "staff",
 	},
 	taxonomy: {
-		tags: [[Object]],
 		sites: [],
-		sections: [[Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object]],
 		primary_site: {
 			_id: "/news",
 			type: "site",
@@ -159,7 +140,6 @@ export default {
 			description: null,
 			path: "/news",
 			parent_id: "/",
-			additional_properties: [Object],
 		},
 		primary_section: {
 			_id: "/news",
@@ -170,8 +150,6 @@ export default {
 			description: null,
 			path: "/news",
 			parent_id: "/",
-			parent: [Object],
-			additional_properties: [Object],
 		},
 	},
 	related_content: {
@@ -181,25 +159,21 @@ export default {
 	promo_items: {
 		basic: {
 			_id: "DBUX66M3LRFMHKXZOM46RO4EXM",
-			additional_properties: [Object],
+			auth: {
+				2: "ABC",
+			},
 			address: {},
 			caption: "The sun beats down on Four Mile Run in Arlington, Va., on Aug. 17.",
 			created_date: "2020-01-30T23:47:39Z",
-			credits: [Object],
 			height: 782,
 			image_type: "photograph",
 			last_updated_date: "2020-01-30T23:47:39Z",
 			licensable: false,
-			owner: [Object],
-			source: [Object],
-			status: "",
-			taxonomy: [Object],
 			type: "image",
 			url: "https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/DBUX66M3LRFMHKXZOM46RO4EXM.png",
 			resized_params: {},
 			version: "0.10.3",
 			width: 1179,
-			syndication: [Object],
 		},
 	},
 	distributor: {
@@ -237,7 +211,6 @@ export default {
 	first_publish_date: "2020-01-30T23:47:48.013Z",
 	websites: {
 		dagen: {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-sun": {
@@ -248,27 +221,21 @@ export default {
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		washpost: {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-globe": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-planet": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-gazette": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-mercury": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-prophet": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -16669,9 +16669,9 @@
       "version": "file:blocks/alert-bar-content-source-block"
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-3.6",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.6/6386b311f6347163cef95e98977d15fffb365792",
-      "integrity": "sha512-UD0FgFCOMjjoVnTO7/HQh2Kmdf+/LRUPO3chTZejTkyHbRxNT9mIDxVz7Vyrt7rkOIeF5/DstRgM0lZ5VL1NgQ==",
+      "version": "0.0.4-arc-themes-release-version-2-0-3.7",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.7/d2be56422a7ba7155eab900b13c7fb625f0cb296",
+      "integrity": "sha512-TpGEF+yMQJdDEThVwTGo//NVVp9JxySfLUF4hRfvFJiveNx87hdk9FlqXxRpLvvnSpHG0RmBcrKJx/tRP26nWg==",
       "dev": true,
       "requires": {
         "react-oembed-container": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.7",
-    "@wpmedia/arc-themes-components": "arc-themes-release-version-2.0.3",
+    "@wpmedia/arc-themes-components": "0.0.4-arc-themes-release-version-2-0-3.7",
     "@wpmedia/engine-theme-sdk": "canary",
     "@wpmedia/news-theme-css": "stable",
     "algoliasearch": "^4.13.0",


### PR DESCRIPTION
## Description

Update Extra Large Promo to use image resizer - depends on Components PR (https://github.com/WPMedia/arc-themes-components/pull/149)

## Jira Ticket

- [TMEDIA-938](https://arcpublishing.atlassian.net/browse/TMEDIA-938)


## Test Steps

If components PR is not merged - you'll need to link Arc Themes Components via Feature Pack

1. Checkout this branch `git checkout TMEDIA-938-extra-large-promo-image-updates`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/extra-large-promo-block`
3. Add the extra large promo block to a page and configure the content source `_id` - `PKFVHJKBBVHZRIHJEMQGGREWIE`
4. Verify the Image is now using resizer v2 to display image
5. Test the integrated photo search to verify images selected from the integrated photo search also using resizer v2


## Dependencies or Side Effects

Components PR (https://github.com/WPMedia/arc-themes-components/pull/149)


## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
