### PR TITLE
Fixed results list paragraph margin

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -3970,18 +3970,19 @@
 					"components": (
 						"attribution": (
 							"display": block,
-							"margin-inline-end": calc(33% + var(--global-spacing-6)),
+							"margin-inline-start": calc(33% + var(--global-spacing-6)),
 						),
 						"heading": (
-							"margin-inline-end": calc(33% + var(--global-spacing-6)),
+							"margin-inline-start": calc(33% + var(--global-spacing-6)),
 							"inline-size": auto,
 						),
 						"overline": (
-							"margin-inline-end": var(--global-spacing-6),
+							"margin-inline-start": var(--global-spacing-6),
 							"font-size": var(--global-font-size-7),
 						),
 						"paragraph": (
-							"margin-inline-end": calc(33% + var(--global-spacing-6)),
+							"display": block,
+							"margin-inline-start": calc(33% + var(--global-spacing-6)),
 						),
 					),
 				),

--- a/blocks/results-list-block/themes/news.json
+++ b/blocks/results-list-block/themes/news.json
@@ -82,6 +82,7 @@
 						"margin-inline-start": "var(--global-spacing-6)"
 					},
 					"paragraph": {
+						"display": "block",
 						"margin-inline-start": "calc(33% + var(--global-spacing-6))"
 					}
 				}


### PR DESCRIPTION
**If you have not filled out the checklist below, the pr is not ready for review.**

## Description

Fixed issue with results list’s captions not displaying as expected.

## Jira Ticket

- [THEMES-1627](https://arcpublishing.atlassian.net/browse/THEMES-1627)

## Acceptance Criteria

_copy from ticket_

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-1627`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/results-list-block`
3. Open a page with a results list block
4. Verify that the description displays correctly

## Effect Of Changes

### Before

The caption on the video and the description on the images should be aligned with the headline and header and should meet Figma's design

### After

The caption on the video and the description on the images do not align and start from the middle, and if the line is long, it goes under the image!

## Dependencies or Side Effects

_Examples of dependencies or side effects are:_

- Manifest pr for new block:
- Feature pack pr for local development:
- How to deploy to news: https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3138682964/News+Theme+2.0+Migration+Development+Deployment+Notes
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Dependency on another PR that needs to be merged first

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1627]: https://arcpublishing.atlassian.net/browse/THEMES-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ