### PR TITLE
THEMES-995: ChartBeat field names - 1.25

### DIFF
--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -489,10 +489,10 @@ describe("chartbeat render conditions", () => {
 		expect(wrapper.find('script[data-integration="chartbeat"]').length).toBe(0);
 	});
 
-	it("must not render chartbeat code when chartBeatAccountId property is missing", () => {
+	it("must not render chartbeat code when chartbeatAccountId property is missing", () => {
 		jest.mock("fusion:properties", () =>
 			jest.fn(() => ({
-				chartBeatDomain: "example.com",
+				chartbeatDomain: "example.com",
 			}))
 		);
 
@@ -507,10 +507,10 @@ describe("chartbeat render conditions", () => {
 		expect(wrapper.find('script[data-integration="chartbeat"]').length).toBe(0);
 	});
 
-	it("must not render chartbeat code when chartBeatDomain property is missing", () => {
+	it("must not render chartbeat code when chartbeatDomain property is missing", () => {
 		jest.mock("fusion:properties", () =>
 			jest.fn(() => ({
-				chartBeatAccountId: 994949,
+				chartbeatAccountId: 994949,
 			}))
 		);
 
@@ -528,8 +528,8 @@ describe("chartbeat render conditions", () => {
 	it("must not render chartbeat code when both properties are empty", () => {
 		jest.mock("fusion:properties", () =>
 			jest.fn(() => ({
-				chartBeatAccountId: "",
-				chartBeatDomain: "",
+				chartbeatAccountId: "",
+				chartbeatDomain: "",
 			}))
 		);
 
@@ -544,11 +544,11 @@ describe("chartbeat render conditions", () => {
 		expect(wrapper.find('script[data-integration="chartbeat"]').length).toBe(0);
 	});
 
-	it("must render chartbeat code when chartBeatDomain and chartBeatAccountID properties are present", () => {
+	it("must render chartbeat code when chartbeatDomain and chartbeatAccountID properties are present", () => {
 		jest.mock("fusion:properties", () =>
 			jest.fn(() => ({
-				chartBeatAccountId: 994949,
-				chartBeatDomain: "example.com",
+				chartbeatAccountId: 994949,
+				chartbeatDomain: "example.com",
 			}))
 		);
 

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -106,8 +106,8 @@ const SampleOutputType = ({
 		resizerURL,
 		facebookAdmins,
 		nativoIntegration,
-		chartBeatAccountId,
-		chartBeatDomain,
+		chartbeatAccountId,
+		chartbeatDomain,
 		fallbackImage,
 		comscoreID,
 		querylyId,
@@ -115,11 +115,11 @@ const SampleOutputType = ({
 		locale = "en",
 	} = getProperties(arcSite);
 
-	const chartBeatInline = `
+	const chartbeatInline = `
     (function() {
       var _sf_async_config = window._sf_async_config = (window._sf_async_config || {});
-      _sf_async_config.uid = ${chartBeatAccountId};
-      _sf_async_config.domain = "${chartBeatDomain}";
+      _sf_async_config.uid = ${chartbeatAccountId};
+      _sf_async_config.domain = "${chartbeatDomain}";
       _sf_async_config.useCanonical = true;
       _sf_async_config.useCanonicalDomain = true;
       _sf_async_config.sections = '';
@@ -151,7 +151,7 @@ const SampleOutputType = ({
 	const inlineScripts = [
 		...new Set([
 			...dangerouslyInjectJS,
-			...(chartBeatAccountId && chartBeatDomain ? [chartBeatInline] : []),
+			...(chartbeatAccountId && chartbeatDomain ? [chartbeatInline] : []),
 			...(comscoreID ? [scriptCodeInline] : []),
 			...(gaID ? [gaScriptInline] : []),
 			...(gtmID ? [gtmScriptInline] : []),
@@ -216,7 +216,7 @@ const SampleOutputType = ({
 				{nativoIntegration ? (
 					<script async data-integration="nativo-ad" src="https://s.ntv.io/serve/load.js" />
 				) : null}
-				{chartBeatAccountId && chartBeatDomain ? (
+				{chartbeatAccountId && chartbeatDomain ? (
 					<script
 						async
 						data-integration="chartbeat"


### PR DESCRIPTION
## Description

This PR updates the chart beat field names used in the default output type to match what is in the Themes settings manifests. This fix is for version 1.25.

## Jira Ticket

- [THEMES-995](https://arcpublishing.atlassian.net/browse/THEMES-995)

## Acceptance Criteria

* The chart beat script shows on the page.

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-995-1.25`
2. Checkout the feature pack branch `THEMES-995-1.25`
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/default-output-block`
4. Visit any page.
5. Inspect it to ensure that the main chartbeat script (`https://static.chartbeat.com/js/chartbeat.js`) is being loaded.

## Dependencies or Side Effects

- Feature pack pr for local development: https://github.com/WPMedia/arc-themes-feature-pack/pull/382

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-995]: https://arcpublishing.atlassian.net/browse/THEMES-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ