### PR TITLE
updated advanced-right-rail layout

### DIFF
--- a/blocks/right-rail-advanced-block/_index.scss
+++ b/blocks/right-rail-advanced-block/_index.scss
@@ -36,9 +36,9 @@
 		@include scss.block-components("right-rail-advanced-main-right-rail");
 	}
 
-	&__main-right-rail-empty {
-		@include scss.block-properties("right-rail-advanced-main-right-rail-empty");
-		@include scss.block-components("right-rail-advanced-main-right-rail-empty");
+	&__empty {
+		@include scss.block-properties("right-rail-advanced-empty");
+		@include scss.block-components("right-rail-advanced-empty");
 	}
 
 	&__rail-container {

--- a/blocks/right-rail-advanced-block/_index.scss
+++ b/blocks/right-rail-advanced-block/_index.scss
@@ -36,6 +36,11 @@
 		@include scss.block-components("right-rail-advanced-main-right-rail");
 	}
 
+	&__main-right-rail-empty {
+		@include scss.block-properties("right-rail-advanced-main-right-rail-empty");
+		@include scss.block-components("right-rail-advanced-main-right-rail-empty");
+	}
+
 	&__rail-container {
 		@include scss.block-properties("right-rail-advanced-rail-container");
 		@include scss.block-components("right-rail-advanced-rail-container");

--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
@@ -30,24 +30,24 @@ const RightRailAdvancedLayout = ({ children }) => {
 	] = React.Children.toArray(children);
 	const featureList = useFeatureList();
 
+	const mainItems =
+		featureList["2"] + featureList["3"] + featureList["4"] + featureList["5"] + featureList["6"];
+
 	return (
 		<div className={LAYOUT_CLASS_NAME}>
-			{navigation ? (
-				<Stack as="header" className={`${LAYOUT_CLASS_NAME}__navigation`}>
-					{navigation}
-				</Stack>
-			) : null}
-
+			<Stack as="header" className={`${LAYOUT_CLASS_NAME}__navigation`}>
+				{navigation}
+			</Stack>
 			<section role="main" tabIndex="-1" className={`${LAYOUT_CLASS_NAME}__main`}>
-				{fullwidth1 ? (
-					<Stack className={`${LAYOUT_CLASS_NAME}__full-width-1`}>{fullwidth1}</Stack>
-				) : null}
-				<Grid className={`${LAYOUT_CLASS_NAME}__rail-container`}>
+				<Stack className={`${LAYOUT_CLASS_NAME}__full-width-1`}>{fullwidth1}</Stack>
+				<Grid className={`${LAYOUT_CLASS_NAME}__rail-container `}>
 					<Stack className={`${LAYOUT_CLASS_NAME}__main-interior-item`}>
 						<Stack className={`${LAYOUT_CLASS_NAME}__main-interior-item-1`}>{main}</Stack>
 						<Stack className={`${LAYOUT_CLASS_NAME}__main-interior-item-2`}>{main2}</Stack>
 					</Stack>
-					<Stack className={`${LAYOUT_CLASS_NAME}__main-right-rail`}>
+					<Stack
+						className={`${LAYOUT_CLASS_NAME}__main-right-rail ${mainItems === 0 && `${LAYOUT_CLASS_NAME}__main-right-rail-empty`}`}
+					>
 						<Stack className={`${LAYOUT_CLASS_NAME}__main-right-rail-top`}>{rightRailTop}</Stack>
 						<Stack className={`${LAYOUT_CLASS_NAME}__main-right-rail-middle`}>
 							{rightRailMiddle}
@@ -57,15 +57,11 @@ const RightRailAdvancedLayout = ({ children }) => {
 						</Stack>
 					</Stack>
 				</Grid>
-				{featureList["7"] > 0 ? (
-					<Stack className={`${LAYOUT_CLASS_NAME}__full-width-2`}>{fullWidth2}</Stack>
-				) : null}
+				<Stack className={`${LAYOUT_CLASS_NAME}__full-width-2`}>{fullWidth2}</Stack>
 			</section>
-			{footer ? (
-				<Stack as="footer" className={`${LAYOUT_CLASS_NAME}__footer`}>
-					{footer}
-				</Stack>
-			) : null}
+			<Stack as="footer" className={`${LAYOUT_CLASS_NAME}__footer`}>
+				{footer}
+			</Stack>
 		</div>
 	);
 };

--- a/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
+++ b/blocks/right-rail-advanced-block/layouts/right-rail-advanced/default.jsx
@@ -30,8 +30,8 @@ const RightRailAdvancedLayout = ({ children }) => {
 	] = React.Children.toArray(children);
 	const featureList = useFeatureList();
 
-	const mainItems =
-		featureList["2"] + featureList["3"] + featureList["4"] + featureList["5"] + featureList["6"];
+	const mainItems = featureList["2"] + featureList["3"];
+	const rightRailItems = featureList["4"] + featureList["5"] + featureList["6"];
 
 	return (
 		<div className={LAYOUT_CLASS_NAME}>
@@ -41,12 +41,14 @@ const RightRailAdvancedLayout = ({ children }) => {
 			<section role="main" tabIndex="-1" className={`${LAYOUT_CLASS_NAME}__main`}>
 				<Stack className={`${LAYOUT_CLASS_NAME}__full-width-1`}>{fullwidth1}</Stack>
 				<Grid className={`${LAYOUT_CLASS_NAME}__rail-container `}>
-					<Stack className={`${LAYOUT_CLASS_NAME}__main-interior-item`}>
+					<Stack
+						className={`${LAYOUT_CLASS_NAME}__main-interior-item${mainItems < 2 ? ` ${LAYOUT_CLASS_NAME}__empty` : ""}`}
+					>
 						<Stack className={`${LAYOUT_CLASS_NAME}__main-interior-item-1`}>{main}</Stack>
 						<Stack className={`${LAYOUT_CLASS_NAME}__main-interior-item-2`}>{main2}</Stack>
 					</Stack>
 					<Stack
-						className={`${LAYOUT_CLASS_NAME}__main-right-rail ${mainItems === 0 && `${LAYOUT_CLASS_NAME}__main-right-rail-empty`}`}
+						className={`${LAYOUT_CLASS_NAME}__main-right-rail${rightRailItems < 2 ? ` ${LAYOUT_CLASS_NAME}__empty` : ""}`}
 					>
 						<Stack className={`${LAYOUT_CLASS_NAME}__main-right-rail-top`}>{rightRailTop}</Stack>
 						<Stack className={`${LAYOUT_CLASS_NAME}__main-right-rail-middle`}>

--- a/blocks/right-rail-advanced-block/themes/news.json
+++ b/blocks/right-rail-advanced-block/themes/news.json
@@ -117,10 +117,10 @@
 			}
 		}
 	},
-	"right-rail-advanced-main-right-rail-empty": {
+	"right-rail-advanced-empty": {
 		"styles": {
 			"default": {
-				"border-inline-start-style": "none"
+				"gap": "0"
 			},
 			"desktop": {}
 		}

--- a/blocks/right-rail-advanced-block/themes/news.json
+++ b/blocks/right-rail-advanced-block/themes/news.json
@@ -117,6 +117,14 @@
 			}
 		}
 	},
+	"right-rail-advanced-main-right-rail-empty": {
+		"styles": {
+			"default": {
+				"border-inline-start-style": "none"
+			},
+			"desktop": {}
+		}
+	},
 	"right-rail-advanced-main-right-rail-bottom": {
 		"styles": {
 			"default": {


### PR DESCRIPTION
## Description

The advanced right rail layout - No divider should appear if no blocks exist in the main and right rail sections.

NOTES:
I went with this approach to avoid a few problems in PB admin. 
- By conditionally rendering sections, users have to refresh the page after adding a block to an empty section in order to see it. Instead, I'm conditionally applying a class to set the gap to zero when there are no blocks in either the main or right rail section, which allows the height of the right-rail-advanced-main to be zero, so the divider doesn't appear. One consideration with my approach is that if users add blocks to multiple right rail sections or both main sections they will have to refresh the page to see the gap between the sections.
- I also removed some of the conditional statements that were already in the layout. Conditionals like: `{fullwidth1 ? (` (in line 42) don't actually do anything, since fullwidth1 always returns an object. Conditionals like: `{featureList["7"] > 0 ? (` (in line 60) work, but force the user to refresh the page when blocks are added to that section

## Jira Ticket

- [THEMES-1576](https://arcpublishing.atlassian.net/browse/THEMES-1576)

## Acceptance Criteria

_copy from ticket_

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-1576`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/right-rail-advanced-block`
3. Create a page with the advanced-right-rail layout
4. Make sure the divider does not appear on the page
5. Add a block to the main section and make sure the divider appears
6. Remove the block and make sure the divider goes away
7. Add a block to one of the right rail sections and make sure the divider appears

## Effect Of Changes

### Before

A small divider appears even if no blocks exist in the main and right rail sections.

### After

No divider should appear if no blocks exist in the main and right rail sections.

## Dependencies or Side Effects

_Examples of dependencies or side effects are:_

- Manifest pr for new block:
- Feature pack pr for local development:
- How to deploy to news: https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3138682964/News+Theme+2.0+Migration+Development+Deployment+Notes
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Dependency on another PR that needs to be merged first

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm run test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1576]: https://arcpublishing.atlassian.net/browse/THEMES-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ