### PR TITLE
Update defaults to use supported format

### DIFF
--- a/.storybook/alias/properties.js
+++ b/.storybook/alias/properties.js
@@ -15,8 +15,8 @@ export default () => ({
 	dateLocalization: {
 		language: "en",
 		timeZone: "America/New_York",
-		dateTimeFormat: "LLLL d, yyyy 'at' K:m bbbb z",
-		dateFormat: "LLLL d, yyyy",
+		dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
+		dateFormat: "%B %d, %Y",
 	},
 	api: {
 		identity: {

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -47,7 +47,7 @@ const CardListItems = (props) => {
 		dateLocalization: { language, timeZone, dateFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateFormat: "LLLL d, yyyy",
+			dateFormat: "%B %d, %Y",
 		},
 	} = props;
 	const phrases = usePhrases();

--- a/blocks/date-block/features/date/default.jsx
+++ b/blocks/date-block/features/date/default.jsx
@@ -12,7 +12,7 @@ const ArticleDate = () => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "LLLL d, yyyy 'at' K:m bbbb z",
+			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
 		},
 	} = getProperties(arcSite);
 	const formattedDate =

--- a/blocks/date-block/features/date/default.test.jsx
+++ b/blocks/date-block/features/date/default.test.jsx
@@ -11,7 +11,7 @@ describe("Given the display time from ANS, it should convert to the proper timez
 			dateLocalization: {
 				language: "en",
 				timeZone: "America/New_York",
-				dateTimeFormat: "LLLL d, yyyy 'at' K:m bbbb z",
+				dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
 			},
 		});
 		useAppContext.mockReturnValue({ globalContent: { display_date: "2019-08-11T16:45:33.209Z" } });

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -39,7 +39,7 @@ const ExtraLargePromo = ({ customFields }) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "LLLL d, yyyy 'at' K:m bbbb z",
+			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
 		},
 		fallbackImage,
 	} = getProperties(arcSite);

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -257,7 +257,7 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "LLLL d, yyyy 'at' K:m bbbb z",
+			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
 		},
 		fallbackImage,
 	} = getProperties(arcSite);

--- a/blocks/masthead-block/features/masthead-block/default.jsx
+++ b/blocks/masthead-block/features/masthead-block/default.jsx
@@ -48,7 +48,7 @@ const MastheadContainer = (props) => {
 		dateLocalization: { language, timeZone, dateFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateFormat: "LLLL d, yyyy",
+			dateFormat: "%B %d, %Y",
 		},
 	} = getProperties(arcSite);
 

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -38,7 +38,7 @@ const MediumPromo = ({ customFields }) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "LLLL d, yyyy 'at' K:m bbbb z",
+			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
 		},
 		fallbackImage,
 	} = getProperties(arcSite);

--- a/blocks/shared-styles/_children/promo-date/index.jsx
+++ b/blocks/shared-styles/_children/promo-date/index.jsx
@@ -13,7 +13,7 @@ const PromoDate = (props) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateFormat: "LLLL d, yyyy 'at' K:m bbbb z",
+			dateFormat: "%B %d, %Y 'at' K:m bbbb z",
 		},
 	} = getProperties(arcSite);
 

--- a/blocks/shared-styles/_children/promo-date/index.test.jsx
+++ b/blocks/shared-styles/_children/promo-date/index.test.jsx
@@ -8,8 +8,8 @@ jest.mock("fusion:properties", () =>
 		dateLocalization: {
 			language: "en",
 			timeZone: "America/New_York",
-			dateTimeFormat: "LLLL d, yyyy 'at' K:m bbbb z",
-			dateFormat: "LLLL d, yyyy",
+			dateTimeFormat: "%B %d, %Y 'at' K:m bbbb z",
+			dateFormat: "%B %d, %Y",
 		},
 	}))
 );

--- a/blocks/top-table-list-block/features/top-table-list/_children/extra-large.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/extra-large.jsx
@@ -49,7 +49,7 @@ const ExtraLarge = (props) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "LLLL d, yyyy 'at' K:m bbbb z",
+			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
 		},
 	} = getProperties(arcSite);
 	const phrases = usePhrases();

--- a/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
@@ -56,7 +56,7 @@ const Large = (props) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "LLLL d, yyyy 'at' K:m bbbb z",
+			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
 		},
 	} = getProperties(arcSite);
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium.jsx
@@ -47,7 +47,7 @@ const Medium = (props) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "LLLL d, yyyy 'at' K:m bbbb z",
+			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
 		},
 	} = getProperties(arcSite);
 	const phrases = usePhrases();


### PR DESCRIPTION
## Description

Update default to use POSIX time format as per SDK defaults - https://github.com/WPMedia/engine-theme-sdk/blob/arc-themes-release-version-2.0.3/src/utils/localizeDateTime.ts#L4


## Test Steps

- Tests coverage as these are defaults

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
