### PR TITLE
THEMES-1900: Fix logic for detecting 404 for sectionId/_id

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_style = space
+indent_style = tab
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.js
+++ b/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.js
@@ -11,11 +11,11 @@ export default {
 		sectionId: "text",
 	},
 	transform: (data, query) => {
-		if (query?.sectionId === data._id) {
-			return data;
+		if (query.sectionId && query.sectionId !== data._id) {
+			const error = new Error("Not found");
+			error.statusCode = 404;
+			throw error;
 		}
-		const error = new Error("Not found");
-		error.statusCode = 404;
-		throw error;
+		return data;
 	},
 };

--- a/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.js
+++ b/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.js
@@ -1,27 +1,21 @@
 export default {
-	resolve(resolveParams) {
-		const { hierarchy, sectionId, "arc-site": arcSite } = resolveParams;
-		return `/site/v3/navigation/${arcSite}?${hierarchy ? `hierarchy=${hierarchy}` : ""}${
-			sectionId ? `&_id=${sectionId}` : ""
-		}`;
-	},
-	schemaName: "navigation-hierarchy",
-	params: {
-		hierarchy: "text",
-		sectionId: "text",
-	},
-	transform: (data, query) => {
-		let idMatch = false;
-		if (query.sectionId) {
-			idMatch = data._id !== query.sectionId;
-		}
-
-		if ((!query.hierarchy && idMatch) || (query.uri && idMatch)) {
-			const error = new Error("Not found");
-			error.statusCode = 404;
-			throw error;
-		}
-
-		return data;
-	},
+    resolve(resolveParams) {
+        const { hierarchy, sectionId, "arc-site": arcSite } = resolveParams;
+        return `/site/v3/navigation/${arcSite}?${hierarchy ? `hierarchy=${hierarchy}` : ""}${
+            sectionId ? `&_id=${sectionId}` : ""
+        }`;
+    },
+    schemaName: "navigation-hierarchy",
+    params: {
+        hierarchy: "text",
+        sectionId: "text",
+    },
+    transform: (data, query) => {
+        if (query?.sectionId === data._id) {
+            return data;
+        }
+        const error = new Error("Not found");
+        error.statusCode = 404;
+        throw error;
+    },
 };

--- a/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.js
+++ b/blocks/site-hierarchy-content-block/sources/site-service-hierarchy.js
@@ -1,21 +1,21 @@
 export default {
-    resolve(resolveParams) {
-        const { hierarchy, sectionId, "arc-site": arcSite } = resolveParams;
-        return `/site/v3/navigation/${arcSite}?${hierarchy ? `hierarchy=${hierarchy}` : ""}${
-            sectionId ? `&_id=${sectionId}` : ""
-        }`;
-    },
-    schemaName: "navigation-hierarchy",
-    params: {
-        hierarchy: "text",
-        sectionId: "text",
-    },
-    transform: (data, query) => {
-        if (query?.sectionId === data._id) {
-            return data;
-        }
-        const error = new Error("Not found");
-        error.statusCode = 404;
-        throw error;
-    },
+	resolve(resolveParams) {
+		const { hierarchy, sectionId, "arc-site": arcSite } = resolveParams;
+		return `/site/v3/navigation/${arcSite}?${hierarchy ? `hierarchy=${hierarchy}` : ""}${
+			sectionId ? `&_id=${sectionId}` : ""
+		}`;
+	},
+	schemaName: "navigation-hierarchy",
+	params: {
+		hierarchy: "text",
+		sectionId: "text",
+	},
+	transform: (data, query) => {
+		if (query?.sectionId === data._id) {
+			return data;
+		}
+		const error = new Error("Not found");
+		error.statusCode = 404;
+		throw error;
+	},
 };


### PR DESCRIPTION
## Description

#### Jira Ticket: [THEMES-1900](https://arcpublishing.atlassian.net/browse/THEMES-1900)

Fixing section api 404 detection

## Test Steps

1. Checkout this branch `git checkout themes-1900`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/site-hierarchy-content-block`
3. http://localhost/pagebuilder/tools/debugger?_website=the-baltimore-banner&type=content-debugger&source=site-service-hierarchy&config={%22sectionId%22:%22/asdf%22,%22hierarchy%22:%22%22}
4. also search for `/topic/education` section which should return data


[THEMES-1900]: https://arcpublishing.atlassian.net/browse/THEMES-1900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ