### PR TITLE
added additional validation for author name

### DIFF
--- a/blocks/results-list-block/features/results-list/results/result-item.jsx
+++ b/blocks/results-list-block/features/results-list/results/result-item.jsx
@@ -81,8 +81,7 @@ const ResultItem = React.memo(
 			const imageURL = imageANSToImageSrc(getImageFromANS(element)) || null;
 			const auth = getImageFromANS(element)?.auth || {};
 			const { searchableField } = useEditableContent();
-			const hasSomeAuthorName = credits?.by.some((author) => author.name && author?.name !== "");
-			const hasAuthors = showByline ? credits?.by && credits?.by.length && hasSomeAuthorName : null;
+			const hasAuthors = showByline ? credits?.by?.some((author) => author?.name !== "") : null;
 			const contentHeading = showHeadline ? headlineText : null;
 			const formattedDate = Date.parse(displayDate)
 				? localizeDateTime(new Date(displayDate), dateTimeFormat, language, timeZone)

--- a/blocks/results-list-block/features/results-list/results/result-item.jsx
+++ b/blocks/results-list-block/features/results-list/results/result-item.jsx
@@ -81,7 +81,8 @@ const ResultItem = React.memo(
 			const imageURL = imageANSToImageSrc(getImageFromANS(element)) || null;
 			const auth = getImageFromANS(element)?.auth || {};
 			const { searchableField } = useEditableContent();
-			const hasAuthors = showByline ? credits?.by && credits?.by.length : null;
+			const hasSomeAuthorName = credits?.by.some((author) => author.name && author?.name !== "");
+			const hasAuthors = showByline ? credits?.by && credits?.by.length && hasSomeAuthorName : null;
 			const contentHeading = showHeadline ? headlineText : null;
 			const formattedDate = Date.parse(displayDate)
 				? localizeDateTime(new Date(displayDate), dateTimeFormat, language, timeZone)


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description

This PR adds a new validation for author value, it finds if for some author name value, since there are some scenarios where the author data comes without name

## Jira Ticket

- [THEMES-1020](https://arcpublishing.atlassian.net/browse/THEMES-1020)

## Acceptance Criteria

Results List Arc Block | by selecting story-feed-query from the drop-down of the content source, then under query type:video the full author's name should appear, and if no author names in the video, "By" should not appear!

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git fetch origin THEMES-1020 && git checkout THEMES-1020`
2. Run fusion repo with linked blocks `npx fusion start -f -l results-list`
3. Go to admin and create a page with result-list block.
4. Set Configure Content:
    - Display Content Info => ans-feed
    - Content Source => story-feed-query
    - query => type:video
 5. Validate stories without author shouldn't show the "By" string

## Effect Of Changes

### Before

Results List Arc Block | by selecting story-feed-query from the drop-down of the content source, then under query type:video no author’s name the "By" text was appearing.

### After

Results List Arc Block | by selecting story-feed-query from the drop-down of the content source, then under query type:video no author’s name the "By" text doesn't appear anymore.


## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1020]: https://arcpublishing.atlassian.net/browse/THEMES-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ