### PR TITLE
[Themes 1676] Fixed triple-chain large-manual-promo Desktop view

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -3417,6 +3417,9 @@
 				"triple-chain-child-item": (
 					"gap": var(--global-spacing-6) 0
 				),
+				"triple-chain-child-item-grid": (
+					"display": "grid"
+				),
 				"triple-chain-child-item-empty": (
 					"display": contents
 				),
@@ -4510,6 +4513,9 @@
 				),
 				"triple-chain-child-item-empty": (
 					"display": initial
+				),
+				"triple-chain-child-item-grid": (
+					"display": "flex"
 				),
 				"triple-chain-children-grid": (
 					"grid-template-columns": 1fr 1fr 1fr,

--- a/blocks/triple-chain-block/_index.scss
+++ b/blocks/triple-chain-block/_index.scss
@@ -16,6 +16,11 @@
 			@include scss.block-components("quad-chain-child-item-empty");
 			@include scss.block-properties("quad-chain-child-item-empty");
 		}
+		
+		.c-grid {
+			@include scss.block-components("triple-chain-child-item-grid");
+			@include scss.block-properties("triple-chain-child-item-grid");
+		}
 
 		@include scss.block-components("triple-chain-child-item");
 		@include scss.block-properties("triple-chain-child-item");

--- a/blocks/triple-chain-block/themes/news.json
+++ b/blocks/triple-chain-block/themes/news.json
@@ -29,7 +29,8 @@
 			},
 			"desktop": {}
 		}
-	},"triple-chain-child-item-grid": {
+	},
+	"triple-chain-child-item-grid": {
 		"styles": {
 			"default": {
 				"display": "grid"

--- a/blocks/triple-chain-block/themes/news.json
+++ b/blocks/triple-chain-block/themes/news.json
@@ -29,6 +29,15 @@
 			},
 			"desktop": {}
 		}
+	},"triple-chain-child-item-grid": {
+		"styles": {
+			"default": {
+				"display": "grid"
+			},
+			"desktop": {
+				"display": "flex"
+			}
+		}
 	},
 	"triple-chain-child-item-empty": {
 		"styles": {


### PR DESCRIPTION
## Description

#### Jira Ticket: [THEMES-1676](https://arcpublishing.atlassian.net/browse/THEMES-1676)


## Test Steps

1. Checkout this branch `git checkout THEMES-1676-fix`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/triple-chain-block`
3. Add large-manual-promo-blocks to triple-chain. 
4. Check for Desktop view, Large-manual-promo Image and description are side-by-side in desktop view


[THEMES-1676]: https://arcpublishing.atlassian.net/browse/THEMES-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ