### PR TITLE
Cleaning up extra key in news.scss

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -2854,10 +2854,6 @@
 					"display": flex,
 					"flex-wrap": wrap
 				),
-				"section-title-links": (
-					"display": flex,
-					"flex-wrap": wrap
-				),
 				"share-bar": (
 					"background": var(--background-color),
 					"box-shadow": var(--global-box-shadow-1),


### PR DESCRIPTION
## Description

Quick clean up PR to fix the news.scss for storybook. Looks like a duplicate key got added as part of resolving a merge conflict.

## Test Steps

1. Checkout this branch `git checkout fox-storybook-news-scss`
2. Run storybook `npm run storybook`
3. Storybook should start with no errors.
