### PR TITLE
URLSearchParams should not have encoded values passed to it

### DIFF
--- a/blocks/search-content-source-block/sources/search-api.js
+++ b/blocks/search-content-source-block/sources/search-api.js
@@ -17,7 +17,7 @@ const fetch = ({ "arc-site": site, page = "1", query }, { cachedCall }) => {
 
 	const urlSearch = new URLSearchParams({
 		page,
-		q: encodeURIComponent(decodeURIComponent(query)),
+		q: decodeURIComponent(query),
 		...(SEARCH_KEY ? { key: SEARCH_KEY } : {}),
 		...(site ? { website_id: site } : {}),
 	});


### PR DESCRIPTION
## Description

During the conversion, the encoding was not removed from the variable passed to URLSearchParams so it was being double encoded.

## Jira Ticket

- [THEMES-932](https://arcpublishing.atlassian.net/browse/THEMES-932)

## Test Steps

1. Checkout this branch `git checkout themes-932`
2. Run `jest -t 'should encode the query value'`
3. This should pass

## Effect Of Changes

### Before

previously it would double encode the search query if it had special characters (vidèo)
![image](https://user-images.githubusercontent.com/2287238/212179658-54d1c1da-3c60-496d-8129-ee208dbee601.png)

### After

now it only encodes it once (vidèo)
![image](https://user-images.githubusercontent.com/2287238/212179823-d9456055-3213-49bd-8665-2d8386a3d14f.png)

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-932]: https://arcpublishing.atlassian.net/browse/THEMES-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ