### PR TITLE
THEMES-1072: Update LazyLoad imports

### DIFF
--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext } from "fusion:context";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
-import { Paragraph, Stack, usePhrases } from "@wpmedia/arc-themes-components";
+import { LazyLoad, Paragraph, Stack, usePhrases } from "@wpmedia/arc-themes-components";
 import adMap from "./ad-mapping";
 import AdUnit from "./_children/AdUnit";
 import ArcAdminAd from "./_children/ArcAdminAd";

--- a/blocks/ads-block/features/ads/default.test.jsx
+++ b/blocks/ads-block/features/ads/default.test.jsx
@@ -3,6 +3,11 @@ import { useFusionContext } from "fusion:context";
 import { mount } from "enzyme";
 import ArcAd from "./default";
 
+jest.mock("@wpmedia/arc-themes-components", () => ({
+	...jest.requireActual("@wpmedia/arc-themes-components"),
+	LazyLoad: ({ children }) => <>{children}</>,
+}));
+
 const SITE_PROPS_MOCK = {
 	breakpoints: {
 		small: 0,

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -2,8 +2,6 @@ import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext } from "fusion:context";
 
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
-
 import {
 	Carousel,
 	Conditional,
@@ -14,6 +12,7 @@ import {
 	Icon,
 	Image,
 	isServerSide,
+	LazyLoad,
 	Link,
 	MediaItem,
 	Paragraph,

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -16,13 +16,10 @@ jest.mock("fusion:properties", () =>
 	}))
 );
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 describe("article-body chain", () => {

--- a/blocks/article-tag-block/features/tag/default.jsx
+++ b/blocks/article-tag-block/features/tag/default.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext } from "fusion:context";
-import { isServerSide, Pill, Stack } from "@wpmedia/arc-themes-components";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
+import { isServerSide, LazyLoad, Pill, Stack } from "@wpmedia/arc-themes-components";
 
 const BLOCK_CLASS_NAME = "b-article-tag";
 

--- a/blocks/article-tag-block/features/tag/default.test.jsx
+++ b/blocks/article-tag-block/features/tag/default.test.jsx
@@ -6,13 +6,10 @@ import ArticleTags from "./default";
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn().mockReturnValue(true),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 describe("the article tag block", () => {
-	jest.mock("@wpmedia/engine-theme-sdk", () => ({
-		LazyLoad: ({ children }) => <>{children}f</>,
-	}));
-
 	describe("when the global content has an array of tags in its taxonomy", () => {
 		const mockReturnData = {
 			arcSite: "the-sun",

--- a/blocks/author-bio-block/features/author-bio/default.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext } from "fusion:context";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
 	Conditional,
 	formatSocialURL,
@@ -10,6 +9,7 @@ import {
 	Icon,
 	Image,
 	isServerSide,
+	LazyLoad,
 	Link,
 	Paragraph,
 	Stack,

--- a/blocks/author-bio-block/features/author-bio/default.test.jsx
+++ b/blocks/author-bio-block/features/author-bio/default.test.jsx
@@ -9,6 +9,7 @@ jest.mock("@wpmedia/arc-themes-components", () => ({
 	__esModule: true,
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn().mockReturnValue(true),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 jest.mock("fusion:themes", () =>
@@ -16,10 +17,6 @@ jest.mock("fusion:themes", () =>
 		"primary-color": "blue",
 	}))
 );
-
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
 
 jest.mock("fusion:context", () => ({
 	useFusionContext: () => ({ isAdmin: false, globalContent: { credits: {} } }),

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -5,7 +5,7 @@ import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
 import { RESIZER_APP_VERSION } from "fusion:environment";
-import { LazyLoad, localizeDate } from "@wpmedia/engine-theme-sdk";
+import { localizeDate } from "@wpmedia/engine-theme-sdk";
 import {
 	Attribution,
 	Date,
@@ -16,6 +16,7 @@ import {
 	HeadingSection,
 	Image,
 	isServerSide,
+	LazyLoad,
 	Link,
 	Overline,
 	Separator,

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -9,6 +9,7 @@ import CardList from "./default";
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => true),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 jest.mock("fusion:content", () => ({
@@ -24,7 +25,6 @@ jest.mock("fusion:context", () => ({
 }));
 
 jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	LazyLoad: ({ children }) => <>{children}</>,
 	localizeDate: jest.fn(() => "date"),
 }));
 

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -11,13 +11,13 @@ import {
 	HeadingSection,
 	Image,
 	isServerSide,
+	LazyLoad,
 	Link,
 	MediaItem,
 	Overline,
 	Paragraph,
 	Stack,
 } from "@wpmedia/arc-themes-components";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 
 const BLOCK_CLASS_NAME = "b-xl-manual-promo";
 

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.test.jsx
@@ -3,13 +3,10 @@ import { render, screen } from "@testing-library/react";
 import { useContent } from "fusion:content";
 import ExtraLargeManualPromo from "./default";
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	LazyLoad: ({ children }) => children,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => true),
+	LazyLoad: ({ children }) => children,
 }));
 
 jest.mock("fusion:content", () => ({

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -19,6 +19,7 @@ import {
 	Image,
 	Join,
 	isServerSide,
+	LazyLoad,
 	Link,
 	MediaItem,
 	Overline,
@@ -29,7 +30,7 @@ import {
 	Video,
 } from "@wpmedia/arc-themes-components";
 
-import { LazyLoad, localizeDateTime } from "@wpmedia/engine-theme-sdk";
+import { localizeDateTime } from "@wpmedia/engine-theme-sdk";
 
 const BLOCK_CLASS_NAME = "b-xl-promo";
 

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -7,14 +7,10 @@ import ExtraLargePromo from "./default";
 import mockData from "./mock-data";
 import mockDataSponsoredVideo from "./mock-data-sponsored";
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	...jest.requireActual("@wpmedia/engine-theme-sdk"),
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => true),
+	LazyLoad: ({ children }) => <>{children}</>,
 	Video: () => "video embed",
 }));
 

--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -4,7 +4,6 @@ import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
 
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
 	Grid,
 	Heading,
@@ -12,6 +11,7 @@ import {
 	isServerSide,
 	Icon,
 	Image,
+	LazyLoad,
 	Link,
 	MediaItem,
 	Paragraph,

--- a/blocks/footer-block/features/footer/default.test.jsx
+++ b/blocks/footer-block/features/footer/default.test.jsx
@@ -104,10 +104,9 @@ jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => true),
 	Icon: ({ name }) => <div data-testid={name} />,
-}));
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
 	LazyLoad: ({ children }) => <>{children}</>,
 }));
+
 jest.mock("fusion:content", () => ({
 	useContent: jest.fn(() => mockPayload),
 }));

--- a/blocks/full-author-bio-block/features/full-author-bio/default.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.jsx
@@ -3,8 +3,7 @@ import React from "react";
 import { useFusionContext } from "fusion:context";
 
 import PropTypes from "@arc-fusion/prop-types";
-import { isServerSide } from "@wpmedia/arc-themes-components";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
+import { isServerSide, LazyLoad } from "@wpmedia/arc-themes-components";
 
 import Presentation from "./_children/Presentation";
 

--- a/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
+++ b/blocks/full-author-bio-block/features/full-author-bio/default.test.jsx
@@ -6,14 +6,10 @@ import getProperties from "fusion:properties";
 
 import FullAuthorBio from "./default";
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	...jest.requireActual("@wpmedia/engine-theme-sdk"),
-	LazyLoad: ({ children }) => children,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => true),
+	LazyLoad: ({ children }) => children,
 }));
 
 const authors = [

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -4,7 +4,6 @@ import { useContent } from "fusion:content";
 import { useFusionContext, useAppContext } from "fusion:context";
 import getProperties from "fusion:properties";
 import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
 	Carousel,
 	formatCredits,
@@ -12,6 +11,7 @@ import {
 	Image,
 	imageANSToImageSrc,
 	isServerSide,
+	LazyLoad,
 	MediaItem,
 	usePhrases,
 } from "@wpmedia/arc-themes-components";

--- a/blocks/gallery-block/features/gallery/default.test.jsx
+++ b/blocks/gallery-block/features/gallery/default.test.jsx
@@ -1,9 +1,8 @@
 import { mount } from "enzyme";
 import React from "react";
-import { isServerSide, Carousel, MediaItem } from "@wpmedia/arc-themes-components";
+import { Carousel, isServerSide, LazyLoad, MediaItem } from "@wpmedia/arc-themes-components";
 import { useContent } from "fusion:content";
 import { useAppContext, useFusionContext } from "fusion:context";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 
 import Gallery from "./default";
 
@@ -27,6 +26,7 @@ jest.mock("fusion:context", () => ({
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => false),
+	LazyLoad: ({ children }) => children,
 	// mocking format credits to return whatever passed in
 	formatCredits: jest.fn((input) => input),
 }));

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -4,7 +4,6 @@ import { RESIZER_APP_VERSION } from "fusion:environment";
 import { useComponentContext, useFusionContext } from "fusion:context";
 import { useContent, useEditableContent } from "fusion:content";
 import getProperties from "fusion:properties";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
 	Conditional,
 	Image,
@@ -13,6 +12,7 @@ import {
 	Grid,
 	Heading,
 	HeadingSection,
+	LazyLoad,
 	Link,
 	MediaItem,
 	Overline,

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.test.jsx
@@ -5,13 +5,10 @@ import { isServerSide } from "@wpmedia/arc-themes-components";
 
 import LargeManualPromo from "./default";
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => true),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 jest.mock("fusion:context", () => ({

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -5,7 +5,7 @@ import { RESIZER_APP_VERSION } from "fusion:environment";
 import { useContent, useEditableContent } from "fusion:content";
 import { useComponentContext, useFusionContext } from "fusion:context";
 
-import { LazyLoad, localizeDateTime } from "@wpmedia/engine-theme-sdk";
+import { localizeDateTime } from "@wpmedia/engine-theme-sdk";
 import {
 	Conditional,
 	Grid,
@@ -13,6 +13,7 @@ import {
 	Icon,
 	Image,
 	Join,
+	LazyLoad,
 	Link,
 	MediaItem,
 	Stack,

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -86,14 +86,10 @@ const largePromoMock = {
 	},
 };
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	...jest.requireActual("@wpmedia/engine-theme-sdk"),
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => false),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 jest.mock("fusion:content", () => ({

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -11,11 +11,11 @@ import {
 	HeadingSection,
 	Image,
 	isServerSide,
+	LazyLoad,
 	Link,
 	MediaItem,
 	Paragraph,
 } from "@wpmedia/arc-themes-components";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 
 const BLOCK_CLASS_NAME = "b-medium-manual-promo";
 

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.test.jsx
@@ -5,13 +5,10 @@ import { useContent } from "fusion:content";
 
 import MediumManualPromo from "./default";
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => false),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 jest.mock("fusion:content", () => ({

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -5,7 +5,7 @@ import { useComponentContext, useFusionContext } from "fusion:context";
 import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
 import getProperties from "fusion:properties";
 import PropTypes from "@arc-fusion/prop-types";
-import { LazyLoad, localizeDateTime } from "@wpmedia/engine-theme-sdk";
+import { localizeDateTime } from "@wpmedia/engine-theme-sdk";
 import {
 	Attribution,
 	Conditional,
@@ -21,6 +21,7 @@ import {
 	Image,
 	isServerSide,
 	Join,
+	LazyLoad,
 	Link,
 	MediaItem,
 	Paragraph,

--- a/blocks/medium-promo-block/features/medium-promo/default.test.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.test.jsx
@@ -5,14 +5,10 @@ import MediumPromo from "./default";
 
 import mockData from "./mock-data";
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	...jest.requireActual("@wpmedia/engine-theme-sdk"),
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => true),
+	LazyLoad: ({ children }) => <>{children}</>,
 	Video: () => "video embed",
 }));
 

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -5,13 +5,13 @@ import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
 import { RESIZER_APP_VERSION } from "fusion:environment";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
 	getImageFromANS,
 	isServerSide,
 	Heading,
 	HeadingSection,
 	Image,
+	LazyLoad,
 	Link,
 	Paragraph,
 	Stack,

--- a/blocks/numbered-list-block/features/numbered-list/default.test.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.test.jsx
@@ -19,13 +19,10 @@ jest.mock("fusion:content", () => ({
 	useContent: jest.fn(() => mockData),
 }));
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 const listContentConfig = {

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -3,8 +3,7 @@ import PropTypes from "@arc-fusion/prop-types";
 
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
-import { isServerSide, HeadingSection } from "@wpmedia/arc-themes-components";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
+import { isServerSide, LazyLoad, HeadingSection } from "@wpmedia/arc-themes-components";
 
 import { resolveDefaultPromoElements } from "./results/helpers";
 import Results from "./results";

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -10,6 +10,7 @@ import ResultsList from "./default";
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn().mockReturnValue(true),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 jest.mock("fusion:intl", () => ({

--- a/blocks/search-results-list-block/features/search-results-list/default.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/default.jsx
@@ -2,8 +2,7 @@ import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext } from "fusion:context";
 
-import { HeadingSection, isServerSide } from "@wpmedia/arc-themes-components";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
+import { HeadingSection, isServerSide, LazyLoad } from "@wpmedia/arc-themes-components";
 
 import CustomSearchResultsList from "./_children/custom-content";
 import GlobalContentSearch from "./_children/global-content";

--- a/blocks/search-results-list-block/features/search-results-list/default.test.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/default.test.jsx
@@ -8,14 +8,12 @@ jest.mock("./_children/custom-content", () => class CustomContentSearchResultsLi
 jest.mock("fusion:context", () => ({
 	useFusionContext: jest.fn(() => ({})),
 }));
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	...jest.requireActual("@wpmedia/engine-theme-sdk"),
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
+
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	HeadingSection: ({ children }) => <>{children}</>,
 	isServerSide: () => true,
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 const defaultPromos = {

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -5,7 +5,6 @@ import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
 import { RESIZER_APP_VERSION } from "fusion:environment";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
 	getImageFromANS,
 	Stack,
@@ -13,6 +12,7 @@ import {
 	Heading,
 	HeadingSection,
 	Image,
+	LazyLoad,
 	Link,
 } from "@wpmedia/arc-themes-components";
 

--- a/blocks/simple-list-block/features/simple-list/default.test.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.test.jsx
@@ -86,13 +86,10 @@ jest.mock("fusion:content", () => ({
 	useContent: jest.fn(() => mockData),
 }));
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 const listContentConfig = {

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -10,11 +10,11 @@ import {
 	HeadingSection,
 	Image,
 	isServerSide,
+	LazyLoad,
 	Link,
 	MediaItem,
 	Grid,
 } from "@wpmedia/arc-themes-components";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 
 const BLOCK_CLASS_NAME = "b-small-manual-promo";
 

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.test.jsx
@@ -4,13 +4,10 @@ import { useContent } from "fusion:content";
 import { isServerSide } from "@wpmedia/arc-themes-components";
 import SmallManualPromo from "./default";
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	LazyLoad: ({ children }) => children,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => true),
+	LazyLoad: ({ children }) => children,
 }));
 
 jest.mock("fusion:content", () => ({

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -10,13 +10,13 @@ import {
 	HeadingSection,
 	Image,
 	isServerSide,
+	LazyLoad,
 	Link,
 	MediaItem,
 	Grid,
 	getImageFromANS,
 	Conditional,
 } from "@wpmedia/arc-themes-components";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 
 const BLOCK_CLASS_NAME = "b-small-promo";
 

--- a/blocks/small-promo-block/features/small-promo/default.test.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.test.jsx
@@ -7,14 +7,10 @@ import SmallPromo from "./default";
 
 import mockData from "./mock-data";
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	...jest.requireActual("@wpmedia/engine-theme-sdk"),
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => true),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 jest.mock("fusion:content", () => ({

--- a/blocks/top-table-list-block/features/top-table-list/_children/large.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/large.test.jsx
@@ -4,14 +4,10 @@ import mockData from "../../../mock-data";
 
 import Large from "./large";
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	...jest.requireActual("@wpmedia/engine-theme-sdk"),
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => false),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 describe("Large Promo", () => {

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium.test.jsx
@@ -4,14 +4,10 @@ import mockData from "../../../mock-data";
 
 import Medium from "./medium";
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	...jest.requireActual("@wpmedia/engine-theme-sdk"),
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => true),
+	LazyLoad: ({ children }) => <>{children}</>,
 	Video: () => "video embed",
 }));
 

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -5,9 +5,8 @@ import PropTypes from "@arc-fusion/prop-types";
 import { RESIZER_APP_VERSION } from "fusion:environment";
 import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
-import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import getProperties from "fusion:properties";
-import { Grid, isServerSide } from "@wpmedia/arc-themes-components";
+import { Grid, isServerSide, LazyLoad } from "@wpmedia/arc-themes-components";
 import imageRatioCustomField from "./shared/imageRatioCustomField";
 import { EXTRA_LARGE, LARGE, MEDIUM, SMALL } from "./shared/storySizeConstants";
 

--- a/blocks/top-table-list-block/features/top-table-list/default.test.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.test.jsx
@@ -25,14 +25,10 @@ jest.mock("fusion:content", () => ({
 	useContent: jest.fn(() => {}),
 }));
 
-jest.mock("@wpmedia/engine-theme-sdk", () => ({
-	...jest.requireActual("@wpmedia/engine-theme-sdk"),
-	LazyLoad: ({ children }) => <>{children}</>,
-}));
-
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(() => false),
+	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
 const config = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17905,9 +17905,9 @@
       }
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-3.29",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.29/717f4718f9f16112e0a95d0955211428144aec1b",
-      "integrity": "sha512-8OxyO/xBzAOWq6FirOE5nq32zd6ExjnaqRDsxqKoahMv7+IDHKgjjeKKrtukQuWop+qpE/0L2RUtzD5gTafS5w==",
+      "version": "0.0.4-arc-themes-release-version-2-0-3.30",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.30/f8e087d1631619cfa8d4726284e4a39d14b370da",
+      "integrity": "sha512-ZA7SkCTEXEpmY2uH5UPjof0ONvZ+enMp95ZETx3M/oYe6x9SSVmv0sCPgARKqntO4Bova04Rx2VBgGGmhArG1A==",
       "dev": true,
       "requires": {
         "lazy-child": "^0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17905,11 +17905,12 @@
       }
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-3.28",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.28/40d0741f60132b95bcf3bce3de2e20ca6e93a8d6",
-      "integrity": "sha512-SrJFc3A0/oY7btKRFjnUWbJs8b/oD7x59Zg2nRk3N+OZE+1fL9wIVMIL0D996iEsixEoOarHsVCcqBlydhGq+A==",
+      "version": "0.0.4-arc-themes-release-version-2-0-3.29",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.29/717f4718f9f16112e0a95d0955211428144aec1b",
+      "integrity": "sha512-8OxyO/xBzAOWq6FirOE5nq32zd6ExjnaqRDsxqKoahMv7+IDHKgjjeKKrtukQuWop+qpE/0L2RUtzD5gTafS5w==",
       "dev": true,
       "requires": {
+        "lazy-child": "^0.3.1",
         "react-oembed-container": "^1.0.1",
         "react-swipeable": "^6.2.1"
       }


### PR DESCRIPTION
## Description

This PR updates the imports for the LazyLoad component to pull it from `arc-themes-components` instead of `engine-theme-sdk`. It also updates necessary test mocks.

## Jira Ticket

- [THEMES-1072](https://arcpublishing.atlassian.net/browse/THEMES-1072)

## Acceptance Criteria

- updating import references 

- move mocks from tests (if exist)

## Test Steps

1. Checkout this branch `git checkout THEMES-1072`.
2. Also checkout the same branch for `arc-themes-components` and `engine-theme-sdk`.
3. Run fusion repo with linked blocks `npx fusion start -f -l` (You'll need nearly every block so it's easier to link them all).
4. Check a page with all blocks placed on it (you can pull the PB data from sandbox if you do not have a local page set up already).
5. All blocks should be loading as expected. Check the "Lazy Load block?" option for the blocks that have it and ensure they still function.

## Dependencies or Side Effects

- `engine-theme-sdk` PR: https://github.com/WPMedia/engine-theme-sdk/pull/732
- `arc-themes-components` PR: https://github.com/WPMedia/arc-themes-components/pull/173

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1072]: https://arcpublishing.atlassian.net/browse/THEMES-1072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ