### PR TITLE
THEMES-897 - Update default dateTimeFormat string to match new requirement

### DIFF
--- a/.storybook/alias/properties.js
+++ b/.storybook/alias/properties.js
@@ -15,7 +15,7 @@ export default () => ({
 	dateLocalization: {
 		language: "en",
 		timeZone: "America/New_York",
-		dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
+		dateTimeFormat: "%B %d, %Y at %l:%M%p %Z",
 		dateFormat: "%B %d, %Y",
 	},
 	api: {

--- a/blocks/date-block/features/date/default.jsx
+++ b/blocks/date-block/features/date/default.jsx
@@ -12,7 +12,7 @@ const ArticleDate = () => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
+			dateTimeFormat: "%B %d, %Y at %l:%M%p %Z",
 		},
 	} = getProperties(arcSite);
 	const formattedDate =

--- a/blocks/date-block/features/date/default.test.jsx
+++ b/blocks/date-block/features/date/default.test.jsx
@@ -11,13 +11,13 @@ describe("Given the display time from ANS, it should convert to the proper timez
 			dateLocalization: {
 				language: "en",
 				timeZone: "America/New_York",
-				dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
+				dateTimeFormat: "%B %d, %Y at %l:%M%p %Z",
 			},
 		});
 		useAppContext.mockReturnValue({ globalContent: { display_date: "2019-08-11T16:45:33.209Z" } });
 		render(<ArticleDate />);
 
-		expect(screen.queryByText("August 11, 2019 at 12:45 pm EDT")).not.toBeNull();
+		expect(screen.queryByText("August 11, 2019 at 12:45PM EDT")).not.toBeNull();
 	});
 
 	it("should use default localization values", () => {
@@ -26,20 +26,20 @@ describe("Given the display time from ANS, it should convert to the proper timez
 
 		render(<ArticleDate />);
 
-		expect(screen.queryByText("August 11, 2019 at 4:45 pm UTC")).not.toBeNull();
+		expect(screen.queryByText("August 11, 2019 at 4:45PM UTC")).not.toBeNull();
 	});
 
 	it("should not output date if display_date is value", () => {
 		useAppContext.mockReturnValue({ globalContent: { display_date: "9-08-11T16:45:33.209Z" } });
 		render(<ArticleDate />);
 
-		expect(screen.queryByText("August 11, 2019 at 12:45 pm EDT")).toBeNull();
+		expect(screen.queryByText("August 11, 2019 at 12:45PM EDT")).toBeNull();
 	});
 
 	it("should not output date", () => {
 		useAppContext.mockReturnValue({});
 		render(<ArticleDate />);
 
-		expect(screen.queryByText("August 11, 2019 at 12:45 pm EDT")).toBeNull();
+		expect(screen.queryByText("August 11, 2019 at 12:45PM EDT")).toBeNull();
 	});
 });

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -39,7 +39,7 @@ const ExtraLargePromo = ({ customFields }) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
+			dateTimeFormat: "%B %d, %Y at %l:%M%p %Z",
 		},
 		fallbackImage,
 	} = getProperties(arcSite);

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -257,7 +257,7 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
+			dateTimeFormat: "%B %d, %Y at %l:%M%p %Z",
 		},
 		fallbackImage,
 	} = getProperties(arcSite);

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -103,7 +103,6 @@ jest.mock("fusion:content", () => ({
 		searchableField: () => {},
 	})),
 }));
-jest.mock("fusion:environment", () => ({}));
 
 describe("Large Promo", () => {
 	afterEach(() => {
@@ -137,7 +136,7 @@ describe("Large Promo", () => {
 		expect(screen.queryByText(largePromoMock.label.basic.text)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.headlines.basic)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.description.basic)).not.toBeNull();
-		expect(screen.queryByText("December 02, 2019 at 6:58 pm UTC")).not.toBeNull();
+		expect(screen.queryByText("December 02, 2019 at 6:58PM UTC")).not.toBeNull();
 		expect(screen.queryByRole("img")).not.toBeNull();
 	});
 
@@ -157,7 +156,7 @@ describe("Large Promo", () => {
 		expect(screen.queryByText(largePromoMock.label.basic.text)).toBeNull();
 		expect(screen.queryByText(largePromoMock.headlines.basic)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.description.basic)).not.toBeNull();
-		expect(screen.queryByText("December 02, 2019 at 6:58 pm UTC")).not.toBeNull();
+		expect(screen.queryByText("December 02, 2019 at 6:58PM UTC")).not.toBeNull();
 		expect(screen.queryByRole("img")).not.toBeNull();
 	});
 
@@ -177,7 +176,7 @@ describe("Large Promo", () => {
 		expect(screen.queryByText(largePromoMock.label.basic.text)).toBeNull();
 		expect(screen.queryByText(largePromoMock.headlines.basic)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.description.basic)).not.toBeNull();
-		expect(screen.queryByText("December 02, 2019 at 6:58 pm UTC")).toBeNull();
+		expect(screen.queryByText("December 02, 2019 at 6:58PM UTC")).toBeNull();
 		expect(screen.queryByRole("img")).not.toBeNull();
 	});
 
@@ -197,7 +196,7 @@ describe("Large Promo", () => {
 		expect(screen.queryByText(largePromoMock.label.basic.text)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.headlines.basic)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.description.basic)).not.toBeNull();
-		expect(screen.queryByText("December 02, 2019 at 6:58 pm UTC")).not.toBeNull();
+		expect(screen.queryByText("December 02, 2019 at 6:58PM UTC")).not.toBeNull();
 		expect(screen.queryByRole("img")).not.toBeNull();
 	});
 
@@ -217,7 +216,7 @@ describe("Large Promo", () => {
 		expect(screen.queryByText(largePromoMock.label.basic.text)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.headlines.basic)).toBeNull();
 		expect(screen.queryByText(largePromoMock.description.basic)).not.toBeNull();
-		expect(screen.queryByText("December 02, 2019 at 6:58 pm UTC")).not.toBeNull();
+		expect(screen.queryByText("December 02, 2019 at 6:58PM UTC")).not.toBeNull();
 		expect(screen.queryByRole("img")).not.toBeNull();
 	});
 
@@ -237,7 +236,7 @@ describe("Large Promo", () => {
 		expect(screen.queryByText(largePromoMock.label.basic.text)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.headlines.basic)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.description.basic)).toBeNull();
-		expect(screen.queryByText("December 02, 2019 at 6:58 pm UTC")).not.toBeNull();
+		expect(screen.queryByText("December 02, 2019 at 6:58PM UTC")).not.toBeNull();
 		expect(screen.queryByRole("img")).not.toBeNull();
 	});
 
@@ -253,7 +252,7 @@ describe("Large Promo", () => {
 		expect(screen.queryByText(largePromoMock.label.basic.text)).toBeNull();
 		expect(screen.queryByText(largePromoMock.headlines.basic)).toBeNull();
 		expect(screen.queryByText(largePromoMock.description.basic)).toBeNull();
-		expect(screen.queryByText("December 02, 2019 at 6:58 pm UTC")).toBeNull();
+		expect(screen.queryByText("December 02, 2019 at 6:58PM UTC")).toBeNull();
 		expect(screen.queryByRole("img")).not.toBeNull();
 	});
 
@@ -295,7 +294,7 @@ describe("Large Promo", () => {
 		expect(screen.queryByText("global.sponsored-content")).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.headlines.basic)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.description.basic)).toBeNull();
-		expect(screen.queryByText("December 02, 2019 at 6:58 pm UTC")).toBeNull();
+		expect(screen.queryByText("December 02, 2019 at 6:58PM UTC")).toBeNull();
 	});
 
 	it("should render image icon label", () => {

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -38,7 +38,7 @@ const MediumPromo = ({ customFields }) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
+			dateTimeFormat: "%B %d, %Y at %l:%M%p %Z",
 		},
 		fallbackImage,
 	} = getProperties(arcSite);

--- a/blocks/top-table-list-block/features/top-table-list/_children/extra-large.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/extra-large.jsx
@@ -49,7 +49,7 @@ const ExtraLarge = (props) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
+			dateTimeFormat: "%B %d, %Y at %l:%M%p %Z",
 		},
 	} = getProperties(arcSite);
 	const phrases = usePhrases();

--- a/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
@@ -56,7 +56,7 @@ const Large = (props) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
+			dateTimeFormat: "%B %d, %Y at %l:%M%p %Z",
 		},
 	} = getProperties(arcSite);
 

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium.jsx
@@ -47,7 +47,7 @@ const Medium = (props) => {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateTimeFormat: "%B %d, %Y at %l:%M %P %Z",
+			dateTimeFormat: "%B %d, %Y at %l:%M%p %Z",
 		},
 	} = getProperties(arcSite);
 	const phrases = usePhrases();

--- a/package-lock.json
+++ b/package-lock.json
@@ -17905,9 +17905,9 @@
       }
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-3.11",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.11/a331b078d19b11e32b5265e26c7772b7fefdf398",
-      "integrity": "sha512-22+Q+OoWAtYrlZQbmfhT/99ootFSzNJFvuTrqJr4DQwnOo9FNhopaj0eF+D7ZEDWPVblT8SweFQXbABokR9WvQ==",
+      "version": "0.0.4-arc-themes-release-version-2-0-3.12",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.12/b8ff476b1a42953a8ca5943f00061a0c98ee4d2d",
+      "integrity": "sha512-Al64c45Lf96eu8/1Z9xeQeoxywDo5IJ3Ep61IwOqs1oauqTzqzNTnC31X2K4tQAHjTjHlmS+5ITthel1UNotNw==",
       "dev": true,
       "requires": {
         "react-oembed-container": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17905,9 +17905,9 @@
       }
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-3.12",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.12/b8ff476b1a42953a8ca5943f00061a0c98ee4d2d",
-      "integrity": "sha512-Al64c45Lf96eu8/1Z9xeQeoxywDo5IJ3Ep61IwOqs1oauqTzqzNTnC31X2K4tQAHjTjHlmS+5ITthel1UNotNw==",
+      "version": "0.0.4-arc-themes-release-version-2-0-3.14",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.14/e73679d6493eebb1e55d09b7c9051082f234febd",
+      "integrity": "sha512-A2ZhfRyN18iJG/b1BSVMjQma1Tirp0mlZ/8hYCTIDRLR84sqXAsDby7Nno6hsku0guTk9lLfYgdO8tIpPG+7AQ==",
       "dev": true,
       "requires": {
         "react-oembed-container": "^1.0.1",


### PR DESCRIPTION
## Description

Update fallback dateTimeFormat syntax to be as directed from product as the default

## Jira Ticket

- [THEMES-897](https://arcpublishing.atlassian.net/browse/THEMES-897)


## Test Steps

Test's have been updated

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-897]: https://arcpublishing.atlassian.net/browse/THEMES-897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ