### PR TITLE
Add editable headline, description and overline for extra-large-promo…

### DIFF
--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.jsx
@@ -39,9 +39,12 @@ const getType = (type, content) => (content?.type === type ? content : undefined
 
 export const ExtraLargePromoPresentation = ({
 	hasOverline,
+	editableOverline,
 	contentHeading,
+	editableHeading,
 	showImage,
 	contentDescription,
+	editableDescription,
 	hasDate,
 	shouldLazyLoad,
 	overlineUrl,
@@ -61,7 +64,11 @@ export const ExtraLargePromoPresentation = ({
 	hasOverline || contentHeading || showImage || contentDescription || contentAuthors || hasDate ? (
 		<LazyLoad enabled={shouldLazyLoad}>
 			<article className={BLOCK_CLASS_NAME}>
-				{hasOverline ? <Overline href={overlineUrl}>{overlineText}</Overline> : null}
+				{hasOverline ? (
+					<Overline href={overlineUrl} suppressContentEditableWarning {...editableOverline}>
+						{overlineText}
+					</Overline>
+				) : null}
 				{contentHeading ||
 				showImage ||
 				contentDescription ||
@@ -71,7 +78,7 @@ export const ExtraLargePromoPresentation = ({
 					<Stack>
 						{contentHeading ? (
 							<HeadingSection>
-								<Heading>
+								<Heading suppressContentEditableWarning {...editableHeading}>
 									<Conditional component={Link} condition={contentUrl} href={contentUrl}>
 										{contentHeading}
 									</Conditional>
@@ -112,7 +119,11 @@ export const ExtraLargePromoPresentation = ({
 								)}
 							</MediaItem>
 						) : null}
-						{contentDescription ? <Paragraph>{contentDescription}</Paragraph> : null}
+						{contentDescription ? (
+							<Paragraph suppressContentEditableWarning {...editableDescription}>
+								{contentDescription}
+							</Paragraph>
+						) : null}
 						{contentAuthors || hasDate ? (
 							<Attribution>
 								<Join separator={Separator}>
@@ -136,7 +147,7 @@ export const ExtraLargePromoPresentation = ({
 
 const ExtraLargePromo = ({ customFields }) => {
 	const { arcSite, isAdmin } = useFusionContext();
-	const { searchableField } = useEditableContent();
+	const { editableContent, searchableField } = useEditableContent();
 	const {
 		dateLocalization: { language, timeZone, dateTimeFormat } = {
 			language: "en",
@@ -290,17 +301,32 @@ const ExtraLargePromo = ({ customFields }) => {
 
 	// Default to websites object data
 	let [overlineText, overlineUrl] = [sectionText, sectionUrl];
+	let editableOverline = content?.websites?.[arcSite]?.website_section?.name
+		? editableContent(content, `websites.${[arcSite]}.website_section.name`)
+		: {};
 
 	if (content?.owner?.sponsored) {
 		overlineText = content?.label?.basic?.text || phrases.t("global.sponsored-content");
 		overlineUrl = null;
+		editableOverline = content?.label?.basic?.text
+			? editableContent(content, "label.basic.text")
+			: {};
 	} else if (shouldUseLabel) {
 		[overlineText, overlineUrl] = [labelText, labelUrl];
+		editableOverline = content?.label?.basic?.text
+			? editableContent(content, "label.basic.text")
+			: {};
 	}
 
 	const hasOverline = showOverline && overlineText;
 	const contentDescription = showDescription ? content?.description?.basic : null;
+	const editableDescription = content?.description
+		? editableContent(content, "description.basic")
+		: {};
 	const contentHeading = showHeadline ? content?.headlines?.basic : null;
+	const editableHeading = content?.headlines?.basic
+		? editableContent(content, "headlines.basic")
+		: {};
 	const contentUrl = content?.websites?.[arcSite]?.website_url;
 	const embedMarkup = playVideoInPlace && getVideoFromANS(content);
 	const contentAuthors =
@@ -351,9 +377,12 @@ const ExtraLargePromo = ({ customFields }) => {
 	return (
 		<ExtraLargePromoPresentation
 			hasOverline={hasOverline}
+			editableOverline={editableOverline}
 			contentHeading={contentHeading}
+			editableHeading={editableHeading}
 			showImage={showImage}
 			contentDescription={contentDescription}
+			editableDescription={editableDescription}
 			hasDate={hasDate}
 			shouldLazyLoad={shouldLazyLoad}
 			overlineUrl={overlineUrl}

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { useContent } from "fusion:content";
 
@@ -45,12 +46,51 @@ describe("the extra large promo feature", () => {
 		expect(screen.queryByRole("link", { name: "Premium" })).not.toBeNull();
 	});
 
+	it("should overline text be an editable field", () => {
+		const arcSite = "dagen"; // using default website
+
+		const config = {
+			showOverline: true,
+		};
+		render(<ExtraLargePromo customFields={config} />);
+
+		let overline = mockData?.websites[arcSite]?.website_section?.name;
+
+		if (!!mockData.owner?.sponsored) {
+			overline = mockData.label.basic.text;
+		} else if (!!mockData?.label?.basic?.display) {
+			overline = mockData?.label?.basic?.text;
+		}
+
+		overline ? expect(screen.getByText(overline)).toHaveAttribute("contenteditable", "true") : null; // Bypass test if overline value doesn't exist (to be editable)
+	});
+
 	it("should return a headline if showHeadline is true", () => {
 		const config = {
 			showHeadline: true,
 		};
 		render(<ExtraLargePromo customFields={config} />);
 		expect(screen.queryByRole("heading", { name: config.headline })).not.toBeNull();
+	});
+
+	it("should headline be an editable field", () => {
+		const config = {
+			showHeadline: true,
+		};
+		render(<ExtraLargePromo customFields={config} />);
+
+		expect(screen.queryByRole("heading", { name: mockData.headlines.basic })).toHaveAttribute(
+			"contenteditable",
+		);
+	});
+
+	it("should description be an editable field", () => {
+		const config = {
+			showDescription: true,
+		};
+		render(<ExtraLargePromo customFields={config} />);
+
+		expect(screen.queryByText(mockData.description.basic)).toHaveAttribute("contenteditable");
 	});
 
 	it("should return a image if showImage is true", () => {

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -56,13 +56,15 @@ describe("the extra large promo feature", () => {
 
 		let overline = mockData?.websites[arcSite]?.website_section?.name;
 
-		if (!!mockData.owner?.sponsored) {
+		if (mockData.owner?.sponsored) {
 			overline = mockData.label.basic.text;
-		} else if (!!mockData?.label?.basic?.display) {
+		} else if (mockData?.label?.basic?.display) {
 			overline = mockData?.label?.basic?.text;
 		}
 
-		overline ? expect(screen.getByText(overline)).toHaveAttribute("contenteditable", "true") : null; // Bypass test if overline value doesn't exist (to be editable)
+		if (overline) {
+			expect(screen.getByText(overline)).toHaveAttribute("contenteditable", "true");
+		}
 	});
 
 	it("should return a headline if showHeadline is true", () => {

--- a/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
+++ b/blocks/extra-large-promo-block/features/extra-large-promo/default.test.jsx
@@ -28,14 +28,14 @@ describe("the extra large promo feature", () => {
 		const config = {
 			lazyLoad: true,
 		};
-		const { container } = render(<ExtraLargePromo customFields={config} />);
-		expect(container.firstChild).toBe(null);
+		render(<ExtraLargePromo customFields={config} />);
+		expect(screen.queryByTestId("extra-large-promo")).toBeNull();
 	});
 
 	it("should return null if no show flag is true", () => {
 		const config = {};
-		const { container } = render(<ExtraLargePromo customFields={config} />);
-		expect(container.firstChild).toBeNull();
+		render(<ExtraLargePromo customFields={config} />);
+		expect(screen.queryByTestId("extra-large-promo")).toBeNull();
 	});
 
 	it("should return an overline if showOverline is true", () => {
@@ -43,7 +43,7 @@ describe("the extra large promo feature", () => {
 			showOverline: true,
 		};
 		render(<ExtraLargePromo customFields={config} />);
-		expect(screen.queryByRole("link", { name: "Premium" })).not.toBeNull();
+		expect(screen.getByRole("link", { name: "Premium" })).not.toBeNull();
 	});
 
 	it("should overline text be an editable field", () => {
@@ -72,7 +72,7 @@ describe("the extra large promo feature", () => {
 			showHeadline: true,
 		};
 		render(<ExtraLargePromo customFields={config} />);
-		expect(screen.queryByRole("heading", { name: config.headline })).not.toBeNull();
+		expect(screen.getByRole("heading", { name: config.headline })).not.toBeNull();
 	});
 
 	it("should headline be an editable field", () => {
@@ -81,7 +81,7 @@ describe("the extra large promo feature", () => {
 		};
 		render(<ExtraLargePromo customFields={config} />);
 
-		expect(screen.queryByRole("heading", { name: mockData.headlines.basic })).toHaveAttribute(
+		expect(screen.getByRole("heading", { name: mockData.headlines.basic })).toHaveAttribute(
 			"contenteditable",
 		);
 	});
@@ -92,7 +92,7 @@ describe("the extra large promo feature", () => {
 		};
 		render(<ExtraLargePromo customFields={config} />);
 
-		expect(screen.queryByText(mockData.description.basic)).toHaveAttribute("contenteditable");
+		expect(screen.getByText(mockData.description.basic)).toHaveAttribute("contenteditable");
 	});
 
 	it("should return a image if showImage is true", () => {
@@ -107,7 +107,7 @@ describe("the extra large promo feature", () => {
 			}),
 		};
 		render(<ExtraLargePromo customFields={config} />);
-		expect(screen.queryByRole("img", { name: config.headline })).not.toBeNull();
+		expect(screen.getByRole("img", { name: config.headline })).not.toBeNull();
 	});
 
 	it("should return a fallback image if showImage is true and imageUrl is not valid", () => {
@@ -116,7 +116,7 @@ describe("the extra large promo feature", () => {
 			showImage: true,
 		};
 		render(<ExtraLargePromo customFields={config} />);
-		expect(screen.queryByRole("img", { name: config.headline })).not.toBeNull();
+		expect(screen.getByRole("img", { name: config.headline })).not.toBeNull();
 	});
 
 	it("should make a blank call to the signing-service if the image is from PhotoCenter and has an Auth value", () => {
@@ -167,7 +167,7 @@ describe("the extra large promo feature", () => {
 		};
 		render(<ExtraLargePromo customFields={config} />);
 		expect(
-			screen.queryByText("Why does August seem hotter? Maybe it comes from weariness."),
+			screen.getByText("Why does August seem hotter? Maybe it comes from weariness."),
 		).not.toBeNull();
 	});
 
@@ -175,10 +175,12 @@ describe("the extra large promo feature", () => {
 		const config = {
 			showByline: true,
 		};
-		const { getByText } = render(<ExtraLargePromo customFields={config} />);
+		render(<ExtraLargePromo customFields={config} />);
 		expect(
-			getByText("global.by-text Example Author1, Example Author2, global.and-text Example Author3"),
-		).not.toBeNull();
+			screen.getByText(
+				"global.by-text Example Author1, Example Author2, global.and-text Example Author3",
+			),
+		).toBeInTheDocument();
 	});
 
 	it("should return a byline if showDate is true", () => {
@@ -186,7 +188,7 @@ describe("the extra large promo feature", () => {
 			showDate: true,
 		};
 		render(<ExtraLargePromo customFields={config} />);
-		expect(screen.queryByText("January 30, 2020", { exact: false })).not.toBeNull();
+		expect(screen.getByText("January 30, 2020", { exact: false })).not.toBeNull();
 	});
 
 	it("should returned a sponsored overline if it's sponsored content", () => {
@@ -195,7 +197,7 @@ describe("the extra large promo feature", () => {
 			showOverline: true,
 		};
 		render(<ExtraLargePromo customFields={config} />);
-		expect(screen.queryByText("Sponsored")).not.toBeNull();
+		expect(screen.getByText("Sponsored")).not.toBeNull();
 	});
 
 	it("should return a video if playVideoInPlace is true and video content available", () => {
@@ -205,6 +207,6 @@ describe("the extra large promo feature", () => {
 			showImage: true,
 		};
 		render(<ExtraLargePromo customFields={config} />);
-		expect(screen.queryByText("video embed")).not.toBeNull();
+		expect(screen.getByText("video embed")).not.toBeNull();
 	});
 });


### PR DESCRIPTION
**Be sure to run `npm test`, `npm run lint`, and write detailed test steps before requesting reviewers**

## Description

#### Jira Ticket: [THEMES-2015](https://arcpublishing.atlassian.net/browse/THEMES-2015)

_Add editable headline, description and overline for extra-large-promo-block_
<img width="1478" alt="Screenshot 2024-10-15 at 6 13 50 AM" src="https://github.com/user-attachments/assets/45e49829-49ff-4632-9601-7593332f1bf7">


## Test Steps

_Add detailed test steps a reviewer must complete to test this PR_

1. Checkout this branch `git checkout THEMES-2015`
2. Run fusion repo with linked blocks `npx fusion start -f -l extra-large-promo-block`
3. Verify that the extra large promo has an editable headline, description and overline in PB Editor


[THEMES-2015]: https://arcpublishing.atlassian.net/browse/THEMES-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ