### PR TITLE
THEMES-1669: Lead art block - add aspect ratio option for images

### DIFF
--- a/blocks/lead-art-block/_index.scss
+++ b/blocks/lead-art-block/_index.scss
@@ -17,14 +17,14 @@
 			@include scss.block-properties("lead-art-carousel-close-button");
 		}
 
-		.b-lead-art__image-wrapper {
-			@include scss.block-components("lead-art-carousel-image-wrapper");
-			@include scss.block-properties("lead-art-carousel-image-wrapper");
-		}
-
 		&__track-button {
 			@include scss.block-components("lead-art-carousel-track-button");
 			@include scss.block-properties("lead-art-carousel-track-button");
+		}
+
+		.b-lead-art__image-wrapper {
+			@include scss.block-components("lead-art-carousel-image-wrapper");
+			@include scss.block-properties("lead-art-carousel-image-wrapper");
 		}
 	}
 

--- a/blocks/lead-art-block/_index.scss
+++ b/blocks/lead-art-block/_index.scss
@@ -2,8 +2,8 @@
 
 .b-lead-art {
 	&__image-wrapper {
-		@include scss.block-components("lead-art-carousel-image-wrapper");
-		@include scss.block-properties("lead-art-carousel-image-wrapper");
+		@include scss.block-components("lead-art-image-wrapper");
+		@include scss.block-properties("lead-art-image-wrapper");
 	}
 
 	&__carousel {
@@ -12,14 +12,19 @@
 			@include scss.block-properties("lead-art-carousel-fullscreen");
 		}
 
-		&__track-button {
-			@include scss.block-components("lead-art-carousel-track-button");
-			@include scss.block-properties("lead-art-carousel-track-button");
-		}
-
 		&__close-button {
 			@include scss.block-components("lead-art-carousel-close-button");
 			@include scss.block-properties("lead-art-carousel-close-button");
+		}
+
+		.b-lead-art__image-wrapper {
+			@include scss.block-components("lead-art-carousel-image-wrapper");
+			@include scss.block-properties("lead-art-carousel-image-wrapper");
+		}
+
+		&__track-button {
+			@include scss.block-components("lead-art-carousel-track-button");
+			@include scss.block-properties("lead-art-carousel-track-button");
 		}
 	}
 

--- a/blocks/lead-art-block/features/leadart/default.jsx
+++ b/blocks/lead-art-block/features/leadart/default.jsx
@@ -32,10 +32,15 @@ export const LeadArtPresentation = (props) => {
 
 	const { arcSite, content, customFields } = props;
 	const {
+		enableAutoplay = false,
 		hideTitle = false,
 		hideCaption = false,
 		hideCredits = false,
-		imageLoadingStrategy,
+		imageLoadingStrategy = "eager",
+		imageRatio = "16:9",
+		playthrough = false,
+		videoRatio = "--",
+		viewportPercentage = 65
 	} = customFields;
 
 	/* istanbul ignore next  */
@@ -68,6 +73,7 @@ export const LeadArtPresentation = (props) => {
 		/* istanbul ignore next */
 		const { default: AdFeature } = require("@wpmedia/ads-block/features/ads/default");
 		/* istanbul ignore next */
+		/* eslint-disable-next-line react/no-unstable-nested-components */
 		AdBlock = () => (
 			<AdFeature
 				customFields={{
@@ -78,6 +84,7 @@ export const LeadArtPresentation = (props) => {
 		);
 	} catch (e) {
 		/* istanbul ignore next */
+		/* eslint-disable-next-line react/no-unstable-nested-components */
 		AdBlock = () => <p>Ad block not found</p>;
 	}
 
@@ -92,8 +99,8 @@ export const LeadArtPresentation = (props) => {
 
 		if (leadArt.type === "video") {
 			const embedMarkup = formatPowaVideoEmbed(leadArt?.embed_html, {
-				autoplay: customFields?.enableAutoplay,
-				playthrough: customFields?.playthrough,
+				autoplay: enableAutoplay,
+				playthrough,
 			});
 
 			return (
@@ -103,9 +110,9 @@ export const LeadArtPresentation = (props) => {
 					title={!hideTitle ? leadArt?.headlines?.basic : null}
 				>
 					<Video
-						aspectRatio={customFields?.aspectRatio}
+						aspectRatio={videoRatio}
 						embedMarkup={embedMarkup}
-						viewportPercentage={customFields?.viewportPercentage}
+						viewportPercentage={viewportPercentage}
 						borderRadius={customFields?.borderRadius}
 					/>
 				</MediaItem>
@@ -133,10 +140,9 @@ export const LeadArtPresentation = (props) => {
 					<div className={`${BLOCK_CLASS_NAME}__image-wrapper`} ref={imgRef}>
 						<Image
 							alt={leadArt.alt_text}
+							aspectRatio={imageRatio || "16:9"}
 							loading={imageLoadingStrategy}
-							// 16:9 aspect ratio
 							width={800}
-							height={450}
 							responsiveImages={[800, 1600]}
 							resizedOptions={{ smart: true }}
 							ansImage={leadArt}
@@ -237,7 +243,6 @@ export const LeadArtPresentation = (props) => {
 									<Image
 										ansImage={galleryItem}
 										loading={itemIndex === 0 ? imageLoadingStrategy : "lazy"}
-										// 16:9 aspect ratio
 										height={450}
 										responsiveImages={[800, 1600]}
 										alt={galleryItem.alt_text}
@@ -299,7 +304,7 @@ LeadArt.propTypes = {
 			defaultValue: 65,
 			group: "Video",
 		}),
-		aspectRatio: PropTypes.oneOf(["--", "16:9", "9:16", "1:1", "4:3"]).isRequired.tag({
+		videoRatio: PropTypes.oneOf(["--", "16:9", "9:16", "1:1", "4:3"]).isRequired.tag({
 			description:
 				"Aspect ratio to use in player (Defaults to the aspect ratio of the resolved video)",
 			label: "Player aspect ratio",
@@ -348,6 +353,12 @@ LeadArt.propTypes = {
 				eager: "Eager",
 				lazy: "Lazy",
 			},
+		}),
+		imageRatio: PropTypes.oneOf(["16:9", "4:3", "3:2"]).tag({
+			defaultValue: "16:9",
+			label: "Image ratio",
+			group: "Display Options",
+			ordered: false
 		}),
 	}),
 };

--- a/blocks/lead-art-block/features/leadart/default.test.jsx
+++ b/blocks/lead-art-block/features/leadart/default.test.jsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import getProperties from "fusion:properties";
 import { useFusionContext } from "fusion:context";
 import LeadArt from "./default";
@@ -48,8 +49,8 @@ describe("LeadArt", () => {
 			},
 		};
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
-		const { queryByText } = render(<LeadArt customFields={{}} />);
-		expect(queryByText(rawHtml)).not.toBeNull();
+		render(<LeadArt customFields={{}} />);
+		expect(screen.getByText(rawHtml)).not.toBeNull();
 	});
 
 	it("renders video lead art type", () => {
@@ -70,10 +71,10 @@ describe("LeadArt", () => {
 			},
 		};
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
-		const { queryByText } = render(<LeadArt customFields={{}} />);
-		expect(queryByText("Title")).not.toBeNull();
-		expect(queryByText("Description")).not.toBeNull();
-		expect(queryByText("(Credit)")).not.toBeNull();
+		render(<LeadArt customFields={{}} />);
+		expect(screen.getByText("Title")).not.toBeNull();
+		expect(screen.getByText("Description")).not.toBeNull();
+		expect(screen.getByText("(Credit)")).not.toBeNull();
 	});
 
 	it("renders video lead art type with no meta data", () => {
@@ -94,7 +95,7 @@ describe("LeadArt", () => {
 			},
 		};
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
-		const { queryByText } = render(
+		render(
 			<LeadArt
 				customFields={{
 					hideTitle: true,
@@ -103,9 +104,9 @@ describe("LeadArt", () => {
 				}}
 			/>,
 		);
-		expect(queryByText("Title")).toBeNull();
-		expect(queryByText("Description")).toBeNull();
-		expect(queryByText("(Credit)")).toBeNull();
+		expect(screen.queryByText("Title")).toBeNull();
+		expect(screen.queryByText("Description")).toBeNull();
+		expect(screen.queryByText("(Credit)")).toBeNull();
 	});
 
 	it("renders image type", () => {
@@ -127,7 +128,7 @@ describe("LeadArt", () => {
 		};
 
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
-		const { queryByAltText, queryByText } = render(
+		render(
 			<LeadArt
 				customFields={{
 					hideTitle: false,
@@ -136,10 +137,10 @@ describe("LeadArt", () => {
 				}}
 			/>,
 		);
-		expect(queryByAltText("a test image")).not.toBeNull();
-		expect(queryByText("Caption")).not.toBeNull();
-		expect(queryByText("Subtitle")).not.toBeNull();
-		expect(queryByText("(Credit)")).not.toBeNull();
+		expect(screen.getByAltText("a test image")).not.toBeNull();
+		expect(screen.getByText("Caption")).not.toBeNull();
+		expect(screen.getByText("Subtitle")).not.toBeNull();
+		expect(screen.getByText("(Credit)")).not.toBeNull();
 	});
 
 	it("renders image type and no meta data", () => {
@@ -161,7 +162,7 @@ describe("LeadArt", () => {
 		};
 
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
-		const { queryByAltText, queryByText } = render(
+		render(
 			<LeadArt
 				customFields={{
 					hideTitle: true,
@@ -170,10 +171,10 @@ describe("LeadArt", () => {
 				}}
 			/>,
 		);
-		expect(queryByAltText("a test image")).not.toBeNull();
-		expect(queryByText("Caption")).toBeNull();
-		expect(queryByText("Subtitle")).toBeNull();
-		expect(queryByText("(Credit)")).toBeNull();
+		expect(screen.getByAltText("a test image")).not.toBeNull();
+		expect(screen.queryByText("Caption")).toBeNull();
+		expect(screen.queryByText("Subtitle")).toBeNull();
+		expect(screen.queryByText("(Credit)")).toBeNull();
 	});
 
 	it("renders gallery lead image type", () => {
@@ -200,12 +201,12 @@ describe("LeadArt", () => {
 			},
 		};
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
-		const { queryByRole, queryByText } = render(<LeadArt customFields={{}} />);
+		render(<LeadArt customFields={{}} />);
 
-		expect(queryByRole("region", { name: "test headline" })).not.toBeNull();
-		expect(queryByText("Caption")).not.toBeNull();
-		expect(queryByText("Subtitle")).not.toBeNull();
-		expect(queryByText("(Credit)")).not.toBeNull();
+		expect(screen.getByRole("region", { name: "test headline" })).not.toBeNull();
+		expect(screen.getByText("Caption")).not.toBeNull();
+		expect(screen.getByText("Subtitle")).not.toBeNull();
+		expect(screen.getByText("(Credit)")).not.toBeNull();
 	});
 
 	it("renders gallery lead image type with no meta data", () => {
@@ -232,7 +233,7 @@ describe("LeadArt", () => {
 			},
 		};
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
-		const { queryByRole, queryByText } = render(
+		render(
 			<LeadArt
 				customFields={{
 					hideTitle: true,
@@ -241,10 +242,10 @@ describe("LeadArt", () => {
 				}}
 			/>,
 		);
-		expect(queryByRole("region", { name: "test headline" })).not.toBeNull();
-		expect(queryByText("Caption")).toBeNull();
-		expect(queryByText("Subtitle")).toBeNull();
-		expect(queryByText("(Credit)")).toBeNull();
+		expect(screen.getByRole("region", { name: "test headline" })).not.toBeNull();
+		expect(screen.queryByText("Caption")).toBeNull();
+		expect(screen.queryByText("Subtitle")).toBeNull();
+		expect(screen.queryByText("(Credit)")).toBeNull();
 	});
 
 	it("renders gallery with an empty ans headline if no basic headline provided", () => {
@@ -259,8 +260,8 @@ describe("LeadArt", () => {
 		};
 
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
-		const { queryByRole } = render(<LeadArt customFields={{}} />);
-		expect(queryByRole("region", { name: "" })).not.toBeNull();
+		render(<LeadArt customFields={{}} />);
+		expect(screen.getByRole("region", { name: "" })).not.toBeNull();
 	});
 
 	it("returns null if invalid lead art type", () => {
@@ -275,7 +276,7 @@ describe("LeadArt", () => {
 
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
 		const { container } = render(<LeadArt customFields={{}} />);
-		expect(container.firstChild).toBeNull();
+		expect(container).toBeEmptyDOMElement();
 	});
 
 	it("returns null if no content promo items", () => {
@@ -283,6 +284,6 @@ describe("LeadArt", () => {
 
 		useFusionContext.mockReturnValue({ ...fusionContext, globalContent });
 		const { container } = render(<LeadArt customFields={{}} />);
-		expect(container.firstChild).toBeNull();
+		expect(container).toBeEmptyDOMElement();
 	});
 });

--- a/blocks/lead-art-block/themes/news.json
+++ b/blocks/lead-art-block/themes/news.json
@@ -43,21 +43,7 @@
 	"lead-art-carousel-image-wrapper": {
 		"styles": {
 			"default": {
-				"align-items": "center",
-				"aspect-ratio": "calc(16/9)",
-				"background-color": "var(--global-black)",
-				"display": "flex",
-				"justify-content": "center",
-				"max-block-size": "75vh",
-				"overflow": "auto",
-				"components": {
-					"image": {
-						"block-size": "auto",
-						"max-block-size": "100%",
-						"max-inline-size": "100%",
-						"object-fit": "contain"
-					}
-				}
+				"aspect-ratio": "calc(16/9)"
 			},
 			"desktop": {}
 		}
@@ -92,6 +78,27 @@
 						"fill": "currentColor",
 						"block-size": "var(--global-spacing-6)",
 						"inline-size": "var(--global-spacing-6)"
+					}
+				}
+			},
+			"desktop": {}
+		}
+	},
+	"lead-art-image-wrapper": {
+		"styles": {
+			"default": {
+				"align-items": "center",
+				"background-color": "var(--global-black)",
+				"display": "flex",
+				"justify-content": "center",
+				"max-block-size": "75vh",
+				"overflow": "auto",
+				"components": {
+					"image": {
+						"block-size": "auto",
+						"max-block-size": "100%",
+						"max-inline-size": "100%",
+						"object-fit": "contain"
 					}
 				}
 			},


### PR DESCRIPTION
## Description

This PR adds in an aspect ratio option for images, for when the lead art is a single image.

## Jira Ticket

- [THEMES-1669](https://arcpublishing.atlassian.net/browse/THEMES-1669)

## Acceptance Criteria

- Configure the block to allow for the following aspect ratios: 
  - 16:9 (default)
  - 4:3 
  - 3:2

## Test Steps

1. Checkout this branch `git checkout THEMES-1669`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/lead-art-block`
3. Create or edit a page with the lead art block.
4. Set the global content to a story with a single promo image (like `/global/news/2023/01/05/winter-storms-move-across-the-us-while-europe-experiences-record-warmth/`).
5. Under the 'Display Options' group, change the 'Image ratio' to the available values. Make sure the aspect ratio is reflected in the block.
6. Also try it with a story that has a gallery as the lead art (like `/2022/12/01/a-gallery-is-my-lead-art/`). 
7. The gallery should maintain it's current look and feel regardless of the option selected. It should have a fixed aspect ratio (16 x 9) for the image wrapper and the image itself should keep it's original aspect ratio.

## Effect Of Changes

### After

![Screenshot 2024-02-15 at 12 50 29 PM](https://github.com/WPMedia/arc-themes-blocks/assets/4759882/123fe981-8dba-4a5b-8bc5-4edde98ee4f8)

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1669]: https://arcpublishing.atlassian.net/browse/THEMES-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ