### PR TITLE
THEMES-729 - Manual Promo Image Resizer Updates

### DIFF
--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -164,11 +164,9 @@ ExtraLargeManualPromo.propTypes = {
 			searchable: "image",
 		}),
 		imageAuth: PropTypes.string.tag({
-			group: "Image",
 			hidden: true,
 		}),
 		imageId: PropTypes.string.tag({
-			group: "Image",
 			hidden: true,
 		}),
 		linkURL: PropTypes.string.tag({

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -126,7 +126,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 									href={formatURL(linkURL)}
 									openInNewTab={newTab}
 									onClick={registerSuccessEvent}
-									assistiveHidden={showImage && showHeadline && showDescription}
+									assistiveHidden={showHeadline && showDescription}
 								>
 									<Image {...imageParams} />
 								</Conditional>

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -1,10 +1,12 @@
 import React from "react";
-import { useEditableContent } from "fusion:content";
-import { useFusionContext } from "fusion:context";
-import getProperties from "fusion:properties";
 import PropTypes from "@arc-fusion/prop-types";
+import { RESIZER_APP_VERSION } from "fusion:environment";
+import { useComponentContext, useFusionContext } from "fusion:context";
+import { useContent, useEditableContent } from "fusion:content";
+import getProperties from "fusion:properties";
 import {
 	Conditional,
+	formatURL,
 	Heading,
 	HeadingSection,
 	Image,
@@ -19,41 +21,14 @@ import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 
 const BLOCK_CLASS_NAME = "b-xl-manual-promo";
 
-const PromoHeadline = ({ children, href, openInNewTab }) => (
-	<HeadingSection>
-		<Heading>
-			<Conditional component={Link} condition={href} href={href} openInNewTab={openInNewTab}>
-				{children}
-			</Conditional>
-		</Heading>
-	</HeadingSection>
-);
-
-const PromoImage = ({ alt, href, imageRatio, openInNewTab, src }) => {
-	const { searchableField } = useEditableContent();
-
-	return (
-		<MediaItem {...searchableField("imageURL")} suppressContentEditableWarning>
-			<Conditional component={Link} condition={href} href={href} openInNewTab={openInNewTab}>
-				<Image
-					alt={alt}
-					src={src}
-					searchableField
-					data-aspect-ratio={imageRatio?.replace(":", "/")}
-				/>
-			</Conditional>
-		</MediaItem>
-	);
-};
-
 const ExtraLargeManualPromo = ({ customFields }) => {
-	const { arcSite, isAdmin } = useFusionContext();
-	const { fallbackImage } = getProperties(arcSite);
 	const {
 		description,
 		headline,
-		imageRatio,
+		imageAuth,
 		imageURL,
+		imageId,
+		imageRatio,
 		lazyLoad,
 		linkURL,
 		newTab,
@@ -64,10 +39,51 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 		showImage,
 		showOverline,
 	} = customFields;
+	const { arcSite, isAdmin } = useFusionContext();
+	const { fallbackImage } = getProperties(arcSite);
+	const { registerSuccessEvent } = useComponentContext();
+	const { searchableField } = useEditableContent();
 	const shouldLazyLoad = lazyLoad && !isAdmin;
+
+	const imageAuthToken = useContent(
+		!imageAuth && imageId
+			? {
+					source: "signing-service",
+					query: { id: imageId },
+			  }
+			: {}
+	);
+
 	if (shouldLazyLoad && isServerSide()) {
 		return null;
 	}
+
+	const imageAuthTokenObj = {};
+	if (imageAuthToken?.hash) {
+		imageAuthToken[RESIZER_APP_VERSION] = imageAuthToken.hash;
+	}
+
+	const alt = headline || description || null;
+	const imageParams =
+		imageId && imageURL
+			? {
+					ansImage: {
+						_id: imageId,
+						url: imageURL,
+						auth: imageAuth ? JSON.parse(imageAuth) : imageAuthTokenObj,
+					},
+					alt,
+					aspectRatio: imageRatio,
+					resizedOptions: {
+						smart: true,
+					},
+					responsiveImages: [200, 400, 600, 800, 1200],
+					width: 600,
+			  }
+			: {
+					src: fallbackImage,
+					alt,
+			  };
 
 	const availableDescription = showDescription ? description : null;
 	const availableHeadline = showHeadline ? headline : null;
@@ -81,18 +97,40 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 				{availableHeadline || availableImageURL || availableDescription ? (
 					<Stack>
 						{availableHeadline ? (
-							<PromoHeadline href={linkURL} openInNewTab={newTab}>
-								{availableHeadline}
-							</PromoHeadline>
+							<HeadingSection>
+								<Heading>
+									<Conditional
+										component={Link}
+										condition={linkURL}
+										href={formatURL(linkURL)}
+										openInNewTab={newTab}
+										onClick={registerSuccessEvent}
+									>
+										{headline}
+									</Conditional>
+								</Heading>
+							</HeadingSection>
 						) : null}
 						{availableImageURL ? (
-							<PromoImage
-								alt={headline}
-								href={linkURL}
-								imageRatio={imageRatio}
-								openInNewTab={newTab}
-								src={availableImageURL}
-							/>
+							<MediaItem
+								{...searchableField({
+									imageURL: "url",
+									imageId: "_id",
+									imageAuth: "auth",
+								})}
+								suppressContentEditableWarning
+							>
+								<Conditional
+									component={Link}
+									condition={linkURL}
+									href={formatURL(linkURL)}
+									openInNewTab={newTab}
+									onClick={registerSuccessEvent}
+									assistiveHidden={showImage && showHeadline && showDescription}
+								>
+									<Image {...imageParams} />
+								</Conditional>
+							</MediaItem>
 						) : null}
 						{availableDescription ? <Paragraph>{availableDescription}</Paragraph> : null}
 					</Stack>
@@ -124,6 +162,14 @@ ExtraLargeManualPromo.propTypes = {
 			label: "Image URL",
 			group: "Configure Content",
 			searchable: "image",
+		}),
+		imageAuth: PropTypes.string.tag({
+			group: "Image",
+			hidden: true,
+		}),
+		imageId: PropTypes.string.tag({
+			group: "Image",
+			hidden: true,
 		}),
 		linkURL: PropTypes.string.tag({
 			label: "Link URL",

--- a/blocks/extra-large-manual-promo-block/index.story.jsx
+++ b/blocks/extra-large-manual-promo-block/index.story.jsx
@@ -17,8 +17,10 @@ const allCustomFields = {
 	description: "This is the description",
 	overline: "overline",
 	overlineURL: "www.google.com",
+	imageId: "P5EYZSWH6FBEHDIQMV7H35ENWM",
 	imageURL:
-		"https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG",
+		"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/P5EYZSWH6FBEHDIQMV7H35ENWM.jpg",
+	imageAuth: '{"2":"2dd3c2a210c92684c52c3fd991646cc7119f623a92e65a3513a6c1086d41cade"}',
 	linkURL: "www.google.com",
 };
 

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -171,6 +171,12 @@ LargeManualPromo.propTypes = {
 			group: "Configure Content",
 			searchable: "image",
 		}),
+		imageAuth: PropTypes.string.tag({
+			hidden: true,
+		}),
+		imageId: PropTypes.string.tag({
+			hidden: true,
+		}),
 		linkURL: PropTypes.string.tag({
 			label: "Link URL",
 			group: "Configure Content",

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
+import { RESIZER_APP_VERSION } from "fusion:environment";
 import { useComponentContext, useFusionContext } from "fusion:context";
-import { useEditableContent } from "fusion:content";
+import { useContent, useEditableContent } from "fusion:content";
 import getProperties from "fusion:properties";
 import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
@@ -22,11 +23,13 @@ import {
 const BLOCK_CLASS_NAME = "b-large-manual-promo";
 
 const LargeManualPromo = ({ customFields }) => {
-	const { isAdmin } = useFusionContext();
 	const {
 		description,
 		headline,
+		imageAuth,
 		imageURL,
+		imageId,
+		imageRatio,
 		lazyLoad,
 		linkURL,
 		newTab,
@@ -37,48 +40,51 @@ const LargeManualPromo = ({ customFields }) => {
 		showImage,
 		showOverline,
 	} = customFields;
-	const shouldLazyLoad = lazyLoad && !isAdmin;
-	const { arcSite } = useFusionContext();
+	const { arcSite, isAdmin } = useFusionContext();
 	const { fallbackImage } = getProperties(arcSite);
 	const { registerSuccessEvent } = useComponentContext();
+	const { searchableField } = useEditableContent();
+	const shouldLazyLoad = lazyLoad && !isAdmin;
+
+	const imageAuthToken = useContent(
+		!imageAuth && imageId
+			? {
+					source: "signing-service",
+					query: { id: imageId },
+			  }
+			: {}
+	);
 
 	if (shouldLazyLoad && isServerSide()) {
-		// On Server
 		return null;
 	}
 
-	const PromoImage = () => {
-		const { searchableField } = useEditableContent();
+	const imageAuthTokenObj = {};
+	if (imageAuthToken?.hash) {
+		imageAuthToken[RESIZER_APP_VERSION] = imageAuthToken.hash;
+	}
 
-		return (
-			<MediaItem {...searchableField("imageURL")} suppressContentEditableWarning>
-				<Conditional
-					component={Link}
-					condition={linkURL}
-					href={formatURL(linkURL)}
-					openInNewTab={newTab}
-					onClick={registerSuccessEvent}
-				>
-					<Image alt={headline} src={imageURL || fallbackImage} searchableField />
-				</Conditional>
-			</MediaItem>
-		);
-	};
-
-	const PromoHeading = () =>
-		showHeadline && headline ? (
-			<Heading>
-				<Conditional
-					component={Link}
-					condition={linkURL}
-					href={formatURL(linkURL)}
-					openInNewTab={newTab}
-					onClick={registerSuccessEvent}
-				>
-					{headline}
-				</Conditional>
-			</Heading>
-		) : null;
+	const alt = headline || description || null;
+	const imageParams =
+		imageId && imageURL
+			? {
+					ansImage: {
+						_id: imageId,
+						url: imageURL,
+						auth: imageAuth ? JSON.parse(imageAuth) : imageAuthTokenObj,
+					},
+					alt,
+					aspectRatio: imageRatio,
+					resizedOptions: {
+						smart: true,
+					},
+					responsiveImages: [200, 400, 600, 800, 1200],
+					width: 600,
+			  }
+			: {
+					src: fallbackImage,
+					alt,
+			  };
 
 	const PromoOverline = () => {
 		if (showOverline && overline) {
@@ -90,19 +96,49 @@ const LargeManualPromo = ({ customFields }) => {
 		return null;
 	};
 
-	const PromoDescription = () => <Paragraph>{description}</Paragraph>;
-
 	return (
 		<LazyLoad enabled={shouldLazyLoad}>
 			<HeadingSection>
 				<Grid as="article" className={BLOCK_CLASS_NAME}>
-					{showImage && imageURL ? <PromoImage /> : null}
+					{showImage ? (
+						<MediaItem
+							{...searchableField({
+								imageURL: "url",
+								imageId: "_id",
+								imageAuth: "auth",
+							})}
+							suppressContentEditableWarning
+						>
+							<Conditional
+								component={Link}
+								condition={linkURL}
+								href={formatURL(linkURL)}
+								openInNewTab={newTab}
+								onClick={registerSuccessEvent}
+								assistiveHidden={showImage && showHeadline && showDescription}
+							>
+								<Image {...imageParams} />
+							</Conditional>
+						</MediaItem>
+					) : null}
 					<Stack className={`${BLOCK_CLASS_NAME}__text`}>
 						<PromoOverline />
 						{showDescription || showHeadline ? (
 							<Stack>
-								<PromoHeading />
-								{showDescription && description ? <PromoDescription /> : null}
+								{showHeadline && headline ? (
+									<Heading>
+										<Conditional
+											component={Link}
+											condition={linkURL}
+											href={formatURL(linkURL)}
+											openInNewTab={newTab}
+											onClick={registerSuccessEvent}
+										>
+											{headline}
+										</Conditional>
+									</Heading>
+								) : null}
+								{showDescription && description ? <Paragraph>{description}</Paragraph> : null}
 							</Stack>
 						) : null}
 					</Stack>

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -115,7 +115,7 @@ const LargeManualPromo = ({ customFields }) => {
 								href={formatURL(linkURL)}
 								openInNewTab={newTab}
 								onClick={registerSuccessEvent}
-								assistiveHidden={showImage && showHeadline && showDescription}
+								assistiveHidden={showHeadline && showDescription}
 							>
 								<Image {...imageParams} />
 							</Conditional>

--- a/blocks/large-manual-promo-block/index.story.jsx
+++ b/blocks/large-manual-promo-block/index.story.jsx
@@ -32,6 +32,7 @@ const sampleData = {
 	author: "Jane and John Dee",
 	dateTime: "2021-01-12 13:23",
 	dateString: "January 12, 2021 at 1:23PM EST",
+	imageRatio: "4:3",
 };
 
 export const allFields = () => {

--- a/blocks/large-manual-promo-block/index.story.jsx
+++ b/blocks/large-manual-promo-block/index.story.jsx
@@ -23,8 +23,10 @@ const sampleData = {
 	description: "This is the description",
 	overline: "overline",
 	overlineURL: "www.google.com",
+	imageId: "P5EYZSWH6FBEHDIQMV7H35ENWM",
 	imageURL:
-		"https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG",
+		"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/P5EYZSWH6FBEHDIQMV7H35ENWM.jpg",
+	imageAuth: '{"2":"2dd3c2a210c92684c52c3fd991646cc7119f623a92e65a3513a6c1086d41cade"}',
 	linkURL: "www.google.com",
 	imagePosition: "bottom",
 	author: "Jane and John Dee",

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -101,7 +101,7 @@ const MediumManualPromo = ({ customFields }) => {
 								href={formatURL(linkURL)}
 								openInNewTab={newTab}
 								onClick={registerSuccessEvent}
-								assistiveHidden={showImage && showHeadline && showDescription}
+								assistiveHidden={showHeadline && showDescription}
 							>
 								<Image {...imageParams} />
 							</Conditional>

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -144,11 +144,9 @@ MediumManualPromo.propTypes = {
 			searchable: "image",
 		}),
 		imageAuth: PropTypes.string.tag({
-			group: "Image",
 			hidden: true,
 		}),
 		imageId: PropTypes.string.tag({
-			group: "Image",
 			hidden: true,
 		}),
 		linkURL: PropTypes.string.tag({

--- a/blocks/medium-manual-promo-block/index.story.jsx
+++ b/blocks/medium-manual-promo-block/index.story.jsx
@@ -18,6 +18,7 @@ const sampleData = {
 	imageURL:
 		"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/P5EYZSWH6FBEHDIQMV7H35ENWM.jpg",
 	imageAuth: '{"2":"2dd3c2a210c92684c52c3fd991646cc7119f623a92e65a3513a6c1086d41cade"}',
+	imageRatio: "3:2",
 	linkURL: "www.google.com",
 	showHeadline: false,
 	showImage: false,

--- a/blocks/medium-manual-promo-block/index.story.jsx
+++ b/blocks/medium-manual-promo-block/index.story.jsx
@@ -14,8 +14,10 @@ export default {
 const sampleData = {
 	headline: "This is the headline",
 	description: "This is the description",
+	imageId: "P5EYZSWH6FBEHDIQMV7H35ENWM",
 	imageURL:
-		"https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG",
+		"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/P5EYZSWH6FBEHDIQMV7H35ENWM.jpg",
+	imageAuth: '{"2":"2dd3c2a210c92684c52c3fd991646cc7119f623a92e65a3513a6c1086d41cade"}',
 	linkURL: "www.google.com",
 	showHeadline: false,
 	showImage: false,

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -96,7 +96,7 @@ const SmallManualPromo = ({ customFields }) => {
 				href={formatURL(linkURL)}
 				openInNewTab={newTab}
 				onClick={registerSuccessEvent}
-				assistiveHidden={showImage && showHeadline}
+				assistiveHidden={showHeadline}
 			>
 				{ImageDisplay}
 			</Link>

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { RESIZER_APP_VERSION } from "fusion:environment";
 import PropTypes from "@arc-fusion/prop-types";
+import { RESIZER_APP_VERSION } from "fusion:environment";
 import { useContent, useEditableContent } from "fusion:content";
 import { useComponentContext, useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
@@ -56,6 +56,7 @@ const SmallManualPromo = ({ customFields }) => {
 		imageAuthToken[RESIZER_APP_VERSION] = imageAuthToken.hash;
 	}
 
+	const alt = headline || null;
 	const imageParams =
 		imageId && imageURL
 			? {
@@ -64,6 +65,7 @@ const SmallManualPromo = ({ customFields }) => {
 						url: imageURL,
 						auth: imageAuth ? JSON.parse(imageAuth) : imageAuthTokenObj,
 					},
+					alt,
 					aspectRatio: imageRatio,
 					resizedOptions: {
 						smart: true,
@@ -73,6 +75,7 @@ const SmallManualPromo = ({ customFields }) => {
 			  }
 			: {
 					src: fallbackImage,
+					alt,
 			  };
 
 	const PromoImage = () => {
@@ -93,7 +96,7 @@ const SmallManualPromo = ({ customFields }) => {
 				href={formatURL(linkURL)}
 				openInNewTab={newTab}
 				onClick={registerSuccessEvent}
-				assistiveHidden
+				assistiveHidden={showImage && showHeadline}
 			>
 				{ImageDisplay}
 			</Link>

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -158,11 +158,9 @@ SmallManualPromo.propTypes = {
 			searchable: "image",
 		}),
 		imageAuth: PropTypes.string.tag({
-			group: "Image",
 			hidden: true,
 		}),
 		imageId: PropTypes.string.tag({
-			group: "Image",
 			hidden: true,
 		}),
 		linkURL: PropTypes.string.tag({

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -1,6 +1,7 @@
 import React from "react";
+import { RESIZER_APP_VERSION } from "fusion:environment";
 import PropTypes from "@arc-fusion/prop-types";
-import { useEditableContent } from "fusion:content";
+import { useContent, useEditableContent } from "fusion:content";
 import { useComponentContext, useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
 import {
@@ -18,22 +19,73 @@ import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 const BLOCK_CLASS_NAME = "b-small-manual-promo";
 
 const SmallManualPromo = ({ customFields }) => {
-	const { headline, imagePosition, imageURL, lazyLoad, linkURL, newTab, showHeadline, showImage } =
-		customFields;
+	const {
+		headline,
+		imagePosition,
+		imageAuth,
+		imageURL,
+		imageId,
+		imageRatio,
+		lazyLoad,
+		linkURL,
+		newTab,
+		showHeadline,
+		showImage,
+	} = customFields;
 	const { registerSuccessEvent } = useComponentContext();
 	const { arcSite, isAdmin } = useFusionContext();
+	const { searchableField } = useEditableContent();
+	const { fallbackImage } = getProperties(arcSite);
 	const shouldLazyLoad = lazyLoad && !isAdmin;
+
+	const imageAuthToken = useContent(
+		!imageAuth && imageId
+			? {
+					source: "signing-service",
+					query: { id: imageId },
+			  }
+			: {}
+	);
 
 	if (shouldLazyLoad && isServerSide()) {
 		return null;
 	}
 
+	const imageAuthTokenObj = {};
+	if (imageAuthToken?.hash) {
+		imageAuthToken[RESIZER_APP_VERSION] = imageAuthToken.hash;
+	}
+
+	const imageParams =
+		imageId && imageURL
+			? {
+					ansImage: {
+						_id: imageId,
+						url: imageURL,
+						auth: imageAuth ? JSON.parse(imageAuth) : imageAuthTokenObj,
+					},
+					aspectRatio: imageRatio,
+					resizedOptions: {
+						smart: true,
+					},
+					responsiveImages: [200, 400, 600, 800, 1200],
+					width: 600,
+			  }
+			: {
+					src: fallbackImage,
+			  };
+
 	const PromoImage = () => {
-		const { searchableField } = useEditableContent();
-		const { fallbackImage } = getProperties(arcSite);
 		const ImageDisplay = showImage ? (
-			<MediaItem {...searchableField("imageURL")} suppressContentEditableWarning>
-				<Image alt={headline} src={imageURL || fallbackImage} searchableField />
+			<MediaItem
+				{...searchableField({
+					imageURL: "url",
+					imageId: "_id",
+					imageAuth: "auth",
+				})}
+				suppressContentEditableWarning
+			>
+				<Image {...imageParams} />
 			</MediaItem>
 		) : null;
 		return showImage && linkURL ? (
@@ -51,7 +103,7 @@ const SmallManualPromo = ({ customFields }) => {
 	};
 
 	const PromoHeading = () =>
-		showHeadline ? (
+		showHeadline && headline ? (
 			<Heading>
 				{linkURL ? (
 					<Link href={formatURL(linkURL)} openInNewTab={newTab} onClick={registerSuccessEvent}>
@@ -101,6 +153,14 @@ SmallManualPromo.propTypes = {
 			label: "Image URL",
 			group: "Configure Content",
 			searchable: "image",
+		}),
+		imageAuth: PropTypes.string.tag({
+			group: "Image",
+			hidden: true,
+		}),
+		imageId: PropTypes.string.tag({
+			group: "Image",
+			hidden: true,
 		}),
 		linkURL: PropTypes.string.tag({
 			label: "Link URL",

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { useContent } from "fusion:content";
 import { isServerSide } from "@wpmedia/arc-themes-components";
 import SmallManualPromo from "./default";
 
@@ -13,6 +14,7 @@ jest.mock("@wpmedia/arc-themes-components", () => ({
 }));
 
 jest.mock("fusion:content", () => ({
+	useContent: jest.fn(() => {}),
 	useEditableContent: jest.fn(() => ({
 		editableContent: () => ({ contentEditable: "true" }),
 		searchableField: () => {},
@@ -33,7 +35,9 @@ const customFields = {
 	headline: "This is the headline",
 	imagePosition: "right",
 	imageRatio: "3:2",
+	imageId: 123,
 	imageURL: "www.google.com/fake.png",
+	imageAuth: '{"2":"1d2390c4cc8df2265924631d707ead2490865f17830bfbb52c8541b8696bf573"}',
 	lazyLoad: false,
 	linkURL: "www.google.com",
 	newTab: true,
@@ -56,14 +60,12 @@ describe("the small manual promo feature", () => {
 
 	it("should have one image when showImage is true", () => {
 		render(<SmallManualPromo customFields={customFields} />);
-		expect(
-			screen.queryByRole("img", { name: "This is the headline", hidden: true })
-		).not.toBeNull();
+		expect(screen.queryByRole("img", { hidden: true })).not.toBeNull();
 	});
 
 	it("should have no image when showImage is false", () => {
 		render(<SmallManualPromo customFields={{ ...customFields, showImage: false }} />);
-		expect(screen.queryByRole("img", { name: "This is the headline" })).toBeNull();
+		expect(screen.queryByRole("img")).toBeNull();
 	});
 
 	it("should have no headline when showHeadline is false", () => {
@@ -106,6 +108,23 @@ describe("the small manual promo feature", () => {
 		const stack = screen.queryByRole("article");
 		const figure = screen.queryByRole("figure");
 		expect(stack.firstChild).toBe(figure);
+	});
+
+	it("should use content source to get image auth", () => {
+		useContent.mockReturnValueOnce({ hash: 123 });
+		render(
+			<SmallManualPromo
+				customFields={{
+					...customFields,
+					imagePosition: "left",
+					linkURL: undefined,
+					imageAuth: undefined,
+					imageId: 123,
+				}}
+			/>
+		);
+		expect(useContent).toHaveBeenCalled();
+		expect(screen.queryByRole("img", { hidden: true })).not.toBeNull();
 	});
 
 	it("should render heading first when imagePosition is set to right", () => {

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
@@ -63,6 +63,11 @@ describe("the small manual promo feature", () => {
 		expect(screen.queryByRole("img", { hidden: true })).not.toBeNull();
 	});
 
+	it("should use fallback image", () => {
+		render(<SmallManualPromo customFields={{ ...customFields, imageId: null }} />);
+		expect(screen.queryByRole("img", { hidden: true })).not.toBeNull();
+	});
+
 	it("should have no image when showImage is false", () => {
 		render(<SmallManualPromo customFields={{ ...customFields, showImage: false }} />);
 		expect(screen.queryByRole("img")).toBeNull();
@@ -70,6 +75,11 @@ describe("the small manual promo feature", () => {
 
 	it("should have no headline when showHeadline is false", () => {
 		render(<SmallManualPromo customFields={{ ...customFields, showHeadline: false }} />);
+		expect(screen.queryByText("This is the headline")).toBeNull();
+	});
+
+	it("should not display headline", () => {
+		render(<SmallManualPromo customFields={{ ...customFields, headline: null }} />);
 		expect(screen.queryByText("This is the headline")).toBeNull();
 	});
 

--- a/blocks/small-manual-promo-block/index.story.jsx
+++ b/blocks/small-manual-promo-block/index.story.jsx
@@ -13,8 +13,10 @@ export default {
 
 const sampleData = {
 	headline: "This is the headline",
+	imageId: "P5EYZSWH6FBEHDIQMV7H35ENWM",
 	imageURL:
-		"https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/4PUA6PJWEBEELOHMHMUUUB2WSM.JPG",
+		"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/P5EYZSWH6FBEHDIQMV7H35ENWM.jpg",
+	imageAuth: '{"2":"2dd3c2a210c92684c52c3fd991646cc7119f623a92e65a3513a6c1086d41cade"}',
 	linkURL: "www.google.com",
 	showHeadline: false,
 	showImage: false,


### PR DESCRIPTION
## Description

Update small, medium, large and extra large manual promos to use resizer v2

Updated tests, and converted to RTL where needed

**Note**: Storybook showing changes for all manual promos due to image updated to use an image that is available via resizer v2

## Jira Ticket

- [THEMES-729](https://arcpublishing.atlassian.net/browse/THEMES-729)

## Test Steps

1. Checkout this branch `git checkout THEMES-729`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/small-manual-promo-block,@wpmedia/medium-manual-promo-block,@wpmedia/large-manual-promo-block,@wpmedia/extra-large-manual-promo-block`
3. Add each manual promo to a page and configure content - use the integrated photo search by using the image icon on the block preview to pick an image from Photo Center
4. Verify the image uses v2 resizer 

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
