### PR TITLE
Update signing service call to use new v2 contract

### DIFF
--- a/blocks/signing-service-content-source-block/sources/signing-service.js
+++ b/blocks/signing-service-content-source-block/sources/signing-service.js
@@ -18,7 +18,7 @@ const fetch = ({
 	serviceVersion = SIGNING_SERVICE_DEFAULT_VERSION,
 }) =>
 	axios({
-		url: `${CONTENT_BASE}/signing-service/v2/sign/${service}/${serviceVersion}?value=${encodeURI(
+		url: `${CONTENT_BASE}/signing-service/v2/sign/${service}/${serviceVersion}?value=${encodeURIComponent(
 			id
 		)}`,
 		headers: {

--- a/blocks/signing-service-content-source-block/sources/signing-service.js
+++ b/blocks/signing-service-content-source-block/sources/signing-service.js
@@ -16,17 +16,19 @@ const fetch = ({
 	id,
 	service = SIGNING_SERVICE_DEFAULT_APP,
 	serviceVersion = SIGNING_SERVICE_DEFAULT_VERSION,
-}) =>
-	axios({
-		url: `${CONTENT_BASE}/signing-service/v2/sign/${service}/${serviceVersion}?value=${encodeURIComponent(
-			id
-		)}`,
+}) => {
+	const urlSearch = new URLSearchParams({
+		value: id,
+	});
+	return axios({
+		url: `${CONTENT_BASE}/signing-service/v2/sign/${service}/${serviceVersion}?${urlSearch.toString()}`,
 		headers: {
 			"content-type": "application/json",
 			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
 		},
 		method: "GET",
 	}).then(({ data: content }) => content);
+};
 
 export default {
 	fetch,

--- a/blocks/signing-service-content-source-block/sources/signing-service.js
+++ b/blocks/signing-service-content-source-block/sources/signing-service.js
@@ -18,7 +18,9 @@ const fetch = ({
 	serviceVersion = SIGNING_SERVICE_DEFAULT_VERSION,
 }) =>
 	axios({
-		url: `${CONTENT_BASE}/signing-service/v1/sign/${service}/${serviceVersion}/${encodeURI(id)}`,
+		url: `${CONTENT_BASE}/signing-service/v2/sign/${service}/${serviceVersion}?value=${encodeURI(
+			id
+		)}`,
 		headers: {
 			"content-type": "application/json",
 			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,

--- a/blocks/signing-service-content-source-block/sources/signing-service.test.js
+++ b/blocks/signing-service-content-source-block/sources/signing-service.test.js
@@ -18,6 +18,6 @@ describe("Test Signing Service content source", () => {
 		};
 		const contentSourceRequest = await contentSource.fetch(key);
 
-		expect(contentSourceRequest.url).toEqual(`/signing-service/v1/sign/resizer/1/test-id`);
+		expect(contentSourceRequest.url).toEqual(`/signing-service/v2/sign/resizer/1?value=test-id`);
 	});
 });

--- a/blocks/signing-service-content-source-block/sources/signing-service.test.js
+++ b/blocks/signing-service-content-source-block/sources/signing-service.test.js
@@ -14,10 +14,12 @@ jest.mock("axios", () => ({
 describe("Test Signing Service content source", () => {
 	it("should build the correct url", async () => {
 		const key = {
-			id: "test-id",
+			id: "test://id",
 		};
 		const contentSourceRequest = await contentSource.fetch(key);
 
-		expect(contentSourceRequest.url).toEqual(`/signing-service/v2/sign/resizer/1?value=test-id`);
+		expect(contentSourceRequest.url).toEqual(
+			`/signing-service/v2/sign/resizer/1?value=test%3A%2F%2Fid`
+		);
 	});
 });


### PR DESCRIPTION
## Description

This updates our signing service to use the v2 implementation to support third party images.

## Test Steps

1. Checkout this branch `git checkout update-to-signing-service-v2`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/signing-service-content-source-block`
3. This should return data... `http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=content-api&config={%22_id%22:%223GBIKGX4CFCCJJXRK4BNYAZNXA%22}`

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
