### PR TITLE
Fix large promo test

### DIFF
--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -281,12 +281,12 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 		fallbackImage,
 	} = getProperties(arcSite);
 
-	const displayDate = content?.display_date ? localizeDateTime(
+	const displayDate = content?.display_date && Date.parse(content?.display_date) ? localizeDateTime(
 		new Date(content?.display_date),
 		dateTimeFormat,
 		language,
 		timeZone
-	) : null;
+	) : "";
 	const phrases = usePhrases();
 
 	const editableDescription = content?.description

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -281,12 +281,12 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 		fallbackImage,
 	} = getProperties(arcSite);
 
-	const displayDate = localizeDateTime(
+	const displayDate = content?.display_date ? localizeDateTime(
 		new Date(content?.display_date),
 		dateTimeFormat,
 		language,
 		timeZone
-	);
+	) : null;
 	const phrases = usePhrases();
 
 	const editableDescription = content?.description

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -93,7 +93,7 @@ jest.mock("@wpmedia/arc-themes-components", () => ({
 }));
 
 jest.mock("fusion:content", () => ({
-	useContent: jest.fn(() => largePromoMock),
+	useContent: jest.fn(() => ({})),
 	useEditableContent: jest.fn(() => ({
 		editableContent: () => {},
 		searchableField: () => {},
@@ -103,10 +103,10 @@ jest.mock("fusion:content", () => ({
 describe("Large Promo", () => {
 	afterEach(() => {
 		jest.resetModules();
-		jest.clearAllMocks();
 	});
 
 	it("should return null if lazyLoad on the server and not in the admin", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		const updatedConfig = {
 			lazyLoad: true,
 		};
@@ -116,6 +116,7 @@ describe("Large Promo", () => {
 	});
 
 	it("should render complete promo", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		render(
 			<LargePromo
 				customFields={{
@@ -137,6 +138,7 @@ describe("Large Promo", () => {
 	});
 
 	it("should not render overline", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		render(
 			<LargePromo
 				customFields={{
@@ -156,7 +158,8 @@ describe("Large Promo", () => {
 		expect(screen.queryByRole("img")).not.toBeNull();
 	});
 
-	it("should not render date", () => {
+	it("should not render date when disabled", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		render(
 			<LargePromo
 				customFields={{
@@ -176,7 +179,33 @@ describe("Large Promo", () => {
 		expect(screen.queryByRole("img")).not.toBeNull();
 	});
 
+	it.only("should not render date when null", () => {
+		useContent.mockReturnValueOnce({
+			owner: {
+				sponsored: true,
+			},
+			headlines: {
+				basic: "Baby panda born at the zoo",
+			},
+		});
+		render(
+			<LargePromo
+				customFields={{
+					showByline: true,
+					showDate: true,
+					showDescription: false,
+					showHeadline: true,
+					showImage: false,
+					imageRatio: "4:3",
+					showOverline: true,
+				}}
+			/>,
+		);
+		expect(screen.queryByText("December 02, 2019 at 6:58PM UTC")).toBeNull();
+	});
+
 	it("should not render byline", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		render(
 			<LargePromo
 				customFields={{
@@ -197,6 +226,7 @@ describe("Large Promo", () => {
 	});
 
 	it("should not render headline", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		render(
 			<LargePromo
 				customFields={{
@@ -217,6 +247,7 @@ describe("Large Promo", () => {
 	});
 
 	it("should not render description", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		render(
 			<LargePromo
 				customFields={{
@@ -237,6 +268,7 @@ describe("Large Promo", () => {
 	});
 
 	it("should only render Image", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		render(
 			<LargePromo
 				customFields={{
@@ -253,6 +285,7 @@ describe("Large Promo", () => {
 	});
 
 	it('should not render Image if "showImage" is false', () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		render(
 			<LargePromo
 				customFields={{
@@ -265,6 +298,7 @@ describe("Large Promo", () => {
 	});
 
 	it("should make a blank call to the signing-service if the image is from PhotoCenter and has an Auth value", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		const config = {
 			imageOverrideAuth: "test hash",
 			imageOverrideURL: "test_id=123",
@@ -277,6 +311,7 @@ describe("Large Promo", () => {
 	});
 
 	it("should make a call to the signing-service if the image is from PhotoCenter but does not have an Auth value", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		const config = {
 			imageOverrideAuth: "",
 			imageOverrideURL: "test_id=123",
@@ -292,6 +327,7 @@ describe("Large Promo", () => {
 	});
 
 	it("should make a call to the signing-service if the image is not from PhotoCenter", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
 		const config = {
 			imageOverrideAuth: "",
 			imageOverrideURL: "test_id=123",
@@ -314,6 +350,7 @@ describe("Large Promo", () => {
 			headlines: {
 				basic: "Baby panda born at the zoo",
 			},
+			display_date: "2019-12-02T18:58:11.638Z",
 		});
 		render(
 			<LargePromo
@@ -332,10 +369,11 @@ describe("Large Promo", () => {
 		expect(screen.queryByText("global.sponsored-content")).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.headlines.basic)).not.toBeNull();
 		expect(screen.queryByText(largePromoMock.description.basic)).toBeNull();
-		expect(screen.queryByText("December 02, 2019 at 6:58PM UTC")).toBeNull();
 	});
 
 	it("should render image icon label", () => {
+		useContent.mockReturnValueOnce(largePromoMock);
+
 		const { container } = render(
 			<LargePromo
 				customFields={{

--- a/blocks/large-promo-block/features/large-promo/default.test.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.test.jsx
@@ -179,7 +179,7 @@ describe("Large Promo", () => {
 		expect(screen.queryByRole("img")).not.toBeNull();
 	});
 
-	it.only("should not render date when null", () => {
+	it("should not render date when null", () => {
 		useContent.mockReturnValueOnce({
 			owner: {
 				sponsored: true,

--- a/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
@@ -60,12 +60,12 @@ const Large = (props) => {
 		},
 	} = getProperties(arcSite);
 
-	const displayDate = localizeDateTime(
+	const displayDate = Date.parse(element?.display_date) ? localizeDateTime(
 		new Date(element?.display_date),
 		dateTimeFormat,
 		language,
 		timeZone
-	);
+	) : "";
 	const phrases = usePhrases();
 
 	const videoOrGalleryContent =


### PR DESCRIPTION
## Description
GitHub CI had a failing test in lg promo. Running it locally showed a single test using mockReturnValueOnce was getting the module level mock. 

Switched to doing a mock return in each unit test. Showed a test failing where the localizeDateTime was taking in an undefined display_date causing the new method for localization to fail. If you pass in null it'll set the date to 1970. So a check was added before even calling localizeDateTime that there must be a value, else "" so the rest of the code can just not render the component.

## Jira Ticket

- [THEMES-](https://arcpublishing.atlassian.net/browse/THEMES-)

## Acceptance Criteria

_copy from ticket_

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout {branch name}`
2. Run fusion repo with linked blocks `npx fusion start -f -l {blocks to link}`
3. {Next ....}

## Effect Of Changes

### Before

_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After

_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects

_Examples of dependencies or side effects are:_

- Manifest pr for new block:
- Feature pack pr for local development:
- How to deploy to news: https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3138682964/News+Theme+2.0+Migration+Development+Deployment+Notes
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Dependency on another PR that needs to be merged first

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
