### PR TITLE
THEMES-1681: Ad misalignment fix

### DIFF
--- a/blocks/ads-block/features/ads/default.jsx
+++ b/blocks/ads-block/features/ads/default.jsx
@@ -35,7 +35,7 @@ export const ArcAdDisplay = (props) => {
 		<Stack id={`arcad-feature-${instanceId}`} className={BLOCK_CLASS_NAME} alignment="center">
 			{showAdLabel ? <Paragraph>{adLabel}</Paragraph> : null}
 			{showAd ? (
-				<div style={sizing}>
+				<div style={sizing} data-testid="ad-block-unit-wrapper">
 					<LazyLoad
 						enabled={lazyLoad}
 						offsetBottom={0}
@@ -76,11 +76,10 @@ const ArcAd = (props) => {
 	// istanbul ignore next
 	const isAMP = () => !!(propsWithContext.outputType && propsWithContext.outputType === "amp");
 
-	const [width, height] = config.adClass ? config.adClass.split("x") : [];
+	const [, height] = config.adClass ? config.adClass.split("x") : [];
 
 	const sizing = {
-		maxWidth: `${width}px`,
-		minHeight: reserveSpace ? `${height}px` : null,
+		minBlockSize: reserveSpace && height ? `${height}px` : null,
 	};
 
 	// shows ADVERTISEMENT (en) string above the ad

--- a/blocks/ads-block/features/ads/default.test.jsx
+++ b/blocks/ads-block/features/ads/default.test.jsx
@@ -81,24 +81,10 @@ describe("<ArcAd>", () => {
 		});
 
 		describe("Reserve Space", () => {
-			it("renders with width only", () => {
-				const adProps = {
-					...AD_PROPS_MOCK,
-					customFields: {
-						reserveSpace: false,
-					},
-				};
-				const { container } = render(<ArcAd {...adProps} />);
-				const adContainer = container.querySelector("div.b-ads-block > div");
-				expect(adContainer.style.maxWidth).not.toBe("");
-				expect(adContainer.style.minHeight).toBe("");
-			});
-
-			it("renders with height and width", () => {
-				const { container } = render(<ArcAd {...AD_PROPS_MOCK} />);
-				const adContainer = container.querySelector("div.b-ads-block > div");
-				expect(adContainer.style.maxWidth).not.toBe("");
-				expect(adContainer.style.minHeight).not.toBe("");
+			it("renders with height", () => {
+				render(<ArcAd {...AD_PROPS_MOCK} />);
+				const adContainer = screen.getByTestId("ad-block-unit-wrapper");
+				expect(adContainer.style.minBlockSize).toBe("250px");
 			});
 		});
 


### PR DESCRIPTION
## Description

This PR fixes an issue with ads overflowing their containers and becoming misaligned.

## Jira Ticket

- [THEMES-1681](https://arcpublishing.atlassian.net/browse/THEMES-1681)

## Acceptance Criteria

- Ads are centered

## Test Steps

1. Checkout this branch `git checkout THEMES-1681`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/ads-block`
3. Visit a rendered page with an ad set on it (like http://localhost/pf/homepage/?_website=the-gazette, the editor shows dummy ad DOM that this change won't affect).
4. Make sure the top ad is not off-center to the right.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1681]: https://arcpublishing.atlassian.net/browse/THEMES-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ