### PR TITLE
THEMES-1587: Results list handle null aspect ratio

### DIFF
--- a/blocks/results-list-block/features/results-list/results/helpers.js
+++ b/blocks/results-list-block/features/results-list/results/helpers.js
@@ -37,7 +37,7 @@ const resolveDefaultPromoElements = (customFields = {}) => {
 	};
 	const fieldKeys = Object.keys(fields);
 	return fieldKeys.reduce((acc, key) => {
-		if (typeof customFields[key] === "undefined") {
+		if (typeof customFields[key] === "undefined" || customFields[key] === null) {
 			acc[key] = fields[key];
 		} else {
 			acc[key] = customFields[key];


### PR DESCRIPTION
## Description

Fixes a small bug with the results list when a user selects the `null` value put in by PB editor.

## Jira Ticket

- [THEMES-1587](https://arcpublishing.atlassian.net/browse/THEMES-1587)

## Test Steps

- Add test steps a reviewer must complete to test this PR

1. Checkout this branch `git checkout THEMES-1587-handle-null`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/results-list-block`
3. Create or edit a page with a results list block.
4. Select `---` in the image ratio option.
5. The images should display with the default aspect ratio of `3:2` and there should be no error.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1587]: https://arcpublishing.atlassian.net/browse/THEMES-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ