### PR TITLE
Correct label casing for aspectRatio fields - DAM-7996

### DIFF
--- a/blocks/article-body-block/chains/article-body/default.jsx
+++ b/blocks/article-body-block/chains/article-body/default.jsx
@@ -456,7 +456,7 @@ ArticleBodyChain.propTypes = {
 		aspectRatio: PropTypes.oneOf(["--", "16:9", "9:16", "1:1", "4:3"]).isRequired.tag({
 			description:
 				"Aspect ratio to use in player (Defaults to the aspect ratio of the resolved video)",
-			label: "Player Aspect Ratio",
+			label: "Player aspect ratio",
 			defaultValue: "--",
 			group: "Video Display Options",
 			labels: {

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -302,7 +302,7 @@ LeadArt.propTypes = {
 		aspectRatio: PropTypes.oneOf(["--", "16:9", "9:16", "1:1", "4:3"]).isRequired.tag({
 			description:
 				"Aspect ratio to use in player (Defaults to the aspect ratio of the resolved video)",
-			label: "Player Aspect Ratio",
+			label: "Player aspect ratio",
 			defaultValue: "--",
 			group: "Video",
 			labels: {

--- a/blocks/video-player-block/features/video-player/default.jsx
+++ b/blocks/video-player-block/features/video-player/default.jsx
@@ -220,7 +220,7 @@ VideoPlayer.propTypes = {
 		aspectRatio: PropTypes.oneOf(["--", "16:9", "9:16", "1:1", "4:3"]).isRequired.tag({
 			description:
 				"Aspect ratio to use in player (Defaults to the aspect ratio of the resolved video)",
-			label: "Player Aspect Ratio",
+			label: "Player aspect ratio",
 			defaultValue: "--",
 			group: "Display Settings",
 			labels: {


### PR DESCRIPTION
This PR addresses the observations made in DQA for [DAM-7996](https://github.com/WPMedia/arc-themes-blocks/pull/1747):

- Correct label casing for the aspectRatio field in the three modified blocks.

[DAM-7996]: https://arcpublishing.atlassian.net/browse/DAM-7996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ