### PR TITLE
THEMES-965: Add themes param to content sources

### DIFF
--- a/blocks/alert-bar-content-source-block/sources/alert-bar-collections.js
+++ b/blocks/alert-bar-content-source-block/sources/alert-bar-collections.js
@@ -1,7 +1,14 @@
 import axios from "axios";
 import { ARC_ACCESS_TOKEN, CONTENT_BASE } from "fusion:environment";
 
-const params = {};
+const params = [
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = ({ "arc-site": website }) => {
 	const urlSearch = new URLSearchParams({

--- a/blocks/alert-bar-content-source-block/sources/alert-bar-collections.test.js
+++ b/blocks/alert-bar-content-source-block/sources/alert-bar-collections.test.js
@@ -35,7 +35,14 @@ jest.mock("axios", () => ({
 
 describe("the author api content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({});
+		expect(contentSource.params).toEqual([
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/author-content-source-block/sources/author-api.js
+++ b/blocks/author-content-source-block/sources/author-api.js
@@ -4,14 +4,22 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	slug: "text",
-};
+const params = [
+	{
+		displayName: "slug",
+		name: "slug",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = ({ slug }, { cachedCall }) => {
-	const urlSearch = new URLSearchParams({
-		slug,
-	});
+	const urlSearch = new URLSearchParams({ slug });
 
 	return axios({
 		url: `${CONTENT_BASE}/author/v2/author-service?${urlSearch.toString()}`,

--- a/blocks/author-content-source-block/sources/author-api.test.js
+++ b/blocks/author-content-source-block/sources/author-api.test.js
@@ -27,9 +27,19 @@ jest.mock("axios", () => ({
 
 describe("the author api content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			slug: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "slug",
+				name: "slug",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -4,14 +4,40 @@ import { CONTENT_BASE, ARC_ACCESS_TOKEN, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	_id: "text",
-	content_alias: "text",
-	from: "text",
-	getNext: "text",
-	size: "text",
-};
-// test
+const params = [
+	{
+		displayName: "_id",
+		name: "_id",
+		type: "text",
+	},
+	{
+		displayName: "content_alias",
+		name: "content_alias",
+		type: "text",
+	},
+	{
+		displayName: "from",
+		name: "from",
+		type: "text",
+	},
+	{
+		displayName: "getNext",
+		name: "getNext",
+		type: "text",
+	},
+	{
+		displayName: "size",
+		name: "size",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
+
 const fetch = (
 	{ _id, "arc-site": site, content_alias: contentAlias, from, getNext = "false", size },
 	{ cachedCall }

--- a/blocks/collections-content-source-block/sources/content-api-collections.test.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.test.js
@@ -28,13 +28,39 @@ jest.mock("axios", () => ({
 
 describe("the collections content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			_id: "text",
-			content_alias: "text",
-			from: "text",
-			getNext: "text",
-			size: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "_id",
+				name: "_id",
+				type: "text",
+			},
+			{
+				displayName: "content_alias",
+				name: "content_alias",
+				type: "text",
+			},
+			{
+				displayName: "from",
+				name: "from",
+				type: "text",
+			},
+			{
+				displayName: "getNext",
+				name: "getNext",
+				type: "text",
+			},
+			{
+				displayName: "size",
+				name: "size",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should be associated with the ans-feed schema", () => {

--- a/blocks/content-api-source-block/sources/content-api.js
+++ b/blocks/content-api-source-block/sources/content-api.js
@@ -4,10 +4,24 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	_id: "text",
-	website_url: "text",
-};
+const params = [
+	{
+		displayName: "_id",
+		name: "_id",
+		type: "text",
+	},
+	{
+		displayName: "website_url",
+		name: "website_url",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = ({ _id, "arc-site": website, website_url: websiteUrl }, { cachedCall }) => {
 	const urlSearch = new URLSearchParams({

--- a/blocks/content-api-source-block/sources/content-api.test.js
+++ b/blocks/content-api-source-block/sources/content-api.test.js
@@ -27,10 +27,24 @@ jest.mock("axios", () => ({
 
 describe("the content api source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentApi.params).toEqual({
-			_id: "text",
-			website_url: "text",
-		});
+		expect(contentApi.params).toEqual([
+			{
+				displayName: "_id",
+				name: "_id",
+				type: "text",
+			},
+			{
+				displayName: "website_url",
+				name: "website_url",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	describe("when a site is provided", () => {

--- a/blocks/related-content-content-source-block/sources/related-content.js
+++ b/blocks/related-content-content-source-block/sources/related-content.js
@@ -4,9 +4,19 @@ import { CONTENT_BASE, ARC_ACCESS_TOKEN, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	_id: "text",
-};
+const params = [
+	{
+		displayName: "_id",
+		name: "_id",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = ({ _id, "arc-site": site }, { cachedCall }) => {
 	if (!_id || !site) {

--- a/blocks/related-content-content-source-block/sources/related-content.test.js
+++ b/blocks/related-content-content-source-block/sources/related-content.test.js
@@ -27,9 +27,19 @@ jest.mock("axios", () => ({
 
 describe("the related-content content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			_id: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "_id",
+				name: "_id",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should use the proper schema", () => {

--- a/blocks/search-content-source-block/sources/search-api.js
+++ b/blocks/search-content-source-block/sources/search-api.js
@@ -4,11 +4,29 @@ import { ARC_ACCESS_TOKEN, RESIZER_APP_VERSION, searchKey as SEARCH_KEY } from "
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	_id: "text",
-	page: "text",
-	query: "text",
-};
+const params = [
+	{
+		displayName: "_id",
+		name: "_id",
+		type: "text",
+	},
+	{
+		displayName: "page",
+		name: "page",
+		type: "text",
+	},
+	{
+		displayName: "query",
+		name: "query",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = ({ "arc-site": site, page = "1", query }, { cachedCall }) => {
 	if (!query) {

--- a/blocks/search-content-source-block/sources/search-api.test.js
+++ b/blocks/search-content-source-block/sources/search-api.test.js
@@ -43,11 +43,29 @@ expect.extend({
 
 describe("the search content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			_id: "text",
-			page: "text",
-			query: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "_id",
+				name: "_id",
+				type: "text",
+			},
+			{
+				displayName: "page",
+				name: "page",
+				type: "text",
+			},
+			{
+				displayName: "query",
+				name: "query",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	describe("when a query is provided", () => {

--- a/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
+++ b/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
@@ -4,11 +4,29 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	authorSlug: "text",
-	feedOffset: "number",
-	feedSize: "number",
-};
+const params = [
+	{
+		displayName: "authorSlug",
+		name: "authorSlug",
+		type: "text",
+	},
+	{
+		displayName: "feedOffset",
+		name: "feedOffset",
+		type: "number",
+	},
+	{
+		displayName: "feedSize",
+		name: "feedSize",
+		type: "number",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = (
 	{ authorSlug, feedOffset: from = 0, feedSize: size = 8, "arc-site": website },

--- a/blocks/story-feed-author-content-source-block/sources/story-feed-author.test.jsx
+++ b/blocks/story-feed-author-content-source-block/sources/story-feed-author.test.jsx
@@ -27,11 +27,29 @@ jest.mock("axios", () => ({
 
 describe("story-feed-author-content-source-block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			authorSlug: "text",
-			feedOffset: "number",
-			feedSize: "number",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "authorSlug",
+				name: "authorSlug",
+				type: "text",
+			},
+			{
+				displayName: "feedOffset",
+				name: "feedOffset",
+				type: "number",
+			},
+			{
+				displayName: "feedSize",
+				name: "feedSize",
+				type: "number",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
+++ b/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
@@ -4,11 +4,29 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	offset: "number",
-	query: "text",
-	size: "number",
-};
+const params = [
+	{
+		displayName: "offset",
+		name: "offset",
+		type: "number",
+	},
+	{
+		displayName: "query",
+		name: "query",
+		type: "text",
+	},
+	{
+		displayName: "size",
+		name: "size",
+		type: "number",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = (
 	{ query: q = "*", size = 8, offset: from = 0, "arc-site": website },

--- a/blocks/story-feed-query-content-source-block/sources/story-feed-query.test.js
+++ b/blocks/story-feed-query-content-source-block/sources/story-feed-query.test.js
@@ -27,11 +27,29 @@ jest.mock("axios", () => ({
 
 describe("story-feed-author-content-source-block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			query: "text",
-			size: "number",
-			offset: "number",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "offset",
+				name: "offset",
+				type: "number",
+			},
+			{
+				displayName: "query",
+				name: "query",
+				type: "text",
+			},
+			{
+				displayName: "size",
+				name: "size",
+				type: "number",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
@@ -12,12 +12,34 @@ import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-b
 export const itemsToArray = (itemString = "") =>
 	itemString.split(",").map((item) => item.trim().replace(/"/g, ""));
 
-const params = {
-	excludeSections: "text",
-	feedOffset: "number",
-	feedSize: "number",
-	includeSections: "text",
-};
+const params = [
+	{
+		displayName: "excludeSections",
+		name: "excludeSections",
+		type: "text",
+	},
+	{
+		displayName: "feedOffset",
+		name: "feedOffset",
+		type: "number",
+	},
+	{
+		displayName: "feedSize",
+		name: "feedSize",
+		type: "number",
+	},
+	{
+		displayName: "includeSections",
+		name: "includeSections",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = (
 	{

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.test.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.test.js
@@ -85,12 +85,34 @@ const body = {
 
 describe("story-feed-author-content-source-block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			excludeSections: "text",
-			feedOffset: "number",
-			feedSize: "number",
-			includeSections: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "excludeSections",
+				name: "excludeSections",
+				type: "text",
+			},
+			{
+				displayName: "feedOffset",
+				name: "feedOffset",
+				type: "number",
+			},
+			{
+				displayName: "feedSize",
+				name: "feedSize",
+				type: "number",
+			},
+			{
+				displayName: "includeSections",
+				name: "includeSections",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
@@ -4,11 +4,29 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	feedOffset: "number",
-	feedSize: "number",
-	tagSlug: "text",
-};
+const params = [
+	{
+		displayName: "feedOffset",
+		name: "feedOffset",
+		type: "number",
+	},
+	{
+		displayName: "feedSize",
+		name: "feedSize",
+		type: "number",
+	},
+	{
+		displayName: "tagSlug",
+		name: "tagSlug",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = (
 	{ feedSize: size = 10, feedOffset: from = 0, tagSlug, "arc-site": website },

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.test.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.test.js
@@ -27,11 +27,29 @@ jest.mock("axios", () => ({
 
 describe("story-feed-author-content-source-block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			feedOffset: "number",
-			feedSize: "number",
-			tagSlug: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "feedOffset",
+				name: "feedOffset",
+				type: "number",
+			},
+			{
+				displayName: "feedSize",
+				name: "feedSize",
+				type: "number",
+			},
+			{
+				displayName: "tagSlug",
+				name: "tagSlug",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/tags-content-source-block/sources/tags-api.js
+++ b/blocks/tags-content-source-block/sources/tags-api.js
@@ -1,9 +1,19 @@
 import axios from "axios";
 import { ARC_ACCESS_TOKEN, CONTENT_BASE } from "fusion:environment";
 
-const params = {
-	slug: "text",
-};
+const params = [
+	{
+		displayName: "slug",
+		name: "slug",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = ({ slug: slugs = "" }) => {
 	const urlSearch = new URLSearchParams({ slugs });

--- a/blocks/tags-content-source-block/sources/tags-api.test.js
+++ b/blocks/tags-content-source-block/sources/tags-api.test.js
@@ -39,9 +39,19 @@ jest.mock("axios", () => ({
 
 describe("the tags content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			slug: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "slug",
+				name: "slug",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	it("should build the correct url", async () => {

--- a/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
+++ b/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
@@ -4,9 +4,19 @@ import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:envi
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
 
-const params = {
-	_id: "text",
-};
+const params = [
+	{
+		displayName: "_id",
+		name: "_id",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
 
 const fetch = ({ _id, "arc-site": website }, { cachedCall }) => {
 	const urlSearch = new URLSearchParams({

--- a/blocks/unpublished-content-source-block/sources/content-api-unpublished.test.js
+++ b/blocks/unpublished-content-source-block/sources/content-api-unpublished.test.js
@@ -27,9 +27,19 @@ jest.mock("axios", () => ({
 
 describe("the unpublished content source block", () => {
 	it("should use the proper param types", () => {
-		expect(contentSource.params).toEqual({
-			_id: "text",
-		});
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "_id",
+				name: "_id",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
 	});
 
 	describe("when an id is provided", () => {


### PR DESCRIPTION

* The difference between this and the last is that this does not pass along the themes param to the endpoints.


## Description

Adding a superfluous parameter to the content sources to force a page builder cache update.

## Jira Ticket

- [THEMES-965](https://arcpublishing.atlassian.net/browse/THEMES-965)

## Acceptance Criteria

For all content sources add a new param named themes with a default value of [~~v~~]2

## Test Steps

1. Checkout this branch `git checkout themes-965`
2. Run fusion repo with linked blocks `npx fusion start -f -l`
3. Ensure the following debugger endpoints work:
http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=alert-bar-collections

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=author-api&config={%22slug%22:%22sara-carothers%22}

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=content-api-collections&config={%22content_alias%22:%22%22,%22_id%22:%22M32OXKKIWFH2FFBXZQV7LAUEYQ%22}

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=content-api&config={%22_id%22:%22%22,%22website_url%22:%22/gallery/2023/01/05/national-bird-day-photography/%22}

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=related-content&config={%22_id%22:%22M32OXKKIWFH2FFBXZQV7LAUEYQ%22}

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=search-api&config={%22query%22:%22test%22,%22_id%22:%22%22}

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=story-feed-author&config={%22authorSlug%22:%22sara-carothers%22}

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=story-feed-query&config={%22query%22:%22type:%20story%22}

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=story-feed-sections&config={%22includeSections%22:%22/travel%22}

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=story-feed-tag&config={%22tagSlug%22:%22world%22}

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=tags-api&config={%22slug%22:%22world%22}

http://localhost/pagebuilder/tools/debugger?_website=the-gazette&type=content-debugger&source=content-api-unpublished&config={%22_id%22:%226VYXKWAW2BDP7GUSA3BFYVSW7E%22}


## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [x] Linting code actions have passed.
- [x] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [x] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-965]: https://arcpublishing.atlassian.net/browse/THEMES-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ