### PR TITLE
Added writing mode style tag to page head

### DIFF
--- a/blocks/default-output-block/output-types/__tests__/default.test.jsx
+++ b/blocks/default-output-block/output-types/__tests__/default.test.jsx
@@ -261,6 +261,41 @@ describe("root html layout", () => {
 		);
 		expect(wrapper.find("html").prop("dir")).toBe("rtl");
 	});
+
+	it("must have a style tag in the page head with writing-mode of horizontal-tb", () => {
+		const { default: DefaultOutputType } = require("../default");
+		const wrapper = shallow(
+			<DefaultOutputType
+				deployment={jest.fn()}
+				metaValue={jest.fn().mockReturnValue("article")}
+				{...mockFuntions}
+			/>
+		);
+		const styleElement = wrapper.find("head style");
+		const styleText = styleElement.text();
+
+		expect(styleText).toContain("body { writing-mode: horizontal-tb; }");
+	});
+
+	it("must use the textFlow property as the writing-mode in the style tag in the page head", () => {
+		jest.mock("fusion:properties", () =>
+			jest.fn(() => ({
+				textFlow: "vertical-rl",
+			}))
+		);
+		const { default: DefaultOutputType } = require("../default");
+		const wrapper = shallow(
+			<DefaultOutputType
+				deployment={jest.fn()}
+				metaValue={jest.fn().mockReturnValue("article")}
+				{...mockFuntions}
+			/>
+		);
+		const styleElement = wrapper.find("head style");
+		const styleText = styleElement.text();
+
+		expect(styleText).toContain("body { writing-mode: vertical-rl; }");
+	});
 });
 
 describe("head content", () => {

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -107,6 +107,7 @@ const SampleOutputType = ({
 		querylyOrg,
 		locale,
 		textDirection = "ltr",
+		textFlow = "horizontal-tb",
 	} = getProperties(arcSite);
 
 	const chartbeatInline = `
@@ -192,6 +193,7 @@ const SampleOutputType = ({
 				{fontUrlLink(fontUrl)}
 				<CssLinks />
 				<Libs />
+				<style>{`body { writing-mode: ${textFlow}; }`}</style>
 				<script
 					async
 					src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver%2CElement.prototype.prepend%2CElement.prototype.remove%2CArray.prototype.find%2CArray.prototype.includes"


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

Added a writing-mode <style> tag in the <head> of the page, to apply the textFlow property to the <body>

_Information about what you changed for this PR_

## Jira Ticket

- [THEMES-1182](https://arcpublishing.atlassian.net/browse/THEMES-1182)

## Acceptance Criteria

The text flow value should map directly to the writing-mode CSS property, and it should be applied to the root element.

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout branch THEMES-1181 in the blocks repo `git checkout THEMES-1181`
2. Run fusion repo with linked blocks npx fusion start -f -l @wpmedia/default-output-block
3. Open a local page, such as: http://localhost/pf/2022/08/11/on-oregons-central-coast-a-low-key-exploration-of-wineries-restaurants-and-nature/?_website=the-gazette
4. Open the dev tools and navigate to the elements tab
5. Verify that there is a <style> tag that pulls in the textDirection value from the feature pack blocks.json, and sets that value as the writing-mode. 
6. Verify that the textDirection style is applied to the <body>

## Effect Of Changes

### Before

There was no writing-mode style applied to the page

### After

The writing-mode is set to the value of the textFlow property:
![image](https://github.com/WPMedia/arc-themes-blocks/assets/85515364/849b7a78-16cd-4755-912c-f64fcc36bf5c)
![image](https://github.com/WPMedia/arc-themes-blocks/assets/85515364/72be86fa-3eda-4ac0-a533-e9dfe307646b)

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1182]: https://arcpublishing.atlassian.net/browse/THEMES-1182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ