### PR TITLE
Themes 788 Gallery/video icon covering most of the image in mobile view and iPad

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1758,6 +1758,8 @@
 						),
 						paragraph: (
 							display: block,
+							width: 100%,
+							overflow: initial,
 						),
 						separator: (
 							padding: 0 var(--global-spacing-2),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1759,7 +1759,6 @@
 						paragraph: (
 							display: block,
 							width: 100%,
-							overflow: initial,
 						),
 						separator: (
 							padding: 0 var(--global-spacing-2),
@@ -2788,6 +2787,7 @@
 						),
 						paragraph: (
 							display: block,
+							width: auto,
 						),
 					),
 				),


### PR DESCRIPTION
## Description

The size of the gallery icon on the image should be proportional to the size of the image in mobile view and iPad

## Jira Ticket

- [THEMES-788](https://arcpublishing.atlassian.net/browse/THEMES-788)

## Acceptance Criteria

Actual Behavior

In mobile and iPad view, the gallery/video icon covers most of the image

Expected Behavior

In mobile and iPad view, the gallery/video label overlay is icon only (no text)

## Test Steps

1. Checkout this branch `git checkout THEMES-788`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/medium-promo-block`
3.  Use _id: YVRVXPSCJNBKBF3TVRFOLKGKBM and inspect for mobile view 

## Effect Of Changes

### Before

<img width="848" alt="Screenshot 2023-02-02 at 10 36 33 AM" src="https://user-images.githubusercontent.com/83021791/216369673-214ed43d-c3e3-4c7b-b030-1b21cb63d711.png">


### After

<img width="871" alt="Screenshot 2023-02-02 at 10 36 00 AM" src="https://user-images.githubusercontent.com/83021791/216369739-f1350575-df4d-47d2-9666-bd09eaaa7ace.png">


## Dependencies or Side Effects

- Feature pack pr for local development: https://github.com/WPMedia/arc-themes-feature-pack/pull/381

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-788]: https://arcpublishing.atlassian.net/browse/THEMES-788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ