### PR TITLE
THEMES-751 - Add divider block

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1916,10 +1916,14 @@
 					margin: 0 0 var(--global-spacing-5) 0,
 				),
 				right-rail-main: (
-					gap: var(--global-spacing-6),
 					max-width: calc(var(--content-max-width) * 1px),
 					width: var(--content-scale-width),
 					margin: auto,
+					components: (
+						stack: (
+							gap: var(--global-spacing-6),
+						),
+					),
 				),
 				right-rail-full-width-2: (
 					margin: var(--global-spacing-6) 0 0 0,
@@ -2940,6 +2944,7 @@
 @use "../../blocks/category-carousel-block";
 @use "../../blocks/date-block";
 @use "../../blocks/double-chain-block";
+@use "../../blocks/divider-block";
 @use "../../blocks/footer-block";
 @use "../../blocks/extra-large-manual-promo-block";
 @use "../../blocks/extra-large-promo-block";

--- a/blocks/divider-block/README.md
+++ b/blocks/divider-block/README.md
@@ -1,0 +1,3 @@
+# @wpmedia/divider-block
+
+Divider block is a simple utilty block that allows PageBuilder Editors to add a divider between blocks within their pages and templates.

--- a/blocks/divider-block/_index.scss
+++ b/blocks/divider-block/_index.scss
@@ -1,0 +1,6 @@
+@use "@wpmedia/arc-themes-components/scss";
+
+.b-divider {
+	@include scss.block-components("divider");
+	@include scss.block-properties("divider");
+}

--- a/blocks/divider-block/features/divider/default.jsx
+++ b/blocks/divider-block/features/divider/default.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import { Divider as DividerComponent } from "@wpmedia/arc-themes-components";
+
+const BLOCK_CLASS_NAME = "b-divider";
+
+const Divider = () => <DividerComponent className={`${BLOCK_CLASS_NAME}`} assistiveHidden />;
+
+Divider.label = "Divider – Arc Block";
+
+Divider.icon = "layout-headline";
+
+export default Divider;

--- a/blocks/divider-block/features/divider/default.test.jsx
+++ b/blocks/divider-block/features/divider/default.test.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+
+import Divider from "./default";
+
+describe("Divider", () => {
+	it("should render", () => {
+		const { container } = render(<Divider />);
+		expect(container.getElementsByTagName("hr")).not.toBeNull();
+	});
+});

--- a/blocks/divider-block/index.story.jsx
+++ b/blocks/divider-block/index.story.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Divider from "./features/divider/default";
+
+// for more info on storybook and using the component explorer
+// https://storybook.js.org/
+export default {
+	title: "Blocks/Divider",
+	parameters: {
+		chromatic: { viewports: [320, 1200] },
+	},
+};
+
+export const divider = () => <Divider />;
+
+export const dividingContent = () => (
+	<>
+		<p>Before divider</p>
+		<Divider />
+		<p>After divider</p>
+	</>
+);

--- a/blocks/divider-block/jest.config.js
+++ b/blocks/divider-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest/jest.config.base");
+
+module.exports = {
+	...base,
+};

--- a/blocks/divider-block/package.json
+++ b/blocks/divider-block/package.json
@@ -20,7 +20,6 @@
     "directory": "blocks/divider-block"
   },
   "peerDependencies": {
-    "@arc-fusion/prop-types": "^0.1.5",
     "@wpmedia/arc-themes-components": "*"
   }
 }

--- a/blocks/divider-block/package.json
+++ b/blocks/divider-block/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@wpmedia/divider-block",
+  "version": "0.1.0",
+  "description": "Divider Block",
+  "author": "Arc XP - Themes",
+  "homepage": "https://github.com/WPMedia/arc-themes-blocks",
+  "license": "CC-BY-NC-ND-4.0",
+  "main": "",
+  "files": [
+    "_index.scss",
+    "features"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+    "directory": "blocks/divider-block"
+  },
+  "peerDependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
+    "@wpmedia/arc-themes-components": "*"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16769,6 +16769,9 @@
     "@wpmedia/default-output-block": {
       "version": "file:blocks/default-output-block"
     },
+    "@wpmedia/divider-block": {
+      "version": "file:blocks/divider-block"
+    },
     "@wpmedia/double-chain-block": {
       "version": "file:blocks/double-chain-block"
     },

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@wpmedia/date-block": "file:blocks/date-block",
     "@wpmedia/default-output-block": "file:blocks/default-output-block",
     "@wpmedia/double-chain-block": "file:blocks/double-chain-block",
+    "@wpmedia/divider-block": "file:blocks/divider-block",
     "@wpmedia/event-tester-block": "file:blocks/event-tester-block",
     "@wpmedia/extra-large-manual-promo-block": "file:blocks/extra-large-manual-promo-block",
     "@wpmedia/extra-large-promo-block": "file:blocks/extra-large-promo-block",


### PR DESCRIPTION
## Description

Added a new block "Divider Block"

## Jira Ticket

- [THEMES-751](https://arcpublishing.atlassian.net/browse/THEMES-751)

## Test Steps

Requires feature pack PR

1. Checkout this branch `git checkout THEMES-751`
2. Checkout the feature pack branch `THEMES-751`
3. Add `@local` to the divider block in the blocks.json blocks array `@wpmedia/divider-block@local`
4. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/divider-block`
5. On an existing page at the divider block to the main section of the right rail layout and place between two blocks
6. Verify a dividing line is output between the two blocks

## Dependencies or Side Effects

Feature Pack PR - https://github.com/WPMedia/arc-themes-feature-pack/pull/373
Manifest PR - https://github.com/WPMedia/arc-themes-manifests/pull/155

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
