### PR TITLE
THEMES-1383: Fixed issue with Github publish action

### DIFF
--- a/.github/workflows/sync-themes-branch-with-themes-tag.yml
+++ b/.github/workflows/sync-themes-branch-with-themes-tag.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Pull tags to give lerna access to git info
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-      - name: Create npmrc
+      - name: Create npmrc for install
         env:
           ARCXP_AUTH_TOKEN: ${{ secrets.WPMEDIA_PUBLIC_REPO_ARCXP_PACKAGE_TOKEN }}
         run: |
@@ -60,11 +60,18 @@ jobs:
       - name: Run all tests
         run: npm run test
 
+      - name: Create npmrc for publish
+        env:
+          REPO_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          rm .npmrc
+          touch .npmrc
+          echo @wpmedia:registry=https://npm.pkg.github.com/ >> .npmrc
+          echo //npm.pkg.github.com/:_authToken=$REPO_AUTH_TOKEN >> .npmrc
+
       # See confluence pages https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/2983788608/How+To+Do+Product-Facing+Tag+Release and https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3013541978/Github+Actions+for+NodeJS+Standards+Best+Practices for documentation
       - name: Publish to target tag based off of branch name
         run: |
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git config --local user.name "$GITHUB_ACTOR"
           npx lerna publish --dist-tag ${{ env.SYNCED_RELEASE_TAG }} --canary --preid ${{ env.SYNCED_RELEASE_TAG }} -y
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Fix for the npm publish action, so the recent updates made to blocks will be available when they are installed.

## Jira Ticket

- [THEMES-1383](https://arcpublishing.atlassian.net/browse/THEMES-1383)


## Test Steps

- This can only be tested once it's merged


[THEMES-1383]: https://arcpublishing.atlassian.net/browse/THEMES-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ