### PR TITLE
added configurations for collections search

### DIFF
--- a/blocks/collections-content-source-block/sources/content-api-collections.js
+++ b/blocks/collections-content-source-block/sources/content-api-collections.js
@@ -40,7 +40,7 @@ const params = [
 
 const fetch = (
 	{ _id, "arc-site": site, content_alias: contentAlias, from, getNext = "false", size },
-	{ cachedCall }
+	{ cachedCall },
 ) => {
 	// Max collection size is 20
 	// See: https://redirector.arcpublishing.com/alc/docs/swagger/?url=./arc-products/content-api.json
@@ -84,7 +84,7 @@ const fetch = (
 									...(data?.content_elements || []),
 									...(next?.content_elements || []),
 								],
-						  }
+							}
 						: {}),
 				}));
 		})
@@ -95,4 +95,5 @@ export default {
 	fetch,
 	params,
 	schemaName: "ans-feed",
+	searchable: "collection",
 };


### PR DESCRIPTION
**Be sure to run `npm test`, `npm run lint`, and write detailed test steps before requesting reviewers**

## Description

#### Jira Ticket: [THEMES-1633](https://arcpublishing.atlassian.net/browse/THEMES-1633)

Updated the content-api-collections block to allow for searchable collections

## Test Steps

_Add detailed test steps a reviewer must complete to test this PR_

1. Checkout this branch `git checkout THEMES-1633`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/collections-content-source-block`
3. Open a page in Pagebuilder, and add a list block.
4. In each block, under 'Display Content Info' select 'ans-feed', and under 'Content Source' select 'content-api-collections'
5. Verify that the "Select collection" button appears, and select a collection
6. Verify that the configure content section correctly populates the collection id and that the collection is successfully rendered in the block.

<img width="322" alt="image" src="https://github.com/WPMedia/arc-themes-blocks/assets/85515364/f8ea10d3-ffeb-4791-9d88-9a3ff55aa4f9">

[THEMES-1633]: https://arcpublishing.atlassian.net/browse/THEMES-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ