### PR TITLE
[Themes 1930] Added height to header-nav-chain-flyout-overlay-open

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1636,7 +1636,8 @@
 					"overflow-y": scroll,
 					"overflow-block": scroll,
 					"transform": translate(0, 0),
-					"inline-size": 100%
+					"inline-size": 100%,
+					"height": calc(100vh - var(--header-nav-chain-height))
 				),
 				"header-nav-chain-flyout-overlay-scrollbar": (
 					"display": none

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1636,8 +1636,7 @@
 					"overflow-y": scroll,
 					"overflow-block": scroll,
 					"transform": translate(0, 0),
-					"inline-size": 100%,
-					"height": calc(100vh - var(--header-nav-chain-height))
+					"inline-size": calc(100vh - var(--header-nav-chain-height))
 				),
 				"header-nav-chain-flyout-overlay-scrollbar": (
 					"display": none

--- a/blocks/header-nav-chain-block/themes/news.json
+++ b/blocks/header-nav-chain-block/themes/news.json
@@ -335,8 +335,7 @@
 				"overflow-y": "scroll",
 				"overflow-block": "scroll",
 				"transform": "translate(0, 0)",
-				"inline-size": "100%",
-				"height": "calc(100vh - var(--header-nav-chain-height))"
+				"inline-size": "calc(100vh - var(--header-nav-chain-height))"
 			},
 			"desktop": {}
 		}

--- a/blocks/header-nav-chain-block/themes/news.json
+++ b/blocks/header-nav-chain-block/themes/news.json
@@ -335,7 +335,8 @@
 				"overflow-y": "scroll",
 				"overflow-block": "scroll",
 				"transform": "translate(0, 0)",
-				"inline-size": "100%"
+				"inline-size": "100%",
+				"height": "calc(100vh - var(--header-nav-chain-height))"
 			},
 			"desktop": {}
 		}


### PR DESCRIPTION
## Description

#### Jira Ticket: [THEMES-1930](https://arcpublishing.atlassian.net/browse/THEMES-1930)
We noticed that there’re some items of the side menu navigation list which never reach to be visible on the screen after scrolling the side menu down.
I attach some screenshots to clarify my description

Once the side menu is scrolled down “to the end of it”, the entire screen starts to scroll like there was no more items to show, but this is no true. 
It appears that the height of the side menu is not being properly calculated.

## Test Steps

1. Checkout this branch `git checkout THEMES-1930`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Flyout overlay should be scrollable when opn


[THEMES-1930]: https://arcpublishing.atlassian.net/browse/THEMES-1930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ