### PR TITLE
DAM-7996

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -8,7 +8,6 @@ import {
 	Conditional,
 	Divider,
 	formatCredits,
-	getAspectRatio,
 	Heading,
 	HeadingSection,
 	Icon,
@@ -48,11 +47,8 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		hideVideoCredits = false,
 		viewportPercentage = 65,
 		borderRadius = false,
+		aspectRatio,
 	} = customFields;
-
-	// This is up here to prevent a lexical declaration in a case block (which throws an error). It goes with the "video" case
-	let videoAspectRatio = "16:9"; // Default to 16:9
-
 	switch (type) {
 		case "text": {
 			return content && content.length > 0 ? (
@@ -217,16 +213,6 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 			}
 
 		case "video":
-			// Calculate the aspect ratio for the item. If the item doesn't have any promo items, then 16:9 is used as a fallback
-			if (item && item.promo_items && item.promo_items.basic) {
-				// Get the width and height of the promo item and calculate the aspect ratio
-				const width = item?.promo_items.basic.width;
-				const height = item?.promo_items.basic.height;
-
-				// Assign the calculated value to aspectRatio if it is non-null, otherwise assign default 16:9
-				videoAspectRatio = getAspectRatio(width, height) || "16:9";
-			}
-
 			return (
 				<MediaItem
 					key={`${type}_${index}_${key}`}
@@ -235,7 +221,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 					title={!hideVideoTitle ? item?.headlines?.basic : null}
 				>
 					<Video
-						aspectRatio={videoAspectRatio}
+						aspectRatio={aspectRatio}
 						viewportPercentage={viewportPercentage}
 						className="video-container"
 						embedMarkup={item.embed_html}

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -453,11 +453,14 @@ ArticleBodyChain.propTypes = {
 			defaultValue: false,
 			group: "Gallery Display Options",
 		}),
-		aspectRatio: PropTypes.oneOf(["16:9", "9:16", "1:1", "4:3"]).tag({
+		aspectRatio: PropTypes.oneOf(["--", "16:9", "9:16", "1:1", "4:3"]).isRequired.tag({
+			description:
+				"Aspect ratio to use in player (Defaults to the aspect ratio of the resolved video)",
 			label: "Player Aspect Ratio",
-			defaultValue: "16:9",
+			defaultValue: "--",
 			group: "Video Display Options",
 			labels: {
+				"--": "Video Source",
 				"16:9": "16:9",
 				"9:16": "9:16",
 				"1:1": "1:1",

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -47,6 +47,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		hideVideoCaption = false,
 		hideVideoCredits = false,
 		viewportPercentage = 65,
+		borderRadius = false,
 	} = customFields;
 
 	// This is up here to prevent a lexical declaration in a case block (which throws an error). It goes with the "video" case
@@ -238,6 +239,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 						viewportPercentage={viewportPercentage}
 						className="video-container"
 						embedMarkup={item.embed_html}
+						borderRadius={borderRadius}
 					/>
 				</MediaItem>
 			);
@@ -479,6 +481,12 @@ ArticleBodyChain.propTypes = {
 		viewportPercentage: PropTypes.number.tag({
 			label: "View height percentage",
 			defaultValue: 65,
+			group: "Video Display Options",
+		}),
+		borderRadius: PropTypes.bool.tag({
+			description: "Only valid for videos in 9:16",
+			label: "Round player edges",
+			defaultValue: false,
 			group: "Video Display Options",
 		}),
 		hideVideoTitle: PropTypes.bool.tag({

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -46,6 +46,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 		hideVideoTitle = false,
 		hideVideoCaption = false,
 		hideVideoCredits = false,
+		viewportPercentage = 65,
 	} = customFields;
 
 	// This is up here to prevent a lexical declaration in a case block (which throws an error). It goes with the "video" case
@@ -234,6 +235,7 @@ function parseArticleItem(item, index, arcSite, phrases, id, customFields) {
 				>
 					<Video
 						aspectRatio={videoAspectRatio}
+						viewportPercentage={viewportPercentage}
 						className="video-container"
 						embedMarkup={item.embed_html}
 					/>
@@ -462,6 +464,22 @@ ArticleBodyChain.propTypes = {
 			label: "Hide Credits",
 			defaultValue: false,
 			group: "Gallery Display Options",
+		}),
+		aspectRatio: PropTypes.oneOf(["16:9", "9:16", "1:1", "4:3"]).tag({
+			label: "Player Aspect Ratio",
+			defaultValue: "16:9",
+			group: "Video Display Options",
+			labels: {
+				"16:9": "16:9",
+				"9:16": "9:16",
+				"1:1": "1:1",
+				"4:3": "4:3",
+			},
+		}),
+		viewportPercentage: PropTypes.number.tag({
+			label: "View height percentage",
+			defaultValue: 65,
+			group: "Video Display Options",
 		}),
 		hideVideoTitle: PropTypes.bool.tag({
 			description: "This display option applies to all Videos in the Article Body",

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -479,6 +479,8 @@ ArticleBodyChain.propTypes = {
 			},
 		}),
 		viewportPercentage: PropTypes.number.tag({
+			description:
+				"Percentage of vertical space the player grabs of the viewport (Applies only for 9:16 videos)",
 			label: "View height percentage",
 			defaultValue: 65,
 			group: "Video Display Options",

--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -469,14 +469,14 @@ ArticleBodyChain.propTypes = {
 		}),
 		viewportPercentage: PropTypes.number.tag({
 			description:
-				"Percentage of vertical space the player grabs of the viewport (Applies only for 9:16 videos)",
+				"Height percentage the player takes from viewport (Applies only for 9:16 videos)",
 			label: "View height percentage",
 			defaultValue: 65,
 			group: "Video Display Options",
 		}),
 		borderRadius: PropTypes.bool.tag({
-			description: "Only valid for videos in 9:16",
-			label: "Round player edges",
+			description: "Applies only for 9:16 videos",
+			label: "Round player corners",
 			defaultValue: false,
 			group: "Video Display Options",
 		}),

--- a/blocks/article-body-block/chains/article-body/default.test.jsx
+++ b/blocks/article-body-block/chains/article-body/default.test.jsx
@@ -17,33 +17,6 @@ jest.mock("fusion:properties", () =>
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
 	isServerSide: jest.fn(),
-	getAspectRatio: (width, height) => {
-		// This arrow function is equivalent to what is in @wpmedia/arc-themes-components/src/utils/get-aspect-ratio/utils.js
-		// Helper function to find GCD
-		const gcd = (valA, valB) => {
-			let a = Math.abs(valA);
-			let b = Math.abs(valB);
-			while (b) {
-				const temp = b;
-				b = a % b;
-				a = temp;
-			}
-
-			return a;
-		};
-
-		// Return undefined if height === 0, so there is no division by zero error
-		if (height === 0) {
-			return undefined;
-		}
-
-		// Calculate the aspect ratio
-		const divisor = gcd(width, height);
-		const aspectWidth = width / divisor;
-		const aspectHeight = height / divisor;
-
-		return `${aspectWidth}:${aspectHeight}`;
-	},
 	LazyLoad: ({ children }) => <>{children}</>,
 }));
 
@@ -2289,40 +2262,6 @@ describe("article-body chain", () => {
 			const wrapper = mount(<ArticleBodyChain />);
 
 			expect(wrapper.find("Video").length).toEqual(1);
-		});
-
-		it("correctly calculates the aspect ratio of a video", () => {
-			useFusionContext.mockImplementation(() => ({
-				globalContent: {
-					_id: "NGGXZJ4HAJH5DI3SS65EVBMEMQ",
-					type: "story",
-					version: "0.10.6",
-					content_elements: [
-						{
-							_id: "TLF25CWTCBBOHOVFPK4C2RR5JA",
-							type: "video",
-							headlines: {
-								basic: "Title",
-							},
-							description: {
-								basic: "Caption",
-							},
-							promo_items: {
-								basic: {
-									width: 1000,
-									height: 500,
-								},
-							},
-						},
-					],
-				},
-				arcSite: "the-sun",
-			}));
-
-			const wrapper = mount(<ArticleBodyChain />);
-
-			expect(wrapper.find("Video")).toExist();
-			expect(wrapper.find("Video").prop("aspectRatio")).toEqual("2:1");
 		});
 	});
 

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -9,7 +9,6 @@ import {
 	Carousel,
 	formatCredits,
 	formatPowaVideoEmbed,
-	getAspectRatio,
 	Icon,
 	Image,
 	MediaItem,
@@ -97,18 +96,6 @@ export const LeadArtPresentation = (props) => {
 				playthrough: customFields?.playthrough,
 			});
 
-			let aspectRatio = customFields?.aspectRatio;
-
-			// Make sure that the content source exists and has an existing promo item
-			if (leadArt && leadArt.promo_items && leadArt.promo_items.basic) {
-				// Get the width and height of the promo item and calculate the aspect ratio
-				const width = leadArt?.promo_items.basic.width;
-				const height = leadArt?.promo_items.basic.height;
-
-				// Assign the calculated value to aspectRatio if it is non-null, otherwise assign default 16:9
-				aspectRatio = aspectRatio || getAspectRatio(width, height) || "16:9";
-			}
-
 			return (
 				<MediaItem
 					caption={!hideCaption ? leadArt?.description?.basic : null}
@@ -116,7 +103,7 @@ export const LeadArtPresentation = (props) => {
 					title={!hideTitle ? leadArt?.headlines?.basic : null}
 				>
 					<Video
-						aspectRatio={aspectRatio}
+						aspectRatio={customFields?.aspectRatio}
 						embedMarkup={embedMarkup}
 						viewportPercentage={customFields?.viewportPercentage}
 						borderRadius={customFields?.borderRadius}

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -306,7 +306,8 @@ LeadArt.propTypes = {
 			group: "Video",
 		}),
 		viewportPercentage: PropTypes.number.tag({
-			description: "Percentage of vertical space the player should grab (defaults to 65%)",
+			description:
+				"Percentage of vertical space the player grabs of the viewport (Applies only for 9:16 videos)",
 			label: "View height percentage",
 			defaultValue: 65,
 			group: "Video",

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -119,6 +119,7 @@ export const LeadArtPresentation = (props) => {
 						aspectRatio={aspectRatio}
 						embedMarkup={embedMarkup}
 						viewportPercentage={customFields?.viewportPercentage}
+						borderRadius={customFields?.borderRadius}
 					/>
 				</MediaItem>
 			);
@@ -343,6 +344,11 @@ LeadArt.propTypes = {
 			label: "Hide Credits",
 			defaultValue: false,
 			group: "Display Options",
+		}),
+		borderRadius: PropTypes.bool.tag({
+			label: "Round player edges",
+			defaultValue: false,
+			group: "Video",
 		}),
 		imageLoadingStrategy: PropTypes.oneOf(["lazy", "eager"]).tag({
 			label: "Image Loading Strategy",

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -294,7 +294,7 @@ LeadArt.propTypes = {
 		}),
 		viewportPercentage: PropTypes.number.tag({
 			description:
-				"Percentage of vertical space the player grabs of the viewport (Applies only for 9:16 videos)",
+				"Height percentage the player takes from viewport (Applies only for 9:16 videos)",
 			label: "View height percentage",
 			defaultValue: 65,
 			group: "Video",
@@ -304,9 +304,9 @@ LeadArt.propTypes = {
 				"Aspect ratio to use in player (Defaults to the aspect ratio of the resolved video)",
 			label: "Player Aspect Ratio",
 			defaultValue: "--",
-			group: "Video Display Options",
-			"--": "Video Source",
+			group: "Video",
 			labels: {
+				"--": "Video Source",
 				"16:9": "16:9",
 				"9:16": "9:16",
 				"1:1": "1:1",
@@ -335,7 +335,8 @@ LeadArt.propTypes = {
 			group: "Display Options",
 		}),
 		borderRadius: PropTypes.bool.tag({
-			label: "Round player edges",
+			label: "Round player corners",
+			description: "Applies only for 9:16 videos",
 			defaultValue: false,
 			group: "Video",
 		}),

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -299,12 +299,13 @@ LeadArt.propTypes = {
 			defaultValue: 65,
 			group: "Video",
 		}),
-		aspectRatio: PropTypes.oneOf(["16:9", "9:16", "1:1", "4:3"]).tag({
+		aspectRatio: PropTypes.oneOf(["--", "16:9", "9:16", "1:1", "4:3"]).isRequired.tag({
 			description:
 				"Aspect ratio to use in player (Defaults to the aspect ratio of the resolved video)",
 			label: "Player Aspect Ratio",
-			defaultValue: "16:9",
-			group: "Video",
+			defaultValue: "--",
+			group: "Video Display Options",
+			"--": "Video Source",
 			labels: {
 				"16:9": "16:9",
 				"9:16": "9:16",

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -97,7 +97,7 @@ export const LeadArtPresentation = (props) => {
 				playthrough: customFields?.playthrough,
 			});
 
-			let aspectRatio = "16:9"; // Default to 16:9
+			let aspectRatio = customFields?.aspectRatio;
 
 			// Make sure that the content source exists and has an existing promo item
 			if (leadArt && leadArt.promo_items && leadArt.promo_items.basic) {
@@ -106,7 +106,7 @@ export const LeadArtPresentation = (props) => {
 				const height = leadArt?.promo_items.basic.height;
 
 				// Assign the calculated value to aspectRatio if it is non-null, otherwise assign default 16:9
-				aspectRatio = getAspectRatio(width, height) || "16:9";
+				aspectRatio = aspectRatio || getAspectRatio(width, height) || "16:9";
 			}
 
 			return (
@@ -303,6 +303,25 @@ LeadArt.propTypes = {
 			label: "Playthrough",
 			defaultValue: false,
 			group: "Video",
+		}),
+		viewportPercentage: PropTypes.number.tag({
+			description: "Percentage of vertical space the player should grab (defaults to 65%)",
+			label: "View height percentage",
+			defaultValue: 65,
+			group: "Video",
+		}),
+		aspectRatio: PropTypes.oneOf(["16:9", "9:16", "1:1", "4:3"]).tag({
+			description:
+				"Aspect ratio to use in player (Defaults to the aspect ratio of the resolved video)",
+			label: "Player Aspect Ratio",
+			defaultValue: "16:9",
+			group: "Video",
+			labels: {
+				"16:9": "16:9",
+				"9:16": "9:16",
+				"1:1": "1:1",
+				"4:3": "4:3",
+			},
 		}),
 		hideTitle: PropTypes.bool.tag({
 			description:

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -2,40 +2,10 @@ import React from "react";
 import { render } from "@testing-library/react";
 import getProperties from "fusion:properties";
 import { useFusionContext } from "fusion:context";
-import { useContent } from "fusion:content";
 import LeadArt from "./default";
-
-const { mount } = require("enzyme");
 
 jest.mock("@wpmedia/arc-themes-components", () => ({
 	...jest.requireActual("@wpmedia/arc-themes-components"),
-	getAspectRatio: (width, height) => {
-		// This arrow function is equivalent to what is in @wpmedia/arc-themes-components/src/utils/get-aspect-ratio/utils.js
-		// Helper function to find GCD
-		const gcd = (valA, valB) => {
-			let a = Math.abs(valA);
-			let b = Math.abs(valB);
-			while (b) {
-				const temp = b;
-				b = a % b;
-				a = temp;
-			}
-
-			return a;
-		};
-
-		// Return undefined if height === 0, so there is no division by zero error
-		if (height === 0) {
-			return undefined;
-		}
-
-		// Calculate the aspect ratio
-		const divisor = gcd(width, height);
-		const aspectWidth = width / divisor;
-		const aspectHeight = height / divisor;
-
-		return `${aspectWidth}:${aspectHeight}`;
-	},
 	usePhrases: jest.fn(() => ({
 		t: jest.fn().mockReturnValue("gallery-expand"),
 	})),
@@ -315,29 +285,5 @@ describe("LeadArt", () => {
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
 		const { container } = render(<LeadArt customFields={{}} />);
 		expect(container.firstChild).toBeNull();
-	});
-
-	it("correctly calculates the aspect ratio of a vertical video", () => {
-		const globalContent = {
-			promo_items: {
-				lead_art: {
-					type: "video",
-					promo_items: {
-						basic: {
-							width: 49,
-							height: 49,
-						},
-					},
-				},
-			},
-		};
-
-		useFusionContext.mockImplementation(() => ({ globalContent }));
-		useContent.mockImplementation(() => globalContent);
-		const wrapper = mount(<LeadArt customFields={{}} />);
-
-		expect(useContent).toHaveBeenCalledTimes(0);
-		expect(wrapper.find("Video")).toExist();
-		expect(wrapper.find("Video").prop("aspectRatio")).toEqual("1:1");
 	});
 });

--- a/blocks/product-gallery-block/README.md
+++ b/blocks/product-gallery-block/README.md
@@ -6,8 +6,8 @@ As a Page Builder user, I want to add the Product Gallery - Arc Block to my PDP 
 
 | **Prop**               | **Required** | **Type** | **Description**                                            |
 | ---------------------- | ------------ | -------- | ---------------------------------------------------------- |
-| isFeaturedImageEnabled | no          | boolean  | Display the product’s featured image.                      |
-| indicatorType          | no          | string   | Type of indicator to be displayed, like thumbnail or dots. |
+| isFeaturedImageEnabled | no           | boolean  | Display the product’s featured image.                      |
+| indicatorType          | no           | string   | Type of indicator to be displayed, like thumbnail or dots. |
 
 ## ANS Schema
 

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -24,6 +24,7 @@ const videoLayouts = {
 	inlineVideo: ({
 		alertBadge,
 		aspectRatio,
+		viewportPercentage,
 		caption,
 		credit,
 		description,
@@ -40,7 +41,12 @@ const videoLayouts = {
 				</HeadingSection>
 			) : null}
 			<MediaItem caption={caption} credit={credit} title={!hideVideoTitle && captionTitle}>
-				<Video aspectRatio={aspectRatio} className="video-container" embedMarkup={embedMarkup} />
+				<Video
+					aspectRatio={aspectRatio}
+					viewportPercentage={viewportPercentage}
+					className="video-container"
+					embedMarkup={embedMarkup}
+				/>
 			</MediaItem>
 			{description ? <Paragraph>{description}</Paragraph> : null}
 		</Stack>
@@ -48,6 +54,7 @@ const videoLayouts = {
 	featureVideo: ({
 		alertBadge,
 		aspectRatio,
+		viewportPercentage,
 		caption,
 		credit,
 		description,
@@ -58,7 +65,12 @@ const videoLayouts = {
 	}) => (
 		<Stack className={`${BLOCK_CLASS_NAME} ${BLOCK_CLASS_NAME}__feature`}>
 			<MediaItem caption={caption} credit={credit} title={!hideVideoTitle && captionTitle}>
-				<Video aspectRatio={aspectRatio} className="video-container" embedMarkup={embedMarkup} />
+				<Video
+					aspectRatio={aspectRatio}
+					viewportPercentage={viewportPercentage}
+					className="video-container"
+					embedMarkup={embedMarkup}
+				/>
 			</MediaItem>
 			<Stack className={`${BLOCK_CLASS_NAME}__feature-meta`}>
 				{alertBadge ? <Badge variant="danger">{alertBadge}</Badge> : null}
@@ -77,6 +89,8 @@ function VideoPlayer({ customFields = {}, embedMarkup }) {
 	const {
 		alertBadge,
 		autoplay,
+		aspectRatio: videoAspectRatio,
+		viewportPercentage = 65,
 		description,
 		displayStyle = "inlineVideo",
 		hideVideoCaption,
@@ -114,10 +128,15 @@ function VideoPlayer({ customFields = {}, embedMarkup }) {
 		? contentSource?.description?.basic
 		: (title && description) || contentSource?.description?.basic;
 
-	let aspectRatio = "16:9"; // Default to 16:9 aspect ratio for videos
+	let aspectRatio = videoAspectRatio;
 
 	// Make sure that the content source exists and has an existing promo item
-	if (contentSource && contentSource.promo_items && contentSource.promo_items.basic) {
+	if (
+		!aspectRatio &&
+		contentSource &&
+		contentSource.promo_items &&
+		contentSource.promo_items.basic
+	) {
 		// Get the width and height of the promo item and calculate the aspect ratio
 		const width = contentSource?.promo_items.basic.width;
 		const height = contentSource?.promo_items.basic.height;
@@ -133,6 +152,7 @@ function VideoPlayer({ customFields = {}, embedMarkup }) {
 		? renderVideoLayout({
 				alertBadge,
 				aspectRatio,
+				viewportPercentage,
 				caption: !hideVideoCaption ? captionDescription : null,
 				credit: !hideVideoCredits ? formatCredits(contentSource?.credits) : null,
 				description,
@@ -190,6 +210,22 @@ VideoPlayer.propTypes = {
 			label: "Hide Credits",
 			defaultValue: false,
 			group: "Video Subtext Options",
+		}),
+		aspectRatio: PropTypes.oneOf(["16:9", "9:16", "1:1", "4:3"]).tag({
+			label: "Player Aspect Ratio",
+			defaultValue: "16:9",
+			group: "Display settings",
+			labels: {
+				"16:9": "16:9",
+				"9:16": "9:16",
+				"1:1": "1:1",
+				"4:3": "4:3",
+			},
+		}),
+		viewportPercentage: PropTypes.number.tag({
+			label: "View height percentage",
+			defaultValue: 65,
+			group: "Display settings",
 		}),
 		title: PropTypes.string.tag({
 			label: "Title",

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -217,11 +217,14 @@ VideoPlayer.propTypes = {
 			defaultValue: false,
 			group: "Video Subtext Options",
 		}),
-		aspectRatio: PropTypes.oneOf(["16:9", "9:16", "1:1", "4:3"]).tag({
+		aspectRatio: PropTypes.oneOf(["--", "16:9", "9:16", "1:1", "4:3"]).isRequired.tag({
+			description:
+				"Aspect ratio to use in player (Defaults to the aspect ratio of the resolved video)",
 			label: "Player Aspect Ratio",
-			defaultValue: "16:9",
-			group: "Display settings",
+			defaultValue: "--",
+			group: "Video Display Options",
 			labels: {
+				"--": "Video Source",
 				"16:9": "16:9",
 				"9:16": "9:16",
 				"1:1": "1:1",

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -222,7 +222,7 @@ VideoPlayer.propTypes = {
 				"Aspect ratio to use in player (Defaults to the aspect ratio of the resolved video)",
 			label: "Player Aspect Ratio",
 			defaultValue: "--",
-			group: "Video Display Options",
+			group: "Display Settings",
 			labels: {
 				"--": "Video Source",
 				"16:9": "16:9",
@@ -232,22 +232,23 @@ VideoPlayer.propTypes = {
 			},
 		}),
 		viewportPercentage: PropTypes.number.tag({
+			label: "View height percentage",
 			description:
-				"Percentage of vertical space the player grabs of the viewport (Applies only for 9:16 videos)",
+				"Height percentage the player takes from viewport (Applies only for 9:16 videos)",
 			defaultValue: 65,
-			group: "Display settings",
+			group: "Display Settings",
 		}),
 		title: PropTypes.string.tag({
 			label: "Title",
-			group: "Display settings",
+			group: "Display Settings",
 		}),
 		description: PropTypes.string.tag({
 			label: "Description",
-			group: "Display settings",
+			group: "Display Settings",
 		}),
 		alertBadge: PropTypes.string.tag({
 			label: "Alert Badge",
-			group: "Display settings",
+			group: "Display Settings",
 		}),
 		displayStyle: PropTypes.oneOf(Object.keys(videoLayouts)).tag({
 			defaultValue: "inlineVideo",
@@ -256,12 +257,13 @@ VideoPlayer.propTypes = {
 				inlineVideo: "Inline Video",
 				featureVideo: "Feature Video",
 			},
-			group: "Display settings",
+			group: "Display Settings",
 		}),
 		borderRadius: PropTypes.bool.tag({
-			label: "Round player edges",
+			label: "Round player corners",
+			description: "Applies only for 9:16 videos",
 			defaultValue: false,
-			group: "Display settings",
+			group: "Display Settings",
 		}),
 	}),
 	embedMarkup: PropTypes.string,

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -229,7 +229,8 @@ VideoPlayer.propTypes = {
 			},
 		}),
 		viewportPercentage: PropTypes.number.tag({
-			label: "View height percentage",
+			description:
+				"Percentage of vertical space the player grabs of the viewport (Applies only for 9:16 videos)",
 			defaultValue: 65,
 			group: "Display settings",
 		}),

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -32,6 +32,7 @@ const videoLayouts = {
 		captionTitle,
 		hideVideoTitle,
 		title,
+		borderRadius,
 	}) => (
 		<Stack className={`${BLOCK_CLASS_NAME} ${BLOCK_CLASS_NAME}__inline`}>
 			{alertBadge ? <Badge variant="danger">{alertBadge}</Badge> : null}
@@ -46,6 +47,7 @@ const videoLayouts = {
 					viewportPercentage={viewportPercentage}
 					className="video-container"
 					embedMarkup={embedMarkup}
+					borderRadius={borderRadius}
 				/>
 			</MediaItem>
 			{description ? <Paragraph>{description}</Paragraph> : null}
@@ -62,6 +64,7 @@ const videoLayouts = {
 		captionTitle,
 		hideVideoTitle,
 		title,
+		borderRadius,
 	}) => (
 		<Stack className={`${BLOCK_CLASS_NAME} ${BLOCK_CLASS_NAME}__feature`}>
 			<MediaItem caption={caption} credit={credit} title={!hideVideoTitle && captionTitle}>
@@ -70,6 +73,7 @@ const videoLayouts = {
 					viewportPercentage={viewportPercentage}
 					className="video-container"
 					embedMarkup={embedMarkup}
+					borderRadius={borderRadius}
 				/>
 			</MediaItem>
 			<Stack className={`${BLOCK_CLASS_NAME}__feature-meta`}>
@@ -98,6 +102,7 @@ function VideoPlayer({ customFields = {}, embedMarkup }) {
 		hideVideoTitle,
 		inheritGlobalContent,
 		playthrough,
+		borderRadius,
 		title,
 		websiteURL,
 	} = customFields;
@@ -163,6 +168,7 @@ function VideoPlayer({ customFields = {}, embedMarkup }) {
 				captionTitle,
 				hideVideoTitle,
 				title,
+				borderRadius,
 		  })
 		: null;
 }
@@ -246,6 +252,11 @@ VideoPlayer.propTypes = {
 				inlineVideo: "Inline Video",
 				featureVideo: "Feature Video",
 			},
+			group: "Display settings",
+		}),
+		borderRadius: PropTypes.bool.tag({
+			label: "Round player edges",
+			defaultValue: false,
 			group: "Display settings",
 		}),
 	}),


### PR DESCRIPTION
## Description
This PR is part of the effort of DAM to give an improved experience in vertical videos across Arc products. it's summarized with this changes:

### article body
- Added new custom fields: `viewportPercentage`, `borderRadius` & `aspectRatio`.
- The aspect ratio of the video is now resolved on the video component or from the user input through the aspectRatio field.

### leadart
- Added new custom fields: `viewportPercentage`, `borderRadius` & `aspectRatio`.
- The aspect ratio of the video is now resolved on the video component or from the user input through the aspectRatio field.

### video-player
- Added new custom fields: `viewportPercentage`, `borderRadius` & `aspectRatio`.

### About the new fields
This three blocks have the same fields and shares the same behavior. Here is a description of each one and what should expect when you interact with them.

**Player Aspect Ratio** -  Handles the aspect-ratio to render for the video player. When you select a value, the block refreshes with the video player rendering at the selected aspect ratio. "Video source" and "--" values renders the player at the aspect ratio of the video. For videos in 9:16 the black background is replaced by a transparent one and the captions gets aligned at the middle of the block.

**View height percentage** - Handles the height percentage the player takes from viewport. The default value is 65. This field only applies for videos in 9:16; videos in other formats takes the 65%.

**Round player corners** - Enables the video player to render with rounded corners. This field only applies for videos in 9:16, videos in other formats render with straight edges.


## Jira Ticket

- [DAM-7996](https://arcpublishing.atlassian.net/browse/DAM-7996)

## Acceptance Criteria
- Users can use the original aspect ratio of the video or use a specific one in the player.
- Users can round the corners only for videos in the 9:16 aspect-ratio.
- Users can modify the height of the video player only for videos in the 9:16 aspect-ratio.

## Test Steps

### Setup
1. Go to `@wpmedia/arc-themes-components` repo
2. Checkout to the **DAM-7996** branch:  `git checkout DAM-7996`
3. Go back to this repo `@wpmedia/arc-themes-blocks`
4. Checkout to the **DAM-7996** branch: `git checkout DAM-7996`
5. Run fusion repo with linked blocks: `npx fusion start -f -l @wpmedia/article-body-block,@wpmedia/lead-art-block,@wpmedia/video-player-block`
6. Create a new Page.
7. Choose `Advanced Right Left` as the **layout**, under the **setup** menu
8. Go to the **curate** menu, And under the **fullwidth1** section of the **Blocks** submenu  Insert the **Article Body**, **Lead Art** and **Video Player** blocks
9. Go to the **Global Content** section, select `content-api` as content source and put `/test/2023/04/06/story-with-video-featured-media/` in the **website_url**. Press the update button.
10. Go to the website selector and choose `The Gazette`

### Article Body
1. Select the article body block.
2. Go to the **Video Display Options** submenu inside the **chain configurations** section
3. The new added fields should be displayed
<img width="331" alt="image" src="https://github.com/WPMedia/arc-themes-blocks/assets/90630582/fa0b1356-0ea9-42d7-8fc3-d5ca30e302df">

4. Interact with the fields.

### Lead Art
1. Select the Lead Art block.
2. Go to the **Video** submenu inside the **Custom Fields** section
3. The new added fields should be displayed:
<img width="334" alt="image" src="https://github.com/WPMedia/arc-themes-blocks/assets/90630582/3c419bb5-a4de-484f-9454-0faac4673abb">

4. Interact with the fields.

### Video Player
1. Select the Video Player block.
2. Go to the **Display settings** submenu inside the **Custom Fields** section
3. The new added fields should be displayed:
<img width="330" alt="image" src="https://github.com/WPMedia/arc-themes-blocks/assets/90630582/4221179b-85b6-4de5-ba4f-de6de723aa90">

4. Interact with the fields.


## Effect Of Changes

### Before

#### Video Player
<img width="1342" alt="image" src="https://github.com/WPMedia/arc-themes-blocks/assets/90630582/655287c6-9f01-4f47-a11c-eb380ec54dc7">
No inputs to manage introduced features.

#### Article Body
<img width="1342" alt="image" src="https://github.com/WPMedia/arc-themes-blocks/assets/90630582/97dd7e8a-36d4-486b-b0e0-141f5e3cb529">
No inputs to manage introduced features.

#### Lead Art
<img width="1342" alt="image" src="https://github.com/WPMedia/arc-themes-blocks/assets/90630582/e25be6a4-c8cf-4637-a37f-15d3f1fbfc90">
No inputs to manage introduced features.

### After

#### Video Player
![video-player](https://github.com/WPMedia/arc-themes-blocks/assets/90630582/0ee1fc41-c129-40cd-819a-09e8ee732cdf)

#### Article Body
![article-body](https://github.com/WPMedia/arc-themes-blocks/assets/90630582/09902641-eb7a-4ba0-b71e-9973e66a6013)

#### Lead Art
![lead-art](https://github.com/WPMedia/arc-themes-blocks/assets/90630582/cdcefc7d-7a5a-4db5-9cda-e8418317e8b9)


## Dependencies or Side Effects
- This PR depends on this changes in the video component: https://github.com/WPMedia/arc-themes-components/pull/212.

## Author Checklist
- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
- [x] Confirmed this PR has unit test files
- [x] Ran `npm run test`, made sure all tests are passing
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.

[DAM-7996]: https://arcpublishing.atlassian.net/browse/DAM-7996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ