### PR TITLE
THEMES-796 - Medium Promo's stacked

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1710,6 +1710,9 @@
 					padding: 0,
 				),
 				medium-promo: (
+					clear: both,
+					display: table,
+					width: 100%,
 					components: (
 						attribution: (
 							display: block,
@@ -1767,6 +1770,9 @@
 					color: var(--global-white),
 				),
 				medium-manual-promo: (
+					clear: both,
+					display: table,
+					width: 100%,
 					components: (
 						attribution: (
 							color: var(--text-color),

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -184,6 +184,7 @@ const MediumPromo = ({ customFields }) => {
 								<Image
 									alt={content?.headlines?.basic}
 									src={imageSrc}
+									aspectRatio={imageRatio}
 									resizedOptions={resizeImage ? { auth: imageAuthToken } : {}}
 									responsiveImages={[100, 500]}
 									resizerURL={resizeImage ? RESIZER_URL : null}

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -184,20 +184,9 @@ const MediumPromo = ({ customFields }) => {
 								<Image
 									alt={content?.headlines?.basic}
 									src={imageSrc}
-									data-aspect-ratio={imageRatio?.replace(":", "/")}
 									resizedOptions={resizeImage ? { auth: imageAuthToken } : {}}
 									responsiveImages={[100, 500]}
 									resizerURL={resizeImage ? RESIZER_URL : null}
-									sizes={[
-										{
-											isDefault: true,
-											sourceSizeValue: "100px",
-										},
-										{
-											sourceSizeValue: "500px",
-											mediaCondition: "(min-width: 48rem)",
-										},
-									]}
 								/>
 								{labelIconName ? (
 									<div className={`${BLOCK_CLASS_NAME}__icon_label`}>


### PR DESCRIPTION
## Description

This fixes the issue where Medium promos can not be placed next to each other without wrapping into each other

## Jira Ticket

- [THEMES-796](https://arcpublishing.atlassian.net/browse/THEMES-796)

## Test Steps


1. Checkout this branch `git checkout THEMES-796-fex`
2. Checkout out the feature pack branch `THEMES-796`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/medium-manual-promo-block,@wpmedia/medium-promo-block`
4. Configure a page with the layout - Right Rail
5. Add two medium promos in the full width 2 section of the layout
6. Verify promos do not overlap each other

## Effect Of Changes

### Before

<img width="2010" alt="Microsoft Edge-2022-12-13-13-51 39" src="https://user-images.githubusercontent.com/868127/207346412-a5eb5ac5-d4e1-468f-a609-3a633a0d5a32.png">


### After

<img width="1548" alt="Microsoft Edge-2022-12-13-13-50 28" src="https://user-images.githubusercontent.com/868127/207345733-f870cf53-7874-46c8-83bb-aa709a495dfb.png">

## Dependencies or Side Effects

Blocks PR for setting stories - https://github.com/WPMedia/arc-themes-blocks/pull/1574
Feature Pack PR - https://github.com/WPMedia/arc-themes-feature-pack/pull/372

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
