### PR TITLE
THEMES-1058: Image bug on Large Manual Promo

### DIFF
--- a/blocks/shared-styles/_children/promos/large/index.jsx
+++ b/blocks/shared-styles/_children/promos/large/index.jsx
@@ -78,7 +78,7 @@ const LargePromoPresentation = ({
 											promoSize="LG"
 											promoLabelSize="large"
 											imageRatio={imageRatio}
-											lazyLoad={content && lazyLoad}
+											lazyLoad={lazyLoad}
 											alt={headline}
 										/>
 									</div>


### PR DESCRIPTION
## Description

This PR fixes an issue where the image on a Large Manual Promo block would 404 if it was set to lazy load

## Jira Ticket

- [THEMES-1058](https://arcpublishing.atlassian.net/browse/THEMES-1058)

## Acceptance Criteria

Images load as expected.

## Test Steps

1. Checkout this branch `git checkout THEMES-1058`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/shared-styles`
3. Create a test page with a Large Manual Promo - Arc block on it.
4. Set the image and make sure the 'Lazy Load block?' option is checked.
5. Share and publish the page.
6. View it on the front end (just checking it in the editor isn't enough as it won't lazy load there).
7. The selected image should be visible in the block, and not the placeholder image.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1058]: https://arcpublishing.atlassian.net/browse/THEMES-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ