### PR TITLE
Updated twitter icon color

### DIFF
--- a/blocks/share-bar-block/features/share-bar/default.jsx
+++ b/blocks/share-bar-block/features/share-bar/default.jsx
@@ -69,7 +69,7 @@ function getLogoComponent(type) {
 		case "pinterest":
 			return <PinterestAltIcon fill="#BD081C" />;
 		case "twitter":
-			return <TwitterIcon fill="#1DA1F2" />;
+			return <TwitterIcon fill="#384355" />;
 		default:
 		case "email":
 			return <EnvelopeIcon fill="#C72A22" />;
@@ -126,7 +126,7 @@ export const ShareBar = ({
 					onClick={() => share[social](encodedUrl, encodedTitle, websiteName)}
 				>
 					{getLogoComponent(social)}
-				</button>
+				</button>,
 			);
 		}
 	});


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description

update twitter icon color on hover

## Jira Ticket

- [THEMES-1440](https://arcpublishing.atlassian.net/browse/THEMES-1440)

## Acceptance Criteria

Update twitter icon

## Test Steps

1. Checkout this branch `git checkout THEMES-1440-twitter-share-bar`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/share-bar-block`
3. Check for twitter icon 

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1440]: https://arcpublishing.atlassian.net/browse/THEMES-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ