### PR TITLE
Fix for THEMES-961 broken message on initial load

### DIFF
--- a/blocks/search-results-list-block/features/search-results-list/_children/search-field.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-field.jsx
@@ -29,7 +29,7 @@ const SearchField = ({
 					{phrases.t("search-results-block.search-button")}
 				</Button>
 			</Stack>
-			{showResultsStats ? (
+			{showResultsStats && typeof searchTerm === "string" ? (
 				<Paragraph>
 					{phrases.t("search-results-block.search-result-number", {
 						smart_count: totalItems,


### PR DESCRIPTION
## Description

When testing THEMES-961, @alshwaikit noticed that the results message is broken when the `search-results-list` block loads for the first time (i.e., before any searches have been performed). I noticed that the `searchTerm` in the block has type `undefined` when it loads for the first time. However, `search-field.jsx`, where the results message is, assumes that `searchTerm` is a String. Because of this, the broken results message shows up when the `search-results-list` initially loads.  
  
To fix it, I added a type check in the conditional for showing the results message in `search-field.jsx`. This makes it so the results message is only shown if `searchTerm` is a string. Now, the results message doesn't show up on the initial load, and it correctly shows once searches are performed.

## Jira Ticket

[THEMES-961](https://arcpublishing.atlassian.net/browse/THEMES-961)

## Acceptance Criteria

1. No result message should show below the search bar when loading for the first time (see images below)
2. <0 results for> should appear when no results are found in the search results list

## Test Steps

**Necessary**
1. Checkout this branch: `git checkout THEMES-961-quick-fix`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/search-results-list-block`
3. Open your local PageBuilder instance:
    * Create a new page (the name and URL don't matter)
    * Choose any layout you want, and place a "Search Results List - Arc Block" block on the page
    * Make sure there is no results message below the search bar that says *%{smart_count} result for "%{searchTerm}" |||| %{smart_count} results for "%{search_term}"*
  
**Optional - If you want to look at the original functionality from [the first search results list PR](https://github.com/WPMedia/arc-themes-blocks/pull/1691)**
1. Select the "Search Results List" block from above
    * Open the block details
    * Under the "Configure Content" drop down, set "Display Content Info" to `search-api`, and set the query to `type:story`
    * Go back to the "Curate" tab, and scroll down to the "Global Content" drop down. Set the content source to `search-api`, and set the number of pages to 1
5. To test the search bar, enter text into the "query" text box, and click the "Update" button. This ticket only covers the text box below the search bar, not the searching itself.
    * Make sure that when something has zero results (I used "mmm", but anything works), the text below the search bar says '0 results for "[your query]"'
    * Make sure that when something has >= 1 result(s) (I used "global," which has 6 results, and "html embed," which has 1 result. But, anything works), the text appears with the correct value, and the story results still show

## Effect Of Changes

### Before

| Initial load | Zero results | One or more results |
| --- | --- | --- |
| ![image](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/60000a9b-aaf8-41c4-bc4e-65a06fe07a6c) | ![Screenshot 2023-06-30 at 3 09 30 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/59714a68-6a10-4895-b7fd-95f5592665e3) | ![Screenshot 2023-06-30 at 3 09 47 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/b4561c44-28b1-4e48-a5a2-4f860e4f2c67) |

The original V2 search behavior can be tested [here](https://themesinternal-the-gazette-dev.web.arc-cdn.net/search/global/).

### After

| Initial load | Zero results | One or more results |
| --- | --- | --- |
| ![Screenshot 2023-07-06 at 1 34 48 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/f346267b-6cca-42e9-bdca-72c37b33e24e) | ![Screenshot 2023-06-30 at 3 11 54 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/18cf8e07-8312-4ec2-9f3c-070ef4b3c281) | ![Screenshot 2023-06-30 at 3 12 25 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/cfc28139-ab4f-4493-9b43-266d1e260910) |

## Dependencies or Side Effects

There are no dependencies or side effects.

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-961]: https://arcpublishing.atlassian.net/browse/THEMES-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ