### PR TITLE
Themes 1088

### DIFF
--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -148,6 +148,7 @@ export const GalleryPresentation = ({
 								src={imageANSToImageSrc(galleryItem)}
 								resizerURL={resizerURL}
 								resizedOptions={{ auth: galleryItem.auth[resizerAppVersion] }}
+								loading="eager"
 								// 16:9 aspect ratio
 								height={281.25}
 								alt={galleryItem.alt_text}

--- a/blocks/gallery-block/features/gallery/default.jsx
+++ b/blocks/gallery-block/features/gallery/default.jsx
@@ -148,7 +148,7 @@ export const GalleryPresentation = ({
 								src={imageANSToImageSrc(galleryItem)}
 								resizerURL={resizerURL}
 								resizedOptions={{ auth: galleryItem.auth[resizerAppVersion] }}
-								loading="eager"
+								loading={itemIndex === 0 ? "eager" : "lazy"}
 								// 16:9 aspect ratio
 								height={281.25}
 								alt={galleryItem.alt_text}

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -109,7 +109,6 @@ export const LeadArtPresentation = (props) => {
 				</MediaItem>
 			);
 		}
-		console.log("strategy", imageLoadingStrategy);
 
 		if (leadArt.type === "image") {
 			return (

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -248,7 +248,7 @@ export const LeadArtPresentation = (props) => {
 								<div className={`${BLOCK_CLASS_NAME}__image-wrapper`}>
 									<Image
 										ansImage={galleryItem}
-										loading={imageLoadingStrategy}
+										loading={itemIndex === 0 ? imageLoadingStrategy : "lazy"}
 										// 16:9 aspect ratio
 										height={450}
 										responsiveImages={[800, 1600]}

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -109,6 +109,7 @@ export const LeadArtPresentation = (props) => {
 				</MediaItem>
 			);
 		}
+		console.log("strategy", imageLoadingStrategy);
 
 		if (leadArt.type === "image") {
 			return (
@@ -234,6 +235,7 @@ export const LeadArtPresentation = (props) => {
 								<div className={`${BLOCK_CLASS_NAME}__image-wrapper`}>
 									<Image
 										ansImage={galleryItem}
+										loading={imageLoadingStrategy}
 										// 16:9 aspect ratio
 										height={450}
 										responsiveImages={[800, 1600]}


### PR DESCRIPTION
## Description

The underlying engine-theme-sdk doesn’t allow eager loading of images. We’d need to make updates to enable passing eager down through the tree of children gallery (block) > gallery (sdk) > image (sdk). 

## Jira Ticket

- [THEMES-1088](https://arcpublishing.atlassian.net/browse/THEMES-1088)

## Acceptance Criteria

Eager loading policy can be applied on the gallery lead art block and gallery block so they can specify which image(s) eager load

Note: the rest default to lazy
## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-1088
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/lead-art-block,@wpmedia/gallery-block`
3. Image load as eager

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1088]: https://arcpublishing.atlassian.net/browse/THEMES-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ