### PR TITLE
THEMES-1587: Add aspect ratio options to Results List block

### DIFF
--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -37,6 +37,7 @@ const ResultsList = ({ customFields }) => {
 					configuredSize={configuredSize}
 					contentConfigValues={contentConfigValues}
 					contentService={contentService}
+					imageRatio={promoElements.imageRatio}
 					isServerSideLazy={isServerSideLazy}
 					showByline={promoElements.showByline}
 					showDate={promoElements.showDate}
@@ -80,6 +81,11 @@ ResultsList.propTypes = {
 		showImage: PropTypes.bool.tag({
 			label: "Show image",
 			defaultValue: true,
+			group: "Show promo elements",
+		}),
+		imageRatio: PropTypes.oneOf(["3:2", "4:3", "16:9"]).tag({
+			defaultValue: "3:2",
+			label: "Image ratio",
 			group: "Show promo elements",
 		}),
 		showDescription: PropTypes.bool.tag({

--- a/blocks/results-list-block/features/results-list/results/helpers.js
+++ b/blocks/results-list-block/features/results-list/results/helpers.js
@@ -1,8 +1,4 @@
-const defaultResultList = {
-	content_elements: [],
-};
-
-const reduceResultList = (state = defaultResultList, action) => {
+const reduceResultList = (state, action) => {
 	const { type, data } = action;
 
 	if (!data) {

--- a/blocks/results-list-block/features/results-list/results/helpers.js
+++ b/blocks/results-list-block/features/results-list/results/helpers.js
@@ -31,6 +31,7 @@ const reduceResultList = (state = defaultResultList, action) => {
 
 const resolveDefaultPromoElements = (customFields = {}) => {
 	const fields = {
+		imageRatio: "3:2",
 		showByline: true,
 		showDate: true,
 		showDescription: true,

--- a/blocks/results-list-block/features/results-list/results/helpers.test.js
+++ b/blocks/results-list-block/features/results-list/results/helpers.test.js
@@ -4,6 +4,7 @@ describe("resolveDefaultPromoElements", () => {
 	it("should use default custom fields as empty object", () => {
 		const result = resolveDefaultPromoElements();
 		const expectedResult = {
+			imageRatio: "3:2",
 			showByline: true,
 			showDate: true,
 			showDescription: true,
@@ -16,6 +17,7 @@ describe("resolveDefaultPromoElements", () => {
 
 	it("should use valid passed field values when available", () => {
 		const result = resolveDefaultPromoElements({
+			imageRatio: "16:9",
 			showByline: true,
 			showDate: true,
 			showDescription: true,
@@ -24,6 +26,7 @@ describe("resolveDefaultPromoElements", () => {
 			showItemOverline: false,
 		});
 		const expectedResult = {
+			imageRatio: "16:9",
 			showByline: true,
 			showDate: true,
 			showDescription: true,

--- a/blocks/results-list-block/features/results-list/results/helpers.test.js
+++ b/blocks/results-list-block/features/results-list/results/helpers.test.js
@@ -59,8 +59,8 @@ describe("reduceResultList", () => {
 		});
 	});
 
-	it("should return the new collection when the state is undefined", () => {
-		const result = reduceResultList(undefined, {
+	it("should return the new collection when the state is in initial form", () => {
+		const result = reduceResultList({ content_elements: [] }, {
 			type: "appendUnique",
 			data: {
 				content_elements: [{ _id: "a" }, { _id: "c" }, { _id: "d" }],

--- a/blocks/results-list-block/features/results-list/results/index.jsx
+++ b/blocks/results-list-block/features/results-list/results/index.jsx
@@ -14,6 +14,7 @@ const Results = ({
 	configuredSize,
 	contentConfigValues,
 	contentService,
+	imageRatio,
 	isServerSideLazy = false,
 	showByline = false,
 	showDate = false,
@@ -21,7 +22,6 @@ const Results = ({
 	showHeadline = false,
 	showImage = false,
 	showItemOverline = false,
-	imageRatio,
 	targetFallbackImage,
 }) => {
 	const [queryOffset, setQueryOffset] = useState(configuredOffset);
@@ -199,6 +199,7 @@ const Results = ({
 						ref={elementRefs[index]}
 						arcSite={arcSite}
 						element={element}
+						imageRatio={imageRatio}
 						placeholderResizedImageOptions={placeholderResizedImageOptions}
 						showByline={showByline}
 						showDate={showDate}
@@ -207,7 +208,6 @@ const Results = ({
 						showImage={showImage}
 						showItemOverline={showItemOverline}
 						targetFallbackImage={targetFallbackImage}
-						imageRatio={imageRatio}
 					/>
 				))}
 				{isThereMore && (

--- a/blocks/results-list-block/features/results-list/results/index.jsx
+++ b/blocks/results-list-block/features/results-list/results/index.jsx
@@ -139,7 +139,7 @@ const Results = ({
     }`,
 	});
 
-	const [resultList, alterResultList] = useReducer(reduceResultList, requestedResultList);
+	const [resultList, alterResultList] = useReducer(reduceResultList, { content_elements: [] });
 
 	useEffect(() => {
 		if (requestedResultList) {

--- a/blocks/results-list-block/features/results-list/results/index.test.jsx
+++ b/blocks/results-list-block/features/results-list/results/index.test.jsx
@@ -602,7 +602,7 @@ describe("fallback image", () => {
 		);
 
 		expect(
-			screen.queryByText(/"targetFallbackImage":"http:\/\/test\/fallback.jpg"/i),
+			screen.getByText(/"targetFallbackImage":"http:\/\/test\/fallback.jpg"/i),
 		).toBeInTheDocument();
 
 		unmount();

--- a/blocks/results-list-block/features/results-list/results/result-item.jsx
+++ b/blocks/results-list-block/features/results-list/results/result-item.jsx
@@ -32,6 +32,7 @@ const ResultItem = React.memo(
 			{
 				arcSite,
 				element,
+				imageRatio,
 				targetFallbackImage,
 				showByline,
 				showDate,
@@ -109,21 +110,21 @@ const ResultItem = React.memo(
 								<Image
 									src={imageURL !== null ? imageURL : targetFallbackImage}
 									alt={headlineText}
+									aspectRatio={imageRatio}
 									resizedOptions={{ auth: auth[RESIZER_TOKEN_VERSION], smart: true }}
 									resizerURL={resizerURL}
 									sizes={[
 										{
 											isDefault: true,
-											sourceSizeValue: "100px",
+											sourceSizeValue: "250px",
 										},
 										{
 											sourceSizeValue: "500px",
 											mediaCondition: "(min-width: 48rem)",
 										},
 									]}
-									responsiveImages={[100, 500]}
+									responsiveImages={[250, 500]}
 									width={500}
-									height={333}
 								/>
 							</Conditional>
 						</MediaItem>

--- a/blocks/results-list-block/features/results-list/results/result-item.test.jsx
+++ b/blocks/results-list-block/features/results-list/results/result-item.test.jsx
@@ -113,6 +113,26 @@ describe("Result parts", () => {
 		unmount();
 	});
 
+	it("does not show the date if data is missing", () => {
+		const { unmount } = render(
+			<ResultItem
+				arcSite="the-sun"
+				element={{
+					...element,
+					display_date: ""
+				}}
+				imageProperties={imageProperties}
+				targetFallbackImage={fallbackImage}
+				placeholderResizedImageOptions={{}}
+				showDate
+			/>,
+		);
+
+		expect(screen.queryByText(/January 01, 2021 at 12:01AM UTC/i)).toBeNull();
+
+		unmount();
+	});
+
 	it("should show the description if showDescription", () => {
 		const { unmount } = render(
 			<ResultItem
@@ -250,8 +270,9 @@ describe("Result parts", () => {
 					...element,
 					promo_items: {
 						basic: {
+							_id: "ABCDEFG12345678910",
 							type: "image",
-							url: "http://test/resources/promo.jpg",
+							url: "http://test/resources/ABCDEFG12345678910.jpg",
 						},
 					},
 				}}
@@ -262,8 +283,31 @@ describe("Result parts", () => {
 			/>,
 		);
 
-		expect(screen.getAllByAltText(/Test headline 1/i)).toHaveLength(1);
+		const imageSrc = screen.getByAltText(/Test headline 1/i);
+		expect(imageSrc.src).toContain("ABCDEFG12345678910.jpg");
 
 		unmount();
 	});
+
+	it("should be null if all show* values are false", () => {
+		const { container, unmount } = render(
+			<ResultItem
+				arcSite="the-sun"
+				element={element}
+				imageProperties={imageProperties}
+				targetFallbackImage={fallbackImage}
+				placeholderResizedImageOptions={{}}
+				showByline={false}
+				showDate={false}
+				showDescription={false}
+				showHeadline={false}
+				showImage={false}
+				showItemOverline={false}
+			/>,
+		);
+
+		expect(container).toBeEmptyDOMElement();;
+
+		unmount();
+	})
 });


### PR DESCRIPTION
## Description

This PR adds 3 aspect ratio options to the results list block. It also improves related test coverage and corrects a lint issue.

## Jira Ticket

- [THEMES-1587](https://arcpublishing.atlassian.net/browse/THEMES-1587)

## Acceptance Criteria

- Configure the block to allow for the following aspect ratios: 
  - 3:2 (default)
  - 4:3 
  - 16:9 

## Test Steps

1. Checkout this branch `git checkout THEMES-1587`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/results-list-block`
3. Create or edit a page and add a Results List block that displays some stories.
4. Under "Show Promo Elements", right next to "Show Image", is a new option "Image ratio".
5. Select each option and make sure that the images in the block update to reflect the correct aspect ratio.

## Effect Of Changes

![Screenshot 2024-02-13 at 2 49 55 PM](https://github.com/WPMedia/arc-themes-blocks/assets/4759882/d2720b44-6ed6-4b22-83ea-a0194fa953a6)

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1587]: https://arcpublishing.atlassian.net/browse/THEMES-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ