### PR TITLE
Fixed Nav Menu scroll behavior

### DIFF
--- a/blocks/alias-tokens/themes/news.json
+++ b/blocks/alias-tokens/themes/news.json
@@ -54,8 +54,8 @@
 		"layout-max-width": 1600,
 		"content-max-width": 1440,
 		"content-scale-width": "calc(var(--content-max-width) / var(--layout-max-width) * 100%)",
-		"header-nav-chain-height": "56px",
-		"header-nav-chain-height-scrolled": "56px",
+		"header-nav-chain-height": "80px",
+		"header-nav-chain-height-scrolled": "80px",
 		"header-nav-chain-overlay-background-color": "rgba(25, 25, 25, 0.5)"
 	},
 	"desktop": {

--- a/blocks/default-output-block/_index.scss
+++ b/blocks/default-output-block/_index.scss
@@ -4,6 +4,10 @@
 	@include scss.block-properties("application");
 }
 
+.nav-open {
+	overflow: hidden;
+}
+
 // do not delete this as it's used to inject scss
 .skip-main {
 	left: -999px;


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description

Fixed Side Menu scroll behavior

## Jira Ticket

- [THEMES-1399](https://arcpublishing.atlassian.net/browse/THEMES-1399)

## Acceptance Criteria

In v2, when the side menu is open, users can still scroll in the main body of the page. This scroll should be disabled

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-1399`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/alias-tokens,@wpmedia/default-output-block`
3. Verify that the scroll behavior is correct when the nav menu is open (Users can't scroll the part of the screen behind the overlay)
4. Verify that the overlay starts right at the bottom of the navbar, with no overlap.

## Effect Of Changes

### Before
Users could scroll the background of the website even when the section menu overlay was present:

https://github.com/WPMedia/arc-themes-blocks/assets/85515364/270f47e3-9083-4124-b6eb-a5534de90f77



Nav Overlay went up too high on the screen, so it covered part of the nav menu (adjusted the alias token to account for this):
<img width="1187" alt="image" src="https://github.com/WPMedia/arc-themes-blocks/assets/85515364/35e57f11-ede9-461a-943d-227f29a1a237">


### After

The overlay is placed at the correct height and the scroll behavior is fixed:

https://github.com/WPMedia/arc-themes-blocks/assets/85515364/42d8e0a0-ad64-4820-b422-c7d01f8de898



## Dependencies or Side Effects

_Examples of dependencies or side effects are:_

- Manifest pr for new block:
- Feature pack pr for local development:
- How to deploy to news: https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3138682964/News+Theme+2.0+Migration+Development+Deployment+Notes
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Dependency on another PR that needs to be merged first

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1399]: https://arcpublishing.atlassian.net/browse/THEMES-1399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ