### PR TITLE
Lead Art Gallery + Article Body Gallery | Disable smart crop

### DIFF
--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -232,7 +232,6 @@ export const LeadArtPresentation = (props) => {
 								<div className={`${BLOCK_CLASS_NAME}__image-wrapper`}>
 									<Image
 										ansImage={galleryItem}
-										resizedOptions={{ smart: true }}
 										// 16:9 aspect ratio
 										width={800}
 										height={450}


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description
This PR set to false the smart crop for the carousel image for LeadArt block.


## Jira Ticket

- [THEMES-1034](https://arcpublishing.atlassian.net/browse/THEMES-1034)

## Acceptance Criteria

GIVEN I am an Editor, WHEN a gallery is the lead art on in the article body on an article, THEN: 

Smart crop is false for the images on the gallery lead art and the article body galleries

Full images display in the gallery view

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-1034`
2. Run fusion repo with linked blocks `npx fusion start -f -l lead-art-block`
3. In composer create a new story with carousel
4. Use page builder to use the lead-art-block in a page bringing the story that was created
5. Safe and Publish
6. Go to the page preview

## Effect Of Changes
Images should display a black frame without resizing or cutting the content

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1034]: https://arcpublishing.atlassian.net/browse/THEMES-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ