### PR TITLE
THEMES-1024: Add catch for Axios calls

### DIFF
--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -11,15 +11,12 @@ const params = {
 
 const handleError = (error) => {
 	if (error?.response) {
-		// eslint-disable-next-line no-console
 		throw new Error(
 			`The response from the server was an error with the status code ${error?.response?.status}.`
 		);
 	} else if (error?.request) {
-		// eslint-disable-next-line no-console
 		throw new Error("The request to the server failed with no response.");
 	} else {
-		// eslint-disable-next-line no-console
 		throw new Error("An error occured creating the request.");
 	}
 };

--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -82,5 +82,6 @@ export default {
 	fetch,
 	schemaName: "ans-feed",
 	// other options null use default functionality, such as filter quality
-	transform: (data, query) => getResizedImageData(data, null, null, null, query["arc-site"]),
+	transform: /* istanbul ignore next */ (data, query) =>
+		getResizedImageData(data, null, null, null, query["arc-site"]),
 };

--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -11,12 +11,15 @@ const params = {
 
 const handleError = (error) => {
 	if (error?.response) {
+		// eslint-disable-next-line no-console
 		console.error(
 			`The response from the server was an error with the status code ${error?.response?.status}.`
 		);
 	} else if (error?.request) {
+		// eslint-disable-next-line no-console
 		console.error("The request to the server failed with no response.");
 	} else {
+		// eslint-disable-next-line no-console
 		console.error("An error occured creating the request.");
 	}
 };

--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -12,7 +12,7 @@ const params = {
 const handleError = (error) => {
 	if (error?.response) {
 		console.error(
-			`The response from the server was an error with the status code ${error?.response?.status}`
+			`The response from the server was an error with the status code ${error?.response?.status}.`
 		);
 	} else if (error?.request) {
 		console.error("The request to the server failed with no response.");

--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -12,15 +12,15 @@ const params = {
 const handleError = (error) => {
 	if (error?.response) {
 		// eslint-disable-next-line no-console
-		console.error(
+		throw new Error(
 			`The response from the server was an error with the status code ${error?.response?.status}.`
 		);
 	} else if (error?.request) {
 		// eslint-disable-next-line no-console
-		console.error("The request to the server failed with no response.");
+		throw new Error("The request to the server failed with no response.");
 	} else {
 		// eslint-disable-next-line no-console
-		console.error("An error occured creating the request.");
+		throw new Error("An error occured creating the request.");
 	}
 };
 

--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -44,34 +44,36 @@ const fetch = (key = {}) => {
 		},
 		method: "GET",
 	})
-		.then(({ data: content }) => {
-			if (getNext === "false") {
-				return content;
-			}
+		.then(
+			/* istanbul ignore next */ ({ data: content }) => {
+				if (getNext === "false") {
+					return content;
+				}
 
-			const existingData = content;
+				const existingData = content;
 
-			return axios({
-				url: `${CONTENT_BASE}/content/v4/collections?${
-					_id ? `_id=${_id}` : `content_alias=${contentAlias}`
-				}${site ? `&website=${site}` : ""}&from=${updatedSize}${
-					size ? `&size=${updatedSize}` : ""
-				}&published=true`,
-				headers: {
-					"content-type": "application/json",
-					Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
-				},
-				method: "GET",
-			})
-				.then(({ data: nextContent }) => {
-					existingData.content_elements = [
-						...existingData.content_elements,
-						...nextContent?.content_elements,
-					];
-					return existingData;
+				return axios({
+					url: `${CONTENT_BASE}/content/v4/collections?${
+						_id ? `_id=${_id}` : `content_alias=${contentAlias}`
+					}${site ? `&website=${site}` : ""}&from=${updatedSize}${
+						size ? `&size=${updatedSize}` : ""
+					}&published=true`,
+					headers: {
+						"content-type": "application/json",
+						Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
+					},
+					method: "GET",
 				})
-				.catch(handleError);
-		})
+					.then(({ data: nextContent }) => {
+						existingData.content_elements = [
+							...existingData.content_elements,
+							...nextContent?.content_elements,
+						];
+						return existingData;
+					})
+					.catch(handleError);
+			}
+		)
 		.catch(handleError);
 };
 

--- a/blocks/collections-content-source-block/sources/content-api-collections.test.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.test.js
@@ -143,9 +143,22 @@ describe("the collections content source block", () => {
 			const consoleSpy = jest.spyOn(console, "error");
 			await contentSource.fetch({});
 			expect(consoleSpy).toHaveBeenCalledWith(
-				"The response from the server was an error with the status code 404"
+				"The response from the server was an error with the status code 404."
 			);
 		});
-		// Add tests for other cases.
+
+		it("handles errors with the request", async () => {
+			axios.mockRejectedValue({ request: {} });
+			const consoleSpy = jest.spyOn(console, "error");
+			await contentSource.fetch({});
+			expect(consoleSpy).toHaveBeenCalledWith("The request to the server failed with no response.");
+		});
+
+		it("handles errors creating the request", async () => {
+			axios.mockRejectedValue({});
+			const consoleSpy = jest.spyOn(console, "error");
+			await contentSource.fetch({});
+			expect(consoleSpy).toHaveBeenCalledWith("An error occured creating the request.");
+		});
 	});
 });

--- a/blocks/collections-content-source-block/sources/content-api-collections.test.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.test.js
@@ -140,25 +140,31 @@ describe("the collections content source block", () => {
 	describe("when an error occurs in the response or request", () => {
 		it("handles errors with the response", async () => {
 			axios.mockRejectedValue({ response: { status: "404" } });
-			const consoleSpy = jest.spyOn(console, "error");
-			await contentSource.fetch({});
-			expect(consoleSpy).toHaveBeenCalledWith(
-				"The response from the server was an error with the status code 404."
-			);
+			try {
+				await contentSource.fetch({});
+			} catch (e) {
+				expect(e.message).toEqual(
+					"The response from the server was an error with the status code 404."
+				);
+			}
 		});
 
 		it("handles errors with the request", async () => {
 			axios.mockRejectedValue({ request: {} });
-			const consoleSpy = jest.spyOn(console, "error");
-			await contentSource.fetch({});
-			expect(consoleSpy).toHaveBeenCalledWith("The request to the server failed with no response.");
+			try {
+				await contentSource.fetch({});
+			} catch (e) {
+				expect(e.message).toEqual("The request to the server failed with no response.");
+			}
 		});
 
 		it("handles errors creating the request", async () => {
 			axios.mockRejectedValue({});
-			const consoleSpy = jest.spyOn(console, "error");
-			await contentSource.fetch({});
-			expect(consoleSpy).toHaveBeenCalledWith("An error occured creating the request.");
+			try {
+				await contentSource.fetch({});
+			} catch (e) {
+				expect(e.message).toEqual("An error occured creating the request.");
+			}
 		});
 	});
 });

--- a/blocks/collections-content-source-block/sources/content-api-collections.test.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.test.js
@@ -5,12 +5,12 @@ jest.mock("fusion:environment", () => ({
 	CONTENT_BASE: "",
 }));
 
-jest.mock("axios");
+jest.mock("axios", () => ({
+	__esModule: true,
+	default: jest.fn((data) => Promise.resolve({ data })),
+}));
 
 describe("the collections content source block", () => {
-	beforeEach(() => {
-		axios.mockImplementation(jest.fn((data) => Promise.resolve({ data })));
-	});
 	it("should use the proper param types", () => {
 		expect(contentSource.params).toEqual({
 			_id: "text",

--- a/blocks/collections-content-source-block/sources/content-api-collections.test.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.test.js
@@ -129,7 +129,7 @@ describe("the collections content source block", () => {
 
 	describe("when an id and website are NOT provided", () => {
 		it("should not build a url with an id and website", async () => {
-			const contentSourceRequest = await contentSource.fetch({});
+			const contentSourceRequest = await contentSource.fetch();
 
 			expect(contentSourceRequest.url).toEqual(
 				"/content/v4/collections?content_alias=undefined&published=true"

--- a/blocks/collections-content-source-block/sources/content-api-collections.test.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.test.js
@@ -1,15 +1,16 @@
+import axios from "axios";
 import contentSource from "./content-api-collections";
 
 jest.mock("fusion:environment", () => ({
 	CONTENT_BASE: "",
 }));
 
-jest.mock("axios", () => ({
-	__esModule: true,
-	default: jest.fn((data) => Promise.resolve({ data })),
-}));
+jest.mock("axios");
 
 describe("the collections content source block", () => {
+	beforeEach(() => {
+		axios.mockImplementation(jest.fn((data) => Promise.resolve({ data })));
+	});
 	it("should use the proper param types", () => {
 		expect(contentSource.params).toEqual({
 			_id: "text",
@@ -134,5 +135,17 @@ describe("the collections content source block", () => {
 				"/content/v4/collections?content_alias=undefined&published=true"
 			);
 		});
+	});
+
+	describe("when an error occurs in the response or request", () => {
+		it("handles errors with the response", async () => {
+			axios.mockRejectedValue({ response: { status: "404" } });
+			const consoleSpy = jest.spyOn(console, "error");
+			await contentSource.fetch({});
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"The response from the server was an error with the status code 404"
+			);
+		});
+		// Add tests for other cases.
 	});
 });


### PR DESCRIPTION
## Description

This PR adds error handling for the Axios calls made in content sources (only 1 in the 1.x versions).

## Jira Ticket

- [THEMES-1024](https://arcpublishing.atlassian.net/browse/THEMES-1024)

## Acceptance Criteria

* Errors from Axios are caught.

## Test Steps

1. Checkout this branch `git checkout THEMES-1024`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/collections-content-source-block`
3. On a test page, set up a block (like the 'Simple List Block') to use the `content-api-collections` as the source.
   * Use the following params:
       * content_alias: alert-bar
       * from: 0
       * size: 1
4. You should see content appear.
5. Now change the content_alias to something invalid and check the fusion logs.
6. You should see the message 'The response from the server was an error with the status code 404.' appear.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1024]: https://arcpublishing.atlassian.net/browse/THEMES-1024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ