### PR TITLE
Update ad size maps for Google update change (flex-cube to right-rail…

### DIFF
--- a/blocks/ads-block/features/ads/ad-mapping.js
+++ b/blocks/ads-block/features/ads/ad-mapping.js
@@ -7,7 +7,7 @@
   ]
 */
 
-const sz0x0 = [0, 0];
+const sz0x0 = [];
 const sz1x1 = [1, 1];
 const sz300x250 = [300, 250];
 const sz300x600 = [300, 600];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9348,9 +9348,9 @@
       "version": "file:blocks/double-chain-block"
     },
     "@wpmedia/engine-theme-sdk": {
-      "version": "2.13.2-arc-themes-release-version-1-26.0",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/engine-theme-sdk/2.13.2-arc-themes-release-version-1-26.0/23f322e631247b842bd4d1461c3dd8da94669517",
-      "integrity": "sha512-su6NAMHNuJZl6QBe27T1Cv/GBfQxMi5FpAThcOW83XrvnDK8jVaQdrVCkpheelHfqppdOX7rR6xvP4ZBxHvNLw==",
+      "version": "2.13.2-arc-themes-release-version-1-27.1",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/engine-theme-sdk/2.13.2-arc-themes-release-version-1-27.1/7b8e20a7fb7c639fd8b139b911cc57f651118065",
+      "integrity": "sha512-bDATazdicxLJaowvSviL3LSLJlI02Br+0VZA82rHNw4N6t6ipjhmM266opTLJNnsn+VWw9ou0oNvsIPRgY9ptw==",
       "dev": true,
       "requires": {
         "@arc-fusion/prop-types": "^0.1.5",


### PR DESCRIPTION
## Description

Google pushed an update that broke ads for using the [0,0] size designation for ad sizing to designate that no ad should be shown.  This will update the sizing to the newer acceptable values.

## Jira Ticket

- [THEMES-1077](https://arcpublishing.atlassian.net/browse/THEMES-1077)

## Dependencies

Needs to be run in Node v14

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1077]: https://arcpublishing.atlassian.net/browse/THEMES-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ