### PR TITLE
THEMES-1062: Lead Art block | Use new gallery component prop

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -212,6 +212,7 @@ class LeadArt extends Component {
 						displayTitle={!hideTitle}
 						displayCaption={!hideCaption}
 						displayCredits={!hideCredits}
+						eagerLoadFirstImage
 					/>
 				);
 			}


### PR DESCRIPTION
## Description

This PR changes the lead art block to use the new prop for the gallery SDK component, so that the first image is eager loaded.

## Jira Ticket

- [THEMES-1062](https://arcpublishing.atlassian.net/browse/THEMES-1062)

## Acceptance Criteria

The first image in a lead art gallery is eager loaded.

## Test Steps

1. Checkout this branch `git checkout THEMES-1062`
2. Checkout the `engine-theme-sdk` branch as well `git checkout THEMES-1062`.
3. Make sure the feature pack is on the `news` branch.
4. Set `ENGINE_SDK_REPO` in your `.env` if it is not already.
5. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/lead-art-block`
6. Visit a story with a lead art gallery (such as http://localhost/pf/2022/12/01/a-gallery-is-my-lead-art/?_website=daily-intelligencer)
7. The first image in the gallery should have `loading="eager"` as an attribute, and the other images should be `loading="lazy"`.

## Dependencies or Side Effects

- `engine-theme-sdk`: https://github.com/WPMedia/engine-theme-sdk/pull/731

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1062]: https://arcpublishing.atlassian.net/browse/THEMES-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ