### PR TITLE
WIP: Handle twitter oembed fallback with interstitial link 

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -34,6 +34,28 @@ const StyledLink = styled.a`
 	color: ${(props) => props.primaryColor};
 `;
 
+const InterstitialLink = ({ key, url, content, arcSite, phrases }) => {
+	// link string will have to be truthy (non-zero length string) to render below
+	if (!(url && content)) return null;
+	const beforeContent = "[&nbsp;";
+	const afterContent = "&nbsp;]";
+
+	return (
+		<Fragment key={key}>
+			<p className="interstitial-link block-margin-bottom">
+				<span dangerouslySetInnerHTML={{ __html: beforeContent }} />
+				<StyledLink
+					href={url}
+					aria-label={phrases.t("article-body-block.interstitial-link-aria-label")}
+					dangerouslySetInnerHTML={{ __html: content }}
+					primaryColor={getThemeStyle(arcSite)["primary-color"]}
+				/>
+				<span dangerouslySetInnerHTML={{ __html: afterContent }} />
+			</p>
+		</Fragment>
+	);
+};
+
 function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 	const { _id: key = index, type, content } = item;
 
@@ -177,25 +199,14 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		}
 
 		case "interstitial_link": {
-			const { url } = item;
-			// link string will have to be truthy (non-zero length string) to render below
-			if (!(url && content)) return null;
-			const beforeContent = "[&nbsp;";
-			const afterContent = "&nbsp;]";
-
 			return (
-				<Fragment key={key}>
-					<p className="interstitial-link block-margin-bottom">
-						<span dangerouslySetInnerHTML={{ __html: beforeContent }} />
-						<StyledLink
-							href={url}
-							aria-label={phrases.t("article-body-block.interstitial-link-aria-label")}
-							dangerouslySetInnerHTML={{ __html: content }}
-							primaryColor={getThemeStyle(arcSite)["primary-color"]}
-						/>
-						<span dangerouslySetInnerHTML={{ __html: afterContent }} />
-					</p>
-				</Fragment>
+				<InterstitialLink
+					key={key}
+					url={item?.url}
+					content={item?.content}
+					arcSite={arcSite}
+					phrases={phrases}
+				/>
 			);
 		}
 
@@ -248,6 +259,17 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 			) : null;
 
 		case "oembed_response": {
+			if (item.subtype === "twitter" && !item?.raw_oembed?.html?.includes(item?.raw_oembed?.url)) {
+				return (
+					<InterstitialLink
+						key={key}
+						url={item?.raw_oembed?.url}
+						content={item?.raw_oembed?.url}
+						arcSite={arcSite}
+						phrases={phrases}
+					/>
+				);
+			}
 			return item.raw_oembed ? <Oembed key={key} element={item} /> : null;
 		}
 


### PR DESCRIPTION
if Twitter API calls get blocked on 2/9 and html is no longer populated

**If you have not filled out the checklist below, the pr is not ready for review.**

## Description

_Information about what you changed for this PR_

## Jira Ticket

- [THEMES-](https://arcpublishing.atlassian.net/browse/THEMES-)

## Acceptance Criteria

_copy from ticket_

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout {branch name}`
2. Run fusion repo with linked blocks `npx fusion start -f -l {blocks to link}`
3. {Next ....}

## Effect Of Changes

### Before

_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After

_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects

_Examples of dependencies or side effects are:_

- Manifest pr for new block:
- Feature pack pr for local development:
- How to deploy to news: https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3138682964/News+Theme+2.0+Migration+Development+Deployment+Notes
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Dependency on another PR that needs to be merged first

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
