### PR TITLE
Corrected styling for nav overlay

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -2010,10 +2010,11 @@
 				),
 				"header-nav-chain-flyout-overlay-open": (
 					"background": var(--header-nav-chain-overlay-background-color),
+					"block-size": calc(100vh - var(--header-nav-chain-height)),
+					"inline-size": 100%,
 					"overflow-y": scroll,
 					"overflow-block": scroll,
-					"transform": translate(0, 0),
-					"inline-size": calc(100vh - var(--header-nav-chain-height))
+					"transform": translate(0, 0)
 				),
 				"header-nav-chain-flyout-overlay-scrollbar": (
 					"display": none

--- a/blocks/header-nav-chain-block/themes/news.json
+++ b/blocks/header-nav-chain-block/themes/news.json
@@ -354,10 +354,11 @@
 		"styles": {
 			"default": {
 				"background": "var(--header-nav-chain-overlay-background-color)",
+				"block-size": "calc(100vh - var(--header-nav-chain-height))",
 				"overflow-y": "scroll",
 				"overflow-block": "scroll",
 				"transform": "translate(0, 0)",
-				"inline-size": "calc(100vh - var(--header-nav-chain-height))"
+				"inline-size": "100%"
 			},
 			"desktop": {}
 		}


### PR DESCRIPTION
## Description

Corrected a regression where vertical height was being used to calculate the inline size.

## Test Steps

1. Checkout this branch `git checkout nav-overlay-bug`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/header-nav-chain-block`
3. Go to a page and open the section nav menu.
4. The overlay should cover the expected part of the screen, rather than only about half of it.

### Before
![Screenshot 2024-05-28 at 9 49 34 AM](https://github.com/WPMedia/arc-themes-blocks/assets/4759882/c643e6bf-763a-4088-83b7-f774e21e2095)

### After
![Screenshot 2024-05-28 at 9 50 12 AM](https://github.com/WPMedia/arc-themes-blocks/assets/4759882/0745e1be-68da-454b-8b46-0e7ef51e8513)
