### PR TITLE
patch for Google recaptcha version - 3.0.0 (#2323)

### DIFF
--- a/blocks/identity-block/README.md
+++ b/blocks/identity-block/README.md
@@ -1,3 +1,3 @@
 # `@wpmedia/identity-block`
 
-ARC XP Themes Identity block for handling integrating ARC's identity into a theme's website. 
+ARC XP Themes Identity block for handling integrating ArcXP's identity into a Themes website. 

--- a/blocks/identity-block/package-lock.json
+++ b/blocks/identity-block/package-lock.json
@@ -12,7 +12,7 @@
         "@arc-fusion/prop-types": "^0.1.5",
         "@arc-publishing/sdk-identity": "^1.91.1",
         "react-google-recaptcha": "^3.1.0",
-        "react-google-recaptcha-v3": "^1.10.1"
+        "react-google-recaptcha-v3": "1.10.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.6",

--- a/blocks/identity-block/package.json
+++ b/blocks/identity-block/package.json
@@ -32,7 +32,7 @@
     "@arc-fusion/prop-types": "^0.1.5",
     "@arc-publishing/sdk-identity": "^1.91.1",
     "react-google-recaptcha": "^3.1.0",
-    "react-google-recaptcha-v3": "^1.10.1"
+    "react-google-recaptcha-v3": "1.10.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,7 +142,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-google-recaptcha": "^3.1.0",
-				"react-google-recaptcha-v3": "^1.10.1",
+				"react-google-recaptcha-v3": "1.10.1",
 				"react-oembed-container": "^1.0.1",
 				"sass": "^1.69.4",
 				"sass-loader": "^14.0.0",
@@ -416,7 +416,7 @@
 				"@arc-fusion/prop-types": "^0.1.5",
 				"@arc-publishing/sdk-identity": "^1.91.1",
 				"react-google-recaptcha": "^3.1.0",
-				"react-google-recaptcha-v3": "^1.10.1"
+				"react-google-recaptcha-v3": "1.10.1"
 			},
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.4.6",
@@ -7931,7 +7931,7 @@
 				"lodash.get": "^4.4.2",
 				"node-fetch": "^2.7.0",
 				"react-google-recaptcha": "^3.1.0",
-				"react-google-recaptcha-v3": "^1.10.1",
+				"react-google-recaptcha-v3": "1.10.1",
 				"react-oembed-container": "^1.0.1",
 				"react-swipeable": "^7.0.1"
 			}

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-google-recaptcha": "^3.1.0",
-		"react-google-recaptcha-v3": "^1.10.1",
+		"react-google-recaptcha-v3": "1.10.1",
 		"react-oembed-container": "^1.0.1",
 		"sass": "^1.69.4",
 		"sass-loader": "^14.0.0",


### PR DESCRIPTION
bring patch to 3.1.0 since 3.1.0 was cut before the patch came in to 3.0.0