### PR TITLE
THEMES-1577: Card list block - show time

### DIFF
--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -17,7 +17,7 @@ import {
 	isServerSide,
 	LazyLoad,
 	Link,
-	localizeDate,
+	localizeDateTime,
 	Overline,
 	Separator,
 	Stack,
@@ -48,7 +48,7 @@ const CardListItems = (props) => {
 		dateLocalization: { language, timeZone, dateFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateFormat: "%B %d, %Y",
+			dateFormat: "%B %d, %Y at %l:%M%p %Z",
 		},
 	} = props;
 	const phrases = usePhrases();
@@ -135,7 +135,7 @@ const CardListItems = (props) => {
 
 	const sourceContent = contentElements[0];
 
-	const displayDate = localizeDate(sourceContent.display_date, dateFormat, language, timeZone);
+	const displayDate = localizeDateTime(sourceContent.display_date, dateFormat, language, timeZone);
 
 	/* Author Formatting */
 	const bylineNodes = formatAuthors(sourceContent?.credits?.by, phrases.t("global.and-text"));
@@ -210,7 +210,7 @@ const CardListItems = (props) => {
 									{hasAuthor ? (
 										<>
 											<span>{phrases.t("global.by-text")}</span> <span>{bylineNodes}</span>
-											<Separator />
+											<Separator data-testid="card-list-separator" />
 										</>
 									) : null}
 									<Date dateTime={sourceContent.display_date} dateString={displayDate} />

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -1,274 +1,218 @@
-describe("This test is disabled", () => {
-	it("should succeed", () => {
-		expect(true);
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import getThemeStyle from "fusion:themes";
+import { useContent } from "fusion:content";
+import { useFusionContext } from "fusion:context";
+import mockData, { oneListItem, oneListItemDisplayLabel, twoListItemNoSiteUrl } from "./mock-data";
+import CardList from "./default";
+
+jest.mock("@wpmedia/arc-themes-components", () => ({
+	...jest.requireActual("@wpmedia/arc-themes-components"),
+	isServerSide: jest.fn(() => true),
+	LazyLoad: ({ children }) => children,
+	localizeDateTime: jest.fn(() => "date"),
+}));
+
+jest.mock("fusion:content", () => ({
+	useContent: jest.fn(() => mockData),
+}));
+
+jest.mock("fusion:context", () => ({
+	useFusionContext: jest.fn(() => ({
+		id: "",
+		arcSite: "the-sun",
+		deployment: jest.fn(() => {}),
+	})),
+}));
+
+describe("Card list", () => {
+	it("should render null if isServerSide and lazyLoad enabled", () => {
+		const listContentConfig = {
+			contentConfigValues: {
+				offset: "0",
+				query: "type:story",
+				size: "30",
+			},
+			contentService: "story-feed-query",
+		};
+		const customFields = {
+			listContentConfig,
+			lazyLoad: true,
+		};
+
+		useFusionContext.mockReturnValueOnce({
+			id: "",
+			arcSite: "the-sun",
+			deployment: jest.fn(() => {}),
+		});
+
+		const { container } = render(<CardList customFields={customFields} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("it should not render anything if no list of stories", () => {
+		const listContentConfig = {
+			contentConfigValues: {
+				offset: "0",
+				query: "type:story",
+				size: "10",
+			},
+			contentService: "fake-service",
+		};
+		const customFields = {
+			listContentConfig,
+			offsetOverride: 100,
+		};
+		useContent.mockReturnValueOnce(null);
+
+		render(<CardList customFields={customFields} />);
+
+		expect(screen.queryByRole("article")).toBeNull();
+	});
+
+	it("should render a list of stories", () => {
+		const listContentConfig = {
+			contentConfigValues: {
+				offset: "0",
+				query: "type:story",
+				size: "30",
+			},
+			contentService: "story-feed-query",
+		};
+		const customFields = { listContentConfig };
+
+		render(<CardList customFields={customFields} />);
+		expect(screen.getAllByRole("article").length).toEqual(9);
+	});
+
+	it("should only render amount of stories based on displayAmount", () => {
+		const listContentConfig = {
+			contentConfigValues: {
+				offset: "0",
+				query: "type:story",
+				size: "30",
+			},
+			contentService: "story-feed-query",
+		};
+		const customFields = { listContentConfig, displayAmount: 5 };
+
+		render(<CardList customFields={customFields} />);
+		expect(screen.getAllByRole("article").length).toEqual(5);
+	});
+
+	it("should render first item based on offsetOverride", () => {
+		const listContentConfig = {
+			contentConfigValues: {
+				offset: "0",
+				query: "type:story",
+				size: "30",
+			},
+			contentService: "story-feed-query",
+		};
+		const customFields = { listContentConfig, offsetOverride: 1 };
+
+		render(<CardList customFields={customFields} />);
+
+		expect(screen.getByText("2nd Story Title")).not.toBeNull();
+	});
+
+	it("should render a list of stories only for the arcSite", () => {
+		const listContentConfig = {
+			contentConfigValues: {
+				offset: "0",
+				query: "type:story",
+				size: "30",
+			},
+			contentService: "story-feed-query",
+		};
+		const customFields = { listContentConfig };
+
+		jest.mock("fusion:context", () => ({
+			useFusionContext: jest.fn(() => ({
+				arcSite: "the-mercury",
+				deployment: jest.fn(() => {}),
+			})),
+		}));
+		useContent.mockReturnValueOnce(oneListItem);
+		render(<CardList customFields={customFields} />);
+		expect(screen.getAllByRole("article").length).toEqual(1);
+	});
+
+	describe("renders the main list item correctly", () => {
+		const setup = () => {
+			const listContentConfig = {
+				contentConfigValues: {
+					offset: "0",
+					query: "type:story",
+					size: "1",
+				},
+				contentService: "story-feed-query",
+			};
+			const title = "Test Title";
+			const customFields = { listContentConfig, title };
+	
+			getThemeStyle.mockImplementation(() => ({
+				"primary-font-family": "Papyrus",
+			}));
+	
+			useContent.mockReturnValueOnce(oneListItem);
+			render(<CardList customFields={customFields} />);
+		};
+		
+
+		it("should render a title with the right text", () => {
+			setup();
+			expect(screen.getByText("Test Title")).not.toBeNull();
+		});
+
+		it("should render anchor tags", () => {
+			setup();
+			const links = screen.getAllByRole("link");
+			expect(links.length).toEqual(2);
+			expect(links[0]).toHaveAttribute("href", "/this/is/the/correct/url");
+		});
+
+		it("should render one image", () => {
+			setup();
+			expect(screen.getByRole("img", {hidden: true})).not.toBeNull();
+		});
+
+		it("should render an overline", () => {
+			setup();
+			expect(screen.getByText("global.sponsored-content")).not.toBeNull();
+		});
+
+		it("should render a main headline", () => {
+			setup();
+			expect(screen.getByText("Article with a YouTube embed in it")).not.toBeNull();
+		});
+
+		it("should render a byline", () => {
+			setup();
+			expect(screen.getByText("global.by-text")).not.toBeNull();
+		});
+
+		it("should render a separator", () => {
+			setup();
+			expect(screen.getByTestId("card-list-separator")).not.toBeNull();
+		});
+
+		it("should render a publish date", () => {
+			setup();
+			expect(screen.getByText("date")).not.toBeNull();
+		});
+	});
+
+	it("should render an overline using the label data if sourceContent.label.display is true and there is no owner", () => {
+		useContent.mockReturnValueOnce(oneListItemDisplayLabel);
+		render(<CardList customFields={{}} />);
+		expect(screen.getByText("Display Label")).not.toBeNull();
+	});
+
+	it("render one list item without a secondary item for a bad site website_url", () => {
+		useContent.mockReturnValueOnce(twoListItemNoSiteUrl);
+		render(<CardList customFields={{}} />);
+		expect(screen.getAllByRole("article").length).toEqual(1);
 	});
 });
-
-// import React from "react";
-// import { mount } from "enzyme";
-// import getThemeStyle from "fusion:themes";
-// import { useContent } from "fusion:content";
-// import { useFusionContext } from "fusion:context";
-// import mockData, { oneListItem, oneListItemDisplayLabel, twoListItemNoSiteUrl } from "./mock-data";
-// import CardList from "./default";
-
-// jest.mock("@wpmedia/arc-themes-components", () => ({
-// 	...jest.requireActual("@wpmedia/arc-themes-components"),
-// 	isServerSide: jest.fn(() => true),
-// 	LazyLoad: ({ children }) => children,
-// 	localizeDate: jest.fn(() => "date"),
-// }));
-
-// jest.mock("fusion:content", () => ({
-// 	useContent: jest.fn(() => mockData),
-// }));
-
-// jest.mock("fusion:context", () => ({
-// 	useFusionContext: jest.fn(() => ({
-// 		id: "",
-// 		arcSite: "the-sun",
-// 		deployment: jest.fn(() => {}),
-// 	})),
-// }));
-
-// describe("Card list", () => {
-// 	it("should render null if isServerSide and lazyLoad enabled", () => {
-// 		const listContentConfig = {
-// 			contentConfigValues: {
-// 				offset: "0",
-// 				query: "type:story",
-// 				size: "30",
-// 			},
-// 			contentService: "story-feed-query",
-// 		};
-// 		const customFields = {
-// 			listContentConfig,
-// 			lazyLoad: true,
-// 		};
-
-// 		useFusionContext.mockReturnValueOnce({
-// 			id: "",
-// 			arcSite: "the-sun",
-// 			deployment: jest.fn(() => {}),
-// 		});
-
-// 		const wrapper = mount(<CardList customFields={customFields} />);
-// 		expect(wrapper.html()).toBe(null);
-// 	});
-
-// 	it("it should not render anything if no list of stories", () => {
-// 		const listContentConfig = {
-// 			contentConfigValues: {
-// 				offset: "0",
-// 				query: "type:story",
-// 				size: "10",
-// 			},
-// 			contentService: "fake-service",
-// 		};
-// 		const customFields = {
-// 			listContentConfig,
-// 			offsetOverride: 100,
-// 		};
-// 		useContent.mockReturnValueOnce(null);
-
-// 		const wrapper = mount(<CardList customFields={customFields} />);
-
-// 		expect(wrapper.find("Stack.b-card-list__secondary-item").length).toEqual(0);
-// 	});
-
-// 	it("should render a list of stories", () => {
-// 		const listContentConfig = {
-// 			contentConfigValues: {
-// 				offset: "0",
-// 				query: "type:story",
-// 				size: "30",
-// 			},
-// 			contentService: "story-feed-query",
-// 		};
-// 		const customFields = { listContentConfig };
-
-// 		const wrapper = mount(<CardList customFields={customFields} />);
-// 		expect(wrapper.find("Stack.b-card-list__secondary-item").length).toEqual(8);
-// 	});
-
-// 	it("should only render amount of stories based on displayAmount", () => {
-// 		const listContentConfig = {
-// 			contentConfigValues: {
-// 				offset: "0",
-// 				query: "type:story",
-// 				size: "30",
-// 			},
-// 			contentService: "story-feed-query",
-// 		};
-// 		const customFields = { listContentConfig, displayAmount: 5 };
-
-// 		const wrapper = mount(<CardList customFields={customFields} />);
-// 		expect(wrapper.find("Stack.b-card-list__secondary-item").length).toEqual(4);
-// 	});
-
-// 	it("should render first item based on offsetOverride", () => {
-// 		const listContentConfig = {
-// 			contentConfigValues: {
-// 				offset: "0",
-// 				query: "type:story",
-// 				size: "30",
-// 			},
-// 			contentService: "story-feed-query",
-// 		};
-// 		const customFields = { listContentConfig, offsetOverride: 1 };
-
-// 		const wrapper = mount(<CardList customFields={customFields} />);
-
-// 		expect(wrapper.find("Stack.b-card-list__main-item-text-container .c-heading").text()).toBe(
-// 			"2nd Story Title"
-// 		);
-// 	});
-
-// 	it("should render a list of stories only for the arcSite", () => {
-// 		const listContentConfig = {
-// 			contentConfigValues: {
-// 				offset: "0",
-// 				query: "type:story",
-// 				size: "30",
-// 			},
-// 			contentService: "story-feed-query",
-// 		};
-// 		const customFields = { listContentConfig };
-
-// 		jest.mock("fusion:context", () => ({
-// 			useFusionContext: jest.fn(() => ({
-// 				arcSite: "the-mercury",
-// 				deployment: jest.fn(() => {}),
-// 			})),
-// 		}));
-// 		useContent.mockReturnValueOnce(oneListItem);
-// 		const wrapper = mount(<CardList customFields={customFields} />);
-// 		expect(wrapper.find("Stack.b-card-list").length).toEqual(1);
-// 		expect(wrapper.find("Stack.b-card-list__secondary-item").length).toEqual(0);
-// 	});
-
-// 	describe("renders the main list item correctly", () => {
-// 		const listContentConfig = {
-// 			contentConfigValues: {
-// 				offset: "0",
-// 				query: "type:story",
-// 				size: "1",
-// 			},
-// 			contentService: "story-feed-query",
-// 		};
-// 		const title = "Test Title";
-// 		const customFields = { listContentConfig, title };
-
-// 		getThemeStyle.mockImplementation(() => ({
-// 			"primary-font-family": "Papyrus",
-// 		}));
-
-// 		useContent.mockReturnValueOnce(oneListItem);
-// 		const wrapper = mount(<CardList customFields={customFields} />);
-
-// 		it("should have one parent wrapper", () => {
-// 			expect(wrapper.find("Stack.b-card-list").length).toEqual(1);
-// 		});
-
-// 		it("should render a title with the right text", () => {
-// 			expect(wrapper.find(".b-card-list__title").first().text()).toEqual("Test Title");
-// 		});
-
-// 		it("should render two anchor tags - one around image one for the title", () => {
-// 			expect(wrapper.find(".b-card-list__main-item-image-link").length).toEqual(2);
-// 			expect(wrapper.find(".b-card-list__main-item-image-link").find("Image").length).toEqual(1);
-// 		});
-
-// 		it("should render one image wrapped in an anchor tag", () => {
-// 			expect(wrapper.find(".b-card-list__main-item-image-link Image").length).toEqual(1);
-// 		});
-
-// 		it("should render an anchor ", () => {
-// 			expect(wrapper.find(".b-card-list__main-item-image-link").at(0).find("a").length).toEqual(1);
-// 		});
-
-// 		it("should render an anchor and an image with the correct url", () => {
-// 			const anchors = wrapper.find(".c-link");
-// 			expect(anchors.at(0).prop("href")).toEqual("/this/is/the/correct/url");
-// 			expect(anchors.at(1).prop("href")).toEqual("/this/is/the/correct/url");
-// 		});
-
-// 		it("should render an overline", () => {
-// 			expect(wrapper.find(".c-overline").length).toEqual(1);
-// 		});
-
-// 		it("should render a main headline", () => {
-// 			expect(wrapper.find(".b-card-list__main-item-text-container Heading").text()).toBe(
-// 				"Article with a YouTube embed in it"
-// 			);
-// 		});
-
-// 		it("should render a byline", () => {
-// 			expect(wrapper.find(".c-attribution").length).toEqual(1);
-// 		});
-
-// 		it("should render a separator", () => {
-// 			expect(wrapper.find(".c-separator").length).toEqual(1);
-// 		});
-
-// 		it("should render a publish date", () => {
-// 			expect(wrapper.find(".c-date").length).toEqual(1);
-// 		});
-// 	});
-
-// 	describe("render one list item correctly", () => {
-// 		const listContentConfig = {
-// 			contentConfigValues: {
-// 				offset: "0",
-// 				query: "type:story",
-// 				size: "1",
-// 			},
-// 			contentService: "story-feed-query",
-// 		};
-// 		const title = "Test Title";
-// 		const customFields = { listContentConfig, title };
-
-// 		const wrapper = mount(<CardList customFields={customFields} />);
-
-// 		it("should render one parent wrapper", () => {
-// 			expect(wrapper.find("Stack.b-card-list").length).toEqual(1);
-// 		});
-
-// 		it("should render a parent for headline and a description", () => {
-// 			expect(wrapper.find("Stack.b-card-list__secondary-item").length).toEqual(8);
-// 		});
-
-// 		it("should render a headline", () => {
-// 			expect(wrapper.find(".b-card-list__secondary-item-heading-link .c-heading").length).toEqual(
-// 				8
-// 			);
-
-// 			expect(wrapper.find(".b-card-list__secondary-item-heading-link").first().text()).toEqual(
-// 				"2nd Story Title"
-// 			);
-// 			expect(wrapper.find(".b-card-list__secondary-item-heading-link").at(0).prop("href")).toEqual(
-// 				"/this/is/the/correct/url"
-// 			);
-// 		});
-// 	});
-
-// 	describe("render one list item with display label overline", () => {
-// 		useContent.mockReturnValueOnce(oneListItemDisplayLabel);
-
-// 		const wrapper = mount(<CardList customFields={{}} />);
-
-// 		it("should render an overline using the label data if sourceContent.label.display is true and there is no owner", () => {
-// 			expect(wrapper.find(".c-overline").text()).toEqual("Display Label");
-// 		});
-// 	});
-
-// 	describe("render one list item without a secondary item for a bad site website_url", () => {
-// 		useContent.mockReturnValueOnce(twoListItemNoSiteUrl);
-
-// 		const wrapper = mount(<CardList customFields={{}} />);
-
-// 		it("should render an overline using the label data if sourceContent.label.display is true and there is no owner", () => {
-// 			expect(wrapper.find(".b-card-list__secondary-item")).not.toExist();
-// 		});
-// 	});
-// });

--- a/blocks/card-list-block/themes/news.json
+++ b/blocks/card-list-block/themes/news.json
@@ -34,7 +34,7 @@
 					"separator": {
 						"padding-block-end": "0",
 						"padding-block-start": "0",
-						"paddinginline-end": "var(--global-spacing-2)",
+						"padding-inline-end": "var(--global-spacing-2)",
 						"padding-inline-start": "var(--global-spacing-2)"
 					},
 					"stack": {


### PR DESCRIPTION
## Description

This PR updates the card list block to use date and time, instead of just the date. The unit tests were also updated to use React Testing Library and account for the code change.

## Jira Ticket

- [THEMES-1577](https://arcpublishing.atlassian.net/browse/THEMES-1577)

## Acceptance Criteria

In card list block, the time should display next to the date.

## Test Steps

1. Checkout this branch `git checkout THEMES-1577`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/card-list-block`
3. Add a Card list block to a page. The first item should now show the full date and time, instead of just the date.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1577]: https://arcpublishing.atlassian.net/browse/THEMES-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ