### PR TITLE
THEMES 1187 Header Nav Chain Block - React code update to support RTL

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1306,8 +1306,8 @@
 					margin-right: 0,
 				),
 				header-nav-chain-logo-right: (
-					margin-left: auto,
-					margin-right: 0,
+					margin-inline-start: auto,
+					margin-inline-end: 0,
 				),
 				header-nav-chain-logo-hidden: (
 					opacity: 0,

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1305,6 +1305,10 @@
 				header-nav-chain-logo-center: (
 					margin-right: 0,
 				),
+				header-nav-chain-logo-right: (
+					margin-left: auto,
+					margin-right: 0,
+				),
 				header-nav-chain-logo-hidden: (
 					opacity: 0,
 					transition: (

--- a/blocks/header-nav-chain-block/_index.scss
+++ b/blocks/header-nav-chain-block/_index.scss
@@ -168,6 +168,11 @@
 			@include scss.block-properties("header-nav-chain-logo-center");
 		}
 
+		&--right {
+			@include scss.block-components("header-nav-chain-logo-right");
+			@include scss.block-properties("header-nav-chain-logo-right");
+		}
+
 		&.nav-logo-show {
 			@include scss.block-components("header-nav-chain-logo-show");
 			@include scss.block-properties("header-nav-chain-logo-show");

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-links/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-links/default.jsx
@@ -8,6 +8,7 @@ const NavLinksBar = ({
 	showHorizontalSeperatorDots: showHorizontalSeparatorDots,
 	ariaLabel,
 	blockClassName,
+	justification,
 }) => {
 	const { id } = useFusionContext();
 	const phrases = usePhrases();
@@ -50,6 +51,7 @@ const NavLinksBar = ({
 			className={`${blockClassName}__links-list`}
 			alignment="center"
 			wrap="wrap"
+			justification={justification}
 			aria-label={ariaLabel || phrases.t("header-nav-chain-block.links-element-aria-label")}
 		>
 			{menuItems.map((item, index) => (

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
@@ -67,13 +67,27 @@ const NavLogo = ({ imageAltText, imageSource, blockClassName, logoAlignment }) =
 
 	const isLogoSVG = !!imageSource && String(imageSource).endsWith(".svg");
 
+	// This replaces: logoAlignment === "center" ? `${blockClassName}__logo--center` : ``
+	let logoAlignmentCssClass = "";
+	switch (logoAlignment) {
+		case "center":
+			logoAlignmentCssClass = `${blockClassName}__logo--center`;
+			break;
+		case "right":
+			logoAlignmentCssClass = `${blockClassName}__logog--right`;
+			break;
+		default:
+			logoAlignmentCssClass = ``;
+			break;
+	}
+
 	return (
 		<Link
 			href="/"
 			title={imageAltText}
-			className={`${blockClassName}__logo ${
-				logoAlignment === "center" ? `${blockClassName}__logo--center` : ``
-			} ${isLogoVisible ? "nav-logo-show" : "nav-logo-hidden"} ${isLogoSVG ? "svg-logo" : ""}`}
+			className={`${blockClassName}__logo ${logoAlignmentCssClass} ${
+				isLogoVisible ? "nav-logo-show" : "nav-logo-hidden"
+			} ${isLogoSVG ? "svg-logo" : ""}`}
 			assistiveHidden={!isLogoVisible}
 		>
 			{imageSource ? (

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
@@ -74,7 +74,7 @@ const NavLogo = ({ imageAltText, imageSource, blockClassName, logoAlignment }) =
 			logoAlignmentCssClass = `${blockClassName}__logo--center`;
 			break;
 		case "right":
-			logoAlignmentCssClass = `${blockClassName}__logog--right`;
+			logoAlignmentCssClass = `${blockClassName}__logo--right`;
 			break;
 		default:
 			logoAlignmentCssClass = ``;

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/_children/nav-logo.jsx
@@ -67,7 +67,7 @@ const NavLogo = ({ imageAltText, imageSource, blockClassName, logoAlignment }) =
 
 	const isLogoSVG = !!imageSource && String(imageSource).endsWith(".svg");
 
-	// This replaces: logoAlignment === "center" ? `${blockClassName}__logo--center` : ``
+	// Assign the respective CSS class based on the desired logo alignment
 	let logoAlignmentCssClass = "";
 	switch (logoAlignment) {
 		case "center":

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -295,7 +295,7 @@ Nav.propTypes = {
 		signInOrder: PropTypes.number.tag({
 			hidden: true,
 		}),
-		logoAlignment: PropTypes.oneOf(["center", "left"]).tag({
+		logoAlignment: PropTypes.oneOf(["center", "left", "right"]).tag({
 			label: "Logo alignment",
 			group: "Logo",
 			defaultValue: "center",

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -53,18 +53,28 @@ export function PresentationalNav(props) {
 					>
 						{children}
 					</NavSection>
-					<NavLogo
-						blockClassName={BLOCK_CLASS_NAME}
-						logoAlignment={logoAlignment}
-						imageSource={primaryLogoPath}
-						imageAltText={primaryLogoAlt}
-					/>
+					{logoAlignment !== "right" ? (
+						<NavLogo
+							blockClassName={BLOCK_CLASS_NAME}
+							logoAlignment={logoAlignment}
+							imageSource={primaryLogoPath}
+							imageAltText={primaryLogoAlt}
+						/>
+					) : null}
 					{displayLinks ? (
 						<NavLinksBar
 							hierarchy={horizontalLinksHierarchy}
 							showHorizontalSeperatorDots={showDotSeparators}
 							ariaLabel={ariaLabelLink}
 							blockClassName={BLOCK_CLASS_NAME}
+						/>
+					) : null}
+					{logoAlignment === "right" ? (
+						<NavLogo
+							blockClassName={BLOCK_CLASS_NAME}
+							logoAlignment={logoAlignment}
+							imageSource={primaryLogoPath}
+							imageAltText={primaryLogoAlt}
 						/>
 					) : null}
 					<NavSection
@@ -176,7 +186,7 @@ const Nav = (props) => {
 		ariaLabelLink,
 	} = customFields;
 
-	const displayLinks = horizontalLinksHierarchy && logoAlignment === "left";
+	const displayLinks = horizontalLinksHierarchy && logoAlignment !== "center";
 
 	const showDotSeparators = showHorizontalSeperatorDots ?? true;
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -153,8 +153,10 @@ export function PresentationalNav(props) {
 					</FocusTrap>
 				</Stack>
 			</nav>
-			{horizontalLinksHierarchy && logoAlignment !== "left" && isAdmin ? (
-				<Stack>In order to render horizontal links, the logo must be aligned to the left.</Stack>
+			{horizontalLinksHierarchy && logoAlignment === "center" && isAdmin ? (
+				<Stack>
+					In order to render horizontal links, the logo must be aligned to the left or right.
+				</Stack>
 			) : null}
 		</>
 	);

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -36,6 +36,14 @@ export function PresentationalNav(props) {
 		primaryLogoAlt,
 	} = props;
 
+	// Set the links bar justification based on the logoAlignment
+	let linksBarJustification = "center"; // Default value if logoAlignment === "center", it won't be used
+	if (logoAlignment === "left") {
+		linksBarJustification = "start";
+	} else if (logoAlignment === "right") {
+		linksBarJustification = "end";
+	}
+
 	return (
 		<>
 			<nav
@@ -67,6 +75,7 @@ export function PresentationalNav(props) {
 							showHorizontalSeperatorDots={showDotSeparators}
 							ariaLabel={ariaLabelLink}
 							blockClassName={BLOCK_CLASS_NAME}
+							justification={linksBarJustification}
 						/>
 					) : null}
 					{logoAlignment === "right" ? (

--- a/blocks/header-nav-chain-block/themes/news.json
+++ b/blocks/header-nav-chain-block/themes/news.json
@@ -134,8 +134,8 @@
 	"header-nav-chain-logo-right": {
 		"styles": {
 			"default": {
-				"margin-left": "auto",
-				"margin-right": 0
+				"margin-inline-start": "auto",
+				"margin-inline-end": 0
 			},
 			"desktop": {}
 		}

--- a/blocks/header-nav-chain-block/themes/news.json
+++ b/blocks/header-nav-chain-block/themes/news.json
@@ -131,6 +131,15 @@
 			"desktop": {}
 		}
 	},
+	"header-nav-chain-logo-right": {
+		"styles": {
+			"default": {
+				"margin-left": "auto",
+				"margin-right": 0
+			},
+			"desktop": {}
+		}
+	},
 	"header-nav-chain-logo-hidden": {
 		"styles": {
 			"default": {


### PR DESCRIPTION
**This PR goes with an `arc-themes-feature-pack` PR. You can find it [here](https://github.com/WPMedia/arc-themes-feature-pack/pull/445).**

## Description

The goal of this ticket is to add the ability to right align the site logo in the `header-nav-chain-block`. The guidelines for the styling are in [this Figma document](https://www.figma.com/file/vWVGgZfZVBdSX7ACo3kmjr/Enhanced-Styling-Design-System?type=design&node-id=11274-171782&mode=design&t=AbfV3zIaPqJK5X28-0). I made the following changes:
* I made "right" a selectable option in the `logoAlignment` custom field
* I made the site logo align to the right when "right" is selected:
    * This required adding a new class in `_index.scss` and some new styling in `themes/news.json`, so the logo aligns to the right
    * I also had to change how the `className` is set in `/_children/nav-logo.jsx`
* The links bar shows up for the right-aligned logo (like it would if the logo is left-aligned):
    * `default.jsx` now returns the `NavLogo` and `NavLinksBar` components in the correct order if the logo alignment is set to "right"
    * The logo alignment gets passed into the `Stack` component (but modified to match the parameters for `Stack`), so the links bar aligns to the right when the logo is set to show on the right
    * The "In order to ... to the left" message in PageBuilder to only show for a centered logo (I also adjusted the message to add "or right")
* I updated the news styling in `./storybook/themes` to reflect the changes made to the block's `themes` directory
* Because of these changes, some changes were also automatically made to the `site-styles` directory in `arc-themes-feature-pack`
    * You can find a link to the PR [here](https://github.com/WPMedia/arc-themes-feature-pack/pull/445)
    * These are needed to run this code

## Jira Ticket

[THEMES-1187](https://arcpublishing.atlassian.net/browse/THEMES-1187)

## Acceptance Criteria

1. Right custom-field option for logo alignment is added
    * The nav links bar should display when this new option is selected, just as if it was set to left

## Test Steps

1. Checkout this branch `git checkout THEMES-1187-header-nav-chain`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Go to your local PageBuilder Instance and open the "All-Blocks-Test-TA-Sandbox" (or any page with a header-nav chain). To change the logo alignment, click on the Navigation block, expand the Logo section, and select the desired logo alignment
4. Publish the page (so the published preview updates) and open the preview view
5. Verify the following:
    * When "right" is selected, the site logo aligns to the right
    * When "right" is selected, the links bar moves to the right (and looks equivalent to when the logo alignment is set to "left")
    * The "In order to ... left or center" message only shows up when the logo alignment is set to "center"

## Effect Of Changes

### Before

**Logo alignment selection**

![Screenshot 2023-07-20 at 11 54 23 AM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/90041042-4f37-42d2-a8b4-0f8a34aa2161)

**Left**

![Screenshot 2023-07-20 at 11 43 21 AM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/82f04bf5-fa3b-4b14-94f8-945fb3f4f39f)

**Center**

![Screenshot 2023-07-20 at 11 43 07 AM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/f0999d06-3d53-4949-8234-253aeaf5864d)

### After

**Logo alignment selection**

![Screenshot 2023-07-20 at 11 53 39 AM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/5177116d-0b55-4e6a-aebf-3ed2cd2fdd95)

*New option for right*

**Left**

![Screenshot 2023-07-20 at 11 39 13 AM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/6de21918-405b-4c36-a050-41a5876d1244)

*This should look the same as the "before" image*

**Center**

![Screenshot 2023-07-20 at 11 38 53 AM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/75c1aa3f-ca8d-4a83-a2de-c1886c0ab3d6)

*The only change here should be the message below the nav chain*

**Right**

![Screenshot 2023-07-20 at 11 39 29 AM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/c833d7bd-d585-4e66-b451-2b58b38327fd)

*New*

## Dependencies or Side Effects

This Pr is dependent on some changes to `arc-themes-feature-pack`. The PR is [here](https://github.com/WPMedia/arc-themes-feature-pack/pull/445).

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1187]: https://arcpublishing.atlassian.net/browse/THEMES-1187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ