### PR TITLE
ASUB-7844 Fix issue where identity is not defined in paymentInfo

### DIFF
--- a/blocks/subscriptions-block/features/checkout/_children/PaymentInfo/index.jsx
+++ b/blocks/subscriptions-block/features/checkout/_children/PaymentInfo/index.jsx
@@ -5,7 +5,7 @@ import useSales from "../../../../components/useSales";
 import PayPal from "../../../../components/PayPal";
 import { LABEL_ORDER_NUMBER_PAYPAL } from "../../default";
 
-import { usePhrases, Heading, HeadingSection, Paragraph } from "@wpmedia/arc-themes-components";
+import { usePhrases, Heading, HeadingSection, Paragraph, useIdentity } from "@wpmedia/arc-themes-components";
 
 import PaymentForm from "../../../../components/PaymentForm";
 
@@ -20,7 +20,8 @@ const PaymentInfo = ({
 	isInitialized
 }) => {
 	const { Sales } = useSales();
-	window.Sales = Sales;
+	const { Identity } = useIdentity();
+
 	const [stripeInstance, setStripeInstance] = useState(null);
 
 	const [isStripeInitialized, setIsStripeInitialized] = useState(false);


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description

Getting `Identity` undefined when clicking paypal button. 

<img width="778" alt="Screenshot 2023-12-05 at 12 46 33 PM" src="https://github.com/WPMedia/arc-themes-blocks/assets/67028780/741a81bc-111e-4934-ba88-311f9913e06f">

## Jira Ticket

- [THEMES-](https://arcpublishing.atlassian.net/browse/THEMES-)

## Acceptance Criteria

_copy from ticket_

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout {branch name}`
2. Run fusion repo with linked blocks `npx fusion start -f -l {blocks to link}`
3. {Next ....}

## Effect Of Changes

### Before

_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After

_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects

_Examples of dependencies or side effects are:_

- Manifest pr for new block:
- Feature pack pr for local development:
- How to deploy to news: https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3138682964/News+Theme+2.0+Migration+Development+Deployment+Notes
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Dependency on another PR that needs to be merged first

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
