### PR TITLE
THEMES-920 Gallery + Lead Art | Update autoplay, progress indicator, carousel, and close controls in focus (expand) view

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -312,6 +312,9 @@
 					color: var(--global-neutral-3),
 				),
 				carousel: (
+					font-family: var(--font-family-primary),
+					font-size: var(--body-font-size-tiny),
+					line-height: var(--body-line-height-tiny),
 					--slides: 1,
 				),
 				carousel-actions: (
@@ -320,26 +323,50 @@
 					padding-right: var(--global-spacing-4),
 				),
 				carousel-button: (
-					box-shadow: var(--global-box-shadow-1),
-					border-radius: var(--border-radius),
-					background-color: var(--global-white),
-					height: var(--global-spacing-8),
-					width: auto,
-					padding: 0 var(--global-spacing-2),
-					display: flex,
 					align-items: center,
+					background-color: transparent,
+					border: none,
+					box-shadow: none,
+					display: flex,
+					font-size: var(--body-font-size-tiny),
 					gap: var(--global-spacing-2),
+					height: var(--global-spacing-4),
+					line-height: var(--body-line-height-tiny),
+					padding: 0 var(--global-spacing-2),
+					width: auto,
+				),
+				carousel-button-full-screen: (
+					color: var(--global-white),
+				),
+				carousel-button-full-screen-hover: (
+					color: var(--global-neutral-3),
 				),
 				carousel-button-previous: (
-					background-color: var(--global-white),
+					color: var(--global-white),
 				),
 				carousel-button-next: (
-					background-color: var(--global-white),
+					color: var(--global-white),
 				),
 				carousel-track: (
-					gap: var(--global-spacing-2),
-					max-width: var(--content-scale-width),
+					gap: initial,
+					max-width: initial,
 					width: 100%,
+				),
+				carousel-controls: (
+					display: flex,
+					padding: 0 0 var(--global-spacing-2) 0,
+				),
+				carousel-additional-controls: (
+					display: flex,
+				),
+				carousel-fullscreen: (
+					color: var(--global-white),
+					padding: var(--global-spacing-5),
+				),
+				carousel-icon: (
+					fill: currentColor,
+					height: var(--global-spacing-4),
+					width: var(--global-spacing-4),
 				),
 				date: (
 					font-size: var(--body-font-size-small),
@@ -535,7 +562,7 @@
 					),
 				),
 				article-body: (
-					font-family: var(--font-family-secondary),
+					font-family: var(--font-family-primary),
 					font-size: var(--body-font-size),
 					components: (
 						link: (
@@ -544,19 +571,6 @@
 						paragraph: (
 							display: block,
 							overflow: initial,
-						),
-						carousel-actions: (
-							display: flex,
-						),
-						carousel-track: (
-							gap: initial,
-							max-width: initial,
-						),
-						carousel-button-next: (
-							background-color: transparent,
-						),
-						carousel-button-previous: (
-							background-color: transparent,
 						),
 					),
 				),
@@ -615,38 +629,6 @@
 				),
 				article-body-gallery: (
 					components: (
-						icon: (
-							fill: var(--global-white),
-							height: var(--global-spacing-8),
-							width: var(--global-spacing-8),
-						),
-						carousel-button: (
-							background-color: transparent,
-							box-shadow: none,
-						),
-						carousel-expand-autoplay-container: (
-							gap: var(--global-spacing-4),
-						),
-						carousel-button-enter-full-screen: (
-							background-color: transparent,
-							border: none,
-							box-shadow: none,
-							color: var(--text-color),
-							font-size: var(--body-font-size-small),
-							height: auto,
-							width: auto,
-						),
-						carousel-button-toggle-auto-play: (
-							background-color: transparent,
-							box-shadow: none,
-							color: var(--text-color),
-							font-size: var(--body-font-size-small),
-							height: auto,
-							width: auto,
-						),
-						carousel-image-counter: (
-							font-size: var(--body-font-size-small),
-						),
 						media-item: (
 							background-color: var(--global-neutral-9),
 							gap: 0,
@@ -659,29 +641,16 @@
 						),
 					),
 				),
-				article-body-gallery-additional-next: (
-					border: none,
-					display: none,
-					height: var(--global-spacing-6),
-					width: var(--global-spacing-6),
+				article-body-gallery-track-button: (
+					color: var(--global-white),
 					components: (
-						icon: (
-							fill: var(--text-color),
-							height: var(--global-spacing-4),
-							width: var(--global-spacing-4),
+						button-hover: (
+							color: var(--global-neutral-3),
 						),
-					),
-				),
-				article-body-gallery-additional-previous: (
-					border: none,
-					display: none,
-					height: var(--global-spacing-6),
-					width: var(--global-spacing-6),
-					components: (
 						icon: (
-							fill: var(--text-color),
-							height: var(--global-spacing-4),
-							width: var(--global-spacing-4),
+							fill: currentColor,
+							height: var(--global-spacing-8),
+							width: var(--global-spacing-8),
 						),
 					),
 				),
@@ -746,7 +715,7 @@
 					),
 				),
 				article-body-interstitial-link: (
-					font-family: var(--font-family-secondary),
+					font-family: var(--font-family-primary),
 					font-style: italic,
 					components: (
 						link: (
@@ -781,16 +750,6 @@
 						),
 					),
 				),
-				article-body-start-icon: (
-					fill: var(--text-color),
-					height: var(--global-spacing-4),
-					width: var(--global-spacing-4),
-				),
-				article-body-stop-icon: (
-					fill: var(--text-color),
-					height: var(--global-spacing-4),
-					width: var(--global-spacing-4),
-				),
 				article-body-table: (
 					font-family: var(--font-family-primary),
 					font-size: var(--body-font-size-small),
@@ -811,18 +770,18 @@
 					background-color: var(--global-neutral-4),
 					border: 2px solid var(--border-color),
 				),
+				article-body-ul: (
+					font-size: var(--body-font-size),
+					line-height: var(--body-line-height),
+					list-style-position: inside,
+					list-style-type: disc,
+				),
 				article-tag: (
 					components: (
 						stack: (
 							gap: var(--global-spacing-4),
 						),
 					),
-				),
-				article-body-ul: (
-					font-size: var(--body-font-size),
-					line-height: var(--body-line-height),
-					list-style-position: inside,
-					list-style-type: disc,
 				),
 				author-bio: (
 					gap: var(--global-spacing-4),
@@ -1150,58 +1109,13 @@
 				),
 				gallery: (
 					components: (
-						icon: (
-							fill: var(--text-color),
-							height: var(--global-spacing-4),
-							width: var(--global-spacing-4),
-						),
 						image: (
 							max-height: 100%,
 							object-fit: contain,
 						),
-						carousel-controls: (
-							padding: 0 0 var(--global-spacing-2) 0,
-						),
-						carousel-actions: (
-							display: flex,
-						),
-						carousel-track: (
-							gap: initial,
-							max-width: initial,
-						),
-						carousel-button: (
-							border: none,
-							box-shadow: none,
-							height: var(--global-spacing-4),
-						),
-						carousel-button-enter-full-screen: (
-							padding: 0,
-							font-size: var(--body-font-size-tiny),
-							line-height: var(--body-line-height-tiny),
-						),
-						carousel-additional-controls: (
-							display: none,
-						),
-						carousel-button-toggle-auto-play: (
-							padding: 0 var(--global-spacing-4),
-							font-size: var(--body-font-size-tiny),
-							line-height: var(--body-line-height-tiny),
-						),
-						carousel-image-counter: (
-							font-size: var(--body-font-size-tiny),
-							line-height: var(--body-line-height-tiny),
-						),
-						carousel-button-next: (
-							background-color: transparent,
-						),
-						carousel-button-previous: (
-							background-color: transparent,
-						),
-						carousel-button-additional-previous: (
-							padding: 0,
-						),
-						carousel-button-additional-next: (
-							padding: 0,
+						media-item-fig-caption: (
+							color: var(--global-white),
+							margin: var(--global-spacing-2) var(--global-spacing-4),
 						),
 					),
 				),
@@ -1214,10 +1128,31 @@
 					max-height: unset,
 					overflow: auto,
 				),
-				gallery-track-icon: (
-					fill: var(--global-white),
-					height: var(--global-spacing-8),
-					width: var(--global-spacing-8),
+				gallery-track-button: (
+					color: var(--global-white),
+					components: (
+						button-hover: (
+							color: var(--global-neutral-3),
+						),
+						icon: (
+							fill: currentColor,
+							height: var(--global-spacing-8),
+							width: var(--global-spacing-8),
+						),
+					),
+				),
+				gallery-close-button: (
+					color: var(--global-white),
+					components: (
+						button-hover: (
+							color: var(--global-neutral-3),
+						),
+						icon: (
+							fill: currentColor,
+							height: var(--global-spacing-6),
+							width: var(--global-spacing-6),
+						),
+					),
 				),
 				header: (
 					font-weight: var(--global-font-weight-7),
@@ -1688,60 +1623,6 @@
 				lead-art: (
 					margin-bottom: var(--global-spacing-5),
 					components: (
-						button: (
-							border-style: none,
-							box-shadow: none,
-							height: var(--global-spacing-4),
-						),
-						carousel-controls: (
-							padding: 0 0 var(--global-spacing-2) 0,
-						),
-						carousel-actions: (
-							display: flex,
-						),
-						carousel-track: (
-							gap: initial,
-							max-width: initial,
-						),
-						carousel-button: (
-							border: none,
-							box-shadow: none,
-							height: var(--global-spacing-4),
-						),
-						carousel-button-enter-full-screen: (
-							padding: 0,
-							font-size: var(--body-font-size-tiny),
-							line-height: var(--body-line-height-tiny),
-						),
-						carousel-additional-controls: (
-							display: none,
-						),
-						carousel-button-toggle-auto-play: (
-							padding: 0 var(--global-spacing-4),
-							font-size: var(--body-font-size-tiny),
-							line-height: var(--body-line-height-tiny),
-						),
-						carousel-image-counter: (
-							font-size: var(--body-font-size-tiny),
-							line-height: var(--body-line-height-tiny),
-						),
-						carousel-button-next: (
-							background-color: transparent,
-						),
-						carousel-button-previous: (
-							background-color: transparent,
-						),
-						carousel-button-additional-previous: (
-							padding: 0,
-						),
-						carousel-button-additional-next: (
-							padding: 0,
-						),
-						icon: (
-							fill: var(--text-color),
-							height: var(--global-spacing-4),
-							width: var(--global-spacing-4),
-						),
 						image: (
 							max-height: 100%,
 							object-fit: contain,
@@ -1774,19 +1655,27 @@
 						),
 					),
 				),
-				lead-art-carousel-track-icon: (
-					fill: var(--global-white),
-					height: var(--global-spacing-8),
-					width: var(--global-spacing-8),
-				),
-				lead-art-close-icon: (
-					position: fixed,
-					top: var(--global-spacing-4),
-					right: var(--global-spacing-4),
-					background-color: transparent,
+				lead-art-track-button: (
+					color: var(--global-white),
 					components: (
+						button-hover: (
+							color: var(--global-neutral-3),
+						),
 						icon: (
-							fill: var(--global-white),
+							fill: currentColor,
+							height: var(--global-spacing-8),
+							width: var(--global-spacing-8),
+						),
+					),
+				),
+				lead-art-close-button: (
+					color: var(--global-white),
+					components: (
+						button-hover: (
+							color: var(--global-neutral-3),
+						),
+						icon: (
+							fill: currentColor,
 							height: var(--global-spacing-6),
 							width: var(--global-spacing-6),
 						),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -319,8 +319,11 @@
 				),
 				carousel-actions: (
 					display: none,
-					padding-left: var(--global-spacing-4),
-					padding-right: var(--global-spacing-4),
+					padding-left: var(--global-spacing-5),
+					padding-right: var(--global-spacing-5),
+				),
+				carousel-additional-controls: (
+					display: flex,
 				),
 				carousel-button: (
 					align-items: center,
@@ -335,38 +338,43 @@
 					padding: 0 var(--global-spacing-2),
 					width: auto,
 				),
+				carousel-button-enter-full-screen: (
+					padding-left: 0,
+				),
 				carousel-button-full-screen: (
 					color: var(--global-white),
 				),
 				carousel-button-full-screen-hover: (
 					color: var(--global-neutral-3),
 				),
-				carousel-button-previous: (
-					color: var(--global-white),
-				),
 				carousel-button-next: (
 					color: var(--global-white),
 				),
-				carousel-track: (
-					gap: initial,
-					max-width: initial,
-					width: 100%,
+				carousel-button-previous: (
+					color: var(--global-white),
 				),
 				carousel-controls: (
 					display: flex,
 					padding: 0 0 var(--global-spacing-2) 0,
 				),
-				carousel-additional-controls: (
-					display: flex,
-				),
 				carousel-fullscreen: (
 					color: var(--global-white),
-					padding: var(--global-spacing-5),
+				),
+				carousel-fullscreen-controls: (
+					padding-top: var(--global-spacing-5),
+					padding-right: var(--global-spacing-5),
+					padding-bottom: 0,
+					padding-left: var(--global-spacing-5),
 				),
 				carousel-icon: (
 					fill: currentColor,
 					height: var(--global-spacing-4),
 					width: var(--global-spacing-4),
+				),
+				carousel-track: (
+					gap: initial,
+					max-width: initial,
+					width: 100%,
 				),
 				date: (
 					font-size: var(--body-font-size-small),
@@ -572,6 +580,13 @@
 							display: block,
 							overflow: initial,
 						),
+						media-item-fig-caption: (
+							background-color: var(--global-white),
+							line-height: var(--body-line-height-5),
+						),
+						icon: (
+							fill: currentColor,
+						),
 					),
 				),
 				article-body-blockquote: (
@@ -622,22 +637,10 @@
 					height: auto,
 					width: 100%,
 				),
-				article-body-full-screen-icon: (
-					fill: var(--text-color),
-					height: var(--global-spacing-4),
-					width: var(--global-spacing-4),
-				),
-				article-body-gallery: (
+				article-body-gallery-fullscreen: (
 					components: (
-						media-item: (
-							background-color: var(--global-neutral-9),
-							gap: 0,
-							justify-content: center,
-							width: 100%,
-						),
 						media-item-fig-caption: (
-							background-color: var(--global-white),
-							padding-top: var(--global-spacing-2),
+							padding: 0 var(--global-spacing-5),
 						),
 					),
 				),
@@ -684,13 +687,6 @@
 					font-family: var(--font-family-primary),
 					font-weight: bold,
 				),
-				article-body-image: (
-					components: (
-						image: (
-							max-width: 100%,
-						),
-					),
-				),
 				article-body-image-float-left: (
 					width: 50%,
 					float: left,
@@ -703,6 +699,7 @@
 				),
 				article-body-image-wrapper: (
 					align-items: center,
+					background-color: var(--global-black),
 					display: flex,
 					justify-content: center,
 					max-height: 75vh,
@@ -1109,35 +1106,9 @@
 				),
 				gallery: (
 					components: (
-						image: (
-							max-height: 100%,
-							object-fit: contain,
-						),
 						media-item-fig-caption: (
-							color: var(--global-white),
-							margin: var(--global-spacing-2) var(--global-spacing-4),
-						),
-					),
-				),
-				gallery-image-wrapper: (
-					align-items: center,
-					aspect-ratio: calc(16 / 9),
-					background-color: var(--global-black),
-					display: flex,
-					justify-content: center,
-					max-height: unset,
-					overflow: auto,
-				),
-				gallery-track-button: (
-					color: var(--global-white),
-					components: (
-						button-hover: (
-							color: var(--global-neutral-3),
-						),
-						icon: (
-							fill: currentColor,
-							height: var(--global-spacing-8),
-							width: var(--global-spacing-8),
+							background-color: var(--global-white),
+							line-height: var(--body-line-height-5),
 						),
 					),
 				),
@@ -1151,6 +1122,40 @@
 							fill: currentColor,
 							height: var(--global-spacing-6),
 							width: var(--global-spacing-6),
+						),
+					),
+				),
+				gallery-fullscreen: (
+					components: (
+						media-item-fig-caption: (
+							padding: 0 var(--global-spacing-5),
+						),
+					),
+				),
+				gallery-image-wrapper: (
+					align-items: center,
+					background-color: var(--global-black),
+					display: flex,
+					justify-content: center,
+					max-height: 75vh,
+					components: (
+						image: (
+							height: auto,
+							max-height: 75vh,
+							max-width: 100%,
+						),
+					),
+				),
+				gallery-track-button: (
+					color: var(--global-white),
+					components: (
+						button-hover: (
+							color: var(--global-neutral-3),
+						),
+						icon: (
+							fill: currentColor,
+							height: var(--global-spacing-8),
+							width: var(--global-spacing-8),
 						),
 					),
 				),
@@ -1621,11 +1626,31 @@
 					),
 				),
 				lead-art: (
-					margin-bottom: var(--global-spacing-5),
 					components: (
-						image: (
-							max-height: 100%,
-							object-fit: contain,
+						media-item-fig-caption: (
+							background-color: var(--global-white),
+							line-height: var(--body-line-height-5),
+							margin: var(--global-spacing-2) 0,
+						),
+					),
+				),
+				lead-art-carousel-close-button: (
+					color: var(--global-white),
+					components: (
+						button-hover: (
+							color: var(--global-neutral-3),
+						),
+						icon: (
+							fill: currentColor,
+							height: var(--global-spacing-6),
+							width: var(--global-spacing-6),
+						),
+					),
+				),
+				lead-art-carousel-fullscreen: (
+					components: (
+						media-item-fig-caption: (
+							padding: 0 var(--global-spacing-5),
 						),
 					),
 				),
@@ -1635,27 +1660,18 @@
 					background-color: var(--global-black),
 					display: flex,
 					justify-content: center,
-					max-height: unset,
+					max-height: 75vh,
 					overflow: auto,
 					components: (
-						button: (
-							position: fixed,
-							top: var(--global-spacing-6),
-							right: 0,
-						),
-						button-medium: (
-							padding: var(--global-spacing-4) 0 var(--global-spacing-4) 0,
-							top: var(--global-spacing-4),
-							right: var(--global-spacing-4),
-						),
-						icon: (
-							fill: var(--global-white),
-							height: var(--global-spacing-6),
-							width: var(--global-spacing-6),
+						image: (
+							height: auto,
+							max-height: 100%,
+							max-width: 100%,
+							object-fit: contain,
 						),
 					),
 				),
-				lead-art-track-button: (
+				lead-art-carousel-track-button: (
 					color: var(--global-white),
 					components: (
 						button-hover: (
@@ -1665,19 +1681,6 @@
 							fill: currentColor,
 							height: var(--global-spacing-8),
 							width: var(--global-spacing-8),
-						),
-					),
-				),
-				lead-art-close-button: (
-					color: var(--global-white),
-					components: (
-						button-hover: (
-							color: var(--global-neutral-3),
-						),
-						icon: (
-							fill: currentColor,
-							height: var(--global-spacing-6),
-							width: var(--global-spacing-6),
 						),
 					),
 				),

--- a/blocks/article-body-block/_index.scss
+++ b/blocks/article-body-block/_index.scss
@@ -66,31 +66,16 @@
 	&__gallery {
 		@include scss.block-components("article-body-gallery");
 		@include scss.block-properties("article-body-gallery");
-	}
 
-	&__gallery-additional-next {
-		@include scss.block-components("article-body-gallery-additional-next");
-		@include scss.block-properties("article-body-gallery-additional-next");
-	}
+		&:fullscreen {
+			@include scss.block-components("article-body-gallery-fullscreen");
+			@include scss.block-properties("article-body-gallery-fullscreen");
+		}
 
-	&__gallery-additional-previous {
-		@include scss.block-components("article-body-gallery-additional-previous");
-		@include scss.block-properties("article-body-gallery-additional-previous");
-	}
-
-	&__full-screen-icon {
-		@include scss.block-components("article-body-full-screen-icon");
-		@include scss.block-properties("article-body-full-screen-icon");
-	}
-
-	&__start-icon {
-		@include scss.block-components("article-body-start-icon");
-		@include scss.block-properties("article-body-start-icon");
-	}
-
-	&__stop-icon {
-		@include scss.block-components("article-body-stop-icon");
-		@include scss.block-properties("article-body-stop-icon");
+		&__track-button {
+			@include scss.block-components("article-body-gallery-track-button");
+			@include scss.block-properties("article-body-gallery-track-button");
+		}
 	}
 
 	&__image-wrapper {

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -3,6 +3,7 @@ import PropTypes from "@arc-fusion/prop-types";
 import { useFusionContext } from "fusion:context";
 
 import {
+	Button,
 	Carousel,
 	Conditional,
 	Divider,
@@ -230,14 +231,23 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 						label={item?.description?.basic || "Gallery"}
 						slidesToShow={1}
 						additionalNextButton={
-							<button type="button" className={`${BLOCK_CLASS_NAME}__gallery-additional-next`}>
+							<Carousel.Button type="button">
 								<Icon name="ChevronRight" />
-							</button>
+							</Carousel.Button>
+						}
+						fullScreenMinimizeButton={
+							<Button
+								variant="secondary-reverse"
+								type="button"
+								className={`${BLOCK_CLASS_NAME}__carousel__close-button`}
+							>
+								<Icon name="Close" />
+							</Button>
 						}
 						additionalPreviousButton={
-							<button type="button" className={`${BLOCK_CLASS_NAME}__gallery-additional-previous`}>
+							<Carousel.Button type="button">
 								<Icon name="ChevronLeft" />
-							</button>
+							</Carousel.Button>
 						}
 						autoplayPhraseLabels={{
 							start: phrases.t("global.gallery-autoplay-label-start"),
@@ -246,24 +256,31 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 						enableAutoplay
 						enableFullScreen
 						fullScreenShowButton={
-							<button type="button">
-								<Icon name="Fullscreen" className={`${BLOCK_CLASS_NAME}__full-screen-icon`} />
+							<Carousel.Button type="button">
+								<Icon name="Fullscreen" />
 								{phrases.t("global.gallery-expand-button")}
-							</button>
+							</Carousel.Button>
 						}
-						showAdditionalSlideControls
 						showLabel
-						startAutoplayIcon={<Icon name="Play" className={`${BLOCK_CLASS_NAME}__start-icon`} />}
+						startAutoplayIcon={<Icon name="Play" />}
 						startAutoplayText={phrases.t("global.gallery-autoplay-button")}
-						stopAutoplayIcon={<Icon name="Pause" className={`${BLOCK_CLASS_NAME}__stop-icon`} />}
+						stopAutoplayIcon={<Icon name="Pause" />}
 						stopAutoplayText={phrases.t("global.gallery-pause-autoplay-button")}
 						nextButton={
-							<Carousel.Button id={key} label="Next Slide">
+							<Carousel.Button
+								id={key}
+								label="Next Slide"
+								className={`${BLOCK_CLASS_NAME}__gallery__track-button`}
+							>
 								<Icon name="ChevronRight" />
 							</Carousel.Button>
 						}
 						previousButton={
-							<Carousel.Button id={key} label="Previous Slide">
+							<Carousel.Button
+								id={key}
+								label="Previous Slide"
+								className={`${BLOCK_CLASS_NAME}__gallery__track-button`}
+							>
 								<Icon name="ChevronLeft" />
 							</Carousel.Button>
 						}

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import { mount } from "enzyme";
 import { useFusionContext } from "fusion:context";
 import { isServerSide } from "@wpmedia/arc-themes-components";
-
 import ArticleBodyChain from "./default";
 
 jest.mock("fusion:environment", () => ({

--- a/blocks/article-body-block/themes/news.json
+++ b/blocks/article-body-block/themes/news.json
@@ -12,18 +12,12 @@
 						"display": "block",
 						"overflow": "initial"
 					},
-					"carousel-actions": {
-						"display": "flex"
+					"media-item-fig-caption": {
+						"background-color": "var(--global-white)",
+						"line-height": "var(--body-line-height-5)"
 					},
-					"carousel-track": {
-						"gap": "initial",
-						"max-width": "initial"
-					},
-					"carousel-button-next": {
-						"background-color": "transparent"
-					},
-					"carousel-button-previous": {
-						"background-color": "transparent"
+					"icon": {
+						"fill": "currentColor"
 					}
 				}
 			},
@@ -115,105 +109,34 @@
 			"desktop": {}
 		}
 	},
-	"article-body-full-screen-icon": {
+	"article-body-gallery-fullscreen": {
 		"styles": {
 			"default": {
-				"fill": "var(--text-color)",
-				"height": "var(--global-spacing-4)",
-				"width": "var(--global-spacing-4)"
+				"components": {
+					"media-item-fig-caption": {
+						"padding": "0 var(--global-spacing-5)"
+					}
+				}
 			},
 			"desktop": {}
 		}
 	},
-	"article-body-gallery": {
+	"article-body-gallery-track-button": {
 		"styles": {
 			"default": {
+				"color": "var(--global-white)",
 				"components": {
+					"button-hover": {
+						"color": "var(--global-neutral-3)"
+					},
 					"icon": {
-						"fill": "var(--global-white)",
+						"fill": "currentColor",
 						"height": "var(--global-spacing-8)",
 						"width": "var(--global-spacing-8)"
-					},
-					"carousel-button": {
-						"background-color": "transparent",
-						"box-shadow": "none"
-					},
-					"carousel-expand-autoplay-container": {
-						"gap": "var(--global-spacing-4)"
-					},
-					"carousel-button-enter-full-screen": {
-						"background-color": "transparent",
-						"border": "none",
-						"box-shadow": "none",
-						"color": "var(--text-color)",
-						"font-size": "var(--body-font-size-small)",
-						"height": "auto",
-						"width": "auto"
-					},
-					"carousel-button-toggle-auto-play": {
-						"background-color": "transparent",
-						"box-shadow": "none",
-						"color": "var(--text-color)",
-						"font-size": "var(--body-font-size-small)",
-						"height": "auto",
-						"width": "auto"
-					},
-					"carousel-image-counter": {
-						"font-size": "var(--body-font-size-small)"
-					},
-					"media-item": {
-						"background-color": "var(--global-neutral-9)",
-						"gap": 0,
-						"justify-content": "center",
-						"width": "100%"
-					},
-					"media-item-fig-caption": {
-						"background-color": "var(--global-white)",
-						"padding-top": "var(--global-spacing-2)"
 					}
 				}
 			},
 			"desktop": {}
-		}
-	},
-	"article-body-gallery-additional-next": {
-		"styles": {
-			"default": {
-				"border": "none",
-				"display": "none",
-				"height": "var(--global-spacing-6)",
-				"width": "var(--global-spacing-6)",
-				"components": {
-					"icon": {
-						"fill": "var(--text-color)",
-						"height": "var(--global-spacing-4)",
-						"width": "var(--global-spacing-4)"
-					}
-				}
-			},
-			"desktop": {
-				"display": "block"
-			}
-		}
-	},
-	"article-body-gallery-additional-previous": {
-		"styles": {
-			"default": {
-				"border": "none",
-				"display": "none",
-				"height": "var(--global-spacing-6)",
-				"width": "var(--global-spacing-6)",
-				"components": {
-					"icon": {
-						"fill": "var(--text-color)",
-						"height": "var(--global-spacing-4)",
-						"width": "var(--global-spacing-4)"
-					}
-				}
-			},
-			"desktop": {
-				"display": "block"
-			}
 		}
 	},
 	"article-body-h2": {
@@ -271,18 +194,6 @@
 			"desktop": {}
 		}
 	},
-	"article-body-image": {
-		"styles": {
-			"default": {
-				"components": {
-					"image": {
-						"max-width": "100%"
-					}
-				}
-			},
-			"desktop": {}
-		}
-	},
 	"article-body-image-float-left": {
 		"styles": {
 			"default": {
@@ -307,6 +218,7 @@
 		"styles": {
 			"default": {
 				"align-items": "center",
+				"background-color": "var(--global-black)",
 				"display": "flex",
 				"justify-content": "center",
 				"max-height": "75vh",
@@ -370,26 +282,6 @@
 						"line-height": "var(--heading-level-5-line-height)"
 					}
 				}
-			},
-			"desktop": {}
-		}
-	},
-	"article-body-start-icon": {
-		"styles": {
-			"default": {
-				"fill": "var(--text-color)",
-				"height": "var(--global-spacing-4)",
-				"width": "var(--global-spacing-4)"
-			},
-			"desktop": {}
-		}
-	},
-	"article-body-stop-icon": {
-		"styles": {
-			"default": {
-				"fill": "var(--text-color)",
-				"height": "var(--global-spacing-4)",
-				"width": "var(--global-spacing-4)"
 			},
 			"desktop": {}
 		}

--- a/blocks/gallery-block/_index.scss
+++ b/blocks/gallery-block/_index.scss
@@ -10,6 +10,22 @@
 		@include scss.block-components("gallery-image-wrapper");
 		@include scss.block-properties("gallery-image-wrapper");
 	}
+
+	&__track-button {
+		@include scss.block-components("gallery-track-button");
+		@include scss.block-properties("gallery-track-button");
+	}
+
+	&__close-button {
+		@include scss.block-components("gallery-close-button");
+		@include scss.block-properties("gallery-close-button");
+	}
+
+	&:fullscreen {
+		@include scss.block-components("gallery-fullscreen");
+		@include scss.block-properties("gallery-fullscreen");
+	}
+
 	@include scss.block-components("gallery");
 	@include scss.block-properties("gallery");
 }

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -5,6 +5,7 @@ import { useFusionContext, useAppContext } from "fusion:context";
 import getProperties from "fusion:properties";
 import { RESIZER_TOKEN_VERSION } from "fusion:environment";
 import {
+	Button,
 	Carousel,
 	formatCredits,
 	Icon,
@@ -76,11 +77,10 @@ export const GalleryPresentation = ({
 	return (
 		<Carousel
 			id={_id}
-			className={BLOCK_CLASS_NAME}
+			className={`${BLOCK_CLASS_NAME}`}
 			showLabel
 			label={headlines?.basic ? headlines.basic : ""}
 			slidesToShow={1}
-			showAdditionalSlideControls
 			pageCountPhrase={
 				/* istanbul ignore next */ (current, total) =>
 					phrases.t("global.gallery-page-count-text", { current, total })
@@ -96,26 +96,38 @@ export const GalleryPresentation = ({
 			}}
 			enableFullScreen
 			fullScreenShowButton={
-				<button type="button">
+				<Carousel.Button label={phrases.t("global.gallery-expand-button")}>
 					<Icon name="Fullscreen" />
 					{phrases.t("global.gallery-expand-button")}
-				</button>
+				</Carousel.Button>
 			}
 			fullScreenMinimizeButton={
-				<button type="button">
+				<Button
+					variant="secondary-reverse"
+					type="button"
+					className={`${BLOCK_CLASS_NAME}__close-button`}
+				>
 					<Icon name="Close" />
-				</button>
+				</Button>
 			}
 			adElement={/* istanbul ignore next */ <AdBlock />}
 			adInterstitialClicks={interstitialClicks}
 			nextButton={
-				<Carousel.Button id={_id} label={phrases.t("global.gallery-next-label")}>
-					<Icon className={`${BLOCK_CLASS_NAME}__track-icon`} fill="white" name="ChevronRight" />
+				<Carousel.Button
+					id={_id}
+					label={phrases.t("global.gallery-next-label")}
+					className={`${BLOCK_CLASS_NAME}__track-button`}
+				>
+					<Icon fill="white" name="ChevronRight" />
 				</Carousel.Button>
 			}
 			previousButton={
-				<Carousel.Button id={_id} label={phrases.t("global.gallery-previous-label")}>
-					<Icon className={`${BLOCK_CLASS_NAME}__track-icon`} name="ChevronLeft" />
+				<Carousel.Button
+					id={_id}
+					label={phrases.t("global.gallery-previous-label")}
+					className={`${BLOCK_CLASS_NAME}__track-button`}
+				>
+					<Icon name="ChevronLeft" />
 				</Carousel.Button>
 			}
 		>

--- a/blocks/gallery-block/features/gallery/default.test.jsx
+++ b/blocks/gallery-block/features/gallery/default.test.jsx
@@ -104,6 +104,7 @@ describe("Gallery feature parent block", () => {
 				}}
 			/>
 		);
+
 		expect(wrapper.find(Carousel)).toHaveLength(1);
 		expect(wrapper.find(CarouselItem)).toHaveLength(1);
 	});

--- a/blocks/gallery-block/themes/news.json
+++ b/blocks/gallery-block/themes/news.json
@@ -3,94 +3,80 @@
 		"styles": {
 			"default": {
 				"components": {
-					"icon": {
-						"fill": "var(--text-color)",
-						"height": "var(--global-spacing-4)",
-						"width": "var(--global-spacing-4)"
-					},
-					"image": {
-						"max-height": "100%",
-						"object-fit": "contain"
-					},
-					"carousel-controls": {
-						"padding": "0 0 var(--global-spacing-2) 0"
-					},
-					"carousel-actions": {
-						"display": "flex"
-					},
-					"carousel-track": {
-						"gap": "initial",
-						"max-width": "initial"
-					},
-					"carousel-button": {
-						"border": "none",
-						"box-shadow": "none",
-						"height": "var(--global-spacing-4)"
-					},
-					"carousel-button-enter-full-screen": {
-						"padding": 0,
-						"font-size": "var(--body-font-size-tiny)",
-						"line-height": "var(--body-line-height-tiny)"
-					},
-					"carousel-additional-controls": {
-						"display": "none"
-					},
-					"carousel-button-toggle-auto-play": {
-						"padding": "0 var(--global-spacing-4)",
-						"font-size": "var(--body-font-size-tiny)",
-						"line-height": "var(--body-line-height-tiny)"
-					},
-					"carousel-image-counter": {
-						"font-size": "var(--body-font-size-tiny)",
-						"line-height": "var(--body-line-height-tiny)"
-					},
-					"carousel-button-next": {
-						"background-color": "transparent"
-					},
-					"carousel-button-previous": {
-						"background-color": "transparent"
-					},
-					"carousel-button-additional-previous": {
-						"padding": 0
-					},
-					"carousel-button-additional-next": {
-						"padding": 0
+					"media-item-fig-caption": {
+						"background-color": "var(--global-white)",
+						"line-height": "var(--body-line-height-5)"
 					}
 				}
 			},
-			"desktop": {
+			"desktop": {}
+		}
+	},
+	"gallery-fullscreen": {
+		"styles": {
+			"default": {
 				"components": {
-					"carousel-additional-controls": {
-						"display": "flex",
-						"gap": "var(--global-spacing-2)",
-						"padding": "0 0 0 var(--global-spacing-2)"
+					"media-item-fig-caption": {
+						"padding": "0 var(--global-spacing-5)"
 					}
 				}
-			}
+			},
+			"desktop": {}
 		}
 	},
 	"gallery-image-wrapper": {
 		"styles": {
 			"default": {
 				"align-items": "center",
-				"aspect-ratio": "calc(16/9)",
 				"background-color": "var(--global-black)",
 				"display": "flex",
 				"justify-content": "center",
-				"max-height": "unset",
-				"overflow": "auto"
+				"max-height": "75vh",
+				"components": {
+					"image": {
+						"height": "auto",
+						"max-height": "75vh",
+						"max-width": "100%"
+					}
+				}
 			},
 			"desktop": {
 				"max-height": "75vh"
 			}
 		}
 	},
-	"gallery-track-icon": {
+	"gallery-track-button": {
 		"styles": {
 			"default": {
-				"fill": "var(--global-white)",
-				"height": "var(--global-spacing-8)",
-				"width": "var(--global-spacing-8)"
+				"color": "var(--global-white)",
+				"components": {
+					"button-hover": {
+						"color": "var(--global-neutral-3)"
+					},
+					"icon": {
+						"fill": "currentColor",
+						"height": "var(--global-spacing-8)",
+						"width": "var(--global-spacing-8)"
+					}
+				}
+			},
+			"desktop": {}
+		}
+	},
+	"gallery-close-button": {
+		"styles": {
+			"default": {
+				"color": "var(--global-white)",
+				"components": {
+					"button-hover": {
+						"color": "var(--global-neutral-3)"
+					},
+					"icon": {
+						"fill": "currentColor",
+						"height": "var(--global-spacing-6)",
+						"width": "var(--global-spacing-6)"
+					}
+				}
 			},
 			"desktop": {}
 		}

--- a/blocks/lead-art-block/_index.scss
+++ b/blocks/lead-art-block/_index.scss
@@ -1,20 +1,28 @@
 @use "@wpmedia/arc-themes-components/scss";
 
 .b-lead-art {
-	&__track-icon {
-		@include scss.block-components("lead-art-carousel-track-icon");
-		@include scss.block-properties("lead-art-carousel-track-icon");
-	}
-
 	&__image-wrapper {
 		@include scss.block-components("lead-art-carousel-image-wrapper");
 		@include scss.block-properties("lead-art-carousel-image-wrapper");
 	}
 
-	&__close-icon {
-		@include scss.block-components("lead-art-close-icon");
-		@include scss.block-properties("lead-art-close-icon");
+	&__carousel {
+		&:fullscreen {
+			@include scss.block-components("lead-art-carousel-fullscreen");
+			@include scss.block-properties("lead-art-carousel-fullscreen");
+		}
+
+		&__track-button {
+			@include scss.block-components("lead-art-carousel-track-button");
+			@include scss.block-properties("lead-art-carousel-track-button");
+		}
+
+		&__close-button {
+			@include scss.block-components("lead-art-carousel-close-button");
+			@include scss.block-properties("lead-art-carousel-close-button");
+		}
 	}
+
 	@include scss.block-components("lead-art");
 	@include scss.block-properties("lead-art");
 }

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -118,7 +118,7 @@ export const LeadArtPresentation = (props) => {
 					title={!hideTitle ? leadArt.subtitle : null}
 				>
 					<Button
-						iconLeft={<Icon name="Fullscreen" fill="#6B6B6B" />}
+						iconLeft={<Icon name="Fullscreen" />}
 						accessibilityLabel={
 							!isOpen
 								? phrases.t("lead-art-block.fullscreen-enter")
@@ -159,11 +159,11 @@ export const LeadArtPresentation = (props) => {
 
 			return (
 				<Carousel
+					className={`${BLOCK_CLASS_NAME}__carousel`}
 					id={`${BLOCK_CLASS_NAME}-${leadArt._id}`}
 					showLabel
 					label={leadArt?.headlines?.basic}
 					slidesToShow={1}
-					showAdditionalSlideControls
 					pageCountPhrase={
 						/* istanbul ignore next */ (current, total) =>
 							phrases.t("global.gallery-page-count-text", { current, total })
@@ -179,15 +179,19 @@ export const LeadArtPresentation = (props) => {
 					}}
 					enableFullScreen
 					fullScreenShowButton={
-						<button type="button">
+						<Carousel.Button label={phrases.t("global.gallery-expand-button")}>
 							<Icon name="Fullscreen" />
 							{phrases.t("global.gallery-expand-button")}
-						</button>
+						</Carousel.Button>
 					}
 					fullScreenMinimizeButton={
-						<button type="button" className={`${BLOCK_CLASS_NAME}__close-icon`}>
+						<Button
+							variant="secondary-reverse"
+							type="button"
+							className={`${BLOCK_CLASS_NAME}__carousel__close-button`}
+						>
 							<Icon name="Close" />
-						</button>
+						</Button>
 					}
 					adElement={/* istanbul ignore next */ <AdBlock />}
 					adInterstitialClicks={interstitialClicks}
@@ -195,20 +199,18 @@ export const LeadArtPresentation = (props) => {
 						<Carousel.Button
 							id={`${BLOCK_CLASS_NAME}-${leadArt._id}`}
 							label={phrases.t("global.gallery-next-label")}
+							className={`${BLOCK_CLASS_NAME}__carousel__track-button`}
 						>
-							<Icon
-								className={`${BLOCK_CLASS_NAME}__track-icon`}
-								fill="white"
-								name="ChevronRight"
-							/>
+							<Icon fill="white" name="ChevronRight" />
 						</Carousel.Button>
 					}
 					previousButton={
 						<Carousel.Button
 							id={`${BLOCK_CLASS_NAME}-${leadArt._id}`}
 							label={phrases.t("global.gallery-previous-label")}
+							className={`${BLOCK_CLASS_NAME}__carousel__track-button`}
 						>
-							<Icon className={`${BLOCK_CLASS_NAME}__track-icon`} name="ChevronLeft" />
+							<Icon name="ChevronLeft" />
 						</Carousel.Button>
 					}
 				>

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
+import { EventEmitter } from "@wpmedia/arc-themes-components";
 import getProperties from "fusion:properties";
 import { useFusionContext } from "fusion:context";
 import LeadArt from "./default";
@@ -196,7 +197,12 @@ describe("LeadArt", () => {
 			},
 		};
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
-		const { queryByRole, queryByText } = render(<LeadArt customFields={{}} />);
+		const testRender = render(<LeadArt customFields={{}} />);
+		const { queryByRole, queryByText } = testRender;
+
+		EventEmitter.dispatch("galleryExpandEnter");
+		EventEmitter.dispatch("galleryExpandExit");
+
 		expect(queryByRole("region", { name: "test headline" })).not.toBeNull();
 		expect(queryByText("Caption")).not.toBeNull();
 		expect(queryByText("Subtitle")).not.toBeNull();

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { EventEmitter } from "@wpmedia/arc-themes-components";
 import getProperties from "fusion:properties";
 import { useFusionContext } from "fusion:context";
 import LeadArt from "./default";
@@ -199,9 +198,6 @@ describe("LeadArt", () => {
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
 		const testRender = render(<LeadArt customFields={{}} />);
 		const { queryByRole, queryByText } = testRender;
-
-		EventEmitter.dispatch("galleryExpandEnter");
-		EventEmitter.dispatch("galleryExpandExit");
 
 		expect(queryByRole("region", { name: "test headline" })).not.toBeNull();
 		expect(queryByText("Caption")).not.toBeNull();

--- a/blocks/lead-art-block/themes/news.json
+++ b/blocks/lead-art-block/themes/news.json
@@ -2,74 +2,23 @@
 	"lead-art": {
 		"styles": {
 			"default": {
-				"margin-bottom": "var(--global-spacing-5)",
 				"components": {
-					"button": {
-						"border-style": "none",
-						"box-shadow": "none",
-						"height": "var(--global-spacing-4)"
-					},
-					"carousel-controls": {
-						"padding": "0 0 var(--global-spacing-2) 0"
-					},
-					"carousel-actions": {
-						"display": "flex"
-					},
-					"carousel-track": {
-						"gap": "initial",
-						"max-width": "initial"
-					},
-					"carousel-button": {
-						"border": "none",
-						"box-shadow": "none",
-						"height": "var(--global-spacing-4)"
-					},
-					"carousel-button-enter-full-screen": {
-						"padding": 0,
-						"font-size": "var(--body-font-size-tiny)",
-						"line-height": "var(--body-line-height-tiny)"
-					},
-					"carousel-additional-controls": {
-						"display": "none"
-					},
-					"carousel-button-toggle-auto-play": {
-						"padding": "0 var(--global-spacing-4)",
-						"font-size": "var(--body-font-size-tiny)",
-						"line-height": "var(--body-line-height-tiny)"
-					},
-					"carousel-image-counter": {
-						"font-size": "var(--body-font-size-tiny)",
-						"line-height": "var(--body-line-height-tiny)"
-					},
-					"carousel-button-next": {
-						"background-color": "transparent"
-					},
-					"carousel-button-previous": {
-						"background-color": "transparent"
-					},
-					"carousel-button-additional-previous": {
-						"padding": 0
-					},
-					"carousel-button-additional-next": {
-						"padding": 0
-					},
-					"icon": {
-						"fill": "var(--text-color)",
-						"height": "var(--global-spacing-4)",
-						"width": "var(--global-spacing-4)"
-					},
-					"image": {
-						"max-height": "100%",
-						"object-fit": "contain"
+					"media-item-fig-caption": {
+						"background-color": "var(--global-white)",
+						"line-height": "var(--body-line-height-5)",
+						"margin": "var(--global-spacing-2) 0"
 					}
 				}
 			},
-			"desktop": {
+			"desktop": {}
+		}
+	},
+	"lead-art-carousel-fullscreen": {
+		"styles": {
+			"default": {
 				"components": {
-					"carousel-additional-controls": {
-						"display": "flex",
-						"gap": "var(--global-spacing-2)",
-						"padding": "0 0 0 var(--global-spacing-2)"
+					"media-item-fig-caption": {
+						"padding": "0 var(--global-spacing-5)"
 					}
 				}
 			}
@@ -83,65 +32,59 @@
 				"background-color": "var(--global-black)",
 				"display": "flex",
 				"justify-content": "center",
-				"max-height": "unset",
+				"max-height": "75vh",
 				"overflow": "auto",
 				"components": {
-					"button": {
-						"position": "fixed",
-						"top": "var(--global-spacing-6)",
-						"right": 0
-					},
-					"button-medium": {
-						"padding": "var(--global-spacing-4) 0 var(--global-spacing-4) 0",
-						"top": "var(--global-spacing-4)",
-						"right": "var(--global-spacing-4)"
-					},
-					"icon": {
-						"fill": "var(--global-white)",
-						"height": "var(--global-spacing-6)",
-						"width": "var(--global-spacing-6)"
+					"image": {
+						"height": "auto",
+						"max-height": "100%",
+						"max-width": "100%",
+						"object-fit": "contain"
 					}
 				}
 			},
 			"desktop": {
 				"max-height": "75vh",
 				"components": {
-					"button-medium": {
-						"left": "var(--global-spacing-4)"
-					}
+					"max-height": "75vh"
 				}
 			}
 		}
 	},
-	"lead-art-carousel-track-icon": {
+	"lead-art-carousel-track-button": {
 		"styles": {
 			"default": {
-				"fill": "var(--global-white)",
-				"height": "var(--global-spacing-8)",
-				"width": "var(--global-spacing-8)"
+				"color": "var(--global-white)",
+				"components": {
+					"button-hover": {
+						"color": "var(--global-neutral-3)"
+					},
+					"icon": {
+						"fill": "currentColor",
+						"height": "var(--global-spacing-8)",
+						"width": "var(--global-spacing-8)"
+					}
+				}
 			},
 			"desktop": {}
 		}
 	},
-	"lead-art-close-icon": {
+	"lead-art-carousel-close-button": {
 		"styles": {
 			"default": {
-				"position": "fixed",
-				"top": "var(--global-spacing-4)",
-				"right": "var(--global-spacing-4)",
-				"background-color": "transparent",
+				"color": "var(--global-white)",
 				"components": {
+					"button-hover": {
+						"color": "var(--global-neutral-3)"
+					},
 					"icon": {
-						"fill": "var(--global-white)",
+						"fill": "currentColor",
 						"height": "var(--global-spacing-6)",
 						"width": "var(--global-spacing-6)"
 					}
 				}
 			},
-			"desktop": {
-				"right": "calc(100% - var(--global-spacing-4))",
-				"left": "var(--global-spacing-4)"
-			}
+			"desktop": {}
 		}
 	}
 }


### PR DESCRIPTION
## Description

The main purpose of this PR is to update the styles for the blocks that use the carousel component, in order to get the full-screen view working according to the Figma file definitions.

This PR:

- Removes the common style definitions in gallery block and lead-art block
- Sets a new selector for the close button and close icon in each block
- Invoques the carousel component without auxiliary controls

## Jira Ticket

- [THEMES-920](https://arcpublishing.atlassian.net/browse/THEMES-920)

## Acceptance Criteria

GIVEN I am an Media Site User, WHEN I expand a gallery, THEN:

This will apply on desktop only: 

- Styling is consistent with v2 designs on expanded gallery

- autoplay/pause control

- progress indicator (x of x)

- captions 

   - captions will align with close and left arrow

- background contrast will be added for captions

- carousel controls (><) are removed to avoid duplication

- close 'x' control 

Note: the close control is currently not displaying on lead art, but is on the gallery block where style changes are needed (see examples above)

This should apply to gallery lead art as well as the gallery block

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-920`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/gallery-block,@wpmedia/lead-art-block,@wpmedia/article-body-block`
3. Go to a page that contains the gallery block and lead-art block, for example:
    -  http://localhost/pf/all-blocks-test-ta/?_website=daily-intelligencer
4. Open the full-screen mode
5. Interact with the UI elements as can be the close button, the counter item, the navigation buttons and the caption info

## Effect Of Changes

### Before

- The buttons had no contrast
- The font did not match
- The caption where unaligned
- The gallery and art-lead had repeated and common styles
- Close button did not match with design

**art-lead block full-screen:**
![Screenshot 2023-07-12 at 8 03 59 PM](https://github.com/WPMedia/arc-themes-blocks/assets/133056774/2c910af8-cc89-4410-8a58-2198376e5a05)

**gallery block full-screen:**
![Screenshot 2023-07-12 at 8 04 09 PM](https://github.com/WPMedia/arc-themes-blocks/assets/133056774/ac3eb443-abcc-49a0-a0f6-d0840c86abe6)

### After

**art-lead block full-screen:**
![Screenshot 2023-07-12 at 8 08 37 PM](https://github.com/WPMedia/arc-themes-blocks/assets/133056774/ce2e305e-db08-4037-8653-da203c9f84e6)

**gallery block full-screen:**
![Screenshot 2023-07-12 at 8 09 18 PM](https://github.com/WPMedia/arc-themes-blocks/assets/133056774/a5522a10-cd01-4bcd-94cd-b87d6f4b3ba1)

## Dependencies or Side Effects

_Examples of dependencies or side effects are:_

- Feature pack pr for local development:
https://github.com/WPMedia/arc-themes-blocks/pull/1700

- How to deploy to news: 
https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3138682964/News+Theme+2.0+Migration+Development+Deployment+Notes

- Dependency on another PR that needs to be merged at the same time:
https://github.com/WPMedia/arc-themes-components/pull/196

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-920]: https://arcpublishing.atlassian.net/browse/THEMES-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ