### PR TITLE
THEMES-1654: Card List block not respecting time format

### DIFF
--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -45,10 +45,10 @@ const CardListItems = (props) => {
 			displayAmount,
 		},
 		targetFallbackImage,
-		dateLocalization: { language, timeZone, dateFormat } = {
+		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
 			timeZone: "GMT",
-			dateFormat: "%B %d, %Y at %l:%M%p %Z",
+			dateTimeFormat: "%B %d, %Y at %l:%M%p %Z",
 		},
 	} = props;
 	const phrases = usePhrases();
@@ -135,7 +135,7 @@ const CardListItems = (props) => {
 
 	const sourceContent = contentElements[0];
 
-	const displayDate = localizeDateTime(sourceContent.display_date, dateFormat, language, timeZone);
+	const displayDate = localizeDateTime(sourceContent.display_date, dateTimeFormat, language, timeZone);
 
 	/* Author Formatting */
 	const bylineNodes = formatAuthors(sourceContent?.credits?.by, phrases.t("global.and-text"));
@@ -270,8 +270,7 @@ const CardListItems = (props) => {
 
 const CardList = ({ customFields }) => {
 	const { id, arcSite, contextPath, deployment, isAdmin } = useFusionContext();
-	const { websiteDomain, fallbackImage, primaryLogoAlt } = getProperties(arcSite);
-
+	const { dateLocalization, fallbackImage, primaryLogoAlt, websiteDomain } = getProperties(arcSite);
 	const targetFallbackImage = getFallbackImageURL({
 		deployment,
 		contextPath,
@@ -288,6 +287,7 @@ const CardList = ({ customFields }) => {
 			<CardListItems
 				id={id}
 				customFields={customFields}
+				dateLocalization={dateLocalization}
 				targetFallbackImage={targetFallbackImage}
 				websiteDomain={websiteDomain}
 				primaryLogoAlt={primaryLogoAlt}

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import getThemeStyle from "fusion:themes";
 import { useContent } from "fusion:content";
 import { useFusionContext } from "fusion:context";
+import getProperties from "fusion:properties";
+import { localizeDateTime } from "@wpmedia/arc-themes-components";
 import mockData, { oneListItem, oneListItemDisplayLabel, twoListItemNoSiteUrl } from "./mock-data";
 import CardList from "./default";
 
@@ -152,10 +153,6 @@ describe("Card list", () => {
 			const title = "Test Title";
 			const customFields = { listContentConfig, title };
 	
-			getThemeStyle.mockImplementation(() => ({
-				"primary-font-family": "Papyrus",
-			}));
-	
 			useContent.mockReturnValueOnce(oneListItem);
 			render(<CardList customFields={customFields} />);
 		};
@@ -201,6 +198,26 @@ describe("Card list", () => {
 		it("should render a publish date", () => {
 			setup();
 			expect(screen.getByText("date")).not.toBeNull();
+		});
+
+		it("should use default date format", () => {
+			setup();
+			expect(localizeDateTime).toHaveBeenLastCalledWith("2019-12-18T17:09:22.308Z", "%B %d, %Y at %l:%M%p %Z", "en", "GMT");
+		});
+
+		it("should use custom date format", () => {
+			getProperties.mockReturnValueOnce({
+				locale: "en",
+				fallbackImage: "placeholder.jpg",
+				resizerURL: "http://url.com/",
+				dateLocalization: {
+					language: "fr",
+					timeZone: "CET",
+					dateTimeFormat: "%d-%m-%Y at %l:%M%p %Z",
+				},
+			})
+			setup();
+			expect(localizeDateTime).toHaveBeenLastCalledWith("2019-12-18T17:09:22.308Z", "%d-%m-%Y at %l:%M%p %Z", "fr", "CET");
 		});
 	});
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the card list block would always use the default time format.

## Jira Ticket

- [THEMES-1654](https://arcpublishing.atlassian.net/browse/THEMES-1654)

## Acceptance Criteria

The card list block uses the site's time format when it is set

## Test Steps

1. Checkout this branch `git checkout THEMES-1654`
2. In your local `blocks.json` change the `dateTimeFormat` property to something noticeably different than the default (such as using `%b` instead of `%B` so the short month name appears, or adding `%A` to show the day of the week).
3. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/card-list-block`
4. Add a Card list - Arc block to a page with a query of `type: story` and showing a few items.
5. The top most item should show the date and time in the format specified in the `blocks.json`.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1654]: https://arcpublishing.atlassian.net/browse/THEMES-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ