### PR TITLE
THEMES-720 - Convert ad taboola block to v2

### DIFF
--- a/blocks/ad-taboola-block/README.md
+++ b/blocks/ad-taboola-block/README.md
@@ -1,6 +1,8 @@
 # `@wpmedia/ad-taboola-block`
 
-_Block that implement a [Taboola Block](https://www.taboola.com/)._
+A wrapper for [Taboola](https://www.taboola.com/) - an ad block for use across different page types.
+
+Makes use of a page's meta tag - `page-type` to pass to taboola the value.
 
 ## Props
 
@@ -43,5 +45,5 @@ This properties will be defined on each block added to the page.
 
 ## Additional Considerations
 
-The block will not render inside PageBuilder editor. Inside the editor, when the block has his properties correctly configured, will show a dummy block with the placement name.
+The block will not render fully within PageBuilder editor. Inside the editor, when the block has properties correctly configured, will show a dummy block with the placement name.
 To see the block working, need to publish the page and on the preview url add the parameter `&taboola_sim_domain=XXX`, replacing XXX with the domain provided by Taboola for testing.

--- a/blocks/ad-taboola-block/features/ad-taboola/default.jsx
+++ b/blocks/ad-taboola-block/features/ad-taboola/default.jsx
@@ -74,6 +74,7 @@ class AdTaboola extends Component {
 			return;
 		}
 		const head = document.getElementsByTagName("head")[0];
+		// istanbul ignore next
 		if (!head) {
 			return;
 		}
@@ -96,6 +97,7 @@ class AdTaboola extends Component {
 			return;
 		}
 		const body = document.getElementsByTagName("body")[0];
+		// istanbul ignore next
 		if (!body) {
 			return;
 		}
@@ -123,7 +125,6 @@ class AdTaboola extends Component {
 						<small>Taboola widget&nbsp;</small>
 						<strong>{placement}</strong>
 					</div>
-					<hr />
 				</>
 			);
 		}
@@ -141,7 +142,6 @@ class AdTaboola extends Component {
 		return (
 			<>
 				<div id={`${container}`} />
-				<hr />
 				<script type="text/javascript" dangerouslySetInnerHTML={{ __html: scriptString }} />
 			</>
 		);

--- a/blocks/ad-taboola-block/features/ad-taboola/default.test.jsx
+++ b/blocks/ad-taboola-block/features/ad-taboola/default.test.jsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { shallow } from "enzyme";
-
+import { render } from "@testing-library/react";
 import getProperties from "fusion:properties";
+
+import AdTaboola from "./default";
 
 const TBL_WRAPPER = ".tbl-wrapper";
 
@@ -9,23 +10,21 @@ const metaValueMock = () => "article";
 
 describe("render Taboola widget", () => {
 	describe("when missing configuration parameters", () => {
-		const { default: AdTaboola } = require("./default");
-
 		it("must not render when there isn't parameters", () => {
-			const wrapper = shallow(<AdTaboola metaValue={metaValueMock} />);
+			const { container } = render(<AdTaboola metaValue={metaValueMock} />);
 
-			expect(wrapper.find("#tbl-widget").length).toBe(0);
-			expect(wrapper.find(TBL_WRAPPER).length).toBe(0);
+			expect(container.querySelector("#tbl-widget")).toBe(null);
+			expect(container.querySelector(TBL_WRAPPER)).toBe(null);
 		});
 
 		it("must not render when only the publisher id is present", () => {
 			getProperties.mockImplementation(() => ({
 				taboolaPublisherId: "taboolaPublisherId",
 			}));
-			const wrapper = shallow(<AdTaboola metaValue={metaValueMock} />);
+			const { container } = render(<AdTaboola metaValue={metaValueMock} />);
 
-			expect(wrapper.find("#tbl-widget").length).toBe(0);
-			expect(wrapper.find(TBL_WRAPPER).length).toBe(0);
+			expect(container.querySelector("#tbl-widget")).toBe(null);
+			expect(container.querySelector(TBL_WRAPPER)).toBe(null);
 		});
 
 		it("must not render when some of the widget parameters are missing", () => {
@@ -36,15 +35,15 @@ describe("render Taboola widget", () => {
 				container: "tbl-widget",
 			};
 
-			const wrapper = shallow(<AdTaboola metaValue={metaValueMock} customFields={customFields} />);
-			expect(wrapper.find("#tbl-widget").length).toBe(0);
-			expect(wrapper.find(TBL_WRAPPER).length).toBe(0);
+			const { container } = render(
+				<AdTaboola metaValue={metaValueMock} customFields={customFields} />
+			);
+			expect(container.querySelector("#tbl-widget")).toBe(null);
+			expect(container.querySelector(TBL_WRAPPER)).toBe(null);
 		});
 	});
 
 	describe("when have all config the paramters", () => {
-		const { default: AdTaboola } = require("./default");
-
 		it("must render the widget", () => {
 			getProperties.mockImplementation(() => ({
 				taboolaPublisherId: "taboolaPublisherId",
@@ -55,11 +54,12 @@ describe("render Taboola widget", () => {
 				container: "tbl-widget",
 			};
 
-			const wrapper = shallow(<AdTaboola metaValue={metaValueMock} customFields={customFields} />);
+			const { container } = render(
+				<AdTaboola metaValue={metaValueMock} customFields={customFields} />
+			);
 
-			expect(wrapper.find("#tbl-widget").length).toBe(1);
-			expect(wrapper.find("hr").length).toBe(1);
-			expect(wrapper.find("script").length).toBe(1);
+			expect(container.querySelector("#tbl-widget")).not.toBe(null);
+			expect(container.querySelector("script")).not.toBe(null);
 		});
 
 		it("must render the visual wrapper on admin", () => {
@@ -72,13 +72,13 @@ describe("render Taboola widget", () => {
 				container: "tbl-widget",
 			};
 
-			const wrapper = shallow(
+			const { container } = render(
 				<AdTaboola metaValue={metaValueMock} customFields={customFields} isAdmin />
 			);
 
-			expect(wrapper.find(TBL_WRAPPER).length).toBe(1);
-			expect(wrapper.find("AdTaboola #tbl-widget").length).toBe(0);
-			expect(wrapper.find("AdTaboola script").length).toBe(0);
+			expect(container.querySelector(TBL_WRAPPER)).not.toBe(null);
+			expect(container.querySelector("AdTaboola #tbl-widget")).toBe(null);
+			expect(container.querySelector("AdTaboola script")).toBe(null);
 		});
 	});
 });

--- a/blocks/ad-taboola-block/index.js
+++ b/blocks/ad-taboola-block/index.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/blocks/ad-taboola-block/package.json
+++ b/blocks/ad-taboola-block/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@wpmedia/ad-taboola-block",
   "version": "5.16.0",
-  "description": "Fusion News Theme Taboola Widget",
-  "author": "nelson fernandez <nelson.fernandez@washpost.com>",
+  "description": "Taboola Ad Block",
+  "author": "Arc XP - Themes",
   "homepage": "https://github.com/WPMedia/arc-themes-blocks",
   "license": "CC-BY-NC-ND",
-  "main": "index.js",
+  "main": "",
   "files": [
     "features"
   ],
@@ -17,10 +17,6 @@
     "type": "git",
     "url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
     "directory": "blocks/ad-taboola-block"
-  },
-  "scripts": {
-    "test": "echo \"Error: run tests from root\" && exit 1",
-    "lint": "eslint --ext js --ext jsx features"
   },
   "gitHead": "8afcaeae3d9a0cc126a4a22a9b7fe766669aa88e"
 }


### PR DESCRIPTION
## Description

Not a lot of change for the v2 conversion:
* Remove `hr` tag as this is a bottom divider that is now achievable via the divider block in v2
* Updated tests to use RTL instead of enzyme

## Jira Ticket

- [THEMES-720](https://arcpublishing.atlassian.net/browse/THEMES-720)


## Test Steps

Hard to test output of ad block due to not having an taboola account, but with limited changes in block we should be good to test admin only

1. Checkout this branch `git checkout THEMES-720`
2. Checkout feature pack branch `THEMES-720`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/ad-taboola-block`
4. Add the taboola block in PageBuilder and configure the three custom fields, using any values
5. Verify block shows admin message


## Dependencies or Side Effects

Feature Pack PR - https://github.com/WPMedia/arc-themes-feature-pack/pull/374
Manifest PR - https://github.com/WPMedia/arc-themes-manifests/pull/156

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
