### PR TITLE
Themes 685 Implemented Video icon and label 

### DIFF
--- a/.storybook/mock-content/extraLargePromo.js
+++ b/.storybook/mock-content/extraLargePromo.js
@@ -42,6 +42,9 @@ export const extraLargePromo = {
 			type: "image",
 			url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/EM5DTGYGABDJZODV7YVFOC2DOM.jpeg",
 		},
+		lead_art: {
+			type: "gallery",
+		},
 	},
 	type: "story",
 	website_url: "/test/promo-image-variations/2021/04/23/basic-promo-image/",

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -2560,7 +2560,32 @@
 						stack: (
 							gap: var(--global-spacing-4),
 						),
+						mediaItem: (
+							position: relative,
+						),
 					),
+				),
+				xl-promo-icon-label: (
+					align-items: center,
+					padding: var(--global-spacing-2),
+					background-color: var(--color-primary),
+					border: 0,
+					border-radius: var(--global-spacing-2),
+					bottom: var(--global-spacing-2),
+					margin-left: var(--global-spacing-2),
+					position: absolute,
+					z-index: 1,
+					components: (
+						icon: (
+							fill: var(--global-white),
+							height: var(--global-spacing-4),
+							width: var(--global-spacing-4),
+						),
+					),
+				),
+				xl-promo-label: (
+					margin-left: var(--global-spacing-2),
+					color: var(--global-white),
 				),
 			),
 		),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -2560,7 +2560,7 @@
 						stack: (
 							gap: var(--global-spacing-4),
 						),
-						mediaItem: (
+						media-item: (
 							position: relative,
 						),
 					),

--- a/blocks/extra-large-promo-block/_index.scss
+++ b/blocks/extra-large-promo-block/_index.scss
@@ -3,4 +3,14 @@
 .b-xl-promo {
 	@include scss.block-properties("xl-promo");
 	@include scss.block-components("xl-promo");
+
+	&__icon_label {
+		@include scss.block-components("xl-promo-icon-label");
+		@include scss.block-properties("large-promo-icon-label");
+	}
+
+	&__label {
+		@include scss.block-components("xl-promo-label");
+		@include scss.block-properties("xl-promo-label");
+	}
 }

--- a/blocks/extra-large-promo-block/_index.scss
+++ b/blocks/extra-large-promo-block/_index.scss
@@ -1,9 +1,6 @@
 @use "@wpmedia/arc-themes-components/scss";
 
 .b-xl-promo {
-	@include scss.block-properties("xl-promo");
-	@include scss.block-components("xl-promo");
-
 	&__icon_label {
 		@include scss.block-components("xl-promo-icon-label");
 		@include scss.block-properties("large-promo-icon-label");
@@ -13,4 +10,7 @@
 		@include scss.block-components("xl-promo-label");
 		@include scss.block-properties("xl-promo-label");
 	}
+
+	@include scss.block-properties("xl-promo");
+	@include scss.block-components("xl-promo");
 }

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -322,9 +322,6 @@ const ExtraLargePromo = ({ customFields }) => {
 		image: phrases.t("global.gallery-text"),
 		video: phrases.t("global.video-text"),
 	}[videoOrGalleryContentType?.type];
-	console.log("videoOrGalleryContentType", videoOrGalleryContentType);
-	console.log("embedMarkup", embedMarkup);
-	console.log("content---", content);
 
 	return (
 		<ExtraLargePromoPresentation

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -33,6 +33,106 @@ import { LazyLoad, localizeDateTime } from "@wpmedia/engine-theme-sdk";
 
 const BLOCK_CLASS_NAME = "b-xl-promo";
 
+const getType = (type, content) => (content?.type === type ? content : undefined);
+
+export const ExtraLargePromoPresentation = ({
+	hasOverline,
+	contentHeading,
+	showImage,
+	contentDescription,
+	hasDate,
+	shouldLazyLoad,
+	overlineUrl,
+	overlineText,
+	embedMarkup,
+	contentUrl,
+	imageParams,
+	searchableField,
+	imageRatio,
+	labelIconName,
+	labelIconText,
+	contentAuthors,
+	translationByText,
+	displayDate,
+	formattedDate,
+}) =>
+	hasOverline || contentHeading || showImage || contentDescription || contentAuthors || hasDate ? (
+		<LazyLoad enabled={shouldLazyLoad}>
+			<article className={BLOCK_CLASS_NAME}>
+				{hasOverline ? <Overline href={overlineUrl}>{overlineText}</Overline> : null}
+				{contentHeading ||
+				showImage ||
+				contentDescription ||
+				contentAuthors ||
+				hasDate ||
+				embedMarkup ? (
+					<Stack>
+						{contentHeading ? (
+							<HeadingSection>
+								<Heading>
+									<Conditional component={Link} condition={contentUrl} href={contentUrl}>
+										{contentHeading}
+									</Conditional>
+								</Heading>
+							</HeadingSection>
+						) : null}
+						{embedMarkup || imageParams ? (
+							<MediaItem
+								{...searchableField({
+									imageOverrideURL: "url",
+									imageOverrideId: "_id",
+									imageOverrideAuth: "auth",
+								})}
+								suppressContentEditableWarning
+							>
+								{embedMarkup ? (
+									<Video
+										aspectRatio={imageRatio}
+										embedMarkup={embedMarkup}
+										viewportPercentage={60}
+									/>
+								) : (
+									<>
+										<Conditional
+											component={Link}
+											condition={contentUrl}
+											href={contentUrl}
+											assistiveHidden
+										>
+											<Image {...imageParams} />
+											{labelIconName ? (
+												<div className={`${BLOCK_CLASS_NAME}__icon_label`}>
+													<Icon name={labelIconName} />
+													<span className={`${BLOCK_CLASS_NAME}__label`}>{labelIconText}</span>
+												</div>
+											) : null}
+										</Conditional>
+									</>
+								)}
+							</MediaItem>
+						) : null}
+						{contentDescription ? <Paragraph>{contentDescription}</Paragraph> : null}
+						{contentAuthors || hasDate ? (
+							<Attribution>
+								<Join separator={Separator}>
+									{contentAuthors ? (
+										<Join separator={() => " "}>
+											{translationByText}
+											{contentAuthors}
+										</Join>
+									) : null}
+									{hasDate ? (
+										<DateComponent dateTime={displayDate} dateString={formattedDate} />
+									) : null}
+								</Join>
+							</Attribution>
+						) : null}
+					</Stack>
+				) : null}
+			</article>
+		</LazyLoad>
+	) : null;
+
 const ExtraLargePromo = ({ customFields }) => {
 	const { arcSite, isAdmin } = useFusionContext();
 	const { searchableField } = useEditableContent();
@@ -177,7 +277,10 @@ const ExtraLargePromo = ({ customFields }) => {
 	const contentHeading = showHeadline ? content?.headlines?.basic : null;
 	const contentUrl = content?.websites?.[arcSite]?.website_url;
 	const embedMarkup = playVideoInPlace && getVideoFromANS(content);
-	const hasAuthors = showByline && content?.credits?.by.length > 0;
+	const contentAuthors =
+		showByline && content?.credits?.by?.length > 0
+			? formatAuthors(content.credits.by, phrases.t("global.and-text"))
+			: null;
 	const imageParams =
 		showImage &&
 		(imageOverrideURL || (content && getImageFromANS(content))
@@ -186,7 +289,7 @@ const ExtraLargePromo = ({ customFields }) => {
 						? {
 								_id: imageOverrideId,
 								url: imageOverrideURL,
-								auth: imageOverrideAuth ? JSON.parse(imageOverrideAuth) : {},
+								auth: imageOverrideAuth ? JSON.parse(imageOverrideAuth) : null,
 						  }
 						: getImageFromANS(content),
 					alt: content?.headlines?.basic || "",
@@ -200,107 +303,52 @@ const ExtraLargePromo = ({ customFields }) => {
 			: {
 					src: fallbackImage,
 			  });
-	let videoOrGalleryContentType;
-
-	if (showImage) {
-		videoOrGalleryContentType = "gallery";
-	}
-
-	if (embedMarkup) {
-		videoOrGalleryContentType = "video";
-	}
+	const videoOrGalleryContentType =
+		getType("video", content) ||
+		getType("gallery", content) ||
+		getType("image", content) ||
+		getType("video", content?.promo_items?.lead_art) ||
+		getType("gallery", content?.promo_items?.lead_art) ||
+		getType("image", content?.promo_items?.lead_art);
 
 	const labelIconName = {
 		gallery: "Camera",
 		video: "Play",
-	}[videoOrGalleryContentType];
+		image: "Camera",
+	}[videoOrGalleryContentType?.type];
 
 	const labelIconText = {
 		gallery: phrases.t("global.gallery-text"),
+		image: phrases.t("global.gallery-text"),
 		video: phrases.t("global.video-text"),
-	}[videoOrGalleryContentType];
+	}[videoOrGalleryContentType?.type];
+	console.log("videoOrGalleryContentType", videoOrGalleryContentType);
+	console.log("embedMarkup", embedMarkup);
+	console.log("content---", content);
 
-	return hasOverline ||
-		contentHeading ||
-		showImage ||
-		contentDescription ||
-		hasAuthors ||
-		hasDate ? (
-		<LazyLoad enabled={shouldLazyLoad}>
-			<article className={BLOCK_CLASS_NAME}>
-				{hasOverline ? <Overline href={overlineUrl}>{overlineText}</Overline> : null}
-				{contentHeading ||
-				showImage ||
-				contentDescription ||
-				hasAuthors ||
-				hasDate ||
-				embedMarkup ? (
-					<Stack>
-						{contentHeading ? (
-							<HeadingSection>
-								<Heading>
-									<Conditional component={Link} condition={contentUrl} href={contentUrl}>
-										{contentHeading}
-									</Conditional>
-								</Heading>
-							</HeadingSection>
-						) : null}
-						{embedMarkup || showImage ? (
-							<MediaItem
-								{...searchableField({
-									imageOverrideURL: "url",
-									imageOverrideId: "_id",
-									imageOverrideAuth: "auth",
-								})}
-								suppressContentEditableWarning
-							>
-								{embedMarkup && playVideoInPlace ? (
-									<Video
-										aspectRatio={imageRatio}
-										embedMarkup={embedMarkup}
-										viewportPercentage={60}
-									/>
-								) : (
-									<>
-										<Conditional
-											component={Link}
-											condition={contentUrl}
-											href={contentUrl}
-											assistiveHidden
-										>
-											<Image {...imageParams} />
-											{labelIconName ? (
-												<div className={`${BLOCK_CLASS_NAME}__icon_label`}>
-													<Icon name={labelIconName} />
-													<span className={`${BLOCK_CLASS_NAME}__label`}>{labelIconText}</span>
-												</div>
-											) : null}
-										</Conditional>
-									</>
-								)}
-							</MediaItem>
-						) : null}
-						{contentDescription ? <Paragraph>{contentDescription}</Paragraph> : null}
-						{hasAuthors || hasDate ? (
-							<Attribution>
-								<Join separator={Separator}>
-									{hasAuthors ? (
-										<Join separator={() => " "}>
-											{phrases.t("global.by-text")}
-											{formatAuthors(content?.credits?.by, phrases.t("global.and-text"))}
-										</Join>
-									) : null}
-									{hasDate ? (
-										<DateComponent dateTime={displayDate} dateString={formattedDate} />
-									) : null}
-								</Join>
-							</Attribution>
-						) : null}
-					</Stack>
-				) : null}
-			</article>
-		</LazyLoad>
-	) : null;
+	return (
+		<ExtraLargePromoPresentation
+			hasOverline={hasOverline}
+			contentHeading={contentHeading}
+			showImage={showImage}
+			contentDescription={contentDescription}
+			hasDate={hasDate}
+			shouldLazyLoad={shouldLazyLoad}
+			overlineUrl={overlineUrl}
+			overlineText={overlineText}
+			embedMarkup={embedMarkup}
+			contentUrl={contentUrl}
+			imageParams={imageParams}
+			searchableField={searchableField}
+			imageRatio={imageRatio}
+			labelIconName={labelIconName}
+			contentAuthors={contentAuthors}
+			displayDate={displayDate}
+			labelIconText={labelIconText}
+			formattedDate={formattedDate}
+			translationByText={phrases.t("global.by-text")}
+		/>
+	);
 };
 
 ExtraLargePromo.propTypes = {

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -61,7 +61,6 @@ const ExtraLargePromo = ({ customFields }) => {
 		showHeadline,
 		showImage,
 		showOverline,
-		viewportPercentage,
 	} = customFields;
 
 	const content =
@@ -263,11 +262,11 @@ const ExtraLargePromo = ({ customFields }) => {
 								})}
 								suppressContentEditableWarning
 							>
-								{embedMarkup ? (
+								{embedMarkup && playVideoInPlace ? (
 									<Video
 										aspectRatio={imageRatio}
 										embedMarkup={embedMarkup}
-										viewportPercentage={viewportPercentage}
+										viewportPercentage={60}
 									/>
 								) : (
 									<>
@@ -278,15 +277,15 @@ const ExtraLargePromo = ({ customFields }) => {
 											assistiveHidden
 										>
 											<Image {...imageParams} />
+											{labelIconName ? (
+												<div className={`${BLOCK_CLASS_NAME}__icon_label`}>
+													<Icon name={labelIconName} />
+													<span className={`${BLOCK_CLASS_NAME}__label`}>{labelIconText}</span>
+												</div>
+											) : null}
 										</Conditional>
 									</>
 								)}
-								{labelIconName && !playVideoInPlace ? (
-									<div className={`${BLOCK_CLASS_NAME}__icon_label`}>
-										<Icon name={labelIconName} />
-										<span className={`${BLOCK_CLASS_NAME}__label`}>{labelIconText}</span>
-									</div>
-								) : null}
 							</MediaItem>
 						) : null}
 						{contentDescription ? <Paragraph>{contentDescription}</Paragraph> : null}
@@ -376,16 +375,6 @@ ExtraLargePromo.propTypes = {
 			description:
 				"Turning on lazy-loading will prevent this block from being loaded on the page until it is nearly in-view for the user.",
 			name: "Lazy Load block?",
-		}),
-		viewportPercentage: PropTypes.number.tag({
-			name: "Percentage of viewport height",
-			description:
-				"With Shrink Video enabled, this determines how much vertical viewport real estate the video will occupy.",
-			min: 0,
-			max: 150,
-			defaultValue: 65,
-			hidden: true,
-			group: "Video Settings",
 		}),
 	}),
 };

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -176,7 +176,7 @@ const ExtraLargePromo = ({ customFields }) => {
 	const contentDescription = showDescription ? content?.description?.basic : null;
 	const contentHeading = showHeadline ? content?.headlines?.basic : null;
 	const contentUrl = content?.websites?.[arcSite]?.website_url;
-	const embedMarkup = getVideoFromANS(content);
+	const embedMarkup = playVideoInPlace && getVideoFromANS(content);
 	const hasAuthors = showByline && content?.credits?.by.length > 0;
 	const imageParams =
 		showImage &&

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -33,8 +33,6 @@ import { LazyLoad, localizeDateTime } from "@wpmedia/engine-theme-sdk";
 
 const BLOCK_CLASS_NAME = "b-xl-promo";
 
-// const getType = (type, content) => (content?.type === type ? content : undefined);
-
 const ExtraLargePromo = ({ customFields }) => {
 	const { arcSite, isAdmin } = useFusionContext();
 	const { searchableField } = useEditableContent();
@@ -155,12 +153,6 @@ const ExtraLargePromo = ({ customFields }) => {
 		? localizeDateTime(new Date(displayDate), dateTimeFormat, language, timeZone)
 		: "";
 	const hasDate = showDate && formattedDate;
-
-	// const videoOrGalleryContent =
-	// 	getType("video", content) ||
-	// 	getType("gallery", content) ||
-	// 	getType("video", content?.promo_items?.lead_art) ||
-	// 	getType("gallery", content?.promo_items?.lead_art);
 
 	const { display: labelDisplay, url: labelUrl, text: labelText } = content?.label?.basic || {};
 

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -62,6 +62,11 @@ describe("the extra large promo feature", () => {
 			imageOverrideURL: "#",
 			imageRatio: "4:3",
 			showImage: true,
+			imageOverrideAuth: JSON.stringify({
+				auth: {
+					2: "75f6b4c64c7889dc8eadf6a328999d522be2e2397c7b9a5a0704f6d9afa60fcf",
+				},
+			}),
 		};
 		render(<ExtraLargePromo customFields={config} />);
 		expect(screen.queryByRole("img", { name: config.headline })).not.toBeNull();

--- a/blocks/extra-large-promo-block/index.story.jsx
+++ b/blocks/extra-large-promo-block/index.story.jsx
@@ -86,3 +86,24 @@ export const imageAndDescription = () => {
 
 	return <Promo customFields={updatedCustomFields} />;
 };
+
+export const withGalleryLabelAndImage = () => {
+	const updatedCustomFields = {
+		...allCustomFields,
+		showImage: true,
+		videoOrGalleryContentType: "gallery",
+	};
+
+	return <Promo customFields={updatedCustomFields} />;
+};
+
+export const withVideoLabelAndImage = () => {
+	const updatedCustomFields = {
+		...allCustomFields,
+		showImage: true,
+		videoOrGalleryContentType: "video",
+		playVideoInplace: false,
+	};
+
+	return <Promo customFields={updatedCustomFields} />;
+};

--- a/blocks/extra-large-promo-block/index.story.jsx
+++ b/blocks/extra-large-promo-block/index.story.jsx
@@ -1,8 +1,65 @@
 import React from "react";
-import Promo from "./features/extra-large-promo/default";
+import Promo, { ExtraLargePromoPresentation } from "./features/extra-large-promo/default";
 
 export default {
 	title: "Blocks/Extra Large Promo",
+};
+
+const extraLargePromo = {
+	_id: "K2FFSIYSVRC7HIBZBXLQ2CUPTY",
+	credits: {
+		by: [
+			{
+				_id: "saracarothers",
+				additional_properties: {
+					original: {
+						byline: "Sara Lynn Carothers",
+					},
+				},
+				name: "Sara Carothers",
+				type: "author",
+				url: "/author/sara-carothers/",
+			},
+		],
+	},
+	description: {
+		basic:
+			"This story has only a basic promo image (a large rock on the beach). This image should be seen in promo blocks, as well as in the Lead Art spot on the article page, and as the social promo image.",
+	},
+	display_date: "2021-04-23T21:13:31.477Z",
+	headlines: {
+		basic: "basic promo image",
+	},
+	label: {
+		basic: {
+			display: true,
+			text: "Free",
+		},
+	},
+	owner: {
+		sponsored: false,
+	},
+	promo_items: {
+		basic: {
+			_id: "EM5DTGYGABDJZODV7YVFOC2DOM",
+			auth: {
+				2: "75f6b4c64c7889dc8eadf6a328999d522be2e2397c7b9a5a0704f6d9afa60fcf",
+			},
+			type: "image",
+			url: "https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/EM5DTGYGABDJZODV7YVFOC2DOM.jpeg",
+		},
+	},
+	type: "story",
+	website_url: "/test/promo-image-variations/2021/04/23/basic-promo-image/",
+	websites: {
+		"the-gazette": {
+			website_section: {
+				_id: "/test/promo-image-variations",
+				name: "Promo image variations",
+			},
+			website_url: "/test/promo-image-variations/2021/04/23/basic-promo-image/",
+		},
+	},
 };
 
 const allCustomFields = {
@@ -91,16 +148,26 @@ export const withGalleryLabelAndImage = () => {
 	const updatedCustomFields = {
 		...allCustomFields,
 		showImage: true,
+		labelIconName: "Camera",
+		labelIconText: "Gallery",
+		imageParams: {
+			src: extraLargePromo.promo_items.basic.url,
+		},
 	};
 
-	return <Promo customFields={updatedCustomFields} />;
+	return <ExtraLargePromoPresentation {...updatedCustomFields} searchableField={() => {}} />;
 };
 
 export const withVideoLabelAndImage = () => {
 	const updatedCustomFields = {
 		...allCustomFields,
 		showImage: true,
+		labelIconName: "Play",
+		labelIconText: "Video",
+		imageParams: {
+			src: extraLargePromo.promo_items.basic.url,
+		},
 	};
 
-	return <Promo customFields={updatedCustomFields} />;
+	return <ExtraLargePromoPresentation {...updatedCustomFields} searchableField={() => {}} />;
 };

--- a/blocks/extra-large-promo-block/index.story.jsx
+++ b/blocks/extra-large-promo-block/index.story.jsx
@@ -102,7 +102,6 @@ export const withVideoLabelAndImage = () => {
 		...allCustomFields,
 		showImage: true,
 		videoOrGalleryContentType: "video",
-		playVideoInplace: false,
 	};
 
 	return <Promo customFields={updatedCustomFields} />;

--- a/blocks/extra-large-promo-block/index.story.jsx
+++ b/blocks/extra-large-promo-block/index.story.jsx
@@ -91,7 +91,6 @@ export const withGalleryLabelAndImage = () => {
 	const updatedCustomFields = {
 		...allCustomFields,
 		showImage: true,
-		videoOrGalleryContentType: "gallery",
 	};
 
 	return <Promo customFields={updatedCustomFields} />;
@@ -101,7 +100,6 @@ export const withVideoLabelAndImage = () => {
 	const updatedCustomFields = {
 		...allCustomFields,
 		showImage: true,
-		videoOrGalleryContentType: "video",
 	};
 
 	return <Promo customFields={updatedCustomFields} />;


### PR DESCRIPTION
## Description

As a part of the play in place video feature, a video icon and text should appear on the bottom left of the image when we turn off this feature. and when the play in place video is turned on, this video icon and text disappear. 

## Jira Ticket

- [THEMES-685](https://arcpublishing.atlassian.net/browse/THEMES-685)

## Acceptance Criteria

The actionable large play overlay would display for play in place, but the video text + icon would display to indicate the lead art is a video when play in place is turned off.

## Test Steps

1. Checkout this branch `git checkout THEMES-685`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/extra-large-promo-block`
3. Add Extra large promo block in PB and USE:
    
    Display content-info: ans-item
    Content source: content-api

For video:
    `_id: 3GBIKGX4CFCCJJXRK4BNYAZNXA`

For image:
   `_id: KWRZFECFBVB4VAGV5LD3OG67CU`

Click update to see the results make sure uncheck the "Play video in place" checkbox.

## Dependencies or Side Effects

- Feature pack pr for local development: https://github.com/WPMedia/arc-themes-feature-pack/pull/379

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-685]: https://arcpublishing.atlassian.net/browse/THEMES-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ