### PR TITLE
THEMES-707: fixed fullscreen styling for single image. Added smart crop.

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -130,7 +130,7 @@ export const LeadArtPresentation = (props) => {
 					>
 						{buttonLabel}
 					</Button>
-					<div ref={imgRef}>
+					<div className={`${BLOCK_CLASS_NAME}__image-wrapper`} ref={imgRef}>
 						<Image
 							src={imageANSToImageSrc(lead_art)}
 							alt={lead_art.alt_text}
@@ -139,7 +139,7 @@ export const LeadArtPresentation = (props) => {
 							width={800}
 							height={450}
 							responsiveImages={[800, 1600]}
-							resizedOptions={{ auth: lead_art.auth[RESIZER_APP_VERSION] }}
+							resizedOptions={{ auth: lead_art.auth[RESIZER_APP_VERSION], smart: true }}
 							resizerURL={RESIZER_URL}
 						/>
 					</div>
@@ -227,7 +227,7 @@ export const LeadArtPresentation = (props) => {
 									<Image
 										src={imageANSToImageSrc(galleryItem)}
 										resizerURL={RESIZER_URL}
-										resizedOptions={{ auth: galleryItem.auth[RESIZER_APP_VERSION] }}
+										resizedOptions={{ auth: galleryItem.auth[RESIZER_APP_VERSION], smart: true }}
 										// 16:9 aspect ratio
 										width={800}
 										height={450}


### PR DESCRIPTION
## Description

This PR fixes a styling issue with the fullscreen images. It now uses the same styles as the full screen gallery image. Also, the `smart` parameter was added to the lead art image, and lead art gallery images.

## Jira Ticket

- [THEMES-707](https://arcpublishing.atlassian.net/browse/THEMES-707)

## Acceptance Criteria

- Correct styling when an image is made fullscreen.

## Test Steps

Feature Pack PR -

Use Themes Internal Sandbox for content base

1. Checkout this branch `git checkout THEMES-707-lead-art-v2`
2. Checkout the feature pack branch `git checkout THEMES-707-lead-art-v2`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/lead-art-block`
4. Edit the article right rail template to use the new lead art block.
5. Use the default block settings, and test with a story that has a single image as the featured media.
6. Click the `Expand` button.
7. Verify that the image is centered within the screen with equal spacing around it.


## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
