### PR TITLE
THEMES-838: Update Image resizer.

### DIFF
--- a/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
+++ b/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.jsx
@@ -3,7 +3,6 @@ import PropTypes from "@arc-fusion/prop-types";
 
 import { useFusionContext, useComponentContext } from "fusion:context";
 import { useContent, useEditableContent } from "fusion:content";
-import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
 
 import {
 	Carousel,
@@ -11,7 +10,6 @@ import {
 	HeadingSection,
 	Icon,
 	Image,
-	imageANSToImageSrc,
 	Link,
 	Price,
 	Stack,
@@ -154,9 +152,8 @@ function ProductAssortmentCarousel({ customFields = {} }) {
 										{auth ? (
 											<Image
 												alt={altText}
-												resizedOptions={{ auth: auth[RESIZER_APP_VERSION] }}
-												resizerURL={RESIZER_URL}
-												src={imageANSToImageSrc(featuredImage)}
+												ansImage={featuredImage}
+												resizedOptions={{ smart: true }}
 												width={280}
 												height={280}
 												responsiveImages={[280, 420, 560, 840]}


### PR DESCRIPTION
## Description

Update Product Assortment Carousel Image Resizer Integration

## Jira Ticket

- [THEMES-838](https://arcpublishing.atlassian.net/browse/THEMES-838)

## Acceptance Criteria

Product Assortment Carousel - Arc Block is using Resizer V2

## Test Steps

1. Checkout this branch `git checkout themes-838`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/product-assortment-carousel-block`
3. Switch to `sandbox.arccommerce` api `CONTENT_BASE` in your ENV and download/import the arccommerce PB data
4. Open http://localhost/pagebuilder/editor/curate?p=pzLCMIeQ3y6VXW53t&v=v5qG6tyo56VXW53t
5. Select Assortment: 
![image](https://user-images.githubusercontent.com/2287238/208770282-9e81ccfe-fedb-494e-82af-bafa5c50c587.png)


## Effect Of Changes
Images will have resizer size options:
![image](https://user-images.githubusercontent.com/2287238/208769508-9d12841f-7679-4e85-9272-60fac57ce0fb.png)

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
