### PR TITLE
Update arc-themes-base-to-new-tag.yml

### DIFF
--- a/.github/workflows/arc-themes-base-to-new-tag.yml
+++ b/.github/workflows/arc-themes-base-to-new-tag.yml
@@ -49,12 +49,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node and NPM
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version: "16"
           registry-url: "https://npm.pkg.github.com"
 
       # See confluence pages https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/2983788608/How+To+Do+Product-Facing+Tag+Release and https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3013541978/Github+Actions+for+NodeJS+Standards+Best+Practices for documentation


### PR DESCRIPTION
## Description

PR to test a fix for the github workflow "Tag New Arc Theme Release". This is being made on the 1.29 branch for now, to facilitate the creation of the 1.30 release.
