### PR TITLE
THEMES-1122: Update primary and secondary fonts

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,6 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-	href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Lora:wght@400;700&family=Abel:wght@400;700&display=swap"
+	href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Lora:wght@400;700&display=swap"
 	rel="stylesheet"
 />

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -149,8 +149,8 @@
 	$tokens: (
 		default: (
 			alias: (
-				"font-family-primary": "Abel",
-				"font-family-secondary": "Georgia",
+				"font-family-primary": "Inter",
+				"font-family-secondary": "Lora",
 				"color-primary": var(--global-black),
 				"color-primary-hover": var(--global-neutral-7),
 				"text-color": var(--global-neutral-8),

--- a/blocks/alias-tokens/themes/news.json
+++ b/blocks/alias-tokens/themes/news.json
@@ -1,7 +1,7 @@
 {
 	"default": {
-		"font-family-primary": "Abel",
-		"font-family-secondary": "Georgia",
+		"font-family-primary": "Inter",
+		"font-family-secondary": "Lora",
 		"color-primary": "var(--global-black)",
 		"color-primary-hover": "var(--global-neutral-7)",
 		"text-color": "var(--global-neutral-8)",


### PR DESCRIPTION
## Description

This PR updates the font families in storybook and in the alias tokens `news.json` to 'Inter' and 'Lora'

## Jira Ticket

- [THEMES-1122](https://arcpublishing.atlassian.net/browse/THEMES-1122)

## Acceptance Criteria

In v2:

- primary-font default is Inter
- secondary-font default is Lora
- Updated in storybook

## Test Steps

1. Checkout this branch `git checkout THEMES-1122`
2. Run storybook `npm run storybook`
3. Check some of the blocks, ensure that the primary font is 'Inter' and the secondary font is 'Lora'.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1122]: https://arcpublishing.atlassian.net/browse/THEMES-1122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ