### PR TITLE
Results list block | Removed code causing SSR to be null

### DIFF
--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -28,10 +28,6 @@ const ResultsList = ({ customFields }) => {
 	const configuredSize =
 		parseInt(contentConfigValues?.size, 10) || parseInt(contentConfigValues?.feedSize, 10) || 10;
 
-	if (isServerSideLazy) {
-		// On Server
-		return null;
-	}
 	return (
 		<LazyLoad enabled={lazyLoad && !isAdmin}>
 			<HeadingSection>

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -57,7 +57,7 @@ describe("Results List", () => {
 		};
 
 		const { unmount } = render(<ResultsList customFields={customFields} />);
-		expect(screen.queryByText("Results")).toBeInTheDocument();
+		expect(screen.getByText("Results")).toBeInTheDocument();
 		unmount();
 	});
 
@@ -80,7 +80,7 @@ describe("Results List", () => {
 		};
 
 		const { unmount } = render(<ResultsList customFields={customFields} />);
-		expect(screen.queryByText("Results")).toBeInTheDocument();
+		expect(screen.getByText("Results")).toBeInTheDocument();
 		unmount();
 	});
 });
@@ -132,7 +132,7 @@ describe("configured values", () => {
 		};
 
 		const { unmount } = render(<ResultsList customFields={customFields} />);
-		expect(screen.queryByText(/"configuredOffset":0/i)).toBeInTheDocument();
+		expect(screen.getByText(/"configuredOffset":0/i)).toBeInTheDocument();
 		unmount();
 	});
 	it("should default size to 10 if not configured", () => {
@@ -145,7 +145,7 @@ describe("configured values", () => {
 		};
 
 		const { unmount } = render(<ResultsList customFields={customFields} />);
-		expect(screen.queryByText(/"configuredSize":10/i)).toBeInTheDocument();
+		expect(screen.getByText(/"configuredSize":10/i)).toBeInTheDocument();
 		unmount();
 	});
 });
@@ -161,7 +161,7 @@ describe("isServerSideLazy flag", () => {
 		};
 
 		const { unmount } = render(<ResultsList customFields={customFields} />);
-		expect(screen.queryByText(/"isServerSideLazy":false/i)).toBeInTheDocument();
+		expect(screen.getByText(/"isServerSideLazy":false/i)).toBeInTheDocument();
 		unmount();
 	});
 	it("should be false if isAdmin is true", () => {
@@ -181,7 +181,7 @@ describe("isServerSideLazy flag", () => {
 		};
 
 		const { unmount } = render(<ResultsList customFields={customFields} />);
-		expect(screen.queryByText(/"isServerSideLazy":false/i)).toBeInTheDocument();
+		expect(screen.getByText(/"isServerSideLazy":false/i)).toBeInTheDocument();
 		unmount();
 	});
 	it("should be true if isServerSide is true, admin is false, and lazyload is false", () => {
@@ -201,7 +201,7 @@ describe("isServerSideLazy flag", () => {
 		};
 
 		const { unmount } = render(<ResultsList customFields={customFields} />);
-		expect(screen.queryByText(/"isServerSideLazy":true/i)).toBeInTheDocument();
+		expect(screen.getByText(/"isServerSideLazy":true/i)).toBeInTheDocument();
 		unmount();
 	});
 });

--- a/blocks/results-list-block/features/results-list/results/index.jsx
+++ b/blocks/results-list-block/features/results-list/results/index.jsx
@@ -135,7 +135,7 @@ const Results = ({
     }`,
 	});
 
-	const [resultList, alterResultList] = useReducer(reduceResultList, { content_elements: [] });
+	const [resultList, alterResultList] = useReducer(reduceResultList, { content_elements: requestedResultList?.content_elements || [] });
 
 	useEffect(() => {
 		if (requestedResultList) {

--- a/blocks/results-list-block/features/results-list/results/index.test.jsx
+++ b/blocks/results-list-block/features/results-list/results/index.test.jsx
@@ -139,9 +139,7 @@ describe("seeMore", () => {
 	it("should trigger a state update", () => {
 		useContent
 			.mockReset()
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[0])
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[1]);
 
 		const { unmount } = render(
@@ -168,7 +166,7 @@ describe("seeMore", () => {
 	});
 
 	it("should not show for the last items", () => {
-		useContent.mockReset().mockReturnValueOnce({}).mockReturnValueOnce(mockLastItemContent[0]);
+		useContent.mockReset().mockReturnValueOnce(mockLastItemContent[0]);
 
 		const { unmount } = render(
 			<Results
@@ -191,7 +189,7 @@ describe("seeMore", () => {
 
 describe("focus", () => {
 	it("should not be set on the very first item on the page", () => {
-		useContent.mockReset().mockReturnValueOnce({}).mockReturnValueOnce(mockContent[0]);
+		useContent.mockReset().mockReturnValueOnce(mockContent[0]);
 
 		const { unmount } = render(
 			<Results
@@ -212,9 +210,7 @@ describe("focus", () => {
 	it("should be set on the first new item added", () => {
 		useContent
 			.mockReset()
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[0])
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[1]);
 
 		const { unmount } = render(
@@ -237,9 +233,7 @@ describe("focus", () => {
 	it("should not set focus if there is no link", () => {
 		useContent
 			.mockReset()
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[0])
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[1]);
 
 		const { unmount } = render(
@@ -264,9 +258,7 @@ describe("story-feed-query service", () => {
 	it("should call useContent with appropriate query parameters", () => {
 		useContent
 			.mockReset()
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[0])
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[1]);
 
 		const { unmount } = render(
@@ -313,9 +305,7 @@ describe("content-api-collections service", () => {
 	it("should call useContent with appropriate query parameters", () => {
 		useContent
 			.mockReset()
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[0])
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[1]);
 
 		const { unmount } = render(
@@ -364,9 +354,7 @@ describe("story-feed-author service", () => {
 	it("should call useContent with appropriate query parameters", () => {
 		useContent
 			.mockReset()
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[0])
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[1]);
 
 		const { unmount } = render(
@@ -413,9 +401,7 @@ describe("story-feed-sections service", () => {
 	it("should call useContent with appropriate query parameters", () => {
 		useContent
 			.mockReset()
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[0])
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[1]);
 
 		const { unmount } = render(
@@ -506,9 +492,7 @@ describe("unknown service", () => {
 	it("should call useContent with appropriate query parameters", () => {
 		useContent
 			.mockReset()
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[0])
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[1]);
 
 		const { unmount } = render(
@@ -548,10 +532,8 @@ describe("lazy flags", () => {
 	it("should return nothing if isServerSideLazy is true", () => {
 		useContent
 			.mockReset()
-			.mockReturnValueOnce({})
-			.mockReturnValueOnce(mockContent[0])
-			.mockReturnValueOnce({})
-			.mockReturnValueOnce(mockContent[1]);
+			.mockReturnValueOnce(null)
+			.mockReturnValueOnce(null);
 
 		const { unmount } = render(
 			<Results
@@ -580,9 +562,7 @@ describe("fallback image", () => {
 	it("should return even if the fallback image is not a /resource/ path", () => {
 		useContent
 			.mockReset()
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[0])
-			.mockReturnValueOnce({})
 			.mockReturnValueOnce(mockContent[1]);
 
 		const { unmount } = render(


### PR DESCRIPTION
## Description

Fix to the rendering behavior of the results list block.

## Jira Ticket

- [THEMES-1464](https://arcpublishing.atlassian.net/browse/THEMES-1464)

## Acceptance Criteria

Unit tests should pass

## Test Steps

1. Checkout this branch `git checkout results-list-ssr-fix`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/results-list-block`
3. The results list should function as expected with the lazy load option on or off.
4. Unit tests should pass.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Confirmed there are no linter errors. Please run `npm run lint` to check for errors. Often, `npm run lint:fix` will fix those errors and warnings.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed this PR has reasonable code coverage. You can run `npm run test:coverage` to see your progress.
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm run test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] Linting code actions have passed.
- [ ] Ran the code locally based on the test instructions.
  - [ ] I don’t think this is needed to be tested locally. For example, a padding style change (storybook?) or a logic change (write a test).
- [ ] I am a member of the engine theme team so that I can approve and merge this. If you're not on the team, you won't have access to approve and merge this pr.
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.


[THEMES-1464]: https://arcpublishing.atlassian.net/browse/THEMES-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ