### PR TITLE
THEMES 961 V2 Search Results List | Arc Media Block, a "0 results for (...)" should appear when no results are found 

### DIFF
--- a/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
@@ -84,7 +84,6 @@ class CustomSearchResultsList extends React.Component {
 					onChange={(event) => this.setState({ value: event.value })}
 					onSearch={() => this.fetchStories(false)}
 					searchTerm={searchTerm}
-					showResultsStats={data?.length > 0}
 					totalItems={totalHits}
 				/>
 				<ResultsList

--- a/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/custom-content.jsx
@@ -84,6 +84,7 @@ class CustomSearchResultsList extends React.Component {
 					onChange={(event) => this.setState({ value: event.value })}
 					onSearch={() => this.fetchStories(false)}
 					searchTerm={searchTerm}
+					showResultsStats={searchTerm !== ""}
 					totalItems={totalHits}
 				/>
 				<ResultsList

--- a/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
@@ -104,7 +104,6 @@ class GlobalSearchResultsList extends React.Component {
 					onChange={(event) => this.setState({ value: event.value })}
 					onSearch={() => this.handleSearch()}
 					searchTerm={query}
-					showResultsStats={content?.length > 0}
 					totalItems={totalHits}
 				/>
 				<ResultsList

--- a/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/global-content.jsx
@@ -104,6 +104,7 @@ class GlobalSearchResultsList extends React.Component {
 					onChange={(event) => this.setState({ value: event.value })}
 					onSearch={() => this.handleSearch()}
 					searchTerm={query}
+					showResultsStats={query !== ""}
 					totalItems={totalHits}
 				/>
 				<ResultsList

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-field.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-field.jsx
@@ -8,7 +8,7 @@ const SearchField = ({
 	onChange,
 	onSearch,
 	searchTerm,
-	showResultsStats = true,
+	showResultsStats,
 	totalItems,
 }) => {
 	const phrases = usePhrases();

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-field.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-field.jsx
@@ -8,7 +8,7 @@ const SearchField = ({
 	onChange,
 	onSearch,
 	searchTerm,
-	showResultsStats,
+	showResultsStats = true,
 	totalItems,
 }) => {
 	const phrases = usePhrases();


### PR DESCRIPTION
# WIP

**This PR goes with an `arc-themes-feature-pack` PR. You can find it [here](https://github.com/WPMedia/arc-themes-feature-pack/pull/428).**

## Description

In the `search-results-list` block, there's a text field below the search bar that displays the number of search results for a query. In V2 the text field does not show up for search queries with zero results. The goal of this ticket was to fix that (the desired behavior is to have the text say "0 search results for [...]").  
  
To fix it, I made the following changes:
* In `search-results-list/_children/custom-content.jsx`, I removed the original expression that determined the value of `showResultsStats`. Now, the results stats are shown for any search (and they aren't shown if the user hasn't made a search yet).
* I made a similar change to `search-results-list/_children/custom-content.jsx`. The only difference is the name of the variable that holds the search query.
* These changes preserve test coverage, so no new unit tests were needed
* As a result of these changes, some changes were also automatically made to the `site-styles` directory in `arc-themes-feature-pack`
    * You can find a link to that PR [here](https://github.com/WPMedia/arc-themes-feature-pack/pull/428)
    * These are needed for local development

## Jira Ticket

[THEMES-961](https://arcpublishing.atlassian.net/browse/THEMES-961)

## Acceptance Criteria

1. <0 results for> should appear when no results are found in the search results list

## Test Steps

1. Checkout this branch: `git checkout THEMES-961-search-results-list-2`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/search-results-list-block`
3. Open your local PageBuilder instance:
    * Create a new page (the name and URL don't matter)
    * Choose any layout you want, and place a "Search Results List - Arc Block" block on the page
    * Open the block details
    * Under the "Configure Content" drop down, set "Display Content Info" to `search-api`, and set the query to `type:story`
    * Go back to the "Curate" tab, and scroll down to the "Global Content" drop down. Set the content source to `search-api`, and set the number of pages to 1
5. To test the search bar, enter text into the "query" text box, and click the "Update" button. This ticket only covers the text box below the search bar, not the searching itself.
    * Make sure that when something has zero results (I used "mmm", but anything works), the text below the search bar says '0 results for "[your query]"'
    * Make sure that when something has >= 1 result(s) (I used "global," which has 6 results, and "html embed," which has 1 result. But, anything works), the text appears with the correct value, and the story results still show

## Effect Of Changes

### Before

| Zero results | One or more results |
| --- | --- |
| ![Screenshot 2023-06-30 at 3 09 30 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/59714a68-6a10-4895-b7fd-95f5592665e3) | ![Screenshot 2023-06-30 at 3 09 47 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/b4561c44-28b1-4e48-a5a2-4f860e4f2c67) |

The original V2 search behavior can be tested [here](https://themesinternal-the-gazette-dev.web.arc-cdn.net/search/global/).

### After

| Zero results | One or more results |
| --- | --- |
| ![Screenshot 2023-06-30 at 3 11 54 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/18cf8e07-8312-4ec2-9f3c-070ef4b3c281) | ![Screenshot 2023-06-30 at 3 12 25 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/cfc28139-ab4f-4493-9b43-266d1e260910) |

## Dependencies or Side Effects

This PR is dependent on some changes to `arc-themes-feature-pack`. The PR is [here](https://github.com/WPMedia/arc-themes-feature-pack/pull/428).

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-961]: https://arcpublishing.atlassian.net/browse/THEMES-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ