### PR TITLE
Remove polyfill script tag for Hotfix

### DIFF
--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -199,10 +199,6 @@ const SampleOutputType = ({
 				<CssLinks />
 				<Libs />
 				<script
-					async
-					src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver%2CElement.prototype.prepend%2CElement.prototype.remove%2CArray.prototype.find%2CArray.prototype.includes"
-				/>
-				<script
 					data-integration="inlineScripts"
 					dangerouslySetInnerHTML={{ __html: inlineScripts }}
 				/>


### PR DESCRIPTION
## Description

Removes the polyfill script tag for the default output type block.

## Test Steps

1. Checkout this branch `git checkout remove-polyfill`
2. Run fusion repo with linked blocks `npx fusion start -f -l @wpmedia/default-output-block`
3. On any page, the `polyfill.io` script tag should not be present.
