### PR TITLE
THEMES-965: Add themes=v2 parameter to each used content source

### DIFF
--- a/blocks/alert-bar-content-source-block/sources/alert-bar-collections.js
+++ b/blocks/alert-bar-content-source-block/sources/alert-bar-collections.js
@@ -1,16 +1,23 @@
 import axios from "axios";
 import { ARC_ACCESS_TOKEN, CONTENT_BASE } from "fusion:environment";
 
-const params = {};
+const params = [
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
-const fetch = ({ "arc-site": website }) => {
+const fetch = ({ themes, "arc-site": website }) => {
 	const urlSearch = new URLSearchParams({
 		content_alias: "alert-bar",
 		from: 0,
 		published: true,
 		size: 1,
 		...(website ? { website } : {}),
-		themes: "v2",
+		themes,
 	});
 
 	return (

--- a/blocks/alert-bar-content-source-block/sources/alert-bar-collections.js
+++ b/blocks/alert-bar-content-source-block/sources/alert-bar-collections.js
@@ -10,6 +10,7 @@ const fetch = ({ "arc-site": website }) => {
 		published: true,
 		size: 1,
 		...(website ? { website } : {}),
+		themes: "v2",
 	});
 
 	return (

--- a/blocks/alert-bar-content-source-block/sources/alert-bar-collections.test.js
+++ b/blocks/alert-bar-content-source-block/sources/alert-bar-collections.test.js
@@ -35,7 +35,14 @@ jest.mock("axios", () => ({
 
 describe("the author api content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({});
+		expect(contentSource.params).toEqual([
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/author-content-source-block/sources/author-api.js
+++ b/blocks/author-content-source-block/sources/author-api.js
@@ -11,6 +11,7 @@ const params = {
 const fetch = ({ slug }, { cachedCall }) => {
 	const urlSearch = new URLSearchParams({
 		slug,
+		themes: "v2",
 	});
 
 	return axios({

--- a/blocks/author-content-source-block/sources/author-api.js
+++ b/blocks/author-content-source-block/sources/author-api.js
@@ -4,14 +4,24 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	slug: "text",
-};
+const params = [
+	{
+		displayName: "slug",
+		name: "slug",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
-const fetch = ({ slug }, { cachedCall }) => {
+const fetch = ({ slug, themes }, { cachedCall }) => {
 	const urlSearch = new URLSearchParams({
 		slug,
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/author-content-source-block/sources/author-api.test.js
+++ b/blocks/author-content-source-block/sources/author-api.test.js
@@ -27,9 +27,19 @@ jest.mock("axios", () => ({
 
 describe("the author api content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			slug: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "slug",
+				name: "slug",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -4,16 +4,42 @@ import { CONTENT_BASE, ARC_ACCESS_TOKEN, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	_id: "text",
-	content_alias: "text",
-	from: "text",
-	getNext: "text",
-	size: "text",
-};
-// test
+const params = [
+	{
+		displayName: "_id",
+		name: "_id",
+		type: "text",
+	},
+	{
+		displayName: "content_alias",
+		name: "content_alias",
+		type: "text",
+	},
+	{
+		displayName: "from",
+		name: "from",
+		type: "text",
+	},
+	{
+		displayName: "getNext",
+		name: "getNext",
+		type: "text",
+	},
+	{
+		displayName: "size",
+		name: "size",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
+
 const fetch = (
-	{ _id, "arc-site": site, content_alias: contentAlias, from, getNext = "false", size },
+	{ _id, "arc-site": site, content_alias: contentAlias, from, getNext = "false", size, themes },
 	{ cachedCall }
 ) => {
 	// Max collection size is 20
@@ -25,7 +51,7 @@ const fetch = (
 		published: true,
 		...(site ? { website: site } : {}),
 		...(size ? { size: constrainedSize } : {}),
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -25,6 +25,7 @@ const fetch = (
 		published: true,
 		...(site ? { website: site } : {}),
 		...(size ? { size: constrainedSize } : {}),
+		themes: "v2",
 	});
 
 	return axios({

--- a/blocks/collections-content-source-block/sources/content-api-collections.test.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.test.js
@@ -28,13 +28,39 @@ jest.mock("axios", () => ({
 
 describe("the collections content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			_id: "text",
-			content_alias: "text",
-			from: "text",
-			getNext: "text",
-			size: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "_id",
+				name: "_id",
+				type: "text",
+			},
+			{
+				displayName: "content_alias",
+				name: "content_alias",
+				type: "text",
+			},
+			{
+				displayName: "from",
+				name: "from",
+				type: "text",
+			},
+			{
+				displayName: "getNext",
+				name: "getNext",
+				type: "text",
+			},
+			{
+				displayName: "size",
+				name: "size",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should be associated with the ans-feed schema", () => {

--- a/blocks/content-api-source-block/sources/content-api.js
+++ b/blocks/content-api-source-block/sources/content-api.js
@@ -4,16 +4,30 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	_id: "text",
-	website_url: "text",
-};
+const params = [
+	{
+		displayName: "_id",
+		name: "_id",
+		type: "text",
+	},
+	{
+		displayName: "website_url",
+		name: "website_url",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
-const fetch = ({ _id, "arc-site": website, website_url: websiteUrl }, { cachedCall }) => {
+const fetch = ({ _id, themes, "arc-site": website, website_url: websiteUrl }, { cachedCall }) => {
 	const urlSearch = new URLSearchParams({
 		...(_id ? { _id } : { website_url: websiteUrl }),
 		...(website ? { website } : {}),
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/content-api-source-block/sources/content-api.js
+++ b/blocks/content-api-source-block/sources/content-api.js
@@ -13,6 +13,7 @@ const fetch = ({ _id, "arc-site": website, website_url: websiteUrl }, { cachedCa
 	const urlSearch = new URLSearchParams({
 		...(_id ? { _id } : { website_url: websiteUrl }),
 		...(website ? { website } : {}),
+		themes: "v2",
 	});
 
 	return axios({

--- a/blocks/content-api-source-block/sources/content-api.test.js
+++ b/blocks/content-api-source-block/sources/content-api.test.js
@@ -27,10 +27,24 @@ jest.mock("axios", () => ({
 
 describe("the content api source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentApi.params).toEqual({
-			_id: "text",
-			website_url: "text",
-		});
+		expect(contentApi.params).toEqual([
+			{
+				displayName: "_id",
+				name: "_id",
+				type: "text",
+			},
+			{
+				displayName: "website_url",
+				name: "website_url",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	describe("when a site is provided", () => {

--- a/blocks/related-content-content-source-block/sources/related-content.js
+++ b/blocks/related-content-content-source-block/sources/related-content.js
@@ -16,6 +16,7 @@ const fetch = ({ _id, "arc-site": site }, { cachedCall }) => {
 	const urlSearch = new URLSearchParams({
 		_id,
 		website: site,
+		themes: "v2",
 	});
 
 	return axios({

--- a/blocks/related-content-content-source-block/sources/related-content.js
+++ b/blocks/related-content-content-source-block/sources/related-content.js
@@ -4,11 +4,21 @@ import { CONTENT_BASE, ARC_ACCESS_TOKEN, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	_id: "text",
-};
+const params = [
+	{
+		displayName: "_id",
+		name: "_id",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
-const fetch = ({ _id, "arc-site": site }, { cachedCall }) => {
+const fetch = ({ _id, "arc-site": site, themes }, { cachedCall }) => {
 	if (!_id || !site) {
 		return "";
 	}
@@ -16,7 +26,7 @@ const fetch = ({ _id, "arc-site": site }, { cachedCall }) => {
 	const urlSearch = new URLSearchParams({
 		_id,
 		website: site,
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/related-content-content-source-block/sources/related-content.test.js
+++ b/blocks/related-content-content-source-block/sources/related-content.test.js
@@ -27,9 +27,19 @@ jest.mock("axios", () => ({
 
 describe("the related-content content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			_id: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "_id",
+				name: "_id",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should use the proper schema", () => {

--- a/blocks/search-content-source-block/sources/search-api.js
+++ b/blocks/search-content-source-block/sources/search-api.js
@@ -4,13 +4,31 @@ import { ARC_ACCESS_TOKEN, RESIZER_APP_VERSION, searchKey as SEARCH_KEY } from "
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	_id: "text",
-	page: "text",
-	query: "text",
-};
+const params = [
+	{
+		displayName: "_id",
+		name: "_id",
+		type: "text",
+	},
+	{
+		displayName: "page",
+		name: "page",
+		type: "text",
+	},
+	{
+		displayName: "query",
+		name: "query",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
-const fetch = ({ "arc-site": site, page = "1", query }, { cachedCall }) => {
+const fetch = ({ "arc-site": site, page = "1", themes, query }, { cachedCall }) => {
 	if (!query) {
 		return "";
 	}
@@ -20,7 +38,7 @@ const fetch = ({ "arc-site": site, page = "1", query }, { cachedCall }) => {
 		q: decodeURIComponent(query),
 		...(SEARCH_KEY ? { key: SEARCH_KEY } : {}),
 		...(site ? { website_id: site } : {}),
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/search-content-source-block/sources/search-api.js
+++ b/blocks/search-content-source-block/sources/search-api.js
@@ -20,6 +20,7 @@ const fetch = ({ "arc-site": site, page = "1", query }, { cachedCall }) => {
 		q: decodeURIComponent(query),
 		...(SEARCH_KEY ? { key: SEARCH_KEY } : {}),
 		...(site ? { website_id: site } : {}),
+		themes: "v2",
 	});
 
 	return axios({

--- a/blocks/search-content-source-block/sources/search-api.test.js
+++ b/blocks/search-content-source-block/sources/search-api.test.js
@@ -43,11 +43,29 @@ expect.extend({
 
 describe("the search content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			_id: "text",
-			page: "text",
-			query: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "_id",
+				name: "_id",
+				type: "text",
+			},
+			{
+				displayName: "page",
+				name: "page",
+				type: "text",
+			},
+			{
+				displayName: "query",
+				name: "query",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	describe("when a query is provided", () => {

--- a/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
+++ b/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
@@ -4,14 +4,32 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	authorSlug: "text",
-	feedOffset: "number",
-	feedSize: "number",
-};
+const params = [
+	{
+		displayName: "authorSlug",
+		name: "authorSlug",
+		type: "text",
+	},
+	{
+		displayName: "feedOffset",
+		name: "feedOffset",
+		type: "number",
+	},
+	{
+		displayName: "feedSize",
+		name: "feedSize",
+		type: "number",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = (
-	{ authorSlug, feedOffset: from = 0, feedSize: size = 8, "arc-site": website },
+	{ authorSlug, feedOffset: from = 0, feedSize: size = 8, themes, "arc-site": website },
 	{ cachedCall }
 ) => {
 	const urlSearch = new URLSearchParams({
@@ -20,7 +38,7 @@ const fetch = (
 		sort: "display_date:desc",
 		size,
 		website,
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
+++ b/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
@@ -20,6 +20,7 @@ const fetch = (
 		sort: "display_date:desc",
 		size,
 		website,
+		themes: "v2",
 	});
 
 	return axios({

--- a/blocks/story-feed-author-content-source-block/sources/story-feed-author.test.jsx
+++ b/blocks/story-feed-author-content-source-block/sources/story-feed-author.test.jsx
@@ -27,11 +27,29 @@ jest.mock("axios", () => ({
 
 describe("story-feed-author-content-source-block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			authorSlug: "text",
-			feedOffset: "number",
-			feedSize: "number",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "authorSlug",
+				name: "authorSlug",
+				type: "text",
+			},
+			{
+				displayName: "feedOffset",
+				name: "feedOffset",
+				type: "number",
+			},
+			{
+				displayName: "feedSize",
+				name: "feedSize",
+				type: "number",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
+++ b/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
@@ -4,14 +4,32 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	offset: "number",
-	query: "text",
-	size: "number",
-};
+const params = [
+	{
+		displayName: "offset",
+		name: "offset",
+		type: "number",
+	},
+	{
+		displayName: "query",
+		name: "query",
+		type: "text",
+	},
+	{
+		displayName: "size",
+		name: "size",
+		type: "number",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = (
-	{ query: q = "*", size = 8, offset: from = 0, "arc-site": website },
+	{ query: q = "*", size = 8, offset: from = 0, themes, "arc-site": website },
 	{ cachedCall }
 ) => {
 	const urlSearch = new URLSearchParams({
@@ -20,7 +38,7 @@ const fetch = (
 		size,
 		sort: "display_date:desc",
 		website,
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
+++ b/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
@@ -20,6 +20,7 @@ const fetch = (
 		size,
 		sort: "display_date:desc",
 		website,
+		themes: "v2",
 	});
 
 	return axios({

--- a/blocks/story-feed-query-content-source-block/sources/story-feed-query.test.js
+++ b/blocks/story-feed-query-content-source-block/sources/story-feed-query.test.js
@@ -27,11 +27,29 @@ jest.mock("axios", () => ({
 
 describe("story-feed-author-content-source-block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			query: "text",
-			size: "number",
-			offset: "number",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "offset",
+				name: "offset",
+				type: "number",
+			},
+			{
+				displayName: "query",
+				name: "query",
+				type: "text",
+			},
+			{
+				displayName: "size",
+				name: "size",
+				type: "number",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
@@ -97,6 +97,7 @@ const fetch = (
 		size,
 		sort: "display_date:desc",
 		website,
+		themes: "v2",
 	});
 
 	return axios({

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
@@ -12,12 +12,34 @@ import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-b
 export const itemsToArray = (itemString = "") =>
 	itemString.split(",").map((item) => item.trim().replace(/"/g, ""));
 
-const params = {
-	excludeSections: "text",
-	feedOffset: "number",
-	feedSize: "number",
-	includeSections: "text",
-};
+const params = [
+	{
+		displayName: "excludeSections",
+		name: "excludeSections",
+		type: "text",
+	},
+	{
+		displayName: "feedOffset",
+		name: "feedOffset",
+		type: "number",
+	},
+	{
+		displayName: "feedSize",
+		name: "feedSize",
+		type: "number",
+	},
+	{
+		displayName: "includeSections",
+		name: "includeSections",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = (
 	{
@@ -25,6 +47,7 @@ const fetch = (
 		feedOffset: from = 0,
 		feedSize: size = 10,
 		includeSections,
+		themes,
 		"arc-site": website,
 	},
 	{ cachedCall }
@@ -97,7 +120,7 @@ const fetch = (
 		size,
 		sort: "display_date:desc",
 		website,
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.test.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.test.js
@@ -85,12 +85,34 @@ const body = {
 
 describe("story-feed-author-content-source-block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			excludeSections: "text",
-			feedOffset: "number",
-			feedSize: "number",
-			includeSections: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "excludeSections",
+				name: "excludeSections",
+				type: "text",
+			},
+			{
+				displayName: "feedOffset",
+				name: "feedOffset",
+				type: "number",
+			},
+			{
+				displayName: "feedSize",
+				name: "feedSize",
+				type: "number",
+			},
+			{
+				displayName: "includeSections",
+				name: "includeSections",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
@@ -4,14 +4,32 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	feedOffset: "number",
-	feedSize: "number",
-	tagSlug: "text",
-};
+const params = [
+	{
+		displayName: "feedOffset",
+		name: "feedOffset",
+		type: "number",
+	},
+	{
+		displayName: "feedSize",
+		name: "feedSize",
+		type: "number",
+	},
+	{
+		displayName: "tagSlug",
+		name: "tagSlug",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = (
-	{ feedSize: size = 10, feedOffset: from = 0, tagSlug, "arc-site": website },
+	{ feedSize: size = 10, feedOffset: from = 0, tagSlug, themes, "arc-site": website },
 	{ cachedCall }
 ) => {
 	if (!tagSlug) {
@@ -24,7 +42,7 @@ const fetch = (
 		size,
 		sort: "display_date:desc",
 		website,
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
@@ -24,6 +24,7 @@ const fetch = (
 		size,
 		sort: "display_date:desc",
 		website,
+		themes: "v2",
 	});
 
 	return axios({

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.test.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.test.js
@@ -27,11 +27,29 @@ jest.mock("axios", () => ({
 
 describe("story-feed-author-content-source-block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			feedOffset: "number",
-			feedSize: "number",
-			tagSlug: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "feedOffset",
+				name: "feedOffset",
+				type: "number",
+			},
+			{
+				displayName: "feedSize",
+				name: "feedSize",
+				type: "number",
+			},
+			{
+				displayName: "tagSlug",
+				name: "tagSlug",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/tags-content-source-block/sources/tags-api.js
+++ b/blocks/tags-content-source-block/sources/tags-api.js
@@ -6,7 +6,10 @@ const params = {
 };
 
 const fetch = ({ slug: slugs = "" }) => {
-	const urlSearch = new URLSearchParams({ slugs });
+	const urlSearch = new URLSearchParams({
+		slugs,
+		themes: "v2",
+	});
 
 	return axios({
 		url: `${CONTENT_BASE}/tags/v2/slugs?${urlSearch.toString()}`,

--- a/blocks/tags-content-source-block/sources/tags-api.js
+++ b/blocks/tags-content-source-block/sources/tags-api.js
@@ -1,14 +1,24 @@
 import axios from "axios";
 import { ARC_ACCESS_TOKEN, CONTENT_BASE } from "fusion:environment";
 
-const params = {
-	slug: "text",
-};
+const params = [
+	{
+		displayName: "slug",
+		name: "slug",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
-const fetch = ({ slug: slugs = "" }) => {
+const fetch = ({ slug: slugs = "", themes }) => {
 	const urlSearch = new URLSearchParams({
 		slugs,
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/tags-content-source-block/sources/tags-api.test.js
+++ b/blocks/tags-content-source-block/sources/tags-api.test.js
@@ -39,9 +39,19 @@ jest.mock("axios", () => ({
 
 describe("the tags content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			slug: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "slug",
+				name: "slug",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
+++ b/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
@@ -4,16 +4,26 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	_id: "text",
-};
+const params = [
+	{
+		displayName: "_id",
+		name: "_id",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
-const fetch = ({ _id, "arc-site": website }, { cachedCall }) => {
+const fetch = ({ _id, "arc-site": website, themes }, { cachedCall }) => {
 	const urlSearch = new URLSearchParams({
 		_id,
 		published: "false",
 		website,
-		themes: "v2",
+		themes,
 	});
 
 	return axios({

--- a/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
+++ b/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
@@ -13,6 +13,7 @@ const fetch = ({ _id, "arc-site": website }, { cachedCall }) => {
 		_id,
 		published: "false",
 		website,
+		themes: "v2",
 	});
 
 	return axios({

--- a/blocks/unpublished-content-source-block/sources/content-api-unpublished.test.js
+++ b/blocks/unpublished-content-source-block/sources/content-api-unpublished.test.js
@@ -27,9 +27,19 @@ jest.mock("axios", () => ({
 
 describe("the unpublished content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			_id: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "_id",
+				name: "_id",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	describe("when an id is provided", () => {


### PR DESCRIPTION
## Description

With the updates for Enhanced Styling and Resizer V2 - Content Sources have been converted all to use the fetch method and also have a different response contract. In order for deployments to themes v2 to no cause issues for clients by using existing cached responses and arbitrary param needs added to all content sources to ensure a cached content source is not returned

## Jira Ticket

- [THEMES-965](https://arcpublishing.atlassian.net/browse/THEMES-965)

## Acceptance Criteria

For all content sources add a new param named themes with a default value of v2

## Test Steps

1. Checkout this branch `git checkout themes-965`
2. Run fusion repo with linked blocks `npx fusion start -f -l`
3. Testing this is a bit difficult because the API is called on the back end and only visible in the fusion console and look for the `&themes=v2` appended to the url request:
```
https://api.sandbox.themesinternal.arcpublishing.com/content/v4/search/published?body=%7B%22query%22%3A%7B%22bool%22%3A%7B%22must%22%3A%5B%7B%22term%22%3A%7B%22revision.published%22%3A%22true%22%7D%7D%2C%7B%22nested%22%3A%7B%22path%22%3A%22taxonomy.sections%22%2C%22query%22%3A%7B%22bool%22%3A%7B%22must%22%3A%5B%7B%22terms%22%3A%7B%22taxonomy.sections._id%22%3A%5B%22%2Fnews%22%5D%7D%7D%2C%7B%22term%22%3A%7B%22taxonomy.sections._website%22%3A%22the-gazette%22%7D%7D%5D%7D%7D%7D%7D%5D%2C%22must_not%22%3A%5B%7B%22nested%22%3A%7B%22path%22%3A%22taxonomy.sections%22%2C%22query%22%3A%7B%22bool%22%3A%7B%22must%22%3A%5B%7B%22terms%22%3A%7B%22taxonomy.sections._id%22%3A%5B%22%22%5D%7D%7D%2C%7B%22term%22%3A%7B%22taxonomy.sections._website%22%3A%22the-gazette%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&from=2&size=6&sort=display_date%3Adesc&website=the-gazette&themes=v2
```

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-965]: https://arcpublishing.atlassian.net/browse/THEMES-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ