### PR TITLE
THEMES-1280 Gallery + Lead Art (mobile) | Update autoplay, progress indicator, carousel, and close controls in focus (expand) view

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -637,10 +637,23 @@
 					height: auto,
 					width: 100%,
 				),
+				article-body-gallery-close-button: (
+					color: var(--global-white),
+					components: (
+						button-hover: (
+							color: var(--global-neutral-3),
+						),
+						icon: (
+							fill: currentColor,
+							height: var(--global-spacing-6),
+							width: var(--global-spacing-6),
+						),
+					),
+				),
 				article-body-gallery-fullscreen: (
 					components: (
 						media-item-fig-caption: (
-							padding: 0 var(--global-spacing-5),
+							padding: 0 var(--global-spacing-2),
 						),
 					),
 				),
@@ -699,15 +712,18 @@
 				),
 				article-body-image-wrapper: (
 					align-items: center,
+					aspect-ratio: calc(16 / 9),
 					background-color: var(--global-black),
 					display: flex,
 					justify-content: center,
 					max-height: 75vh,
+					overflow: auto,
 					components: (
 						image: (
 							height: auto,
-							max-height: 75vh,
+							max-height: 100%,
 							max-width: 100%,
+							object-fit: contain,
 						),
 					),
 				),
@@ -1131,21 +1147,24 @@
 				gallery-fullscreen: (
 					components: (
 						media-item-fig-caption: (
-							padding: 0 var(--global-spacing-5),
+							padding: 0 var(--global-spacing-2),
 						),
 					),
 				),
 				gallery-image-wrapper: (
 					align-items: center,
+					aspect-ratio: calc(16 / 9),
 					background-color: var(--global-black),
 					display: flex,
 					justify-content: center,
 					max-height: 75vh,
+					overflow: auto,
 					components: (
 						image: (
 							height: auto,
-							max-height: 75vh,
+							max-height: 100%,
 							max-width: 100%,
+							object-fit: contain,
 						),
 					),
 				),
@@ -1656,7 +1675,7 @@
 				lead-art-carousel-fullscreen: (
 					components: (
 						media-item-fig-caption: (
-							padding: 0 var(--global-spacing-5),
+							padding: 0 var(--global-spacing-2),
 						),
 					),
 				),
@@ -2742,6 +2761,24 @@
 				carousel-actions: (
 					display: flex,
 				),
+				carousel-additional-controls: (
+					gap: var(--global-spacing-2),
+					padding: 0 0 0 var(--global-spacing-2),
+				),
+				carousel-fullscreen: (
+					padding: var(--global-spacing-5) 0,
+				),
+				carousel-fullscreen-button-toggle-auto-play: (
+					display: flex,
+				),
+				carousel-fullscreen-controls: (
+					flex-direction: initial,
+					padding-top: var(--global-spacing-5),
+					padding-right: var(--global-spacing-5),
+					padding-bottom: var(--global-spacing-5),
+					padding-left: var(--global-spacing-5),
+					place-self: flex-start,
+				),
 				carousel-track: (
 					gap: var(--global-spacing-6),
 				),
@@ -2757,11 +2794,15 @@
 				article-body: (
 					font-size: var(--heading-level-6-font-size),
 				),
-				article-body-gallery-additional-next: (
-					display: block,
+				article-body-gallery-fullscreen: (
+					components: (
+						media-item-fig-caption: (
+							padding: 0 var(--global-spacing-5),
+						),
+					),
 				),
-				article-body-gallery-additional-previous: (
-					display: block,
+				article-body-image-wrapper: (
+					max-height: 75vh,
 				),
 				author-bio-social-link-wrapper: (
 					margin-top: var(--global-spacing-4),
@@ -2831,12 +2872,10 @@
 				full-author-bio-social-icons: (
 					justify-content: flex-start,
 				),
-				gallery: (
+				gallery-fullscreen: (
 					components: (
-						carousel-additional-controls: (
-							display: flex,
-							gap: var(--global-spacing-2),
-							padding: 0 0 0 var(--global-spacing-2),
+						media-item-fig-caption: (
+							padding: 0 var(--global-spacing-5),
 						),
 					),
 				),
@@ -2906,26 +2945,15 @@
 						),
 					),
 				),
-				lead-art: (
+				lead-art-carousel-fullscreen: (
 					components: (
-						carousel-additional-controls: (
-							display: flex,
-							gap: var(--global-spacing-2),
-							padding: 0 0 0 var(--global-spacing-2),
+						media-item-fig-caption: (
+							padding: 0 var(--global-spacing-5),
 						),
 					),
-				),
-				lead-art-close-icon: (
-					right: calc(100% - var(--global-spacing-4)),
-					left: var(--global-spacing-4),
 				),
 				lead-art-carousel-image-wrapper: (
 					max-height: 75vh,
-					components: (
-						button-medium: (
-							left: var(--global-spacing-4),
-						),
-					),
 				),
 				masthead: (
 					display: flex,

--- a/blocks/article-body-block/_index.scss
+++ b/blocks/article-body-block/_index.scss
@@ -76,6 +76,11 @@
 			@include scss.block-components("article-body-gallery-track-button");
 			@include scss.block-properties("article-body-gallery-track-button");
 		}
+
+		&__close-button {
+			@include scss.block-components("article-body-gallery-close-button");
+			@include scss.block-properties("article-body-gallery-close-button");
+		}
 	}
 
 	&__image-wrapper {

--- a/blocks/article-body-block/themes/news.json
+++ b/blocks/article-body-block/themes/news.json
@@ -114,11 +114,17 @@
 			"default": {
 				"components": {
 					"media-item-fig-caption": {
-						"padding": "0 var(--global-spacing-5)"
+						"padding": "0 var(--global-spacing-2)"
 					}
 				}
 			},
-			"desktop": {}
+			"desktop": {
+				"components": {
+					"media-item-fig-caption": {
+						"padding": "0 var(--global-spacing-5)"
+					}
+				}
+			}
 		}
 	},
 	"article-body-gallery-track-button": {
@@ -133,6 +139,24 @@
 						"fill": "currentColor",
 						"height": "var(--global-spacing-8)",
 						"width": "var(--global-spacing-8)"
+					}
+				}
+			},
+			"desktop": {}
+		}
+	},
+	"article-body-gallery-close-button": {
+		"styles": {
+			"default": {
+				"color": "var(--global-white)",
+				"components": {
+					"button-hover": {
+						"color": "var(--global-neutral-3)"
+					},
+					"icon": {
+						"fill": "currentColor",
+						"height": "var(--global-spacing-6)",
+						"width": "var(--global-spacing-6)"
 					}
 				}
 			},
@@ -218,19 +242,24 @@
 		"styles": {
 			"default": {
 				"align-items": "center",
+				"aspect-ratio": "calc(16/9)",
 				"background-color": "var(--global-black)",
 				"display": "flex",
 				"justify-content": "center",
 				"max-height": "75vh",
+				"overflow": "auto",
 				"components": {
 					"image": {
 						"height": "auto",
-						"max-height": "75vh",
-						"max-width": "100%"
+						"max-height": "100%",
+						"max-width": "100%",
+						"object-fit": "contain"
 					}
 				}
 			},
-			"desktop": {}
+			"desktop": {
+				"max-height": "75vh"
+			}
 		}
 	},
 	"article-body-interstitial-link": {

--- a/blocks/gallery-block/themes/news.json
+++ b/blocks/gallery-block/themes/news.json
@@ -17,26 +17,35 @@
 			"default": {
 				"components": {
 					"media-item-fig-caption": {
-						"padding": "0 var(--global-spacing-5)"
+						"padding": "0 var(--global-spacing-2)"
 					}
 				}
 			},
-			"desktop": {}
+			"desktop": {
+				"components": {
+					"media-item-fig-caption": {
+						"padding": "0 var(--global-spacing-5)"
+					}
+				}
+			}
 		}
 	},
 	"gallery-image-wrapper": {
 		"styles": {
 			"default": {
 				"align-items": "center",
+				"aspect-ratio": "calc(16/9)",
 				"background-color": "var(--global-black)",
 				"display": "flex",
 				"justify-content": "center",
 				"max-height": "75vh",
+				"overflow": "auto",
 				"components": {
 					"image": {
 						"height": "auto",
-						"max-height": "75vh",
-						"max-width": "100%"
+						"max-height": "100%",
+						"max-width": "100%",
+						"object-fit": "contain"
 					}
 				}
 			},

--- a/blocks/lead-art-block/themes/news.json
+++ b/blocks/lead-art-block/themes/news.json
@@ -18,6 +18,13 @@
 			"default": {
 				"components": {
 					"media-item-fig-caption": {
+						"padding": "0 var(--global-spacing-2)"
+					}
+				}
+			},
+			"desktop": {
+				"components": {
+					"media-item-fig-caption": {
 						"padding": "0 var(--global-spacing-5)"
 					}
 				}
@@ -44,10 +51,7 @@
 				}
 			},
 			"desktop": {
-				"max-height": "75vh",
-				"components": {
-					"max-height": "75vh"
-				}
+				"max-height": "75vh"
 			}
 		}
 	},


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description

- Sets styles for expanding/full-screen view for lead-art, article-body-gallery, gallery-block

## Jira Ticket

- [THEMES-1280](https://arcpublishing.atlassian.net/browse/THEMES-1280)

## Acceptance Criteria

GIVEN I am a Media Site User, WHEN I expand a gallery, THEN:

- Styling is consistent with v2 designs on expanded gallery
- progress indicator (x of x)
- captions
- carousel controls (><) are removed to avoid duplication
- close 'x' control 

Note: the close control is currently not displaying on lead art, but is on the gallery block where style changes are needed (see examples above)

This should apply to gallery lead art as well as the gallery block

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-1280`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/article-body-block,@wpmedia/gallery-block,@wpmedia/lead-art-block`
3. Iterate with the described blocks for example in "http://localhost/pf/all-blocks-test-ta/?_website=daily-intelligencer"

## Effect Of Changes

### After

Lead-art:
![1-lead-art-default](https://github.com/WPMedia/arc-themes-blocks/assets/133056774/c6b2036e-2618-4a70-8a4f-8b422727fef7)
![2-lead-art-full-screen](https://github.com/WPMedia/arc-themes-blocks/assets/133056774/08996798-fee8-4638-b496-acfe15d9e1eb)

Gallery-block:
![3-gallery-block-default](https://github.com/WPMedia/arc-themes-blocks/assets/133056774/2c35823c-a364-4fb7-adfc-6fef7bd8d98c)
![4-gallery-block-full-screen](https://github.com/WPMedia/arc-themes-blocks/assets/133056774/6bde870e-d6c2-486f-8250-004544b064f3)

Article-body-gallery:
![5-article-body-gallery-default](https://github.com/WPMedia/arc-themes-blocks/assets/133056774/f8e26226-f0fe-4a6f-bfd9-1d21e067eb3a)
![6-article-body-gallery-full-screen](https://github.com/WPMedia/arc-themes-blocks/assets/133056774/66650954-445d-47a0-9cb6-c5dc8355c7ee)

## Dependencies or Side Effects

_Examples of dependencies or side effects are:_

- Manifest pr for new block:
- Feature pack pr for local development:
https://github.com/WPMedia/arc-themes-feature-pack/pull/464
- Dependency on another PR that needs to be merged at the same time:


## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1280]: https://arcpublishing.atlassian.net/browse/THEMES-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ