### PR TITLE
THEMES-1663: Separator still has margin

### DIFF
--- a/blocks/section-title-block/themes/news.json
+++ b/blocks/section-title-block/themes/news.json
@@ -14,7 +14,10 @@
 						"font-family": "var(--font-family-primary)"
 					},
 					"separator": {
-						"margin": "0 var(--global-spacing-4)"
+						"margin-block-end": "0",
+						"margin-block-start": "0",
+						"margin-inline-end": "var(--global-spacing-4)",
+						"margin-inline-start": "var(--global-spacing-4)"
 					}
 				}
 			},


### PR DESCRIPTION
## Description

Small PR to convert a leftover `margin` property to the logical equivalent. It was in the section title block and affected the separator component.

## Jira Ticket

- [THEMES-1663](https://arcpublishing.atlassian.net/browse/THEMES-1663)

## Acceptance Criteria

Separators have proper spacing.

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-1663`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/section-title-block`
3. Visit the all blocks example page and make sure that the separators have proper spacing for all blocks, especially the top table list and section title blocks.

## Effect Of Changes

### Before
![Screenshot 2024-01-25 at 4 30 01 PM](https://github.com/WPMedia/arc-themes-blocks/assets/4759882/968c9909-48a6-409c-ab0e-b19aabd62a99)
![Screenshot 2024-01-25 at 4 41 05 PM](https://github.com/WPMedia/arc-themes-blocks/assets/4759882/a690a707-ff67-41cf-9078-2bfcdf5f834d)

### After
![Screenshot 2024-01-25 at 4 30 01 PM](https://github.com/WPMedia/arc-themes-blocks/assets/4759882/e62b95fd-4cdf-482f-abdc-95fd7e88d2f9)
![Screenshot 2024-01-25 at 4 41 21 PM](https://github.com/WPMedia/arc-themes-blocks/assets/4759882/6bdd50f8-9623-4bfc-bf38-65eb8d8dd5b7)


## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1663]: https://arcpublishing.atlassian.net/browse/THEMES-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ