### PR TITLE
Update small promo to use resizer v2

### DIFF
--- a/.storybook/mock-content/smallPromo.js
+++ b/.storybook/mock-content/smallPromo.js
@@ -11,20 +11,12 @@ export const smallPromoMock = {
 	},
 	promo_items: {
 		basic: {
-			resized_params: {
-				"600x400":
-					"IYlSHyCyebwHaotJBuhSSiykktg=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/",
-				"600x450":
-					"pmSxIhr_2yF6wtOJyOkbEaphdok=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/",
-				"800x450":
-					"VD7LAiaSV3kPnNUuP36bbTT2S0Y=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/",
-				"800x533":
-					"4dhmPhU2HvAd69Kkkj0rcfE41mw=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/",
-				"800x600":
-					"6fqhqLAchOq1gB_xNn2lGb-WHmk=filters:format(jpg):quality(70):focal(4335x1885:4345x1895)/",
+			_id: "CDWC6JPN35FPPOHYR4DOTSZCTU",
+			auth: {
+				2: "d2370512e4a061f3744ebecb30cffebcbf99767061400b5418f61b85f28f743d",
 			},
 			type: "image",
-			url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG",
+			url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/CDWC6JPN35FPPOHYR4DOTSZCTU.jpeg",
 		},
 	},
 	type: "story",

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -48,7 +48,7 @@ const SmallPromo = ({ customFields }) => {
 			// does not need embed_html because no video section
 			// does not need website section nor label because no overline
 			// does not need byline because no byline shown
-			filters: `{
+			filter: `{
 		_id
 		description {
 			basic

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -1,141 +1,112 @@
 import React from "react";
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { useContent } from "fusion:content";
 import { isServerSide } from "@wpmedia/arc-themes-components";
+
 import SmallPromo from "./default";
 
-const { default: mockData } = require("./mock-data");
-
-jest.mock("@wpmedia/arc-themes-components", () => {
-	const original = jest.requireActual("@wpmedia/arc-themes-components");
-	return {
-		...original,
-		isServerSide: jest.fn(),
-	};
-});
+import mockData from "./mock-data";
 
 jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	Image: () => <div />,
+	...jest.requireActual("@wpmedia/engine-theme-sdk"),
 	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
-jest.mock("fusion:themes", () => jest.fn(() => ({})));
-jest.mock("fusion:properties", () =>
-	jest.fn(() => ({
-		fallbackImage: "placeholder.jpg",
-	}))
-);
-jest.mock("fusion:context", () => ({
-	useFusionContext: jest.fn(() => ({})),
+jest.mock("@wpmedia/arc-themes-components", () => ({
+	...jest.requireActual("@wpmedia/arc-themes-components"),
+	isServerSide: jest.fn(() => true),
 }));
+
 jest.mock("fusion:content", () => ({
 	useContent: jest.fn(() => mockData),
 	useEditableContent: jest.fn(() => ({
 		editableContent: () => ({ contentEditable: "true" }),
 		searchableField: () => {},
 	})),
-}));
-
-const config = {
-	itemContentConfig: { contentService: "ans-item", contentConfiguration: {} },
-	showHeadline: true,
-	showImage: true,
-};
-
-jest.mock("fusion:context", () => ({
 	useFusionContext: jest.fn(() => ({
-		arcSite: "the-sun",
-		id: "testId",
-	})),
-	useComponentContext: jest.fn(() => ({
-		registerSuccessEvent: () => ({}),
+		isAdmin: false,
 	})),
 }));
 
-describe("the small promo feature", () => {
+jest.mock("fusion:properties", () =>
+	jest.fn(() => ({
+		fallbackImage: "placeholder.jpg",
+	}))
+);
+
+describe("Small Promo", () => {
 	afterEach(() => {
 		jest.resetModules();
 		jest.clearAllMocks();
 	});
 
-	it("should have article container class with component class", () => {
-		const wrapper = mount(<SmallPromo customFields={config} />);
-		expect(wrapper.find("article.b-small-promo")).toHaveLength(1);
-	});
-
-	it("should have two link elements by default", () => {
-		const wrapper = mount(<SmallPromo customFields={config} />);
-		expect(wrapper.find("a")).toHaveLength(2);
-	});
-
-	it("should link the headline to the current site website_url ANS property", () => {
-		const url = mockData.websites["the-sun"].website_url;
-		const wrapper = mount(<SmallPromo customFields={config} />);
-		expect(wrapper.find("a.c-link").first()).toHaveProp("href", url);
-	});
-
-	it("should link the image to the current site website_url ANS property", () => {
-		const url = mockData.websites["the-sun"].website_url;
-		const wrapper = mount(<SmallPromo customFields={config} />);
-		expect(wrapper.find("a").at(1)).toHaveProp("href", url);
-	});
-
-	it("should have one img when show image is true", () => {
-		const wrapper = mount(<SmallPromo customFields={config} />);
-		expect(wrapper.find("Image")).toHaveLength(1);
-	});
-
-	it("should have no Image when show image is false", () => {
-		const noImgConfig = {
-			itemContentConfig: {
-				contentService: "ans-item",
-				contentConfiguration: {},
-			},
-			showHeadline: true,
-			showImage: false,
-		};
-		const wrapper = mount(<SmallPromo customFields={noImgConfig} />);
-		expect(wrapper.find("Image")).toHaveLength(0);
-	});
-
-	it("should only be one link when showHeadline is false and show image is true", () => {
-		const noHeadlineConfig = {
-			itemContentConfig: {
-				contentService: "ans-item",
-				contentConfiguration: {},
-			},
-			showHeadline: false,
-			showImage: true,
-		};
-		const wrapper = mount(<SmallPromo customFields={noHeadlineConfig} />);
-		expect(wrapper.find("a")).toHaveLength(1);
-	});
-
-	it("returns null if null content", () => {
-		const myConfig = {
-			showHeadline: true,
-			showImage: true,
-			imageRatio: "4:3",
-			imageOverrideURL: "overrideImage.jpg",
-		};
-
-		useContent.mockReturnValueOnce(undefined);
-		const wrapper = mount(<SmallPromo customFields={myConfig} />);
-		expect(wrapper).toEqual({});
-		wrapper.unmount();
-	});
-});
-
-describe("the small promo feature on server side", () => {
-	isServerSide.mockImplementation(() => ({ mockedValue: true }));
-
-	it("renders nothing server side with lazyLoad enabled", () => {
-		const updatedConfig = {
-			...config,
+	it("should return null if lazyLoad on the server and not in the admin", () => {
+		const config = {
 			lazyLoad: true,
 		};
+		const { container } = render(<SmallPromo customFields={config} />);
+		expect(container.firstChild).toBe(null);
+	});
 
-		const wrapper = mount(<SmallPromo customFields={updatedConfig} />);
-		expect(wrapper.html()).toBe(null);
+	it("should return null if none of the show... flags are true", () => {
+		const config = {};
+		const { container } = render(<SmallPromo customFields={config} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("should return null on server-side render from PageBuilder Editor when lazyload is true", () => {
+		const config = {
+			itemContentConfig: { contentService: "ans-item", contentConfigValues: { test: 123 } },
+			showHeadline: true,
+		};
+		isServerSide.mockImplementationOnce(() => true);
+		const { container } = render(<SmallPromo customFields={{ ...config, lazyLoad: true }} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("should display a headline if showHeadline is true", () => {
+		const config = {
+			itemContentConfig: { contentService: "ans-item", contentConfigValues: { test: 123 } },
+			showHeadline: true,
+		};
+		render(<SmallPromo customFields={config} />);
+
+		expect(screen.queryByRole("heading", { name: config.headline })).not.toBeNull();
+	});
+
+	it("should display an image if showImage is true", () => {
+		const config = {
+			itemContentConfig: { contentService: "ans-item", contentConfigValues: { test: 123 } },
+			imageOverrideURL: "#",
+			imageRatio: "4:3",
+			showImage: true,
+			showHeadline: true,
+			imagePosition: "below",
+		};
+		render(<SmallPromo customFields={config} />);
+		expect(screen.queryByRole("img", { name: config.headline })).not.toBeNull();
+	});
+
+	it("should display a fallback image if showImage and no content", () => {
+		const config = {
+			itemContentConfig: { contentService: "ans-item", contentConfigValues: { test: 123 } },
+			imageRatio: "4:3",
+			showImage: true,
+		};
+		useContent.mockReturnValueOnce(null);
+		render(<SmallPromo customFields={config} />);
+		expect(screen.queryByRole("img", { name: config.headline })).not.toBeNull();
+	});
+
+	it("should display imageOverride", () => {
+		const config = {
+			itemContentConfig: { contentService: "ans-item", contentConfigValues: { test: 123 } },
+			imageRatio: "4:3",
+			showImage: true,
+			imageOverrideURL: "override.jpg",
+			imageOverrideAuth: "{}",
+		};
+		render(<SmallPromo customFields={config} />);
+		expect(screen.queryByRole("img", { name: config.headline })).not.toBeNull();
 	});
 });

--- a/blocks/small-promo-block/features/small-promo/mock-data.js
+++ b/blocks/small-promo-block/features/small-promo/mock-data.js
@@ -2,124 +2,11 @@ export default {
 	_id: "55FCWHR6SRCQ3OIJJKWPWUGTBM",
 	type: "story",
 	version: "0.10.4",
-	content_elements: [
-		{
-			_id: "L6RMSXTS7RB5XFKZPPAZKXGRF4",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				"No, August isn’t the District’s hottest month, not quite. It’s actually July. But as the area is in the thick of yet another heat wave, August surely feels like it.",
-		},
-		{
-			_id: "BQ3NJWT6UBDCJNDONKJW7E3I2E",
-			type: "text",
-			additional_properties: [Object],
-			content: "Here’s why such feelings can be deceptive.",
-		},
-		{
-			_id: "QYR6VILSJBEJNI45LOBXYIUWNA",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				"The numbers plainly show that July’s heat reigns supreme. The table below displays 30-year “normal” or average temperatures for July and August at Washington’s Reagan National Airport (DCA) from 1981 to 2010 as well as the records from 1871 to the present.",
-		},
-		{
-			_id: "3J4YJHWBLVEXXEQW5O2724TTVY",
-			type: "table",
-			header: [Array],
-			additional_properties: [Object],
-			rows: [Array],
-		},
-		{
-			_id: "SQQV7L2A3BCCPHUVMFNUWLAJJY",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				"*The “mean maximum” and “mean minimum” are the averages over the period of the highest and lowest temperature recorded during the month.",
-		},
-		{
-			_id: "6FNU7LJLBVDGLMEGSWEZHAS2E4",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				"If July and August seem hotter than the above averages to you, you might be right: As the climate warms, the 30-year normal temperatures have steadily increased. But, in any case, you can see that July beats August in every temperature category except the record-high temperature, and in that category, the two months are coequal champions. July also edges August in humidity (based on average dew point).",
-		},
-		{
-			_id: "PHQ7QRFGAJBQPOOV42EV56YWIE",
-			type: "text",
-			additional_properties: [Object],
-			content: "So why does August <i>seem </i>hotter? I think it comes from weariness.",
-		},
-		{
-			_id: "RDWPXSNECRDQNOT5UFZYXMQVTI",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				'By the time August rolls around, we’ve just lived through July: hot, humid, July. By mid-August, most people are tired of the heat. Certainly the Capital Weather Gang’s <a href="https://www.washingtonpost.com/weather/2019/08/19/dc-area-forecast-several-days-sweltering-heat-before-we-find-relief/">narrative forecasts</a> this month have made clear that the CWG is getting tired of the heat!',
-		},
-		{
-			_id: "MCDFYGVX3NG65LUH6XOQLIHQSU",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				'In addition, most D.C.-area summers feature <a href="https://www.washingtonpost.com/weather/2019/08/06/strange-true-dc-area-could-really-use-some-rain/">browning lawns and other signs of plants experiencing stress</a>. Plant stress tends to increase as the summer progresses, and by August, many plants that haven’t been well watered are showing the strain. I think a similar effect can be seen in winter in many locations, where February seems like the coldest month, even though January averages colder.',
-		},
-		{
-			_id: "OMLLHJQ7ZNBJ7IC4AKYVHGYDSA",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				"But it is interesting to ask why August, which is so close to fall in the Northern Hemisphere, is even nearly as hot as July. Look out the window today. The sun is not as high at noon as it was at the beginning of July, or even three weeks ago; your shadow never gets as short now as it did then. The sun in D.C. now sets before 8 p.m., instead of 8.37 pm in early July.",
-		},
-		{
-			_id: "RWKSCBHFP5FUXPTVOTFNFFRXKM",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				"Sunrise has got later, as well, and we’ve lost a full hour of daylight. That means there’s less time for the sun to heat us up, and it’s less effective than before because of the lower sun angle; and there’s more time for nighttime cooling. Yet average temperatures in Washington don’t really start to dip until the last 10 days of August. Why?",
-		},
-		{
-			_id: "ACZ7AO2DQRHNFHJC5BM7EBL5XI",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				"The main reason is that the ocean (and, to some extent, the ground) continues to warm at least until the end of August, which counteracts the decreased daytime heating and increased opportunity for nighttime cooling. There are some places in the country where June is neck and neck with July for the hottest month, which is what you’d predict from the sun’s angle and day length alone.",
-		},
-		{
-			_id: "36V64M5IOBHO3HDGG4GVUXNOGA",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				"In Tucson, the average high temperature in June is 100.3, while in July it’s “only” 99.7. The highest temperature ever recorded in Tucson was 117 in June; in July, the highest was “only” 114. The reason for all of this is the summer monsoon. Tucson averages 0.20 inches of rain in June and 2.25 inches in July. The rain reduces sunshine and provides a break from the heat, and the water that falls has to be turned into steam for it to get excessively hot, which takes energy. August is slightly wetter and cooler than July.",
-		},
-		{
-			_id: "BSBXLQICK5EWHFM6G2QVE64ZZI",
-			type: "text",
-			additional_properties: [Object],
-			content:
-				"So for the short term, take heart. The worst of D.C.’s summer heat is almost behind us. By mid-September, heat waves are fairly unlikely. For the medium and longer term, I am not so sanguine. The combination of global warming caused by human activities and local warming caused by the increasing footprint of the urban heat island promise ever hotter and longer summers in the area over the coming years. Brace yourselves.",
-		},
-		{
-			_id: "PJYLLGASWBCBHN3KFINPDURGGM",
-			type: "correction",
-			correction_type: "correction",
-			additional_properties: [Object],
-			text: "Update: We initially compared average relative humidity between July and August, for which August had a slightly higher value. But, at the recommendation of readers, we compared average dew point, which is an absolute measurement of humidity, and found July’s had a higher average. This article has been updated using the dew point information.",
-		},
-	],
 	created_date: "2020-01-30T23:45:26.554Z",
-	revision: {
-		revision_id: "HT3HRPOF7JACVIME6UXYF57T2M",
-		parent_id: "DXYZISRS6FDBLHCWZWORNF66JM",
-		editions: ["default"],
-		branch: "default",
-		user_id: "CAROTHERSSL@washpost.com",
-		published: true,
-	},
 	last_updated_date: "2020-01-31T00:26:08.612Z",
 	canonical_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 	headlines: {
-		basic: "August may feel like Washington’s hottest month, but it’s not",
+		basic: "August may feel like Washington's hottest month, but it's not",
 		mobile: "",
 		native: "",
 		print: "",
@@ -132,141 +19,69 @@ export default {
 		id: "corecomponents",
 	},
 	content_restrictions: { content_code: "free" },
-	address: {},
-	workflow: { status_code: 1 },
 	subheadlines: {
 		basic: "Why does August seem hotter? Maybe it comes from weariness.",
 	},
 	description: {
 		basic: "Why does August seem hotter? Maybe it comes from weariness.",
 	},
-	language: "",
-	label: {},
 	source: {
 		name: "corecomponents",
 		system: "composer",
 		source_type: "staff",
 	},
-	taxonomy: {
-		tags: [[Object]],
-		sites: [],
-		sections: [[Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object]],
-		primary_site: {
-			_id: "/news",
-			type: "site",
-			version: "0.5.8",
-			name: "News",
-			description: null,
-			path: "/news",
-			parent_id: "/",
-			additional_properties: [Object],
-		},
-		primary_section: {
-			_id: "/news",
-			_website: "the-sun",
-			type: "section",
-			version: "0.6.0",
-			name: "News",
-			description: null,
-			path: "/news",
-			parent_id: "/",
-			parent: [Object],
-			additional_properties: [Object],
-		},
-	},
-	related_content: {
-		basic: [],
-		redirect: [],
-	},
 	promo_items: {
 		basic: {
 			_id: "DBUX66M3LRFMHKXZOM46RO4EXM",
-			additional_properties: [Object],
+			auth: {
+				2: "ABC",
+			},
 			address: {},
 			caption: "The sun beats down on Four Mile Run in Arlington, Va., on Aug. 17.",
 			created_date: "2020-01-30T23:47:39Z",
-			credits: [Object],
 			height: 782,
 			image_type: "photograph",
 			last_updated_date: "2020-01-30T23:47:39Z",
 			licensable: false,
-			owner: [Object],
-			source: [Object],
 			status: "",
-			taxonomy: [Object],
 			type: "image",
 			url: "https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/DBUX66M3LRFMHKXZOM46RO4EXM.png",
 			resized_params: {},
 			version: "0.10.3",
 			width: 1179,
-			syndication: [Object],
 		},
-	},
-	distributor: {
-		name: "corecomponents",
-		category: "staff",
-		subcategory: "",
 	},
 	canonical_website: "the-sun",
-	planning: {
-		internal_note: "",
-		story_length: {
-			word_count_actual: 663,
-			line_count_actual: 27,
-			inch_count_actual: 4,
-		},
-	},
 	display_date: "2020-01-30T14:47:46.926Z",
-	credits: { by: [[Object]] },
 	subtype: "right-rail-template",
 	first_publish_date: "2020-01-30T23:47:48.013Z",
 	websites: {
 		dagen: {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-sun": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		washpost: {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-globe": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-planet": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-gazette": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-mercury": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 		"the-prophet": {
-			website_section: [Object],
 			website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 		},
 	},
-	additional_properties: {
-		clipboard: {},
-		has_published_copy: true,
-		is_published: true,
-		publish_date: "2020-01-31T00:25:46.270Z",
-	},
 	publish_date: "2020-01-31T00:26:08.651Z",
-	publishing: {
-		scheduled_operations: {
-			publish_edition: [],
-			unpublish_edition: [],
-		},
-	},
 	website: "the-sun",
 	website_url: "/news/2020/01/30/august-may-feel-like-washingtons-hottest-month-but-its-not/",
 };

--- a/jest/mocks/environment.js
+++ b/jest/mocks/environment.js
@@ -4,4 +4,6 @@ const resizerKey = "%{FKDFJK}";
 
 const searchKey = "ABCDEF";
 
-export { TIMEZONE, resizerKey, searchKey };
+const RESIZER_APP_VERSION = 2;
+
+export { TIMEZONE, resizerKey, searchKey, RESIZER_APP_VERSION };


### PR DESCRIPTION
## Description

Update Small Promo to use Resizer

## Jira Ticket

- [THEMES-736](https://arcpublishing.atlassian.net/browse/THEMES-736)

## Test Steps

1. Checkout this branch `git checkout THEMES-736-small-promo-resizer-update`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/small-promo-block`
3. Add the small promo block to a page and configure a content source
4. Validate the Image is being rendered via resizer v2

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
