### PR TITLE
THEMES-836: Quilted Image Block - QA fix

### DIFF
--- a/blocks/quilted-image-block/features/quilted-image/default.jsx
+++ b/blocks/quilted-image-block/features/quilted-image/default.jsx
@@ -310,7 +310,7 @@ QuiltedImage.propTypes = {
 		}).isRequired,
 		image3AspectRatio: PropTypes.oneOf(Object.keys(ASPECT_RATIO_MAP)).tag({
 			labels: ASPECT_RATIO_MAP,
-			defaultValue: "16/9",
+			defaultValue: "4/3",
 			hidden: true,
 			group: "Image 3",
 		}),

--- a/blocks/quilted-image-block/index.story.jsx
+++ b/blocks/quilted-image-block/index.story.jsx
@@ -40,7 +40,7 @@ const customFields = {
 	button2Variant: "primary",
 	image3URL:
 		"https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/Y3STKUZ2CVHUBN4CLLFKP4JRQU.jpg",
-	image3AspectRatio: "16/9",
+	image3AspectRatio: "4/3",
 	image3Id: "Y3STKUZ2CVHUBN4CLLFKP4JRQU",
 	image3Auth: '{"2":"e1ee90266f0068204492e7212dc50cf4a7f9a05a21480ec1821346511a09b65b"}',
 	image3Alt: "Smiling dog",
@@ -58,8 +58,6 @@ export const fullWidthImageOnTop = () => (
 		customFields={{
 			...customFields,
 			fullWidthImage: "top",
-			image1AspectRatio: "16/9",
-			image3AspectRatio: "4/3",
 		}}
 	/>
 );


### PR DESCRIPTION
## Description

This PR addresses a qa issue with the quilted image block. The image aspect ratios should all be set to 4/3 for the time being.

## Jira Ticket

- [THEMES-836](https://arcpublishing.atlassian.net/browse/THEMES-836)


## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-836-qa-fix`
2. Use the `commerce` branch of the feature pack.
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/quilted-image-block`
4. Set a quilted image block on a test page.
5. Verify that the images have a 4/3 aspect ratio.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
