### PR TITLE
THEMES-1042: updated RESIZER_TOKEN_VERSION var

### DIFF
--- a/.storybook/alias/environment.js
+++ b/.storybook/alias/environment.js
@@ -1,3 +1,3 @@
-export const RESIZER_APP_VERSION = 2;
+export const RESIZER_TOKEN_VERSION = 2;
 export const RESIZER_URL =
 	"https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/";

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -6,7 +6,7 @@ import { isServerSide } from "@wpmedia/arc-themes-components";
 import ArticleBodyChain from "./default";
 
 jest.mock("fusion:environment", () => ({
-	RESIZER_APP_VERSION: 2,
+	RESIZER_TOKEN_VERSION: 2,
 	RESIZER_URL: "http://some.url",
 }));
 

--- a/blocks/article-body-block/chains/article-body/shared/get-resize-params-from-ans-image.js
+++ b/blocks/article-body-block/chains/article-body/shared/get-resize-params-from-ans-image.js
@@ -1,10 +1,10 @@
-import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION, RESIZER_URL } from "fusion:environment";
 import { imageANSToImageSrc } from "@wpmedia/arc-themes-components";
 
 const getResizeParamsFromANSImage = (ansImageItem, defaultWidth, responsiveWidths = []) => ({
 	height: Math.floor((ansImageItem.height / ansImageItem.width) * defaultWidth),
 	resizerURL: RESIZER_URL,
-	resizedOptions: { auth: ansImageItem.auth[RESIZER_APP_VERSION] },
+	resizedOptions: { auth: ansImageItem.auth[RESIZER_TOKEN_VERSION] },
 	...(responsiveWidths.length ? { responsiveImages: responsiveWidths } : {}),
 	src: imageANSToImageSrc(ansImageItem),
 	width: defaultWidth,

--- a/blocks/article-body-block/chains/article-body/shared/get-resize-params-from-ans-image.test.js
+++ b/blocks/article-body-block/chains/article-body/shared/get-resize-params-from-ans-image.test.js
@@ -1,7 +1,7 @@
 import getResizeParamsFromANSImage from "./get-resize-params-from-ans-image";
 
 jest.mock("fusion:environment", () => ({
-	RESIZER_APP_VERSION: 2,
+	RESIZER_TOKEN_VERSION: 2,
 	RESIZER_URL: "https://image.url",
 }));
 

--- a/blocks/author-content-source-block/sources/author-api.js
+++ b/blocks/author-content-source-block/sources/author-api.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:environment";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_TOKEN_VERSION } from "fusion:environment";
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
@@ -29,7 +29,7 @@ const fetch = ({ slug }, { cachedCall }) => {
 		},
 		method: "GET",
 	})
-		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 		.then(({ data }) => data)
 		.catch(handleFetchError);
 };

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -4,7 +4,7 @@ import PropTypes from "@arc-fusion/prop-types";
 import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { LazyLoad, localizeDate } from "@wpmedia/engine-theme-sdk";
 import {
 	Attribution,
@@ -86,7 +86,7 @@ const CardListItems = (props) => {
 				type
 				url
 				auth {
-					${RESIZER_APP_VERSION}
+					${RESIZER_TOKEN_VERSION}
 				}
 			 }
 			 lead_art {
@@ -96,7 +96,7 @@ const CardListItems = (props) => {
 					type
 					url
 					auth {
-						${RESIZER_APP_VERSION}
+						${RESIZER_TOKEN_VERSION}
 					}
 				  }
 				}

--- a/blocks/category-carousel-block/features/category-carousel/default.jsx
+++ b/blocks/category-carousel-block/features/category-carousel/default.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import { useFusionContext } from "fusion:context";
 import { useContent, useEditableContent } from "fusion:content";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import PropTypes from "@arc-fusion/prop-types";
 import {
 	Carousel,
@@ -65,7 +65,7 @@ const CategoryImage = ({ imageAlt, imageAuth, imageId, imageUrl }) => {
 
 	const imageAuthTokenObj = {};
 	if (imageAuthToken?.hash) {
-		imageAuthTokenObj[RESIZER_APP_VERSION] = imageAuthToken.hash;
+		imageAuthTokenObj[RESIZER_TOKEN_VERSION] = imageAuthToken.hash;
 	}
 
 	const imageParams =

--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { CONTENT_BASE, ARC_ACCESS_TOKEN, RESIZER_APP_VERSION } from "fusion:environment";
+import { CONTENT_BASE, ARC_ACCESS_TOKEN, RESIZER_TOKEN_VERSION } from "fusion:environment";
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
@@ -61,7 +61,7 @@ const fetch = (
 		},
 		method: "GET",
 	})
-		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 		.then(({ data }) => {
 			if (getNext === "false") {
 				return data;
@@ -75,7 +75,7 @@ const fetch = (
 				},
 				method: "GET",
 			})
-				.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+				.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 				.then(({ data: next }) => ({
 					...data,
 					...(data?.content_elements || next?.content_elements

--- a/blocks/content-api-source-block/sources/content-api.js
+++ b/blocks/content-api-source-block/sources/content-api.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:environment";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_TOKEN_VERSION } from "fusion:environment";
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
@@ -37,7 +37,7 @@ const fetch = ({ _id, "arc-site": website, website_url: websiteUrl }, { cachedCa
 		},
 		method: "GET",
 	})
-		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 		.then(({ data }) => data)
 		.catch(handleFetchError);
 };

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { useComponentContext, useFusionContext } from "fusion:context";
 import { useContent, useEditableContent } from "fusion:content";
 import getProperties from "fusion:properties";
@@ -60,7 +60,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 
 	const imageAuthTokenObj = {};
 	if (imageAuthToken?.hash) {
-		imageAuthToken[RESIZER_APP_VERSION] = imageAuthToken.hash;
+		imageAuthToken[RESIZER_TOKEN_VERSION] = imageAuthToken.hash;
 	}
 
 	const alt = headline || description || null;

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { useContent, useEditableContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
@@ -215,7 +215,7 @@ const ExtraLargePromo = ({ customFields }) => {
 								type
 								url
 								auth {
-									${RESIZER_APP_VERSION}
+									${RESIZER_TOKEN_VERSION}
 								}
 							}
 						}
@@ -225,7 +225,7 @@ const ExtraLargePromo = ({ customFields }) => {
 						type
 						url
 						auth {
-							${RESIZER_APP_VERSION}
+							${RESIZER_TOKEN_VERSION}
 						}
 					}
 				}

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -3,7 +3,7 @@ import PropTypes from "@arc-fusion/prop-types";
 import { useContent } from "fusion:content";
 import { useFusionContext, useAppContext } from "fusion:context";
 import getProperties from "fusion:properties";
-import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION, RESIZER_URL } from "fusion:environment";
 import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
 	Carousel,
@@ -166,7 +166,7 @@ const GalleryFeature = ({ customFields = {} }) => {
 				arcSite={arcSite}
 				customFields={customFields}
 				globalContent={globalContent}
-				resizerAppVersion={RESIZER_APP_VERSION}
+				resizerAppVersion={RESIZER_TOKEN_VERSION}
 				resizerURL={RESIZER_URL}
 			/>
 		</LazyLoad>

--- a/blocks/gallery-block/features/gallery/default.test.jsx
+++ b/blocks/gallery-block/features/gallery/default.test.jsx
@@ -10,7 +10,7 @@ import Gallery from "./default";
 const { Item: CarouselItem } = Carousel;
 window.matchMedia = jest.fn();
 jest.mock("fusion:environment", () => ({
-	RESIZER_APP_VERSION: 2,
+	RESIZER_TOKEN_VERSION: 2,
 	RESIZER_URL: "https://resizer.com",
 }));
 jest.mock("fusion:content", () => ({

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { useComponentContext, useFusionContext } from "fusion:context";
 import { useContent, useEditableContent } from "fusion:content";
 import getProperties from "fusion:properties";
@@ -61,7 +61,7 @@ const LargeManualPromo = ({ customFields }) => {
 
 	const imageAuthTokenObj = {};
 	if (imageAuthToken?.hash) {
-		imageAuthToken[RESIZER_APP_VERSION] = imageAuthToken.hash;
+		imageAuthToken[RESIZER_TOKEN_VERSION] = imageAuthToken.hash;
 	}
 
 	const alt = headline || description || null;

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import getProperties from "fusion:properties";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { useContent, useEditableContent } from "fusion:content";
 import { useComponentContext, useFusionContext } from "fusion:context";
 
@@ -222,7 +222,7 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 								type
 								url
 								auth {
-									${RESIZER_APP_VERSION}
+									${RESIZER_TOKEN_VERSION}
 								}
 							}
 						}
@@ -232,7 +232,7 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 						type
 						url
 						auth {
-							${RESIZER_APP_VERSION}
+							${RESIZER_TOKEN_VERSION}
 						}
 					}
 				}

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { useContent, useEditableContent } from "fusion:content";
 import { useComponentContext, useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
@@ -55,7 +55,7 @@ const MediumManualPromo = ({ customFields }) => {
 
 	const imageAuthTokenObj = {};
 	if (imageAuthToken?.hash) {
-		imageAuthToken[RESIZER_APP_VERSION] = imageAuthToken.hash;
+		imageAuthToken[RESIZER_TOKEN_VERSION] = imageAuthToken.hash;
 	}
 
 	const alt = headline || description || null;

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useContent, useEditableContent } from "fusion:content";
 import { useComponentContext, useFusionContext } from "fusion:context";
-import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION, RESIZER_URL } from "fusion:environment";
 import getProperties from "fusion:properties";
 import PropTypes from "@arc-fusion/prop-types";
 import { LazyLoad, localizeDateTime } from "@wpmedia/engine-theme-sdk";
@@ -95,14 +95,14 @@ const MediumPromo = ({ customFields }) => {
 				lead_art {
 					_id
 					auth {
-						${RESIZER_APP_VERSION}
+						${RESIZER_TOKEN_VERSION}
 					}
 					type
 					promo_items {
 						basic {
 							_id
 							auth {
-								${RESIZER_APP_VERSION}
+								${RESIZER_TOKEN_VERSION}
 							}
 							type
 							url
@@ -112,7 +112,7 @@ const MediumPromo = ({ customFields }) => {
 				basic {
 					_id
 					auth {
-						${RESIZER_APP_VERSION}
+						${RESIZER_TOKEN_VERSION}
 					}
 					type
 					url
@@ -154,7 +154,7 @@ const MediumPromo = ({ customFields }) => {
 
 	// Image logic
 	const promoImageData = getImageFromANS(content);
-	const imageAuthToken = promoImageData?.auth?.[RESIZER_APP_VERSION] || null;
+	const imageAuthToken = promoImageData?.auth?.[RESIZER_TOKEN_VERSION] || null;
 	let resizeImage = false;
 	let imageSrc = imageOverrideURL || fallbackImage;
 	if (!imageOverrideURL) {

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -4,7 +4,7 @@ import PropTypes from "@arc-fusion/prop-types";
 import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
 	getImageFromANS,
@@ -55,7 +55,7 @@ const NumberedList = (props) => {
           basic {
 			_id
 			auth {
-				${RESIZER_APP_VERSION}
+				${RESIZER_TOKEN_VERSION}
 			}
             type
             url
@@ -65,7 +65,7 @@ const NumberedList = (props) => {
               basic {
 				_id
 				auth {
-					${RESIZER_APP_VERSION}
+					${RESIZER_TOKEN_VERSION}
 				}
                 type
                 url

--- a/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.test.jsx
+++ b/blocks/product-assortment-carousel-block/features/product-assortment-carousel/default.test.jsx
@@ -7,7 +7,7 @@ import { useFusionContext } from "fusion:context";
 import ProductAssortmentCarousel from "./default";
 
 jest.mock("fusion:environment", () => ({
-	RESIZER_APP_VERSION: 2,
+	RESIZER_TOKEN_VERSION: 2,
 	RESIZER_URL: "https://resizer.com",
 }));
 

--- a/blocks/product-featured-image-block/features/product-featured-image/default.jsx
+++ b/blocks/product-featured-image-block/features/product-featured-image/default.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useFusionContext } from "fusion:context";
 import { imageANSToImageSrc, Image } from "@wpmedia/arc-themes-components";
-import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION, RESIZER_URL } from "fusion:environment";
 
 const BLOCK_CLASS_NAME = "b-product-featured-image";
 
@@ -30,7 +30,7 @@ function ProductFeaturedImage() {
 	return featuredImage ? (
 		<ProductFeaturedImageDisplay
 			featuredImage={featuredImage}
-			resizerAppVersion={RESIZER_APP_VERSION}
+			resizerAppVersion={RESIZER_TOKEN_VERSION}
 			resizerURL={RESIZER_URL}
 		/>
 	) : null;

--- a/blocks/product-gallery-block/features/product-gallery/_children/MainImage/index.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/_children/MainImage/index.jsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from "react";
-import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION, RESIZER_URL } from "fusion:environment";
 import { Image, imageANSToImageSrc } from "@wpmedia/arc-themes-components";
 
 function useOnScreen(ref) {
@@ -35,7 +35,7 @@ const MainImage = ({ image, loading, onVisible }) => {
 				alt=""
 				className={`${BLOCK_CLASS_NAME}__focus-view-main-image`}
 				loading={loading || (isVisible ? "eager" : "lazy")}
-				resizedOptions={{ auth: image.auth[RESIZER_APP_VERSION] }}
+				resizedOptions={{ auth: image.auth[RESIZER_TOKEN_VERSION] }}
 				resizerURL={RESIZER_URL}
 				responsiveImages={[150, 375, 500, 1500, 2000]}
 				src={imageANSToImageSrc(image)}

--- a/blocks/product-gallery-block/features/product-gallery/_children/MainImage/index.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/_children/MainImage/index.test.jsx
@@ -5,7 +5,7 @@ import MainImage from "./index";
 import mockData from "../../mock-data";
 
 jest.mock("fusion:environment", () => ({
-	RESIZER_APP_VERSION: 1,
+	RESIZER_TOKEN_VERSION: 1,
 	RESIZER_URL: "https://resizer.com",
 }));
 

--- a/blocks/product-gallery-block/features/product-gallery/_children/ProductFocusView/index.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/_children/ProductFocusView/index.test.jsx
@@ -15,7 +15,7 @@ import ProductFocusView from "./index";
 import mockData from "../../mock-data";
 
 jest.mock("fusion:environment", () => ({
-	RESIZER_APP_VERSION: 1,
+	RESIZER_TOKEN_VERSION: 1,
 	RESIZER_URL: "https://resizer.com",
 }));
 

--- a/blocks/product-gallery-block/features/product-gallery/_children/ThumbnailBar/index.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/_children/ThumbnailBar/index.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION, RESIZER_URL } from "fusion:environment";
 
 import {
 	Button,
@@ -130,7 +130,7 @@ const ThumbnailBar = ({ images, selectedIndex, onImageSelect }) => {
 									onClick={() => {
 										onImageSelect(getImageIndexById(image._id));
 									}}
-									resizedOptions={{ auth: image.auth[RESIZER_APP_VERSION] }}
+									resizedOptions={{ auth: image.auth[RESIZER_TOKEN_VERSION] }}
 									resizerURL={RESIZER_URL}
 									responsiveImages={[120]}
 									src={imageANSToImageSrc(image)}

--- a/blocks/product-gallery-block/features/product-gallery/_children/ThumbnailBar/index.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/_children/ThumbnailBar/index.test.jsx
@@ -15,7 +15,7 @@ import ThumbnailBar from "./index";
 import mockData from "../../mock-data";
 
 jest.mock("fusion:environment", () => ({
-	RESIZER_APP_VERSION: 1,
+	RESIZER_TOKEN_VERSION: 1,
 	RESIZER_URL: "https://resizer.com/",
 }));
 

--- a/blocks/product-gallery-block/features/product-gallery/default.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext, useComponentContext } from "fusion:context";
-import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION, RESIZER_URL } from "fusion:environment";
 
 import { Carousel, Image, imageANSToImageSrc, usePhrases } from "@wpmedia/arc-themes-components";
 
@@ -142,7 +142,7 @@ function ProductGallery({ customFields }) {
 			carouselItems={carouselItems}
 			id={id}
 			isFeaturedImageEnabled={isFeaturedImageEnabled}
-			resizerAppVersion={RESIZER_APP_VERSION}
+			resizerAppVersion={RESIZER_TOKEN_VERSION}
 			resizerURL={RESIZER_URL}
 			indicatorType={indicatorType}
 		/>

--- a/blocks/product-gallery-block/features/product-gallery/default.test.jsx
+++ b/blocks/product-gallery-block/features/product-gallery/default.test.jsx
@@ -6,7 +6,7 @@ import { useFusionContext } from "fusion:context";
 import ProductGallery from "./default";
 
 jest.mock("fusion:environment", () => ({
-	RESIZER_APP_VERSION: 2,
+	RESIZER_TOKEN_VERSION: 2,
 	RESIZER_URL: "https://resizer.com",
 }));
 

--- a/blocks/quilted-image-block/features/quilted-image/default.jsx
+++ b/blocks/quilted-image-block/features/quilted-image/default.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 import { useContent, useEditableContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 // Arc Themes Components - Base set of components used to compose blocks
 // https://github.com/WPMedia/arc-themes-components/
 import {
@@ -50,7 +50,7 @@ const ImageItem = ({
 
 	const imageAuthTokenObj = {};
 	if (imageAuthToken?.hash) {
-		imageAuthTokenObj[RESIZER_APP_VERSION] = imageAuthToken.hash;
+		imageAuthTokenObj[RESIZER_TOKEN_VERSION] = imageAuthToken.hash;
 	}
 
 	const imageParams =

--- a/blocks/related-content-content-source-block/sources/related-content.js
+++ b/blocks/related-content-content-source-block/sources/related-content.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { CONTENT_BASE, ARC_ACCESS_TOKEN, RESIZER_APP_VERSION } from "fusion:environment";
+import { CONTENT_BASE, ARC_ACCESS_TOKEN, RESIZER_TOKEN_VERSION } from "fusion:environment";
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
@@ -36,7 +36,7 @@ const fetch = ({ _id, "arc-site": site }, { cachedCall }) => {
 		},
 		method: "GET",
 	})
-		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 		.then(({ data }) => data)
 		.catch(handleFetchError);
 };

--- a/blocks/results-list-block/features/results-list/results/index.jsx
+++ b/blocks/results-list-block/features/results-list/results/index.jsx
@@ -1,5 +1,5 @@
 import React, { createRef, useCallback, useEffect, useReducer, useState } from "react";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { useContent } from "fusion:content";
 import { Button, Divider, Join, Stack, usePhrases } from "@wpmedia/arc-themes-components";
 
@@ -107,7 +107,7 @@ const Results = ({
           basic {
 			_id
             auth {
-				${RESIZER_APP_VERSION}
+				${RESIZER_TOKEN_VERSION}
 			}
             type
             url
@@ -117,7 +117,7 @@ const Results = ({
               basic {
 				_id
 				auth {
-					${RESIZER_APP_VERSION}
+					${RESIZER_TOKEN_VERSION}
 				}
                 type
                 url

--- a/blocks/results-list-block/features/results-list/results/result-item.jsx
+++ b/blocks/results-list-block/features/results-list/results/result-item.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useEditableContent } from "fusion:content";
 import { useComponentContext } from "fusion:context";
 import getProperties from "fusion:properties";
-import { RESIZER_APP_VERSION, RESIZER_URL } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION, RESIZER_URL } from "fusion:environment";
 import { localizeDateTime } from "@wpmedia/engine-theme-sdk";
 
 import {
@@ -108,7 +108,7 @@ const ResultItem = React.memo(
 								<Image
 									src={imageURL !== null ? imageURL : targetFallbackImage}
 									alt={headlineText}
-									resizedOptions={{ auth: auth[RESIZER_APP_VERSION], smart: true }}
+									resizedOptions={{ auth: auth[RESIZER_TOKEN_VERSION], smart: true }}
 									resizerURL={RESIZER_URL}
 									sizes={[
 										{

--- a/blocks/search-content-source-block/sources/search-api.js
+++ b/blocks/search-content-source-block/sources/search-api.js
@@ -1,5 +1,9 @@
 import axios from "axios";
-import { ARC_ACCESS_TOKEN, RESIZER_APP_VERSION, searchKey as SEARCH_KEY } from "fusion:environment";
+import {
+	ARC_ACCESS_TOKEN,
+	RESIZER_TOKEN_VERSION,
+	searchKey as SEARCH_KEY,
+} from "fusion:environment";
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
@@ -48,7 +52,7 @@ const fetch = ({ "arc-site": site, page = "1", query }, { cachedCall }) => {
 		},
 		method: "GET",
 	})
-		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 		.then(({ data }) => data)
 		.catch(handleFetchError);
 };

--- a/blocks/signing-service-content-source-block/README.md
+++ b/blocks/signing-service-content-source-block/README.md
@@ -6,10 +6,10 @@ A Fusion content source for interacting with the Arc Signing Service for generat
 
 The signing content source relies on the following environment variables
 
-| Variable                        | Description                                                                                |
-| ------------------------------- | ------------------------------------------------------------------------------------------ |
-| SIGNING_SERVICE_DEFAULT_APP     | The name of the signing service app that should be used as the default app for API request |
-| SIGNING_SERVICE_DEFAULT_VERSION | The signing service app version that aligns with the default app                           |
+| Variable                    | Description                                                                                |
+| --------------------------- | ------------------------------------------------------------------------------------------ |
+| SIGNING_SERVICE_DEFAULT_APP | The name of the signing service app that should be used as the default app for API request |
+| RESIZER_TOKEN_VERSION       | The signing service app version that aligns with the default app                           |
 
 ## Content Source Params
 
@@ -17,7 +17,7 @@ The signing content source relies on the following environment variables
 | -------------- | --------------------------------------------------------------------------------------------------------------------- |
 | id             | The string to be hashed - this will be passed to the signing service as an encoded string generate a hashed string on |
 | service        | The signing service app to use, by default will use the value from `SIGNING_SERVICE_DEFAULT_APP` environment variable |
-| serviceVersion | The signing service app version to use, by default will use the value from `SIGNING_SERVICE_DEFAULT_VERSION`          |
+| serviceVersion | The signing service app version to use, by default will use the value from `RESIZER_TOKEN_VERSION`                    |
 
 ## TTL
 

--- a/blocks/signing-service-content-source-block/sources/signing-service.js
+++ b/blocks/signing-service-content-source-block/sources/signing-service.js
@@ -3,7 +3,7 @@ import {
 	ARC_ACCESS_TOKEN,
 	CONTENT_BASE,
 	SIGNING_SERVICE_DEFAULT_APP,
-	SIGNING_SERVICE_DEFAULT_VERSION,
+	RESIZER_TOKEN_VERSION,
 } from "fusion:environment";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 
@@ -16,7 +16,7 @@ const params = {
 const fetch = ({
 	id,
 	service = SIGNING_SERVICE_DEFAULT_APP,
-	serviceVersion = SIGNING_SERVICE_DEFAULT_VERSION,
+	serviceVersion = RESIZER_TOKEN_VERSION,
 }) => {
 	const urlSearch = new URLSearchParams({
 		value: id,

--- a/blocks/signing-service-content-source-block/sources/signing-service.test.js
+++ b/blocks/signing-service-content-source-block/sources/signing-service.test.js
@@ -3,7 +3,7 @@ import contentSource from "./signing-service";
 jest.mock("fusion:environment", () => ({
 	CONTENT_BASE: "",
 	SIGNING_SERVICE_DEFAULT_APP: "resizer",
-	SIGNING_SERVICE_DEFAULT_VERSION: 1,
+	RESIZER_TOKEN_VERSION: 1,
 }));
 
 jest.mock("axios", () => ({

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -4,7 +4,7 @@ import PropTypes from "@arc-fusion/prop-types";
 import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { LazyLoad } from "@wpmedia/engine-theme-sdk";
 import {
 	getImageFromANS,
@@ -88,7 +88,7 @@ const SimpleList = (props) => {
 					type
 					url
 					auth {
-						${RESIZER_APP_VERSION}
+						${RESIZER_TOKEN_VERSION}
 					}
 			 	}
 				lead_art {
@@ -98,7 +98,7 @@ const SimpleList = (props) => {
 							type
 							url
 							auth {
-								${RESIZER_APP_VERSION}
+								${RESIZER_TOKEN_VERSION}
 							}
 						}
 					}

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { useContent, useEditableContent } from "fusion:content";
 import { useComponentContext, useFusionContext } from "fusion:context";
 import getProperties from "fusion:properties";
@@ -53,7 +53,7 @@ const SmallManualPromo = ({ customFields }) => {
 
 	const imageAuthTokenObj = {};
 	if (imageAuthToken?.hash) {
-		imageAuthToken[RESIZER_APP_VERSION] = imageAuthToken.hash;
+		imageAuthToken[RESIZER_TOKEN_VERSION] = imageAuthToken.hash;
 	}
 
 	const alt = headline || null;

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import PropTypes from "@arc-fusion/prop-types";
 import { useContent, useEditableContent } from "fusion:content";
 import { useComponentContext, useFusionContext } from "fusion:context";
@@ -66,7 +66,7 @@ const SmallPromo = ({ customFields }) => {
 				type
 				url
 				auth {
-					${RESIZER_APP_VERSION}
+					${RESIZER_TOKEN_VERSION}
 				}
 			}
 			basic {
@@ -74,7 +74,7 @@ const SmallPromo = ({ customFields }) => {
 				type
 				url
 				auth {
-					${RESIZER_APP_VERSION}
+					${RESIZER_TOKEN_VERSION}
 				}
 			}
 		}

--- a/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
+++ b/blocks/story-feed-author-content-source-block/sources/story-feed-author.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:environment";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_TOKEN_VERSION } from "fusion:environment";
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
@@ -48,7 +48,7 @@ const fetch = (
 		},
 		method: "GET",
 	})
-		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 		.then(({ data }) => data)
 		.catch(handleFetchError);
 };

--- a/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
+++ b/blocks/story-feed-query-content-source-block/sources/story-feed-query.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:environment";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_TOKEN_VERSION } from "fusion:environment";
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
@@ -48,7 +48,7 @@ const fetch = (
 		},
 		method: "GET",
 	})
-		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 		.then(({ data }) => data)
 		.catch(handleFetchError);
 };

--- a/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
+++ b/blocks/story-feed-sections-content-source-block/sources/story-feed-sections.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:environment";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_TOKEN_VERSION } from "fusion:environment";
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
@@ -129,7 +129,7 @@ const fetch = (
 		},
 		method: "GET",
 	})
-		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 		.then(({ data }) => data)
 		.catch(handleFetchError);
 };

--- a/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
+++ b/blocks/story-feed-tag-content-source-block/sources/story-feed-tag.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:environment";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_TOKEN_VERSION } from "fusion:environment";
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
@@ -52,7 +52,7 @@ const fetch = (
 		},
 		method: "GET",
 	})
-		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 		.then(({ data }) => data)
 		.catch(handleFetchError);
 };

--- a/blocks/top-table-list-block/features/top-table-list/default.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/default.jsx
@@ -2,7 +2,7 @@
 import React from "react";
 import PropTypes from "@arc-fusion/prop-types";
 
-import { RESIZER_APP_VERSION } from "fusion:environment";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
 import { LazyLoad } from "@wpmedia/engine-theme-sdk";
@@ -150,7 +150,7 @@ const TopTableListWrapper = ({ customFields }) => {
             type
             url
 				auth {
-					${RESIZER_APP_VERSION}
+					${RESIZER_TOKEN_VERSION}
 				}
           }
           lead_art {
@@ -163,7 +163,7 @@ const TopTableListWrapper = ({ customFields }) => {
                 type
                 url
 					 auth {
-						${RESIZER_APP_VERSION}
+						${RESIZER_TOKEN_VERSION}
 					}
               }
             }

--- a/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
+++ b/blocks/unpublished-content-source-block/sources/content-api-unpublished.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_APP_VERSION } from "fusion:environment";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE, RESIZER_TOKEN_VERSION } from "fusion:environment";
 import signImagesInANSObject from "@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
 import { fetch as resizerFetch } from "@wpmedia/signing-service-content-source-block";
@@ -33,7 +33,7 @@ const fetch = ({ _id, "arc-site": website }, { cachedCall }) => {
 		},
 		method: "GET",
 	})
-		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_APP_VERSION))
+		.then(signImagesInANSObject(cachedCall, resizerFetch, RESIZER_TOKEN_VERSION))
 		.then(({ data }) => data)
 		.catch(handleFetchError);
 };

--- a/jest/mocks/environment.js
+++ b/jest/mocks/environment.js
@@ -4,8 +4,8 @@ const resizerKey = "%{FKDFJK}";
 
 const searchKey = "ABCDEF";
 
-const RESIZER_APP_VERSION = 2;
+const RESIZER_TOKEN_VERSION = 2;
 
 const RESIZER_URL = "http://url.com/";
 
-export { TIMEZONE, resizerKey, searchKey, RESIZER_APP_VERSION, RESIZER_URL };
+export { TIMEZONE, resizerKey, searchKey, RESIZER_TOKEN_VERSION, RESIZER_URL };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17905,9 +17905,9 @@
       }
     },
     "@wpmedia/arc-themes-components": {
-      "version": "0.0.4-arc-themes-release-version-2-0-3.30",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.30/f8e087d1631619cfa8d4726284e4a39d14b370da",
-      "integrity": "sha512-ZA7SkCTEXEpmY2uH5UPjof0ONvZ+enMp95ZETx3M/oYe6x9SSVmv0sCPgARKqntO4Bova04Rx2VBgGGmhArG1A==",
+      "version": "0.0.4-arc-themes-release-version-2-0-3.31",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-2-0-3.31/3871811059604b04da6da4037597e529b3fb8997",
+      "integrity": "sha512-Uaw4mxNkIfvcWuFPJcIL94KnCFRXASzQZt8OYB2RCVLq20Gkn/VQ5bcWUekpC2eWkRZRfLKNfKepfDdXg/IcyA==",
       "dev": true,
       "requires": {
         "lazy-child": "^0.3.1",


### PR DESCRIPTION
## Description

Updated all instances of SIGNING_SERVICE_DEFAULT_VERSION and RESIZER_APP_VERSION to RESIZER_TOKEN_VERSION

NOTE: Chromatic tests will show UI changes until the corresponding [feature-pack PR](https://github.com/WPMedia/arc-themes-feature-pack/pull/397) has been merged in. 

## Jira Ticket

- [THEMES-1042](https://arcpublishing.atlassian.net/browse/THEMES-1042)

## Test Steps

1. Checkout the `THEMES-1042` branch for the feature pack, component repo, and blocks repo
2. run npm i in all three repos
3. Run fusion repo with linked blocks `npx fusion start -f -l`
4. Verify that the blocks and content sources are working correctly (look at the [All-Blocks-Test-TA Page](http://localhost/pagebuilder/editor/curate?p=pFV68o01WD2rps16t&v=v3gTrWiVLE2rps16t) to view all blocks at once

## Effect Of Changes

There should be no visible changes in Pagebuilder.

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1042]: https://arcpublishing.atlassian.net/browse/THEMES-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ