### PR TITLE
TMEDIA-967 - Move top level alias map to $tokens.default

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -159,82 +159,82 @@
 		"border-style-1": solid,
 		"border-width-1": 1px,
 	),
-	$alias: (
-		// Font families
-		"font-family-primary": "Inter",
-		"font-family-secondary": "Lora",
-
-		// Colors
-		"color-primary": var(--global-black),
-		"text-color": var(--global-neutral-8),
-		"text-color-subtle": var(--global-neutral-5),
-		"background-color": var(--global-white),
-		"icon-fill-color": var(--global-neutral-8),
-		"icon-fill-color-subtle": var(--global-neutral-5),
-		"border-color": var(--global-neutral-4),
-		"form-background-color": var(--global-white),
-		"form-border-color": var(--global-neutral-5),
-		"form-border-color-primary": var(--global-blue-5),
-		"status-color-success": var(--global-green-5),
-		"status-color-success-subtle": var(--global-green-1),
-		"status-color-warning": var(--global-orange-5),
-		"status-color-warning-subtle": var(--global-orange-1),
-		"status-color-danger": var(--global-red-5),
-		"status-color-danger-subtle": var(--global-red-1),
-		"status-color-info": var(--global-blue-5),
-		"status-color-info-subtle": var(--global-blue-1),
-		// Border Radius
-		"border-radius": var(--global-border-radius-1),
-		"border-radius-pill": var(--global-border-radius-2),
-		"border-radius-circle": var(--global-border-radius-3),
-		// Typography
-		// headings
-		// heading-level-1 : 36px fs -> 43.2px lh
-		"heading-level-1-font-size": var(--global-font-size-12),
-		"heading-level-1-line-height": var(--global-line-height-3),
-		"heading-level-1-font-weight": var(--global-font-weight-7),
-		// heading-level-2 : 32px fs -> 41.6px lh
-		"heading-level-2-font-size": var(--global-font-size-11),
-		"heading-level-2-line-height": var(--global-line-height-4),
-		"heading-level-2-font-weight": var(--global-font-weight-7),
-		// heading-level-3 : 28px fs -> 36.4px lh
-		"heading-level-3-font-size": var(--global-font-size-10),
-		"heading-level-3-line-height": var(--global-line-height-4),
-		"heading-level-3-font-weight": var(--global-font-weight-7),
-		// heading-level-4 : 24px fs -> 33.6px lh
-		"heading-level-4-font-size": var(--global-font-size-9),
-		"heading-level-4-line-height": var(--global-line-height-5),
-		"heading-level-4-font-weight": var(--global-font-weight-7),
-		// heading-level-5 : 20px fs -> 28px lh
-		"heading-level-5-font-size": var(--global-font-size-7),
-		"heading-level-5-line-height": var(--global-line-height-5),
-		"heading-level-5-font-weight": var(--global-font-weight-7),
-		// heading-level-6 : 18px fs -> 25.2px lh
-		"heading-level-6-font-size": var(--global-font-size-5),
-		"heading-level-6-line-height": var(--global-line-height-5),
-		"heading-level-6-font-weight": var(--global-font-weight-7),
-		// body : 16px fs -> 24px lh
-		"body-font-weight": var(--global-font-weight-4),
-		"body-font-size": var(--global-font-size-4),
-		"body-line-height": var(--global-line-height-6),
-		// body-small : 14px fs -> 21px lh
-		"body-font-weight-small": var(--global-font-weight-4),
-		"body-font-size-small": var(--global-font-size-3),
-		"body-line-height-small": var(--global-line-height-6),
-		// body-tiny : 12px fs -> 18px lh
-		"body-font-weight-tiny": var(--global-font-weight-4),
-		"body-font-size-tiny": var(--global-font-size-2),
-		"body-line-height-tiny": var(--global-line-height-6),
-		// Layout
-		"layout-max-width": 1440,
-		"content-max-width": 1216,
-		//
-		// --content-scale-width identifies the inner document width for header and content
-		//
-		"content-scale-width": calc(var(--content-max-width) / var(--layout-max-width) * 100%),
-	),
 	$tokens: (
 		default: (
+			alias: (
+				// Font families
+				"font-family-primary": "Inter",
+				"font-family-secondary": "Lora",
+
+				// Colors
+				"color-primary": var(--global-black),
+				"text-color": var(--global-neutral-8),
+				"text-color-subtle": var(--global-neutral-5),
+				"background-color": var(--global-white),
+				"icon-fill-color": var(--global-neutral-8),
+				"icon-fill-color-subtle": var(--global-neutral-5),
+				"border-color": var(--global-neutral-4),
+				"form-background-color": var(--global-white),
+				"form-border-color": var(--global-neutral-5),
+				"form-border-color-primary": var(--global-blue-5),
+				"status-color-success": var(--global-green-5),
+				"status-color-success-subtle": var(--global-green-1),
+				"status-color-warning": var(--global-orange-5),
+				"status-color-warning-subtle": var(--global-orange-1),
+				"status-color-danger": var(--global-red-5),
+				"status-color-danger-subtle": var(--global-red-1),
+				"status-color-info": var(--global-blue-5),
+				"status-color-info-subtle": var(--global-blue-1),
+				// Border Radius
+				"border-radius": var(--global-border-radius-1),
+				"border-radius-pill": var(--global-border-radius-2),
+				"border-radius-circle": var(--global-border-radius-3),
+				// Typography
+				// headings
+				// heading-level-1 : 36px fs -> 43.2px lh
+				"heading-level-1-font-size": var(--global-font-size-12),
+				"heading-level-1-line-height": var(--global-line-height-3),
+				"heading-level-1-font-weight": var(--global-font-weight-7),
+				// heading-level-2 : 32px fs -> 41.6px lh
+				"heading-level-2-font-size": var(--global-font-size-11),
+				"heading-level-2-line-height": var(--global-line-height-4),
+				"heading-level-2-font-weight": var(--global-font-weight-7),
+				// heading-level-3 : 28px fs -> 36.4px lh
+				"heading-level-3-font-size": var(--global-font-size-10),
+				"heading-level-3-line-height": var(--global-line-height-4),
+				"heading-level-3-font-weight": var(--global-font-weight-7),
+				// heading-level-4 : 24px fs -> 33.6px lh
+				"heading-level-4-font-size": var(--global-font-size-9),
+				"heading-level-4-line-height": var(--global-line-height-5),
+				"heading-level-4-font-weight": var(--global-font-weight-7),
+				// heading-level-5 : 20px fs -> 28px lh
+				"heading-level-5-font-size": var(--global-font-size-7),
+				"heading-level-5-line-height": var(--global-line-height-5),
+				"heading-level-5-font-weight": var(--global-font-weight-7),
+				// heading-level-6 : 18px fs -> 25.2px lh
+				"heading-level-6-font-size": var(--global-font-size-5),
+				"heading-level-6-line-height": var(--global-line-height-5),
+				"heading-level-6-font-weight": var(--global-font-weight-7),
+				// body : 16px fs -> 24px lh
+				"body-font-weight": var(--global-font-weight-4),
+				"body-font-size": var(--global-font-size-4),
+				"body-line-height": var(--global-line-height-6),
+				// body-small : 14px fs -> 21px lh
+				"body-font-weight-small": var(--global-font-weight-4),
+				"body-font-size-small": var(--global-font-size-3),
+				"body-line-height-small": var(--global-line-height-6),
+				// body-tiny : 12px fs -> 18px lh
+				"body-font-weight-tiny": var(--global-font-weight-4),
+				"body-font-size-tiny": var(--global-font-size-2),
+				"body-line-height-tiny": var(--global-line-height-6),
+				// Layout
+				"layout-max-width": 1440,
+				"content-max-width": 1216,
+				//
+				// --content-scale-width identifies the inner document width for header and content
+				//
+				"content-scale-width": calc(var(--content-max-width) / var(--layout-max-width) * 100%),
+			),
 			components: (
 				attribution: (
 					color: var(--text-color),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -158,85 +158,85 @@
 		"border-style-1": solid,
 		"border-width-1": 1px,
 	),
-	$alias: (
-		// Font families
-		"font-family-primary": "Abel",
-		"font-family-secondary": "Georgia",
-		// Colors
-		"color-primary": var(--global-black),
-		"color-primary-hover": var(--global-neutral-7),
-		"text-color": var(--global-neutral-8),
-		"text-color-subtle": var(--global-neutral-5),
-		"background-color": var(--global-white),
-		"icon-fill-color": var(--global-neutral-8),
-		"icon-fill-color-subtle": var(--global-neutral-4),
-		"border-color": var(--global-neutral-4),
-		"form-background-color": var(--global-white),
-		"form-border-color": var(--global-neutral-5),
-		"form-border-color-primary": var(--global-blue-5),
-		"status-color-success": var(--global-green-5),
-		"status-color-success-subtle": var(--global-green-1),
-		"status-color-warning": var(--global-orange-5),
-		"status-color-warning-subtle": var(--global-orange-1),
-		"status-color-danger": var(--global-red-5),
-		"status-color-danger-subtle": var(--global-red-1),
-		"status-color-info": var(--global-blue-5),
-		"status-color-info-subtle": var(--global-blue-1),
-		// Border Radius
-		"border-radius": var(--global-border-radius-1),
-		"border-radius-pill": var(--global-border-radius-2),
-		"border-radius-circle": var(--global-border-radius-3),
-		// Typography
-		// headings
-		// heading-level-1 : 36px fs -> 43.2px lh
-		"heading-level-1-font-size": var(--global-font-size-12),
-		"heading-level-1-line-height": var(--global-line-height-3),
-		"heading-level-1-font-weight": var(--global-font-weight-7),
-		// heading-level-2 : 32px fs -> 41.6px lh
-		"heading-level-2-font-size": var(--global-font-size-11),
-		"heading-level-2-line-height": var(--global-line-height-4),
-		"heading-level-2-font-weight": var(--global-font-weight-7),
-		// heading-level-3 : 28px fs -> 36.4px lh
-		"heading-level-3-font-size": var(--global-font-size-10),
-		"heading-level-3-line-height": var(--global-line-height-4),
-		"heading-level-3-font-weight": var(--global-font-weight-7),
-		// heading-level-4 : 24px fs -> 33.6px lh
-		"heading-level-4-font-size": var(--global-font-size-9),
-		"heading-level-4-line-height": var(--global-line-height-5),
-		"heading-level-4-font-weight": var(--global-font-weight-7),
-		// heading-level-5 : 20px fs -> 28px lh
-		"heading-level-5-font-size": var(--global-font-size-7),
-		"heading-level-5-line-height": var(--global-line-height-5),
-		"heading-level-5-font-weight": var(--global-font-weight-7),
-		// heading-level-6 : 18px fs -> 25.2px lh
-		"heading-level-6-font-size": var(--global-font-size-5),
-		"heading-level-6-line-height": var(--global-line-height-5),
-		"heading-level-6-font-weight": var(--global-font-weight-7),
-		// body : 16px fs -> 24px lh
-		"body-font-weight": var(--global-font-weight-4),
-		"body-font-size": var(--global-font-size-4),
-		"body-line-height": var(--global-line-height-6),
-		// body-small : 14px fs -> 21px lh
-		"body-font-weight-small": var(--global-font-weight-4),
-		"body-font-size-small": var(--global-font-size-3),
-		"body-line-height-small": var(--global-line-height-6),
-		// body-tiny : 12px fs -> 18px lh
-		"body-font-weight-tiny": var(--global-font-weight-4),
-		"body-font-size-tiny": var(--global-font-size-2),
-		"body-line-height-tiny": var(--global-line-height-6),
-		// Layout
-		"layout-max-width": 1600,
-		"content-max-width": 1440,
-		//
-		// --content-scale-width identifies the inner document width for header and content
-		//
-		"content-scale-width": calc(var(--content-max-width) / var(--layout-max-width) * 100%),
-		"header-nav-chain-height": 56px,
-		"header-nav-chain-height-scrolled": 56px,
-		"header-nav-chain-overlay-background-color": rgba(25, 25, 25, 0.5),
-	),
 	$tokens: (
 		default: (
+			alias: (
+				// Font families
+				"font-family-primary": "Abel",
+				"font-family-secondary": "Georgia",
+				// Colors
+				"color-primary": var(--global-black),
+				"color-primary-hover": var(--global-neutral-7),
+				"text-color": var(--global-neutral-8),
+				"text-color-subtle": var(--global-neutral-5),
+				"background-color": var(--global-white),
+				"icon-fill-color": var(--global-neutral-8),
+				"icon-fill-color-subtle": var(--global-neutral-4),
+				"border-color": var(--global-neutral-4),
+				"form-background-color": var(--global-white),
+				"form-border-color": var(--global-neutral-5),
+				"form-border-color-primary": var(--global-blue-5),
+				"status-color-success": var(--global-green-5),
+				"status-color-success-subtle": var(--global-green-1),
+				"status-color-warning": var(--global-orange-5),
+				"status-color-warning-subtle": var(--global-orange-1),
+				"status-color-danger": var(--global-red-5),
+				"status-color-danger-subtle": var(--global-red-1),
+				"status-color-info": var(--global-blue-5),
+				"status-color-info-subtle": var(--global-blue-1),
+				// Border Radius
+				"border-radius": var(--global-border-radius-1),
+				"border-radius-pill": var(--global-border-radius-2),
+				"border-radius-circle": var(--global-border-radius-3),
+				// Typography
+				// headings
+				// heading-level-1 : 36px fs -> 43.2px lh
+				"heading-level-1-font-size": var(--global-font-size-12),
+				"heading-level-1-line-height": var(--global-line-height-3),
+				"heading-level-1-font-weight": var(--global-font-weight-7),
+				// heading-level-2 : 32px fs -> 41.6px lh
+				"heading-level-2-font-size": var(--global-font-size-11),
+				"heading-level-2-line-height": var(--global-line-height-4),
+				"heading-level-2-font-weight": var(--global-font-weight-7),
+				// heading-level-3 : 28px fs -> 36.4px lh
+				"heading-level-3-font-size": var(--global-font-size-10),
+				"heading-level-3-line-height": var(--global-line-height-4),
+				"heading-level-3-font-weight": var(--global-font-weight-7),
+				// heading-level-4 : 24px fs -> 33.6px lh
+				"heading-level-4-font-size": var(--global-font-size-9),
+				"heading-level-4-line-height": var(--global-line-height-5),
+				"heading-level-4-font-weight": var(--global-font-weight-7),
+				// heading-level-5 : 20px fs -> 28px lh
+				"heading-level-5-font-size": var(--global-font-size-7),
+				"heading-level-5-line-height": var(--global-line-height-5),
+				"heading-level-5-font-weight": var(--global-font-weight-7),
+				// heading-level-6 : 18px fs -> 25.2px lh
+				"heading-level-6-font-size": var(--global-font-size-5),
+				"heading-level-6-line-height": var(--global-line-height-5),
+				"heading-level-6-font-weight": var(--global-font-weight-7),
+				// body : 16px fs -> 24px lh
+				"body-font-weight": var(--global-font-weight-4),
+				"body-font-size": var(--global-font-size-4),
+				"body-line-height": var(--global-line-height-6),
+				// body-small : 14px fs -> 21px lh
+				"body-font-weight-small": var(--global-font-weight-4),
+				"body-font-size-small": var(--global-font-size-3),
+				"body-line-height-small": var(--global-line-height-6),
+				// body-tiny : 12px fs -> 18px lh
+				"body-font-weight-tiny": var(--global-font-weight-4),
+				"body-font-size-tiny": var(--global-font-size-2),
+				"body-line-height-tiny": var(--global-line-height-6),
+				// Layout
+				"layout-max-width": 1600,
+				"content-max-width": 1440,
+				//
+				// --content-scale-width identifies the inner document width for header and content
+				//
+				"content-scale-width": calc(var(--content-max-width) / var(--layout-max-width) * 100%),
+				"header-nav-chain-height": 56px,
+				"header-nav-chain-height-scrolled": 56px,
+				"header-nav-chain-overlay-background-color": rgba(25, 25, 25, 0.5),
+			),
 			components: (
 				attribution: (
 					color: var(--text-color),


### PR DESCRIPTION
## Description

Move the alias tokens from a top level Sass map into `$tokens.default` to allow for upcoming work on moving styling definitions to JSON files 

## Jira Ticket

- [TMEDIA-967](https://arcpublishing.atlassian.net/browse/TMEDIA-967)

## Test Steps

Chromatic should be enough to validate no regressions

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
