### PR TITLE
TBRANDS-129 - Feedback

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -841,6 +841,9 @@
 					right: var(--global-spacing-5),
 					top: var(--global-spacing-5),
 					components: (
+						button-medium: (
+							padding: var(--global-spacing-4),
+						),
 						icon: (
 							fill: currentColor,
 						),

--- a/blocks/product-gallery-block/features/product-gallery/_children/ThumbnailBar/index.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/_children/ThumbnailBar/index.jsx
@@ -97,10 +97,9 @@ const ThumbnailBar = ({ images, selectedIndex, onImageSelect }) => {
 					<Button
 						accessibilityLabel={phrases.t("product-gallery.focus-thumbnail-previous")}
 						onClick={() => {
-							const inViewItems = viewableItems;
-							const firstItem = inViewItems.pop();
-							inViewItems.unshift(firstItem - 1);
-
+							const inViewItems = [...viewableItems];
+							inViewItems.pop();
+							inViewItems.unshift(inViewItems[0] - 1);
 							setViewableItems([...inViewItems]);
 						}}
 						ref={upButtonRef}


### PR DESCRIPTION
## Description

* Fix padding on close button
* Fix bug on previous button logic where the calculation was happening on the removed item vs the first item of the new array 

## Jira Ticket

- [TBRANDS-129](https://arcpublishing.atlassian.net/browse/TBRANDS-129)

## Test Steps

Feature Pack - https://github.com/WPMedia/arc-themes-feature-pack/pull/361

1. Checkout this branch `git checkout TBRANDS-129-feedback`
2. Checkout the feature pack branch `TBRANDS-129-feedback`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/product-gallery-block`
4. Either using an existing page with the product gallery block / or creating a new page with the product gallery block
     * Verify spacing on close button
     * Verify the previous button (up arrow) works as expected


## Dependencies or Side Effects

Feature Pack PR - https://github.com/WPMedia/arc-themes-feature-pack/pull/361

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
