### PR TITLE
Themes 1986: Add Alt tags to images where missing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
 		Atomics: "readonly",
 		SharedArrayBuffer: "readonly",
 		Fusion: "readonly",
-		history: "readonly"
+		history: "readonly",
 	},
 	ignorePatterns: [
 		"**/features/ad-taboola/default.jsx",

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
 	"useTabs": true,
-	"printWidth": 100
+	"printWidth": 100,
+	experimentalTernaries: false,
 }

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -144,7 +144,12 @@ const CardListItems = (props) => {
 
 	const sourceContent = contentElements[offsetOverride];
 
-	const displayDate = localizeDateTime(sourceContent.display_date, dateTimeFormat, language, timeZone);
+	const displayDate = localizeDateTime(
+		sourceContent.display_date,
+		dateTimeFormat,
+		language,
+		timeZone,
+	);
 
 	/* Author Formatting */
 	const bylineNodes = formatAuthors(sourceContent?.credits?.by, phrases.t("global.and-text"));

--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -178,9 +178,7 @@ const CardListItems = (props) => {
 		? {
 				ansImage,
 				aspectRatio: "4:3",
-				resizedOptions: {
-					...getFocalFromANS(ansImage),
-				},
+				resizedOptions: getFocalFromANS(ansImage),
 				responsiveImages: [377, 754, 1508],
 				width: 377,
 			}
@@ -238,9 +236,7 @@ const CardListItems = (props) => {
 								? {
 										ansImage: itemAnsImage,
 										aspectRatio: "3:2",
-										resizedOptions: {
-											...getFocalFromANS(itemAnsImage),
-										},
+										resizedOptions: getFocalFromANS(itemAnsImage),
 										responsiveImages: [105, 210, 420],
 										width: 105,
 									}

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -83,9 +83,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 				ansImage,
 				alt,
 				aspectRatio: imageRatio,
-				resizedOptions: {
-					...getFocalFromANS(ansImage)
-				},
+					resizedOptions: getFocalFromANS(ansImage),
 				responsiveImages: [200, 400, 600, 800, 1200],
 				width: 600,
 			}

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -57,7 +57,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 			: {
 				source: "signing-service",
 				query: { id: manualImageId || imageURL },
-			}
+				},
 	);
 	if (imageAuth && !resizedAuth) {
 		resizedAuth = JSON.parse(imageAuth);
@@ -74,8 +74,8 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 		_id: resizedImage ? imageId : manualImageId,
 		url: imageURL,
 		auth: resizedAuth,
-		focal_point: imageFocalPoint ? JSON.parse(imageFocalPoint) : undefined
-	}
+		focal_point: imageFocalPoint ? JSON.parse(imageFocalPoint) : undefined,
+	};
 	const alt = headline || description || null;
 	const imageParams =
 		imageURL && resizedAuth
@@ -124,7 +124,7 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 									imageURL: "url",
 									imageId: "_id",
 									imageAuth: "auth",
-									imageFocalPoint: "focal_point"
+									imageFocalPoint: "focal_point",
 								})}
 								suppressContentEditableWarning
 							>

--- a/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
+++ b/blocks/extra-large-manual-promo-block/features/extra-large-manual-promo/default.jsx
@@ -55,8 +55,8 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 		resizedImage || !imageURL
 			? {}
 			: {
-				source: "signing-service",
-				query: { id: manualImageId || imageURL },
+					source: "signing-service",
+					query: { id: manualImageId || imageURL },
 				},
 	);
 	if (imageAuth && !resizedAuth) {
@@ -80,17 +80,17 @@ const ExtraLargeManualPromo = ({ customFields }) => {
 	const imageParams =
 		imageURL && resizedAuth
 			? {
-				ansImage,
-				alt,
-				aspectRatio: imageRatio,
+					alt,
+					ansImage,
+					aspectRatio: imageRatio,
 					resizedOptions: getFocalFromANS(ansImage),
-				responsiveImages: [200, 400, 600, 800, 1200],
-				width: 600,
-			}
+					responsiveImages: [200, 400, 600, 800, 1200],
+					width: 600,
+				}
 			: {
-				src: fallbackImage,
-				alt,
-			};
+					alt,
+					src: fallbackImage,
+				};
 
 	const availableDescription = showDescription ? description : null;
 	const availableHeadline = showHeadline ? headline : null;

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -169,7 +169,7 @@ const ExtraLargePromo = ({ customFields }) => {
 				? {
 						feature: "extra-large-promo",
 						...itemContentConfig.contentConfigValues,
-				  }
+					}
 				: null,
 			filter: `{
 				_id
@@ -312,22 +312,22 @@ const ExtraLargePromo = ({ customFields }) => {
 		showImage &&
 		(imageOverrideURL || ansImage
 			? {
+					alt: content?.headlines?.basic || "",
 					ansImage: imageOverrideURL
 						? {
-							_id: resizedImage ? imageOverrideId : manualImageId,
-							url: imageOverrideURL,
-							auth: resizedAuth || {},
-						}
+								_id: resizedImage ? imageOverrideId : manualImageId,
+								url: imageOverrideURL,
+								auth: resizedAuth || {},
+							}
 						: ansImage,
-					alt: content?.headlines?.basic || "",
 					aspectRatio: imageRatio,
 					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [400, 600, 800, 1200],
 					width: 800,
-			  }
+				}
 			: {
 					src: fallbackImage,
-			  });
+				});
 	const videoOrGalleryContentType =
 		getType("video", content) ||
 		getType("gallery", content) ||

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -321,9 +321,7 @@ const ExtraLargePromo = ({ customFields }) => {
 						: ansImage,
 					alt: content?.headlines?.basic || "",
 					aspectRatio: imageRatio,
-					resizedOptions: {
-						...getFocalFromANS(ansImage),
-					},
+					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [400, 600, 800, 1200],
 					width: 800,
 			  }

--- a/blocks/hero-block/features/hero/default.jsx
+++ b/blocks/hero-block/features/hero/default.jsx
@@ -89,41 +89,42 @@ function Hero({ customFields }) {
 	const desktopImageParams =
 		imageId && imageDesktopURL
 			? {
-					src: imageANSToImageSrc({
-						_id: imageId,
-						url: imageDesktopURL,
-					}),
+					alt,
+					height: 800,
 					resizedOptions: {
 						auth: desktopAuth || {},
 						smart: true,
 					},
-					width: 1200,
-					height: 800,
 					resizerURL,
-			  }
+					src: imageANSToImageSrc({
+						_id: imageId,
+						url: imageDesktopURL,
+					}),
+					width: 1200,
+				}
 			: {
 					src: fallbackImage,
-			  };
+				};
 	const mobileImageParams =
 		imageMobileId && imageMobileURL
 			? {
+					alt,
 					ansImage: {
 						_id: imageMobileId,
 						url: imageMobileURL,
 						auth: mobileAuth || {},
 					},
-					alt,
+					height: 400,
 					resizedOptions: {
 						smart: true,
 					},
-					width: 320,
-					height: 400,
 					resizerURL,
-			  }
+					width: 320,
+				}
 			: {
-					src: fallbackImage,
 					alt: imageMobileAlt,
-			  };
+					src: fallbackImage,
+				};
 	const HeadingWrapper = headline ? HeadingSection : Fragment;
 	return (
 		<div className={classes}>

--- a/blocks/hero-block/features/hero/default.jsx
+++ b/blocks/hero-block/features/hero/default.jsx
@@ -45,20 +45,16 @@ function Hero({ customFields }) {
 	const { arcSite } = useFusionContext();
 	const { searchableField } = useEditableContent();
 	const { fallbackImage, resizerURL } = getProperties(arcSite);
-	const imageId = imageDesktopURL
-		? getManualImageID(imageDesktopURL)
-		: desktopImgId;
+	const imageId = imageDesktopURL ? getManualImageID(imageDesktopURL) : desktopImgId;
 
-	const imageMobileId = imageMobileURL
-		? getManualImageID(imageMobileURL)
-		: imgMobileId;
+	const imageMobileId = imageMobileURL ? getManualImageID(imageMobileURL) : imgMobileId;
 	let desktopAuth = useContent(
 		!imageDesktopAuth && imageId
 			? {
 					source: "signing-service",
 					query: { id: imageId },
-			  }
-			: {}
+				}
+			: {},
 	);
 
 	if (!desktopAuth || (desktopAuth && !Object.keys(desktopAuth).length)) {
@@ -74,8 +70,8 @@ function Hero({ customFields }) {
 			? {
 					source: "signing-service",
 					query: { id: imageMobileId },
-			  }
-			: {}
+				}
+			: {},
 	);
 	if (mobileAuth?.hash) {
 		mobileAuth[RESIZER_TOKEN_VERSION] = mobileAuth.hash;

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -93,9 +93,7 @@ const LargeManualPromo = ({ customFields }) => {
 				ansImage,
 				alt,
 				aspectRatio: imageRatio,
-				resizedOptions: {
-					...getFocalFromANS(ansImage)
-				},
+					resizedOptions: getFocalFromANS(ansImage),
 				responsiveImages: [200, 400, 600, 800, 1200],
 				width: 600,
 			}

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -90,17 +90,17 @@ const LargeManualPromo = ({ customFields }) => {
 	const imageParams =
 		imageURL && resizedAuth
 			? {
-				ansImage,
-				alt,
-				aspectRatio: imageRatio,
+					alt,
+					ansImage,
+					aspectRatio: imageRatio,
 					resizedOptions: getFocalFromANS(ansImage),
-				responsiveImages: [200, 400, 600, 800, 1200],
-				width: 600,
-			}
+					responsiveImages: [200, 400, 600, 800, 1200],
+					width: 600,
+				}
 			: {
-				src: fallbackImage,
-				alt,
-			};
+					alt,
+					src: fallbackImage,
+				};
 
 	return (
 		<LazyLoad enabled={shouldLazyLoad}>

--- a/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
+++ b/blocks/large-manual-promo-block/features/large-manual-promo/default.jsx
@@ -65,9 +65,9 @@ const LargeManualPromo = ({ customFields }) => {
 		resizedImage || !imageURL
 			? {}
 			: {
-				source: "signing-service",
-				query: { id: manualImageId || imageURL },
-			}
+					source: "signing-service",
+					query: { id: manualImageId || imageURL },
+				},
 	);
 	if (imageAuth && !resizedAuth) {
 		resizedAuth = JSON.parse(imageAuth);
@@ -83,8 +83,8 @@ const LargeManualPromo = ({ customFields }) => {
 		_id: resizedImage ? imageId : manualImageId,
 		url: imageURL,
 		auth: resizedAuth,
-		focal_point: imageFocalPoint ? JSON.parse(imageFocalPoint) : undefined
-	}
+		focal_point: imageFocalPoint ? JSON.parse(imageFocalPoint) : undefined,
+	};
 
 	const alt = headline || description || null;
 	const imageParams =
@@ -130,7 +130,11 @@ const LargeManualPromo = ({ customFields }) => {
 						</MediaItem>
 					) : null}
 					<Stack className={`${BLOCK_CLASS_NAME}__text`}>
-						<PromoOverline showOverline={showOverline} overline={overline} overlineURL={overlineURL} />
+						<PromoOverline
+							showOverline={showOverline}
+							overline={overline}
+							overlineURL={overlineURL}
+						/>
 						{showDescription || showHeadline ? (
 							<Stack>
 								{showHeadline && headline ? (

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -272,7 +272,7 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 	let resizedAuth = useContent(
 		resizedImage || !imageOverrideURL
 			? {}
-			: { source: "signing-service", query: { id: manualImageId || imageOverrideURL } }
+			: { source: "signing-service", query: { id: manualImageId || imageOverrideURL } },
 	);
 	if (imageOverrideAuth && !resizedAuth) {
 		resizedAuth = JSON.parse(imageOverrideAuth);
@@ -292,12 +292,10 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 		fallbackImage,
 	} = getProperties(arcSite);
 
-	const displayDate = content?.display_date && Date.parse(content?.display_date) ? localizeDateTime(
-		new Date(content?.display_date),
-		dateTimeFormat,
-		language,
-		timeZone
-	) : "";
+	const displayDate =
+		content?.display_date && Date.parse(content?.display_date)
+			? localizeDateTime(new Date(content?.display_date), dateTimeFormat, language, timeZone)
+			: "";
 	const phrases = usePhrases();
 
 	const editableDescription = content?.description

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -179,7 +179,7 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 						"arc-site": arcSite,
 						feature: "large-promo",
 						...customFields?.itemContentConfig?.contentConfigValues,
-				  }
+					}
 				: null,
 			filter: `{
 				_id
@@ -347,26 +347,26 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 	const contentUrl = content?.websites?.[arcSite]?.website_url;
 	const embedMarkup = playVideoInPlace && getVideoFromANS(content);
 	const ansImage = getImageFromANS(content);
-	const promoImageParams = 
+	const promoImageParams =
 		showImage &&
 		(imageOverrideURL || ansImage
 			? {
+					alt: content?.headlines?.basic || "",
 					ansImage: imageOverrideURL
 						? {
 								_id: resizedImage ? imageOverrideId : manualImageId,
-								url: imageOverrideURL,
 								auth: resizedAuth || {},
-						  }
+								url: imageOverrideURL,
+							}
 						: ansImage,
-					alt: content?.headlines?.basic || "",
 					aspectRatio: imageRatio,
 					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [400, 600, 800, 1200],
 					width: 377,
-			  }
+				}
 			: {
 					src: fallbackImage,
-			  });
+				});
 	return (
 		<LargePromoPresentation
 			aspectRatio={imageRatio}

--- a/blocks/large-promo-block/features/large-promo/default.jsx
+++ b/blocks/large-promo-block/features/large-promo/default.jsx
@@ -362,9 +362,7 @@ const LargePromoItem = ({ customFields, arcSite }) => {
 						: ansImage,
 					alt: content?.headlines?.basic || "",
 					aspectRatio: imageRatio,
-					resizedOptions: {
-						...getFocalFromANS(ansImage),
-					},
+					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [400, 600, 800, 1200],
 					width: 377,
 			  }

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -50,9 +50,9 @@ const MediumManualPromo = ({ customFields }) => {
 		resizedImage || !imageURL
 			? {}
 			: {
-				source: "signing-service",
-				query: { id: manualImageId || imageURL },
-			}
+					source: "signing-service",
+					query: { id: manualImageId || imageURL },
+				},
 	);
 	if (imageAuth && !resizedAuth) {
 		resizedAuth = JSON.parse(imageAuth);
@@ -69,8 +69,8 @@ const MediumManualPromo = ({ customFields }) => {
 		_id: resizedImage ? imageId : manualImageId,
 		url: imageURL,
 		auth: resizedAuth,
-		focal_point: imageFocalPoint ? JSON.parse(imageFocalPoint) : undefined
-	}
+		focal_point: imageFocalPoint ? JSON.parse(imageFocalPoint) : undefined,
+	};
 	const alt = headline || description || null;
 	const imageParams =
 		imageURL && resizedAuth
@@ -99,7 +99,7 @@ const MediumManualPromo = ({ customFields }) => {
 								imageURL: "url",
 								imageId: "_id",
 								imageAuth: "auth",
-								imageFocalPoint: "focal_point"
+								imageFocalPoint: "focal_point",
 							})}
 							suppressContentEditableWarning
 						>

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -75,17 +75,17 @@ const MediumManualPromo = ({ customFields }) => {
 	const imageParams =
 		imageURL && resizedAuth
 			? {
-				ansImage,
-				alt,
-				aspectRatio: imageRatio,
+					alt,
+					ansImage,
+					aspectRatio: imageRatio,
 					resizedOptions: getFocalFromANS(ansImage),
-				responsiveImages: [200, 400, 600, 800, 1200],
-				width: 600,
-			}
+					responsiveImages: [200, 400, 600, 800, 1200],
+					width: 600,
+				}
 			: {
-				src: fallbackImage,
-				alt,
-			};
+					alt,
+					src: fallbackImage,
+				};
 
 	return (
 		<LazyLoad enabled={shouldLazyLoad}>

--- a/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
+++ b/blocks/medium-manual-promo-block/features/medium-manual-promo/default.jsx
@@ -78,9 +78,7 @@ const MediumManualPromo = ({ customFields }) => {
 				ansImage,
 				alt,
 				aspectRatio: imageRatio,
-				resizedOptions: {
-					...getFocalFromANS(ansImage)
-				},
+					resizedOptions: getFocalFromANS(ansImage),
 				responsiveImages: [200, 400, 600, 800, 1200],
 				width: 600,
 			}

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -194,9 +194,7 @@ const MediumPromo = ({ customFields }) => {
 						: ansImage,
 					alt: content?.headlines?.basic || "",
 					aspectRatio: imageRatio,
-					resizedOptions: {
-						...getFocalFromANS(ansImage),
-					},
+					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [200, 400, 600, 800, 1200],
 					width: 600,
 			  }

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -147,7 +147,7 @@ const MediumPromo = ({ customFields }) => {
 	let resizedAuth = useContent(
 		resizedImage || !imageOverrideURL
 			? {}
-			: { source: "signing-service", query: { id: manualImageId || imageOverrideURL } }
+			: { source: "signing-service", query: { id: manualImageId || imageOverrideURL } },
 	);
 	if (imageOverrideAuth && !resizedAuth) {
 		resizedAuth = JSON.parse(imageOverrideAuth);

--- a/blocks/medium-promo-block/features/medium-promo/default.jsx
+++ b/blocks/medium-promo-block/features/medium-promo/default.jsx
@@ -66,7 +66,7 @@ const MediumPromo = ({ customFields }) => {
 				? {
 						feature: "medium-promo",
 						...customFields?.itemContentConfig?.contentConfigValues,
-				  }
+					}
 				: null,
 			// does not need embed_html because no video section
 			// does not need website section nor label because no overline
@@ -185,22 +185,22 @@ const MediumPromo = ({ customFields }) => {
 	const imageParams =
 		imageOverrideURL || ansImage
 			? {
+					alt: content?.headlines?.basic || "",
 					ansImage: imageOverrideURL
 						? {
 								_id: resizedImage ? imageOverrideId : manualImageId,
 								url: imageOverrideURL,
 								auth: resizedAuth || {},
-						  }
+							}
 						: ansImage,
-					alt: content?.headlines?.basic || "",
 					aspectRatio: imageRatio,
 					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [200, 400, 600, 800, 1200],
 					width: 600,
-			  }
+				}
 			: {
 					src: fallbackImage,
-			  };
+				};
 
 	return showHeadline || showImage || showDescription || showByline || showDate ? (
 		<LazyLoad enabled={shouldLazyLoad}>

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -103,18 +103,21 @@ const NumberedList = (props) => {
 						{contentElements.length
 							? contentElements.map((element, i) => {
 									const { headlines: { basic: headlineText = "" } = {}, websites } = element;
-									const imageObj = getImageFromANS(element);
-									const imageProps = imageObj
+									const ansImage = getImageFromANS(element);
+									const imageProps = ansImage
 										? {
-												ansImage: imageObj,
+												...(!showHeadline && element?.headlines?.basic !== ""
+													? { alt: element?.headlines?.basic }
+													: {}),
+												ansImage,
 												aspectRatio: "3:2",
 												resizedOptions: getFocalFromANS(ansImage),
 												responsiveImages: [137, 274, 548],
 												width: 274,
-										  }
+											}
 										: {
 												src: targetFallbackImage,
-										  };
+											};
 
 									if (!websites[arcSite]) {
 										return null;
@@ -142,7 +145,7 @@ const NumberedList = (props) => {
 											</Stack>
 										</React.Fragment>
 									);
-							  })
+								})
 							: null}
 					</Stack>
 				</Wrapper>

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -108,9 +108,7 @@ const NumberedList = (props) => {
 										? {
 												ansImage: imageObj,
 												aspectRatio: "3:2",
-												resizedOptions: {
-													...getFocalFromANS(imageObj),
-												},
+												resizedOptions: getFocalFromANS(ansImage),
 												responsiveImages: [137, 274, 548],
 												width: 274,
 										  }

--- a/blocks/quilted-image-block/features/quilted-image/default.jsx
+++ b/blocks/quilted-image-block/features/quilted-image/default.jsx
@@ -56,23 +56,23 @@ const ImageItem = ({
 	const imageParams =
 		imageId && imageURL
 			? {
+					alt: imageAlt,
 					ansImage: {
 						_id: imageId,
-						url: imageURL,
 						auth: imageAuth ? JSON.parse(imageAuth) : imageAuthTokenObj,
+						url: imageURL,
 					},
-					alt: imageAlt,
 					aspectRatio: ASPECT_RATIO_MAP[imageAspectRatio],
 					resizedOptions: {
 						smart: true,
 					},
 					responsiveImages: [200, 400, 600, 800, 1000],
 					width: 600,
-			  }
+				}
 			: {
 					src: imageURL,
 					alt: overlayText,
-			  };
+				};
 
 	if ((imageURL && itemAction && overlayText && buttonText) || isAdmin) {
 		return (

--- a/blocks/quilted-image-block/features/quilted-image/default.jsx
+++ b/blocks/quilted-image-block/features/quilted-image/default.jsx
@@ -44,8 +44,8 @@ const ImageItem = ({
 			? {
 					source: "signing-service",
 					query: { id: imageId },
-			  }
-			: {}
+				}
+			: {},
 	);
 
 	const imageAuthTokenObj = {};

--- a/blocks/results-list-block/features/results-list/results/result-item.jsx
+++ b/blocks/results-list-block/features/results-list/results/result-item.jsx
@@ -38,9 +38,9 @@ const ResultItem = React.memo(
 				showHeadline,
 				showImage,
 				showItemOverline,
-				loading
+				loading,
 			},
-			ref
+			ref,
 		) => {
 			const {
 				description: { basic: descriptionText } = {},
@@ -77,7 +77,7 @@ const ResultItem = React.memo(
 			}
 
 			/* Author Formatting */
-			const ansImage = getImageFromANS(element)
+			const ansImage = getImageFromANS(element);
 			const hasAuthors = showByline ? credits?.by?.some((author) => author?.name !== "") : null;
 			const contentHeading = showHeadline ? headlineText : null;
 			const formattedDate = Date.parse(displayDate)
@@ -105,7 +105,7 @@ const ResultItem = React.memo(
 				  }
 				: {
 						src: targetFallbackImage,
-						loading
+						loading,
 				  };
 			return showHeadline ||
 				showImage ||
@@ -126,10 +126,7 @@ const ResultItem = React.memo(
 								onClick={registerSuccessEvent}
 								assistiveHidden
 							>
-								<Image
-									alt={headlineText}
-									{ ...imageParams }
-								/>
+								<Image alt={headlineText} {...imageParams} />
 							</Conditional>
 						</MediaItem>
 					) : null}
@@ -170,8 +167,8 @@ const ResultItem = React.memo(
 					) : null}
 				</div>
 			) : null;
-		}
-	)
+		},
+	),
 );
 
 export default ResultItem;

--- a/blocks/results-list-block/features/results-list/results/result-item.jsx
+++ b/blocks/results-list-block/features/results-list/results/result-item.jsx
@@ -89,9 +89,7 @@ const ResultItem = React.memo(
 						ansImage,
 						aspectRatio: imageRatio,
 						loading,
-						resizedOptions: {
-							...getFocalFromANS(ansImage),
-						},
+						resizedOptions: getFocalFromANS(ansImage),
 						responsiveImages: [250, 500],	
 						sizes: [
 							{

--- a/blocks/results-list-block/features/results-list/results/result-item.jsx
+++ b/blocks/results-list-block/features/results-list/results/result-item.jsx
@@ -86,11 +86,14 @@ const ResultItem = React.memo(
 			const url = websites[arcSite].website_url;
 			const imageParams = ansImage
 				? {
+						...(!showHeadline && element?.headlines?.basic !== ""
+							? { alt: element?.headlines?.basic }
+							: {}),
 						ansImage,
 						aspectRatio: imageRatio,
 						loading,
 						resizedOptions: getFocalFromANS(ansImage),
-						responsiveImages: [250, 500],	
+						responsiveImages: [250, 500],
 						sizes: [
 							{
 								isDefault: true,
@@ -102,11 +105,11 @@ const ResultItem = React.memo(
 							},
 						],
 						width: 500,
-				  }
+					}
 				: {
 						src: targetFallbackImage,
 						loading,
-				  };
+					};
 			return showHeadline ||
 				showImage ||
 				showDescription ||

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
@@ -60,9 +60,7 @@ const SearchResult = ({ arcSite, className, content, promoElements }) => {
 			? {
 					ansImage,
 					aspectRatio: imageRatio,
-					resizedOptions: {
-						...getFocalFromANS(ansImage),
-					},
+					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [200, 400, 800],
 					sizes: [
 						{

--- a/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
+++ b/blocks/search-results-list-block/features/search-results-list/_children/search-result.jsx
@@ -58,6 +58,9 @@ const SearchResult = ({ arcSite, className, content, promoElements }) => {
 	const imageParams =
 		content && ansImage
 			? {
+					...(!showHeadline && content?.headlines?.basic !== ""
+						? { alt: content?.headlines?.basic }
+						: {}),
 					ansImage,
 					aspectRatio: imageRatio,
 					resizedOptions: getFocalFromANS(ansImage),
@@ -73,10 +76,10 @@ const SearchResult = ({ arcSite, className, content, promoElements }) => {
 						},
 					],
 					width: 500,
-			  }
+				}
 			: {
 					src: fallbackImage,
-			  };
+				};
 
 	const displayDate = content?.display_date;
 	const formattedDate = Date.parse(displayDate)

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -133,23 +133,24 @@ const SimpleList = (props) => {
 					<Stack className={`${BLOCK_CLASS_NAME}__items`} divider>
 						{contentElements.map((element) => {
 							const { headlines: { basic: headlineText = "" } = {}, websites } = element;
-							const image = getImageFromANS(element);
-
 							if (!websites[arcSite]) {
 								return null;
 							}
 							const url = websites[arcSite].website_url;
-							const imageParams = image
+
+							const ansImage = getImageFromANS(element);
+							const imageParams = ansImage
 								? {
-										ansImage: image,
+										...(!showHeadline && headlineText !== "" ? { alt: headlineText } : {}),
+										ansImage,
 										aspectRatio: "3:2",
-										resizedOptions: getFocalFromANS(image),
+										resizedOptions: getFocalFromANS(ansImage),
 										responsiveImages: [274, 548, 1096],
 										width: 274,
-								  }
+									}
 								: {
 										src: targetFallbackImage,
-								  };
+									};
 
 							return (
 								<Stack

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -143,9 +143,7 @@ const SimpleList = (props) => {
 								? {
 										ansImage: image,
 										aspectRatio: "3:2",
-										resizedOptions: {
-											...getFocalFromANS(image),
-										},
+										resizedOptions: getFocalFromANS(image),
 										responsiveImages: [274, 548, 1096],
 										width: 274,
 								  }

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -133,9 +133,7 @@ const SmallManualPromo = ({ customFields }) => {
 				ansImage,
 				alt,
 				aspectRatio: imageRatio,
-				resizedOptions: {
-					...getFocalFromANS(ansImage)
-				},
+					resizedOptions: getFocalFromANS(ansImage),
 				responsiveImages: [200, 400, 600, 800, 1200],
 				width: 600,
 			}

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -27,7 +27,7 @@ const PromoImage = ({
 	linkURL,
 	newTab,
 	registerSuccessEvent,
-	showHeadline
+	showHeadline,
 }) => {
 	const ImageDisplay = showImage ? (
 		<MediaItem
@@ -35,7 +35,7 @@ const PromoImage = ({
 				imageURL: "url",
 				imageId: "_id",
 				imageAuth: "auth",
-				imageFocalPoint: "focal_point"
+				imageFocalPoint: "focal_point",
 			})}
 			suppressContentEditableWarning
 		>
@@ -57,13 +57,7 @@ const PromoImage = ({
 	);
 };
 
-const PromoHeading = ({
-	showHeadline,
-	headline,
-	linkURL,
-	newTab,
-	registerSuccessEvent
-}) =>
+const PromoHeading = ({ showHeadline, headline, linkURL, newTab, registerSuccessEvent }) =>
 	showHeadline && headline ? (
 		<Heading>
 			{linkURL ? (
@@ -104,9 +98,9 @@ const SmallManualPromo = ({ customFields }) => {
 		resizedImage || !imageURL
 			? {}
 			: {
-				source: "signing-service",
-				query: { id: manualImageId || imageURL },
-			}
+					source: "signing-service",
+					query: { id: manualImageId || imageURL },
+				},
 	);
 	if (imageAuth && !resizedAuth) {
 		resizedAuth = JSON.parse(imageAuth);
@@ -123,8 +117,8 @@ const SmallManualPromo = ({ customFields }) => {
 		_id: resizedImage ? imageId : manualImageId,
 		url: imageURL,
 		auth: resizedAuth,
-		focal_point: imageFocalPoint ? JSON.parse(imageFocalPoint) : undefined
-	}
+		focal_point: imageFocalPoint ? JSON.parse(imageFocalPoint) : undefined,
+	};
 
 	const alt = headline || null;
 	const imageParams =

--- a/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
+++ b/blocks/small-manual-promo-block/features/small-manual-promo/default.jsx
@@ -124,17 +124,17 @@ const SmallManualPromo = ({ customFields }) => {
 	const imageParams =
 		imageURL && resizedAuth
 			? {
-				ansImage,
-				alt,
-				aspectRatio: imageRatio,
+					alt,
+					ansImage,
+					aspectRatio: imageRatio,
 					resizedOptions: getFocalFromANS(ansImage),
-				responsiveImages: [200, 400, 600, 800, 1200],
-				width: 600,
-			}
+					responsiveImages: [200, 400, 600, 800, 1200],
+					width: 600,
+				}
 			: {
-				src: fallbackImage,
-				alt,
-			};
+					alt,
+					src: fallbackImage,
+				};
 
 	const containerClassNames = [
 		BLOCK_CLASS_NAME,

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -111,7 +111,7 @@ const SmallPromo = ({ customFields }) => {
 	let resizedAuth = useContent(
 		resizedImage || !imageOverrideURL
 			? {}
-			: { source: "signing-service", query: { id: manualImageId || imageOverrideURL } }
+			: { source: "signing-service", query: { id: manualImageId || imageOverrideURL } },
 	);
 	if (imageOverrideAuth && !resizedAuth) {
 		resizedAuth = JSON.parse(imageOverrideAuth);
@@ -131,8 +131,9 @@ const SmallPromo = ({ customFields }) => {
 
 	const { fallbackImage } = getProperties(arcSite);
 	const ansImage = getImageFromANS(content);
-	const imageParams = imageOverrideURL || ansImage
-		? {
+	const imageParams =
+		imageOverrideURL || ansImage
+			? {
 			ansImage: imageOverrideURL
 				? {
 						_id: resizedImage ? imageOverrideId : manualImageId,
@@ -146,10 +147,9 @@ const SmallPromo = ({ customFields }) => {
 			responsiveImages: [200, 400, 600, 800, 1200],
 			width: 600,
 		}
-		: { src: fallbackImage, };
+			: { src: fallbackImage };
 
-	const promoImage = showImage
-		? (
+	const promoImage = showImage ? (
 			<Conditional
 				className={`${BLOCK_CLASS_NAME}__img`}
 				component={Link}
@@ -171,8 +171,8 @@ const SmallPromo = ({ customFields }) => {
 			</Conditional>
 		) : null;
 
-	const promoHeading = showHeadline && headline
-		? (
+	const promoHeading =
+		showHeadline && headline ? (
 			<Heading>
 				<Conditional
 					component={Link}

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -45,7 +45,7 @@ const SmallPromo = ({ customFields }) => {
 				? {
 						feature: "small-promo",
 						...customFields.itemContentConfig.contentConfigValues,
-				  }
+					}
 				: null,
 			// does not need embed_html because no video section
 			// does not need website section nor label because no overline
@@ -134,42 +134,42 @@ const SmallPromo = ({ customFields }) => {
 	const imageParams =
 		imageOverrideURL || ansImage
 			? {
-			ansImage: imageOverrideURL
-				? {
-						_id: resizedImage ? imageOverrideId : manualImageId,
-						url: imageOverrideURL,
-						auth: resizedAuth || {},
-					}
-				: ansImage,
-			alt: content?.headlines?.basic || "",
-			aspectRatio: imageRatio,
+					alt: content?.headlines?.basic || "",
+					ansImage: imageOverrideURL
+						? {
+								_id: resizedImage ? imageOverrideId : manualImageId,
+								url: imageOverrideURL,
+								auth: resizedAuth || {},
+							}
+						: ansImage,
+					aspectRatio: imageRatio,
 					resizedOptions: getFocalFromANS(ansImage),
-			responsiveImages: [200, 400, 600, 800, 1200],
-			width: 600,
-		}
+					responsiveImages: [200, 400, 600, 800, 1200],
+					width: 600,
+				}
 			: { src: fallbackImage };
 
 	const promoImage = showImage ? (
-			<Conditional
-				className={`${BLOCK_CLASS_NAME}__img`}
-				component={Link}
-				condition={linkURL}
-				href={formatURL(linkURL)}
-				onClick={registerSuccessEvent}
-				assistiveHidden
+		<Conditional
+			className={`${BLOCK_CLASS_NAME}__img`}
+			component={Link}
+			condition={linkURL}
+			href={formatURL(linkURL)}
+			onClick={registerSuccessEvent}
+			assistiveHidden
+		>
+			<MediaItem
+				{...searchableField({
+					imageOverrideURL: "url",
+					imageOverrideId: "_id",
+					imageOverrideAuth: "auth",
+				})}
+				suppressContentEditableWarning
 			>
-				<MediaItem
-					{...searchableField({
-						imageOverrideURL: "url",
-						imageOverrideId: "_id",
-						imageOverrideAuth: "auth",
-					})}
-					suppressContentEditableWarning
-				>
-					<Image {...imageParams} />
-				</MediaItem>
-			</Conditional>
-		) : null;
+				<Image {...imageParams} />
+			</MediaItem>
+		</Conditional>
+	) : null;
 
 	const promoHeading =
 		showHeadline && headline ? (
@@ -198,13 +198,13 @@ const SmallPromo = ({ customFields }) => {
 				<Grid as="article" className={containerClassNames}>
 					{["below", "right"].includes(imagePosition) ? (
 						<>
-							{ promoHeading }
-							{ promoImage }
+							{promoHeading}
+							{promoImage}
 						</>
 					) : (
 						<>
-							{ promoImage }
-							{ promoHeading }
+							{promoImage}
+							{promoHeading}
 						</>
 					)}
 				</Grid>

--- a/blocks/small-promo-block/features/small-promo/default.jsx
+++ b/blocks/small-promo-block/features/small-promo/default.jsx
@@ -142,9 +142,7 @@ const SmallPromo = ({ customFields }) => {
 				: ansImage,
 			alt: content?.headlines?.basic || "",
 			aspectRatio: imageRatio,
-			resizedOptions: {
-				...getFocalFromANS(ansImage),
-			},
+					resizedOptions: getFocalFromANS(ansImage),
 			responsiveImages: [200, 400, 600, 800, 1200],
 			width: 600,
 		}

--- a/blocks/top-table-list-block/features/top-table-list/_children/extra-large.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/extra-large.jsx
@@ -93,16 +93,16 @@ const ExtraLarge = (props) => {
 	const imageParams =
 		element && ansImage
 			? {
-					ansImage,
 					alt: element?.headlines?.basic || "",
+					ansImage,
 					aspectRatio: imageRatioXL,
 					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [400, 600, 800, 1200],
 					width: 800,
-			  }
+				}
 			: {
 					src: fallbackImage,
-			  };
+				};
 
 	return hasOverline ||
 		contentHeading ||

--- a/blocks/top-table-list-block/features/top-table-list/_children/extra-large.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/extra-large.jsx
@@ -96,9 +96,7 @@ const ExtraLarge = (props) => {
 					ansImage,
 					alt: element?.headlines?.basic || "",
 					aspectRatio: imageRatioXL,
-					resizedOptions: {
-						...getFocalFromANS(ansImage),
-					},
+					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [400, 600, 800, 1200],
 					width: 800,
 			  }

--- a/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
@@ -121,9 +121,7 @@ const Large = (props) => {
 					ansImage,
 					alt: element?.headlines?.basic || "",
 					aspectRatio: imageRatioLG,
-					resizedOptions: {
-						...getFocalFromANS(ansImage),
-					},
+					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [400, 600, 800, 1200],
 					width: 800,
 			  }

--- a/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
@@ -114,16 +114,16 @@ const Large = (props) => {
 	const imageParams =
 		element && ansImage
 			? {
-					ansImage,
 					alt: element?.headlines?.basic || "",
+					ansImage,
 					aspectRatio: imageRatioLG,
 					resizedOptions: getFocalFromANS(ansImage),
 					responsiveImages: [400, 600, 800, 1200],
 					width: 800,
-			  }
+				}
 			: {
 					src: fallbackImage,
-			  };
+				};
 
 	return embedMarkup ||
 		contentOverline ||

--- a/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/large.jsx
@@ -27,7 +27,6 @@ import {
 	Stack,
 	usePhrases,
 	Video,
-	
 } from "@wpmedia/arc-themes-components";
 
 const BLOCK_CLASS_NAME = "b-top-table-list-large";
@@ -62,12 +61,9 @@ const Large = (props) => {
 		},
 	} = getProperties(arcSite);
 
-	const displayDate = Date.parse(element?.display_date) ? localizeDateTime(
-		new Date(element?.display_date),
-		dateTimeFormat,
-		language,
-		timeZone
-	) : "";
+	const displayDate = Date.parse(element?.display_date)
+		? localizeDateTime(new Date(element?.display_date), dateTimeFormat, language, timeZone)
+		: "";
 	const phrases = usePhrases();
 
 	const videoOrGalleryContent =

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium.jsx
@@ -79,15 +79,16 @@ const Medium = (props) => {
 
 	const imageParams = ANSImage
 		? {
+				alt: element?.headlines?.basic || "",
 				ansImage: ANSImage,
 				aspectRatio: imageRatioMD,
 				resizedOptions: getFocalFromANS(ANSImage),
 				responsiveImages: [400, 600, 800, 1200],
 				width: 800,
-		  }
+			}
 		: {
 				src: fallbackImage,
-		  };
+			};
 
 	return showHeadlineMD || showImageMD || showDescriptionMD || showBylineMD || showDateMD ? (
 		<HeadingSection>

--- a/blocks/top-table-list-block/features/top-table-list/_children/medium.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/medium.jsx
@@ -81,9 +81,7 @@ const Medium = (props) => {
 		? {
 				ansImage: ANSImage,
 				aspectRatio: imageRatioMD,
-				resizedOptions: {
-					...getFocalFromANS(ANSImage),
-				},
+				resizedOptions: getFocalFromANS(ANSImage),
 				responsiveImages: [400, 600, 800, 1200],
 				width: 800,
 		  }

--- a/blocks/top-table-list-block/features/top-table-list/_children/small.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small.jsx
@@ -42,9 +42,7 @@ const Small = (props) => {
 		? {
 				ansImage: ANSImage,
 				aspectRatio: imageRatioSM,
-				resizedOptions: {
-					...getFocalFromANS(ANSImage),
-				},
+				resizedOptions: getFocalFromANS(ansImage),
 				responsiveImages: [400, 600, 800, 1200],
 				width: 800,
 		  }

--- a/blocks/top-table-list-block/features/top-table-list/_children/small.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small.jsx
@@ -35,20 +35,21 @@ const Small = (props) => {
 	const showBottomBorder = typeof showBottomBorderSM === "undefined" ? true : showBottomBorderSM;
 
 	const linkURL = element?.websites?.[arcSite]?.website_url;
-	const ANSImage = getImageFromANS(element);
+	const ansImage = getImageFromANS(element);
 	const headline = element?.headlines?.basic;
 
-	const imageParams = ANSImage
+	const imageParams = ansImage
 		? {
-				ansImage: ANSImage,
+				alt: element?.headlines?.basic || "",
+				ansImage,
 				aspectRatio: imageRatioSM,
 				resizedOptions: getFocalFromANS(ansImage),
 				responsiveImages: [400, 600, 800, 1200],
 				width: 800,
-		  }
+			}
 		: {
 				src: fallbackImage,
-		  };
+			};
 
 	const containerClassNames = [
 		BLOCK_CLASS_NAME,
@@ -79,13 +80,13 @@ const Small = (props) => {
 			<Grid as="article" className={containerClassNames}>
 				{["below", "right"].includes(imagePosition) ? (
 					<>
-						{ promoHeading }
-						{ promoImage }
+						{promoHeading}
+						{promoImage}
 					</>
 				) : (
 					<>
-						{ promoImage }
-						{ promoHeading }
+						{promoImage}
+						{promoHeading}
 					</>
 				)}
 				{showBottomBorder ? <Divider /> : null}

--- a/blocks/top-table-list-block/features/top-table-list/_children/small.jsx
+++ b/blocks/top-table-list-block/features/top-table-list/_children/small.jsx
@@ -57,17 +57,16 @@ const Small = (props) => {
 		.filter((classString) => classString)
 		.join(" ");
 
-	const promoImage = showImageSM
-		? (
-			<Conditional component={Link} condition={linkURL} href={formatURL(linkURL)} assistiveHidden>
-				<MediaItem>
-					<Image {...imageParams} />
-				</MediaItem>
-			</Conditional>
-		) : null;
+	const promoImage = showImageSM ? (
+		<Conditional component={Link} condition={linkURL} href={formatURL(linkURL)} assistiveHidden>
+			<MediaItem>
+				<Image {...imageParams} />
+			</MediaItem>
+		</Conditional>
+	) : null;
 
-	const promoHeading = showHeadlineSM && headline
-		? (
+	const promoHeading =
+		showHeadlineSM && headline ? (
 			<Heading>
 				<Conditional component={Link} condition={linkURL} href={formatURL(linkURL)}>
 					{headline}


### PR DESCRIPTION
## Description

#### Jira Ticket: [THEMES-1986](https://arcpublishing.atlassian.net/browse/THEMES-1986)

Adding alt tags to images where they were not previously (as necessary)

## Test Steps

1. Checkout this branch `git checkout themes-1986`
2. Run fusion repo with linked blocks `npx fusion start -f -l`
3. Verify that the medium and small top table list promos have alt values: http://localhost/pagebuilder/editor/curate?p=puOvG1XS6AaSAy1u&v=vy3r49MKAaSAy1u
4. Verify that the alt property is applied to the search-results-list, results-list, numbered-list, and simple list where the header is NOT enabled in the block config: http://localhost/pagebuilder/editor/curate?p=pldHYSIJj7fEkicu&v=vOlaaYHh67fEkicu


[THEMES-1986]: https://arcpublishing.atlassian.net/browse/THEMES-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ