### PR TITLE
Themes 726 Migrated dividers used in non-list instances within blocks to use the divider component

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -7,6 +7,7 @@ import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
 	Carousel,
 	Conditional,
+	Divider,
 	formatCredits,
 	Heading,
 	HeadingSection,

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -64,13 +64,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		}
 
 		case "divider": {
-			return (
-				<Divider
-					assistiveHidden={false}
-					className={`${BLOCK_CLASS_NAME}__divider`}
-					key={`${type}_${index}_${key}`}
-				/>
-			);
+			return <Divider assistiveHidden={false} key={`${type}_${index}_${key}`} />;
 		}
 
 		case "image": {

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -63,7 +63,13 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		}
 
 		case "divider": {
-			return <hr className={`${BLOCK_CLASS_NAME}__divider`} key={`${type}_${index}_${key}`} />;
+			return (
+				<Divider
+					assistiveHidden={false}
+					className={`${BLOCK_CLASS_NAME}__divider`}
+					key={`${type}_${index}_${key}`}
+				/>
+			);
 		}
 
 		case "image": {

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -2105,7 +2105,7 @@ describe("article-body chain", () => {
 					<span>3</span>
 				</ArticleBodyChain>
 			);
-			expect(wrapper.find(".b-article-body__divider").length).toEqual(4);
+			expect(wrapper.find("Divider").length).toEqual(2);
 		});
 	});
 

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -2105,7 +2105,7 @@ describe("article-body chain", () => {
 					<span>3</span>
 				</ArticleBodyChain>
 			);
-			expect(wrapper.find(".b-article-body__divider").length).toEqual(2);
+			expect(wrapper.find(".b-article-body__divider").length).toEqual(4);
 		});
 	});
 

--- a/blocks/links-bar-block/features/links-bar/default.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
-import { Link, Stack, Separator, usePhrases } from "@wpmedia/arc-themes-components";
+import { Divider, Link, Stack, Separator, usePhrases } from "@wpmedia/arc-themes-components";
 
 const BLOCK_CLASS_NAME = "b-links-bar";
 
@@ -52,7 +52,7 @@ const LinksBar = ({ customFields: { navigationConfig = {}, ariaLabel } }) => {
 							</React.Fragment>
 						))}
 					</Stack>
-					<hr />
+					<Divider />
 				</>
 			)}
 		</>

--- a/blocks/links-bar-block/features/links-bar/default.test.jsx
+++ b/blocks/links-bar-block/features/links-bar/default.test.jsx
@@ -67,7 +67,7 @@ describe("the links bar feature for the default output type", () => {
 		const wrapper = shallow(<LinksBar customFields={{ navigationConfig: "links" }} />);
 
 		expect(wrapper.html()).toMatchInlineSnapshot(
-			`"<nav aria-label=\\"More Links\\" class=\\"c-stack b-links-bar\\" data-style-direction=\\"row\\" data-style-justification=\\"center\\" data-style-alignment=\\"unset\\" data-style-inline=\\"false\\" data-style-wrap=\\"wrap\\"><a class=\\"c-link\\" href=\\"id_1\\">test link 1</a></nav><hr/>"`
+			`"<nav aria-label=\\"More Links\\" class=\\"c-stack b-links-bar\\" data-style-direction=\\"row\\" data-style-justification=\\"center\\" data-style-alignment=\\"unset\\" data-style-inline=\\"false\\" data-style-wrap=\\"wrap\\"><a class=\\"c-link\\" href=\\"id_1\\">test link 1</a></nav><hr class=\\"c-divider\\"/>"`
 		);
 	});
 
@@ -96,7 +96,7 @@ describe("the links bar feature for the default output type", () => {
 		const wrapper = shallow(<LinksBar customFields={{ navigationConfig: "links" }} />);
 
 		expect(wrapper.html()).toMatchInlineSnapshot(
-			`"<nav aria-label=\\"More Links\\" class=\\"c-stack b-links-bar\\" data-style-direction=\\"row\\" data-style-justification=\\"center\\" data-style-alignment=\\"unset\\" data-style-inline=\\"false\\" data-style-wrap=\\"wrap\\"><a class=\\"c-link\\" href=\\"id_1\\">test link 1</a><span class=\\"c-separator\\"></span><a class=\\"c-link\\" href=\\"id_2\\">test link 2</a><span class=\\"c-separator\\"></span><a class=\\"c-link\\" href=\\"/\\">Link Text</a></nav><hr/>"`
+			`"<nav aria-label=\\"More Links\\" class=\\"c-stack b-links-bar\\" data-style-direction=\\"row\\" data-style-justification=\\"center\\" data-style-alignment=\\"unset\\" data-style-inline=\\"false\\" data-style-wrap=\\"wrap\\"><a class=\\"c-link\\" href=\\"id_1\\">test link 1</a><span class=\\"c-separator\\"></span><a class=\\"c-link\\" href=\\"id_2\\">test link 2</a><span class=\\"c-separator\\"></span><a class=\\"c-link\\" href=\\"/\\">Link Text</a></nav><hr class=\\"c-divider\\"/>"`
 		);
 	});
 


### PR DESCRIPTION
## Description

There is a use for dividers within blocks. Most dividers here will need to be stylistic only, using the assistiveHidden true on the Divider component. One block – the Article Body – will need `assitiveHidden` to be `false` because it is a true thematic paragraph level change, based on the html spec. It is up to the composer authors to use the divider as a true thematic shift, rather than decorative.

## Jira Ticket

- [THEMES-726](https://arcpublishing.atlassian.net/browse/THEMES-726)

## Acceptance Criteria

- Update the Article Body block’s divider to use the component’s Divider. 

       `assistiveHidden` will be `false`. `aria-hidden` will be `false` as a result, based on that ticket  

- Update the Links Bar block’s divider to use the component’s Divider.

## Test Steps

1. Checkout this branch `git checkout THEMES-726`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/links-bar-block,@wpmedia/article-body-block`
3. For for the divider component updated

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
