### PR TITLE
Themes 1185 Card List Block - React code update to support RTL

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -923,7 +923,7 @@
 						),
 					),
 				),
-				byline-container: (
+				card-list-byline-container: (
 					display: flex,
 					flex-direction: row,
 					flex-wrap: wrap,

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -925,6 +925,7 @@
 				),
 				card-list-byline-container: (
 					display: flex,
+					align-items: center,
 					flex-direction: row,
 					flex-wrap: wrap,
 					justify-content: flex-start,

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -923,6 +923,12 @@
 						),
 					),
 				),
+				byline-container: (
+					display: flex,
+					flex-direction: row,
+					flex-wrap: wrap,
+					justify-content: flex-start,
+				),
 				card-list-title: (
 					padding: 0 var(--global-spacing-4),
 					font-size: var(--heading-level-5-font-size),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -879,6 +879,9 @@
 						),
 					),
 				),
+				card-list-by-text: (
+					margin-inline-end: var(--global-spacing-1),
+				),
 				card-list-byline-container: (
 					display: flex,
 					align-items: flex-end,

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -881,7 +881,7 @@
 				),
 				card-list-byline-container: (
 					display: flex,
-					align-items: center,
+					align-items: flex-end,
 					flex-direction: row,
 					flex-wrap: wrap,
 					justify-content: flex-start,

--- a/blocks/card-list-block/_index.scss
+++ b/blocks/card-list-block/_index.scss
@@ -1,6 +1,11 @@
 @use "@wpmedia/arc-themes-components/scss";
 
 .b-card-list {
+	&__byline-container {
+		@include scss.block-components("byline-container");
+		@include scss.block-properties("byline-container");
+	}
+
 	&__title {
 		@include scss.block-components("card-list-title");
 		@include scss.block-properties("card-list-title");

--- a/blocks/card-list-block/_index.scss
+++ b/blocks/card-list-block/_index.scss
@@ -2,8 +2,8 @@
 
 .b-card-list {
 	&__byline-container {
-		@include scss.block-components("byline-container");
-		@include scss.block-properties("byline-container");
+		@include scss.block-components("card-list-byline-container");
+		@include scss.block-properties("card-list-byline-container");
 	}
 
 	&__title {

--- a/blocks/card-list-block/_index.scss
+++ b/blocks/card-list-block/_index.scss
@@ -1,6 +1,11 @@
 @use "@wpmedia/arc-themes-components/scss";
 
 .b-card-list {
+	&__by-text {
+		@include scss.block-components("card-list-by-text");
+		@include scss.block-properties("card-list-by-text");
+	}
+
 	&__byline-container {
 		@include scss.block-components("card-list-byline-container");
 		@include scss.block-properties("card-list-byline-container");

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -209,9 +209,10 @@ const CardListItems = (props) => {
 								<Attribution>
 									{hasAuthor ? (
 										<div className={`${BLOCK_CLASS_NAME}__byline-container`}>
-											<span>
-												{phrases.t("global.by-text")} {bylineNodes}
+											<span className={`${BLOCK_CLASS_NAME}__by-text`}>
+												{phrases.t("global.by-text")}
 											</span>
+											<span>{bylineNodes}</span>
 											<Separator />
 											<Date dateTime={sourceContent.display_date} dateString={displayDate} />
 										</div>

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -208,12 +208,16 @@ const CardListItems = (props) => {
 								</Heading>
 								<Attribution>
 									{hasAuthor ? (
-										<>
-											<span>{phrases.t("global.by-text")}</span> <span>{bylineNodes}</span>
+										<div className={`${BLOCK_CLASS_NAME}__byline-container`}>
+											<span>
+												{phrases.t("global.by-text")} {bylineNodes}
+											</span>
 											<Separator />
-										</>
-									) : null}
-									<Date dateTime={sourceContent.display_date} dateString={displayDate} />
+											<Date dateTime={sourceContent.display_date} dateString={displayDate} />
+										</div>
+									) : (
+										<Date dateTime={sourceContent.display_date} dateString={displayDate} />
+									)}
 								</Attribution>
 							</Stack>
 						</Stack>

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -212,7 +212,7 @@ const CardListItems = (props) => {
 											<span className={`${BLOCK_CLASS_NAME}__by-text`}>
 												{phrases.t("global.by-text")}
 											</span>
-											<span>{bylineNodes}</span>
+											<div>{bylineNodes}</div>
 											<Separator />
 											<Date dateTime={sourceContent.display_date} dateString={displayDate} />
 										</div>

--- a/blocks/card-list-block/themes/news.json
+++ b/blocks/card-list-block/themes/news.json
@@ -36,6 +36,13 @@
 			"desktop": {}
 		}
 	},
+	"card-list-by-text": {
+		"styles": {
+			"default": {
+				"margin-inline-end": "var(--global-spacing-1)"
+			}
+		}
+	},
 	"card-list-byline-container": {
 		"styles": {
 			"default": {

--- a/blocks/card-list-block/themes/news.json
+++ b/blocks/card-list-block/themes/news.json
@@ -40,6 +40,7 @@
 		"styles": {
 			"default": {
 				"display": "flex",
+				"align-items": "center",
 				"flex-direction": "row",
 				"flex-wrap": "wrap",
 				"justify-content": "flex-start"

--- a/blocks/card-list-block/themes/news.json
+++ b/blocks/card-list-block/themes/news.json
@@ -36,7 +36,7 @@
 			"desktop": {}
 		}
 	},
-	"byline-container": {
+	"card-list-byline-container": {
 		"styles": {
 			"default": {
 				"display": "flex",

--- a/blocks/card-list-block/themes/news.json
+++ b/blocks/card-list-block/themes/news.json
@@ -36,6 +36,16 @@
 			"desktop": {}
 		}
 	},
+	"byline-container": {
+		"styles": {
+			"default": {
+				"display": "flex",
+				"flex-direction": "row",
+				"flex-wrap": "wrap",
+				"justify-content": "flex-start"
+			}
+		}
+	},
 	"card-list-list": {
 		"styles": {
 			"default": {

--- a/blocks/card-list-block/themes/news.json
+++ b/blocks/card-list-block/themes/news.json
@@ -40,7 +40,7 @@
 		"styles": {
 			"default": {
 				"display": "flex",
-				"align-items": "center",
+				"align-items": "flex-end",
 				"flex-direction": "row",
 				"flex-wrap": "wrap",
 				"justify-content": "flex-start"


### PR DESCRIPTION
**This PR goes with an `arc-themes-feature-pack` PR. You can find it [here](https://github.com/WPMedia/arc-themes-feature-pack/pull/460).**

## Description

The `card-list-block` needed updates for RTL. The items in the byline didn't flip when `dir="rtl"`. My goal in this ticket was to fix the byline so it matches the [styling guidelines in Figma](https://www.figma.com/file/vWVGgZfZVBdSX7ACo3kmjr/Enhanced-Styling-Design-System?type=design&node-id=11116-178539&mode=design&t=uRkjsGYYw1FevTKd-0).  
  
I made the following changes:
* In `features/card-list/default.jsx`, I created a container within `Attribution` and put the byline and date inside. This allowed me to add the styling that flips the byline items around in RTL mode. I moved the `by-text` and `bylineNodes` into the same `span` because otherwise the space between "By" and the author names wouldn't appear
* In `_index.scss`, I added a selector for the container I created in `default.jsx`
* In `themes/news.scss`, I added styling to the container. I used a flex box, so the items in the container will flip around when the text direction changes without changing the HTML code at all. I added other CSS flex-box styling to make sure the byline elements look good and behave correctly
* I updated the news styling in `./storybook/themes` to reflect the changes made to the block's `themes` directory
* Because of these changes, some changes were also automatically made to the `site-styles` directory in `arc-themes-feature-pack`. You can view them [here](https://github.com/WPMedia/arc-themes-feature-pack/pull/460). These changes are needed to run this code

## Jira Ticket

[THEMES-1185](https://arcpublishing.atlassian.net/browse/THEMES-1185)

## Acceptance Criteria

1. The order of elements in the byline will need to be reversed if `textDirection` is set to `rtl`
    * I.e., byline elements should either be: 1. author 2. separator 3. date from RTL (or any direction)

## Test Steps

1. Checkout this branch: `git checkout THEMES-1185-card-list-block-rtl`
2. Run fusion repo with linked blocks: `npx fusion start -f -l @wpmedia/card-list-block`
3. Open your local PageBuilder instance, and open the "All-Blocks-Test-TA-Sandbox" page
4. Open the published preview and go to the developer console
5. Switch the `dir` attribute in the `html` tag between `ltr` and `rtl` and make sure:
    * In LTR mode, the byline goes "[authors] [separator] [date]" (when looking from left to right)
    * In RTL mode, the byline goes "[date] [separator] [authors]" (when looking from left to right)
    * The rest of the byline styling looks good (there are design guidelines in [Figma](https://www.figma.com/file/vWVGgZfZVBdSX7ACo3kmjr/Enhanced-Styling-Design-System?type=design&node-id=11116-178539&mode=design&t=hMobmRojnnQ4TKfi-0) if you want them)

## Effect Of Changes

### Before

| LTR | RTL |
| :---: | :---: |
| ![Screenshot 2023-08-15 at 12 59 02 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/c2244921-8243-4226-8707-c18ea936d4e1) | ![Screenshot 2023-08-15 at 12 59 39 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/c4f92b77-05fa-465b-8d39-96374b714d54) |

### After

| LTR | RTL |
| :---: | :---: |
| ![Screenshot 2023-08-15 at 1 04 29 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/92173fad-92b9-4772-ae93-fe089f4d7420) | ![Screenshot 2023-08-15 at 1 04 49 PM](https://github.com/WPMedia/arc-themes-blocks/assets/103296586/700e2e6e-260f-453d-b614-7f540df9971c) |

## Dependencies or Side Effects

This PR is dependent on some changes to `arc-themes-feature-pack`. The PR is [here](https://github.com/WPMedia/arc-themes-feature-pack/pull/460).

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1185]: https://arcpublishing.atlassian.net/browse/THEMES-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ