### PR TITLE
Updated right-rail layout for THEMES-923

### DIFF
--- a/blocks/right-rail-block/layouts/right-rail/default.jsx
+++ b/blocks/right-rail-block/layouts/right-rail/default.jsx
@@ -42,7 +42,7 @@ const RightRailLayout = ({ children }) => {
 				</Grid>
 
 				{featureList["4"] > 0 ? (
-					<div className={`${LAYOUT_CLASS_NAME}__full-width-2`}>{fullWidth2}</div>
+					<Stack className={`${LAYOUT_CLASS_NAME}__full-width-2`}>{fullWidth2}</Stack>
 				) : null}
 			</section>
 			{footer ? (


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

Updated full-width-2 section of Right Rail layout from <div> to <Stack> so css styles (specifically .c-stack gap) would be applied to items in the section. 

_Information about what you changed for this PR_

## Jira Ticket

- [THEMES-923](https://arcpublishing.atlassian.net/browse/THEMES-923)

## Acceptance Criteria

Spacing in fullwidth2 section should be consistent with other sections (see FullWidth1).

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-923`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/right-rail-block   `
3. Open (or create) a page or template with the Right Rail - Arc Layout
4. Add multiple blocks to the fullwidth2 section in the curate tab
5. Make sure that there is a gap between the blocks

## Effect Of Changes

### Before

There was no gap between items in the fullwidth 2 section
<img width="970" alt="image" src="https://user-images.githubusercontent.com/85515364/219746710-95ae5fb6-24d8-4fb1-99a8-29c97ca017a1.png">


### After

There is a gap between items in the fullwidth2 section, consistent with the gap between items in the fullwidth1 section

<img width="925" alt="image" src="https://user-images.githubusercontent.com/85515364/219747167-cc337f2e-f809-413d-b4d2-e251b40f51d8.png">

## Dependencies or Side Effects

- Additional css classes could be applied to items in the fullwidth2 section beyond just the gap.

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-923]: https://arcpublishing.atlassian.net/browse/THEMES-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ