### PR TITLE
replace deployment fn with pagebuilderURL and fix tests

### DIFF
--- a/blocks/card-list-block/features/card-list/default.jsx
+++ b/blocks/card-list-block/features/card-list/default.jsx
@@ -27,11 +27,11 @@ import {
 
 const BLOCK_CLASS_NAME = "b-card-list";
 
-const getFallbackImageURL = ({ deployment, contextPath, fallbackImage }) => {
+const getFallbackImageURL = ({ pagebuilderURL, contextPath, fallbackImage }) => {
 	let targetFallbackImage = fallbackImage;
 
 	if (!targetFallbackImage.includes("http")) {
-		targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
+		targetFallbackImage = pagebuilderURL(`${contextPath}/${targetFallbackImage}`);
 	}
 
 	return targetFallbackImage;
@@ -279,10 +279,10 @@ const CardListItems = (props) => {
 };
 
 const CardList = ({ customFields }) => {
-	const { id, arcSite, contextPath, deployment, isAdmin } = useFusionContext();
+	const { id, arcSite, contextPath, pagebuilderURL, isAdmin } = useFusionContext();
 	const { dateLocalization, fallbackImage, primaryLogoAlt, websiteDomain } = getProperties(arcSite);
 	const targetFallbackImage = getFallbackImageURL({
-		deployment,
+		pagebuilderURL,
 		contextPath,
 		fallbackImage,
 	});

--- a/blocks/card-list-block/features/card-list/default.test.jsx
+++ b/blocks/card-list-block/features/card-list/default.test.jsx
@@ -23,7 +23,7 @@ jest.mock("fusion:context", () => ({
 	useFusionContext: jest.fn(() => ({
 		id: "",
 		arcSite: "the-sun",
-		deployment: jest.fn(() => {}),
+		pagebuilderURL: jest.fn(() => {}),
 	})),
 }));
 
@@ -45,7 +45,7 @@ describe("Card list", () => {
 		useFusionContext.mockReturnValueOnce({
 			id: "",
 			arcSite: "the-sun",
-			deployment: jest.fn(() => {}),
+			pagebuilderURL: jest.fn(() => {}),
 		});
 
 		const { container } = render(<CardList customFields={customFields} />);
@@ -133,7 +133,7 @@ describe("Card list", () => {
 		jest.mock("fusion:context", () => ({
 			useFusionContext: jest.fn(() => ({
 				arcSite: "the-mercury",
-				deployment: jest.fn(() => {}),
+				pagebuilderURL: jest.fn(() => {}),
 			})),
 		}));
 		useContent.mockReturnValueOnce(oneListItem);

--- a/blocks/default-output-block/output-types/default.jsx
+++ b/blocks/default-output-block/output-types/default.jsx
@@ -78,7 +78,7 @@ const fontUrlLink = (fontUrl) => {
 const SampleOutputType = ({
 	children,
 	contextPath,
-	deployment,
+	pagebuilderURL,
 	CssLinks,
 	Fusion,
 	Libs,
@@ -164,7 +164,7 @@ const SampleOutputType = ({
 				<link
 					rel="icon"
 					type="image/x-icon"
-					href={deployment(`${contextPath}/resources/favicon.ico`)}
+					href={pagebuilderURL(`${contextPath}/resources/favicon.ico`)}
 				/>
 				<MetaData
 					arcSite={arcSite}

--- a/blocks/footer-block/features/footer/default.jsx
+++ b/blocks/footer-block/features/footer/default.jsx
@@ -22,7 +22,7 @@ import {
 const BLOCK_CLASS_NAME = "b-footer";
 
 const FooterItem = ({ customFields: { navigationConfig } }) => {
-	const { arcSite, deployment, contextPath } = useFusionContext();
+	const { arcSite, pagebuilderURL, contextPath } = useFusionContext();
 	const {
 		facebookPage,
 		twitterUsername,
@@ -38,7 +38,7 @@ const FooterItem = ({ customFields: { navigationConfig } }) => {
 	// Check if URL is absolute/base64
 	let logoUrl = lightBackgroundLogo || primaryLogo;
 	if (logoUrl && !(logoUrl.indexOf("http") === 0 || logoUrl.indexOf("base64") === 0))
-		logoUrl = deployment(`${contextPath}/${logoUrl}`);
+		logoUrl = pagebuilderURL(`${contextPath}/${logoUrl}`);
 
 	const content = useContent({
 		source: navigationConfig.contentService,

--- a/blocks/footer-block/features/footer/default.test.jsx
+++ b/blocks/footer-block/features/footer/default.test.jsx
@@ -1,755 +1,314 @@
-describe("This test is disabled", () => {
-	it("should succeed", () => {
-		expect(true);
-	});
+/* @jest-environment jsdom */
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import { useFusionContext } from "fusion:context";
+import { useContent } from "fusion:content";
+import getProperties from "fusion:properties";
+import { isServerSide } from "@wpmedia/arc-themes-components";
+import Footer from "./default";
+
+// Mocks
+jest.mock("fusion:context", () => ({
+  useFusionContext: jest.fn(),
+}));
+
+jest.mock("fusion:content", () => ({
+  useContent: jest.fn(),
+}));
+
+jest.mock("fusion:properties", () => jest.fn());
+
+// Lightweight component mocks to keep DOM simple and assertable
+jest.mock("@wpmedia/arc-themes-components", () => ({
+    Grid: ({ children, className }) => (
+      <div data-testid="Grid" className={className}>
+        {children}
+      </div>
+    ),
+    Heading: ({ children }) => <h2>{children}</h2>,
+    HeadingSection: ({ children }) => <section data-testid="HeadingSection">{children}</section>,
+    isServerSide: jest.fn(),
+    Icon: ({ name }) => <i data-testid="Icon" data-icon={name} />,
+    Image: ({ alt, src, className, height }) => (
+      <img alt={alt} src={src} className={className} data-height={height} />
+    ),
+    LazyLoad: ({ enabled, children }) => (
+      <div data-testid="LazyLoad" data-enabled={String(enabled)}>
+        {children}
+      </div>
+    ),
+    Link: ({ href, children, supplementalText }) => (
+      <a href={href} data-supplemental-text={supplementalText}>
+        {children}
+      </a>
+    ),
+    MediaItem: ({ children }) => <figure data-testid="MediaItem">{children}</figure>,
+    Paragraph: ({ children }) => <p>{children}</p>,
+    Stack: ({ children, className, direction, id }) => (
+      <div id={id} className={className} data-direction={direction || ""}>
+        {children}
+      </div>
+    ),
+  usePhrases: () => ({ t: (k) => `T:${k}` }),
+}));
+
+// Reusable helpers
+const makeProps = (overrides = {}) => ({
+  customFields: {
+    navigationConfig: {
+      contentService: "navigation",
+      contentConfigValues: { foo: "bar" },
+    },
+    lazyLoad: false,
+    ...overrides.customFields,
+  },
 });
 
-// import React from "react";
-// import { mount } from "enzyme";
-// import getProperties from "fusion:properties";
-// import { useContent } from "fusion:content";
-// import Footer from "./default";
-
-// // A payload with 4 columns and 11 column items
-// const mockPayload = {
-// 	children: [
-// 		{
-// 			_id: "terms-of-use",
-// 			name: "Terms of Use",
-// 			children: [
-// 				{
-// 					display_name: "Terms of Service",
-// 					url: "www.some-website",
-// 					_id: "column-item-1",
-// 				},
-// 				{
-// 					display_name: "RSS Terms of Service",
-// 					url: "www.some-website2",
-// 					_id: "column-item-2",
-// 				},
-// 				{
-// 					display_name: "Some other Terms of Service",
-// 					url: "www.some-website3",
-// 					_id: "column-item-3",
-// 				},
-// 			],
-// 		},
-// 		{
-// 			_id: "contact-us",
-// 			name: "Contact Us",
-// 			children: [
-// 				{
-// 					display_name: "Phone",
-// 					url: "www.phone.com",
-// 					_id: "column-item-4",
-// 				},
-// 				{
-// 					display_name: "Email",
-// 					url: "www.email.com",
-// 					_id: "column-item-5",
-// 				},
-// 				{
-// 					display_name: "Fax",
-// 					url: "www.who-uses-fax.com",
-// 					_id: "column-item-6",
-// 				},
-// 			],
-// 		},
-// 		{
-// 			_id: "about-us",
-// 			name: "About Us",
-// 			children: [
-// 				{
-// 					display_name: "Events",
-// 					url: "www.events.com",
-// 					_id: "column-item-7",
-// 				},
-// 				{
-// 					display_name: "Careers",
-// 					url: "www.plz-hire-me.com",
-// 					_id: "column-item-8",
-// 				},
-// 				{
-// 					display_name: "The Team",
-// 					url: "www.the-world.com",
-// 					_id: "column-item-9",
-// 				},
-// 				{
-// 					display_name: "External Link",
-// 					node_type: "link",
-// 					url: "https://www.the-world.com",
-// 					_id: "column-item-10",
-// 				},
-// 			],
-// 		},
-// 		{
-// 			_id: "get-us",
-// 			name: "", // empty name should not render due to accessibility requirement
-// 			children: [
-// 				{
-// 					display_name: "Why Our Product",
-// 					url: "www.plz-buy-our-products.com",
-// 					_id: "column-item-11",
-// 				},
-// 				{
-// 					display_name: "Pricing",
-// 					url: "www.the-dollars.com",
-// 					_id: "column-item-12",
-// 				},
-// 			],
-// 		},
-// 		{
-// 			_id: "blank-column",
-// 			name: "", // Empty string header name
-// 			// no children items
-// 		},
-// 	],
-// };
-
-// jest.mock("@wpmedia/arc-themes-components", () => ({
-// 	...jest.requireActual("@wpmedia/arc-themes-components"),
-// 	isServerSide: jest.fn(() => true),
-// 	Icon: ({ name }) => <div data-testid={name} />,
-// 	LazyLoad: ({ children }) => children,
-// }));
-
-// jest.mock("fusion:content", () => ({
-// 	useContent: jest.fn(() => mockPayload),
-// }));
-// jest.mock("fusion:context", () => ({
-// 	isAdmin: false,
-// 	useFusionContext: jest.fn(() => ({
-// 		contextPath: "pf",
-// 		deployment: jest.fn((path) => path),
-// 	})),
-// }));
-// jest.mock("fusion:properties", () => jest.fn(() => ({})));
-// jest.mock("fusion:themes", () => jest.fn(() => ({})));
-
-// describe("the footer feature for the default output type", () => {
-// 	afterEach(() => {
-// 		jest.resetModules();
-// 	});
-
-// 	beforeEach(() => {
-// 		jest.mock("fusion:context", () => ({
-// 			useFusionContext: jest.fn(() => ({
-// 				arcSite: "the-sun",
-// 				id: "testId",
-// 			})),
-// 		}));
-// 	});
-
-// 	it("should return null if lazyLoad on the server and not in the admin", () => {
-// 		const config = {
-// 			lazyLoad: true,
-// 		};
-// 		const wrapper = mount(<Footer customFields={config} />);
-// 		expect(wrapper.html()).toBe(null);
-// 	});
-
-// 	it("should have 5 column headers", () => {
-// 		const wrapper = mount(
-// 			<Footer
-// 				customFields={{
-// 					navigationConfig: {
-// 						contentService: "footer-service",
-// 						contentConfiguration: {},
-// 					},
-// 				}}
-// 			/>
-// 		);
-
-// 		// there are only 4 columns with any non-empty string data
-// 		// two of the 5 objects have empty string names
-// 		// therefore those h4 elements should not render if no content is present
-// 		expect(wrapper.find("Heading")).toHaveLength(3);
-// 	});
-
-// 	it("should have 12 column items", () => {
-// 		const wrapper = mount(
-// 			<Footer
-// 				customFields={{
-// 					navigationConfig: {
-// 						contentService: "footer-service",
-// 						contentConfiguration: {},
-// 					},
-// 				}}
-// 			/>
-// 		);
-
-// 		expect(wrapper.find("Link")).toHaveLength(12);
-// 	});
-
-// 	it("should have a link with target blank if is an absolute link with (http(s))", () => {
-// 		const wrapper = mount(
-// 			<Footer
-// 				customFields={{
-// 					navigationConfig: {
-// 						contentService: "footer-service",
-// 						contentConfiguration: {},
-// 					},
-// 				}}
-// 			/>
-// 		);
-
-// 		expect(wrapper.find('a[target="_blank"]')).toHaveLength(1);
-// 	});
-
-// 	it("should have empty column when empty payload is given", () => {
-// 		const wrapper = mount(
-// 			<Footer
-// 				customFields={{
-// 					navigationConfig: {
-// 						contentService: "footer-service",
-// 						contentConfiguration: {},
-// 					},
-// 				}}
-// 			/>
-// 		);
-
-// 		jest.mock("fusion:content", () => ({
-// 			useContent: jest.fn(() => ({})),
-// 		}));
-
-// 		expect(wrapper.find(".b_footer__links-group")).toHaveLength(0);
-// 	});
-
-// 	it("should have empty column without error when undefined payload is given", () => {
-// 		const wrapper = mount(
-// 			<Footer
-// 				customFields={{
-// 					navigationConfig: {
-// 						contentService: "footer-service",
-// 						contentConfiguration: {},
-// 					},
-// 				}}
-// 			/>
-// 		);
-
-// 		jest.mock("fusion:content", () => ({
-// 			useContent: jest.fn(() => undefined),
-// 		}));
-
-// 		expect(wrapper.find(".b_footer__links-group")).toHaveLength(0);
-// 	});
-
-// 	describe("the content source configuration", () => {
-// 		it("should have a default set of query values", () => {
-// 			mount(
-// 				<Footer
-// 					customFields={{
-// 						navigationConfig: {
-// 							contentService: "footer-service",
-// 							contentConfigValues: {},
-// 						},
-// 					}}
-// 				/>
-// 			);
-
-// 			expect(useContent).toHaveBeenCalledWith({
-// 				query: {
-// 					hierarchy: "footer",
-// 					feature: "footer",
-// 				},
-// 				source: "footer-service",
-// 				filter: expect.any(String),
-// 			});
-// 		});
-
-// 		it("should overwrite those values with configured values", () => {
-// 			mount(
-// 				<Footer
-// 					customFields={{
-// 						navigationConfig: {
-// 							contentService: "footer-service",
-// 							contentConfigValues: {
-// 								hierarchy: "not-a-footer",
-// 								extraval: 11111,
-// 							},
-// 						},
-// 					}}
-// 				/>
-// 			);
-
-// 			expect(useContent).toHaveBeenCalledWith({
-// 				query: {
-// 					hierarchy: "not-a-footer",
-// 					extraval: 11111,
-// 					feature: "footer",
-// 				},
-// 				source: "footer-service",
-// 				filter: expect.any(String),
-// 			});
-// 		});
-// 	});
-
-// 	describe("the footer image/logo", () => {
-// 		describe("when the theme manifest provides a logo url", () => {
-// 			it("should make the relative src of the logo the provided image", () => {
-// 				getProperties.mockImplementation(() => ({ locale: "en", primaryLogo: "my-nav-logo.svg" }));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find("img.b-footer__logo")).toHaveProp("src", "pf/my-nav-logo.svg");
-// 			});
-
-// 			it("should make the absolute src of the logo the provided image", () => {
-// 				getProperties.mockImplementation(() => ({
-// 					locale: "en",
-// 					primaryLogo: "http://test/my-nav-logo.svg",
-// 				}));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find("img.b-footer__logo")).toHaveProp("src", "http://test/my-nav-logo.svg");
-// 			});
-
-// 			it("should make the base64 src of the logo the provided image", () => {
-// 				getProperties.mockImplementation(() => ({
-// 					locale: "en",
-// 					primaryLogo: "base64:my-nav-logo.svg",
-// 				}));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find("img.b-footer__logo")).toHaveProp("src", "base64:my-nav-logo.svg");
-// 			});
-
-// 			describe("when the theme manifest provides alt text", () => {
-// 				it("should make the alt text of the logo the provided text", () => {
-// 					getProperties.mockImplementation(() => ({
-// 						locale: "en",
-// 						primaryLogo: "my-nav-logo.svg",
-// 						primaryLogoAlt: "my alt text",
-// 					}));
-// 					const wrapper = mount(
-// 						<Footer
-// 							customFields={{
-// 								navigationConfig: {
-// 									contentService: "footer-service",
-// 									contentConfiguration: {},
-// 								},
-// 							}}
-// 						/>
-// 					);
-
-// 					expect(wrapper.find("img.b-footer__logo")).toHaveProp("alt", "my alt text");
-// 				});
-// 			});
-
-// 			describe("when the theme manifest does not provide alt text", () => {
-// 				it("should make the alt text of the logo blank when not supplied", () => {
-// 					getProperties.mockImplementation(() => ({
-// 						locale: "en",
-// 						primaryLogo: "my-nav-logo.svg",
-// 					}));
-// 					const wrapper = mount(
-// 						<Footer
-// 							customFields={{
-// 								navigationConfig: {
-// 									contentService: "footer-service",
-// 									contentConfiguration: {},
-// 								},
-// 							}}
-// 						/>
-// 					);
-
-// 					expect(wrapper.find("img.b-footer__logo")).toHaveProp("alt", "");
-// 				});
-// 			});
-// 		});
-
-// 		describe("when the theme manifest provides a light logo url", () => {
-// 			it("should use the light logo over the primary logo", () => {
-// 				getProperties.mockImplementation(() => ({
-// 					locale: "en",
-// 					lightBackgroundLogo: "light.svg",
-// 					primaryLogo: "primary.svg",
-// 				}));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find("img.b-footer__logo")).toHaveProp("src", "pf/light.svg");
-// 			});
-
-// 			it("should make the relative src of the logo the provided image", () => {
-// 				getProperties.mockImplementation(() => ({
-// 					locale: "en",
-// 					lightBackgroundLogo: "my-nav-logo.svg",
-// 				}));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find("img.b-footer__logo")).toHaveProp("src", "pf/my-nav-logo.svg");
-// 			});
-
-// 			it("should make the absolute src of the logo the provided image", () => {
-// 				getProperties.mockImplementation(() => ({
-// 					locale: "en",
-// 					lightBackgroundLogo: "http://test/my-nav-logo.svg",
-// 				}));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find("img.b-footer__logo")).toHaveProp("src", "http://test/my-nav-logo.svg");
-// 			});
-
-// 			it("should make the base64 src of the logo the provided image", () => {
-// 				getProperties.mockImplementation(() => ({
-// 					locale: "en",
-// 					lightBackgroundLogo: "base64:my-nav-logo.svg",
-// 				}));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find("img.b-footer__logo")).toHaveProp("src", "base64:my-nav-logo.svg");
-// 			});
-
-// 			describe("when the theme manifest provides alt text", () => {
-// 				it("should make the alt text of the logo the provided text", () => {
-// 					getProperties.mockImplementation(() => ({
-// 						locale: "en",
-// 						lightBackgroundLogo: "my-nav-logo.svg",
-// 						lightBackgroundLogoAlt: "my alt text",
-// 					}));
-// 					const wrapper = mount(
-// 						<Footer
-// 							customFields={{
-// 								navigationConfig: {
-// 									contentService: "footer-service",
-// 									contentConfiguration: {},
-// 								},
-// 							}}
-// 						/>
-// 					);
-
-// 					expect(wrapper.find("img.b-footer__logo")).toHaveProp("alt", "my alt text");
-// 				});
-
-// 				it("should use the light alt text over the primary alt text", () => {
-// 					getProperties.mockImplementation(() => ({
-// 						locale: "en",
-// 						lightBackgroundLogo: "my-nav-logo.svg",
-// 						lightBackgroundLogoAlt: "light",
-// 						primaryLogoAlt: "primary",
-// 					}));
-// 					const wrapper = mount(
-// 						<Footer
-// 							customFields={{
-// 								navigationConfig: {
-// 									contentService: "footer-service",
-// 									contentConfiguration: {},
-// 								},
-// 							}}
-// 						/>
-// 					);
-
-// 					expect(wrapper.find("img.b-footer__logo")).toHaveProp("alt", "light");
-// 				});
-// 			});
-
-// 			describe("when the theme manifest does not provide alt text", () => {
-// 				it("should make the alt text of the logo blank", () => {
-// 					getProperties.mockImplementation(() => ({
-// 						locale: "en",
-// 						lightBackgroundLogo: "my-nav-logo.svg",
-// 					}));
-// 					const wrapper = mount(
-// 						<Footer
-// 							customFields={{
-// 								navigationConfig: {
-// 									contentService: "footer-service",
-// 									contentConfiguration: {},
-// 								},
-// 							}}
-// 						/>
-// 					);
-
-// 					expect(wrapper.find("img.b-footer__logo")).toHaveProp("alt", "");
-// 				});
-// 			});
-// 		});
-
-// 		describe("when the theme does not provide a logo url", () => {
-// 			it("should not render the primary logo div", () => {
-// 				getProperties.mockImplementation(() => ({ locale: "en" }));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find("MediaItem")).toHaveLength(0);
-// 			});
-// 		});
-// 	});
-
-// 	describe("the copyright text", () => {
-// 		describe("when copyright text is provided", () => {
-// 			it("should show copyright text", () => {
-// 				getProperties.mockImplementation(() => ({
-// 					locale: "en",
-// 					copyrightText: "my copyright text",
-// 				}));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find(".b-footer__top-container p").text()).toStrictEqual(
-// 					"my copyright text"
-// 				);
-// 			});
-// 		});
-
-// 		describe("when copyright text is not provided", () => {
-// 			it("should not show copyright text", () => {
-// 				getProperties.mockImplementation(() => ({ locale: "en" }));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find(".b-footer__top-container p").text()).toStrictEqual("");
-// 			});
-// 		});
-// 	});
-
-// 	describe("the social media buttons", () => {
-// 		describe("when a facebook page is provided", () => {
-// 			it("should show a facebook button with the proper url", () => {
-// 				getProperties.mockImplementation(() => ({ locale: "en", facebookPage: "thesun" }));
-
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(
-// 					wrapper.find(`Link[supplementalText="footer-block.facebook-link"] > a`)
-// 				).toHaveLength(1);
-// 				expect(
-// 					wrapper.find(`Link[supplementalText="footer-block.facebook-link"] > a`).prop("href")
-// 				).toEqual("thesun");
-// 			});
-// 		});
-
-// 		describe("when a facebook page is not provided", () => {
-// 			it("should not show a facebook button", () => {
-// 				getProperties.mockImplementation(() => ({ locale: "en", facebookPage: "" }));
-
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(
-// 					wrapper.find(`Link[supplementalText="footer-block.facebook-link"] > a`)
-// 				).toHaveLength(0);
-// 			});
-// 		});
-
-// 		describe("when a twitter username is provided", () => {
-// 			it("should show a twitter button with the proper url", () => {
-// 				getProperties.mockImplementation(() => ({ locale: "en", twitterUsername: "thesun" }));
-
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find(`Link[supplementalText="footer-block.twitter-link"] > a`)).toHaveLength(
-// 					1
-// 				);
-// 				expect(
-// 					wrapper.find(`Link[supplementalText="footer-block.twitter-link"] > a`).prop("href")
-// 				).toEqual("https://twitter.com/thesun");
-// 			});
-// 		});
-
-// 		describe("when a twitter username is not provided", () => {
-// 			it("should not show a twitter button", () => {
-// 				getProperties.mockImplementation(() => ({ locale: "en", twitterUsername: "" }));
-
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find(`Link[supplementalText="footer-block.twitter-link"] > a`)).toHaveLength(
-// 					0
-// 				);
-// 			});
-// 		});
-
-// 		describe("when a rss link is provided", () => {
-// 			it("should show a rss button with the proper url", () => {
-// 				getProperties.mockImplementation(() => ({ locale: "en", rssUrl: "thesun" }));
-
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find(`Link[supplementalText="footer-block.rss-link"] > a`)).toHaveLength(1);
-// 				expect(
-// 					wrapper.find(`Link[supplementalText="footer-block.rss-link"] > a`).prop("href")
-// 				).toEqual("thesun");
-// 			});
-// 		});
-
-// 		describe("when a rss link is not provided", () => {
-// 			it("should not show a rss button", () => {
-// 				getProperties.mockImplementation(() => ({ locale: "en", rssUrl: "" }));
-
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-
-// 				expect(wrapper.find(`Link[supplementalText="footer-block.rss-link"] > a`)).toHaveLength(0);
-// 			});
-// 		});
-
-// 		describe("when no social site properties are provided", () => {
-// 			it("should render no social buttons and no border on container", () => {
-// 				getProperties.mockImplementation(() => ({
-// 					locale: "en",
-// 					facebookPage: "",
-// 					twitterUsername: "",
-// 					rssUrl: "",
-// 				}));
-// 				const wrapper = mount(
-// 					<Footer
-// 						customFields={{
-// 							navigationConfig: {
-// 								contentService: "footer-service",
-// 								contentConfiguration: {},
-// 							},
-// 						}}
-// 					/>
-// 				);
-// 				expect(
-// 					wrapper.find(`Link[supplementalText="footer-block.facebook-link"] > a`)
-// 				).toHaveLength(0);
-// 				expect(wrapper.find(`Link[supplementalText="footer-block.twitter-link"] > a`)).toHaveLength(
-// 					0
-// 				);
-// 				expect(wrapper.find(`Link[supplementalText="footer-block.rss-link"] > a`)).toHaveLength(0);
-// 				const container = wrapper.find(".b-footer__social-links");
-// 				expect(container).toBeDefined();
-// 				expect(container.find("Link").length).toBe(0);
-// 			});
-// 		});
-// 	});
-// });
+const baseProperties = {
+  facebookPage: undefined,
+  twitterUsername: undefined,
+  rssUrl: undefined,
+  copyrightText: "© 2025",
+  lightBackgroundLogo: undefined,
+  lightBackgroundLogoAlt: "Light Alt",
+  primaryLogo: undefined,
+  primaryLogoAlt: "Primary Alt",
+};
+
+const setup = ({
+  isAdmin = false,
+  serverSide = false,
+  props = makeProps(),
+  properties = {},
+  content = { children: [] },
+  pagebuilderURLImpl = (p) => p,
+} = {}) => {
+  const pagebuilderURL = jest.fn(pagebuilderURLImpl);
+
+  getProperties.mockReturnValue({ ...baseProperties, ...properties });
+
+  useFusionContext.mockReturnValue({
+    arcSite: "the-site",
+    contextPath: "/pf",
+    isAdmin,
+    pagebuilderURL,
+  });
+
+  isServerSide.mockReturnValue(serverSide);
+  useContent.mockReturnValue(content);
+
+  const utils = render(<Footer {...props} />);
+  return { ...utils, pagebuilderURL };
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Footer", () => {
+  test("returns null on server when lazyLoad is true and user is not admin", () => {
+    setup({
+      serverSide: true,
+      isAdmin: false,
+      props: makeProps({ customFields: { lazyLoad: true } }),
+    });
+    expect(isServerSide).toHaveBeenCalled();
+    expect(screen.queryByTestId("LazyLoad")).toBeNull();
+  });
+
+  test("renders with LazyLoad enabled on client when lazyLoad is true", () => {
+    setup({
+      serverSide: false,
+      isAdmin: false,
+      props: makeProps({ customFields: { lazyLoad: true } }),
+    });
+  const wrapper = screen.getByTestId("LazyLoad");
+  expect(wrapper).toBeInTheDocument();
+  expect(wrapper).toHaveAttribute("data-enabled", "true");
+  // Renders footer content
+  expect(screen.getByText("© 2025")).toBeInTheDocument();
+  });
+
+  test("renders for admins even on server and disables LazyLoad", () => {
+    setup({
+      serverSide: true,
+      isAdmin: true,
+      props: makeProps({ customFields: { lazyLoad: true } }),
+    });
+  const wrapper = screen.getByTestId("LazyLoad");
+  expect(wrapper).toHaveAttribute("data-enabled", "false");
+  expect(screen.getByText("© 2025")).toBeInTheDocument();
+  });
+});
+
+describe("FooterItem", () => {
+  test("renders social links when configured and uses phrases for supplemental text", () => {
+    setup({
+      properties: {
+        facebookPage: "https://facebook.com/theSite",
+        twitterUsername: "theUser",
+        rssUrl: "/rss.xml",
+      },
+    });
+
+  // Facebook (icon-only link; select via href attribute)
+  const allLinks = screen.getAllByRole("link");
+  const fb = allLinks.find((a) => a.getAttribute("href") === "https://facebook.com/theSite");
+  expect(fb).toBeInTheDocument();
+  expect(fb).toHaveAttribute("data-supplemental-text", "T:footer-block.facebook-link");
+
+  // Twitter (select via href attribute)
+  const twitter = allLinks.find((a) => a.getAttribute("href") === "https://twitter.com/theUser");
+  expect(twitter).toBeInTheDocument();
+  expect(twitter).toHaveAttribute("data-supplemental-text", "T:footer-block.twitter-link");
+
+  // RSS (select via href attribute)
+  const rss = allLinks.find((a) => a.getAttribute("href") === "/rss.xml");
+  expect(rss).toBeInTheDocument();
+  expect(rss).toHaveAttribute("data-supplemental-text", "T:footer-block.rss-link");
+
+    // Copyright always renders
+    expect(screen.getByText("© 2025")).toBeInTheDocument();
+  });
+
+  test("does not render social links section when none provided", () => {
+    setup();
+    // No links should render when no social config and no nav content
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+
+  test("renders navigation grid with both link and non-link items; skips empty columns", () => {
+    setup({
+      content: {
+        children: [
+          {
+            _id: "col-1",
+            name: "Column 1",
+            children: [
+              {
+                _id: "i-1",
+                node_type: "link",
+                display_name: "Foo",
+                url: "/foo",
+              },
+              {
+                _id: "/tag2",
+                node_type: "collection",
+                name: "Bar",
+              },
+            ],
+          },
+          {
+            _id: "col-empty",
+            name: "Empty Column",
+            children: [],
+          },
+          {
+            _id: "col-noname",
+            children: [{ _id: "i-3", node_type: "link", display_name: "Baz", url: "/baz" }],
+          },
+        ],
+      },
+    });
+
+    // Grid exists
+    expect(screen.getByTestId("Grid")).toBeInTheDocument();
+
+    // Column 1 heading
+    expect(screen.getByRole("heading", { level: 2, name: "Column 1" })).toBeInTheDocument();
+
+    // Link item
+    expect(screen.getByRole("link", { name: "Foo" })).toHaveAttribute("href", "/foo");
+
+    // Non-link item
+    expect(screen.getByRole("link", { name: "Bar" })).toHaveAttribute("href", "/tag2");
+
+    // Column without children is skipped (no "Empty Column" heading)
+    expect(screen.queryByRole("heading", { name: "Empty Column" })).toBeNull();
+
+    // Column with no name still renders its list
+    expect(screen.getByRole("link", { name: "Baz" })).toHaveAttribute("href", "/baz");
+  });
+
+  test("computes logo URL with pagebuilderURL for relative primaryLogo; uses primary alt", () => {
+    const { pagebuilderURL } = setup({
+      properties: {
+        primaryLogo: "resources/logo.png",
+        primaryLogoAlt: "Primary Alt",
+      },
+      pagebuilderURLImpl: (p) => `BUILT:${p}`,
+    });
+
+    const img = screen.getByRole("img", { name: "Primary Alt" });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "BUILT:/pf/resources/logo.png");
+    expect(img).toHaveAttribute("data-height", "64");
+    expect(pagebuilderURL).toHaveBeenCalledWith("/pf/resources/logo.png");
+  });
+
+  test("uses absolute lightBackgroundLogo without calling pagebuilderURL; uses light alt", () => {
+    const { pagebuilderURL } = setup({
+      properties: {
+        lightBackgroundLogo: "http://cdn.example.com/logo.png",
+        lightBackgroundLogoAlt: "Light Alt CDN",
+        primaryLogo: "resources/ignored.png",
+        primaryLogoAlt: "Primary Alt",
+      },
+    });
+
+    const img = screen.getByRole("img", { name: "Light Alt CDN" });
+    expect(img).toHaveAttribute("src", "http://cdn.example.com/logo.png");
+    expect(pagebuilderURL).not.toHaveBeenCalled();
+  });
+
+  test("uses base64 logo without calling pagebuilderURL", () => {
+    const { pagebuilderURL } = setup({
+      properties: {
+        lightBackgroundLogo: "base64ABC123",
+        lightBackgroundLogoAlt: "Base64 Alt",
+      },
+    });
+
+    const img = screen.getByRole("img", { name: "Base64 Alt" });
+    expect(img).toHaveAttribute("src", "base64ABC123");
+    expect(pagebuilderURL).not.toHaveBeenCalled();
+  });
+
+  test("does not render navigation when content has no children; still renders copyright and trailing div", () => {
+    setup({ content: undefined });
+    expect(screen.queryByTestId("Grid")).toBeNull();
+    expect(screen.getByText("© 2025")).toBeInTheDocument();
+  // implicit: footer rendered
+  expect(screen.getByText("© 2025")).toBeInTheDocument();
+  });
+
+  test("calls useContent with expected params (service, merged query, filter)", () => {
+    setup({
+      props: makeProps({
+        customFields: {
+          navigationConfig: {
+            contentService: "nav-service",
+            contentConfigValues: { region: "us", foo: "baz" },
+          },
+        },
+      }),
+    });
+
+    expect(useContent).toHaveBeenCalledTimes(1);
+    const arg = useContent.mock.calls[0][0];
+
+    expect(arg.source).toBe("nav-service");
+    expect(arg.query).toEqual(
+      expect.objectContaining({
+        hierarchy: "footer",
+        feature: "footer",
+        region: "us",
+        foo: "baz",
+      })
+    );
+    expect(typeof arg.filter).toBe("string");
+    expect(arg.filter).toContain("children");
+  });
+});

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.jsx
@@ -185,7 +185,7 @@ export function PresentationalNav(props) {
 /* Main Component */
 const Nav = (props) => {
 	const [isScrolled, setIsScrolled] = useState(false);
-	const { arcSite, isAdmin, deployment, contextPath } = useFusionContext();
+	const { arcSite, isAdmin, pagebuilderURL, contextPath } = useFusionContext();
 
 	const { primaryLogo, primaryLogoAlt } = getProperties(arcSite);
 
@@ -194,7 +194,7 @@ const Nav = (props) => {
 		primaryLogo &&
 		(primaryLogo.indexOf("http") === 0 || primaryLogo.indexOf("base64") === 0
 			? primaryLogo
-			: deployment(`${contextPath}/${primaryLogo}`));
+			: pagebuilderURL(`${contextPath}/${primaryLogo}`));
 
 	const phrases = usePhrases();
 

--- a/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
+++ b/blocks/header-nav-chain-block/chains/header-nav-chain-block/default.test.jsx
@@ -19,7 +19,7 @@ jest.mock("fusion:properties", () => jest.fn(() => ({})));
 jest.mock("fusion:context", () => ({
 	useFusionContext: jest.fn(() => ({
 		contextPath: "pf",
-		deployment: jest.fn(() => ({})).mockReturnValue("path/image.svg"),
+		pagebuilderURL: jest.fn(() => ({})).mockReturnValue("path/image.svg"),
 	})),
 }));
 
@@ -313,14 +313,14 @@ describe("the header navigation feature for the default output type", () => {
 	});
 
 	describe("primary image", () => {
-		it("shown without deployment function prefix if external http url", () => {
+		it("shown without pagebuilderURL function prefix if external http url", () => {
 			jest.useFakeTimers();
 			getProperties.mockReturnValueOnce({
 				primaryLogo: "http://www.example.com/logo.png",
 			});
 			useFusionContext.mockReturnValueOnce({
 				contextPath: "pf",
-				deployment: jest.fn(() => ({})).mockReturnValue("rendered-from-deployment"),
+				pagebuilderURL: jest.fn(() => ({})).mockReturnValue("rendered-from-pagebuilderURL"),
 			});
 
 			render(<Navigation customFields={DEFAULT_SELECTIONS} />);
@@ -339,7 +339,7 @@ describe("the header navigation feature for the default output type", () => {
 			});
 			useFusionContext.mockReturnValueOnce({
 				contextPath: "pf",
-				deployment: jest.fn(() => ({})).mockReturnValue("rendered-from-deployment"),
+				pagebuilderURL: jest.fn(() => ({})).mockReturnValue("rendered-from-pagebuilderURL"),
 			});
 			render(<Navigation customFields={DEFAULT_SELECTIONS} />);
 			act(() => {
@@ -347,17 +347,17 @@ describe("the header navigation feature for the default output type", () => {
 			});
 			const navLogoImg = screen.getByRole("img")
 			expect(navLogoImg).not.toBeNull();
-			expect(navLogoImg.getAttribute("src")).toEqual("rendered-from-deployment");
+			expect(navLogoImg.getAttribute("src")).toEqual("rendered-from-pagebuilderURL");
 		});
 
-		it("shows image with deployment function used with base64", () => {
+		it("shows image with pagebuilderURL function used with base64", () => {
 			jest.useFakeTimers();
 			getProperties.mockReturnValueOnce({
 				primaryLogo: "base64, iVBORw0KGgoAAAANSUhEUgAAAAUA",
 			});
 			useFusionContext.mockReturnValueOnce({
 				contextPath: "pf",
-				deployment: jest.fn(() => ({})).mockReturnValue("rendered-from-deployment"),
+				pagebuilderURL: jest.fn(() => ({})).mockReturnValue("rendered-from-pagebuilderURL"),
 			});
 			render(<Navigation customFields={DEFAULT_SELECTIONS} />);
 			act(() => {

--- a/blocks/numbered-list-block/features/numbered-list/default.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.jsx
@@ -20,11 +20,11 @@ import {
 
 const BLOCK_CLASS_NAME = "b-numbered-list";
 
-const getFallbackImageURL = ({ deployment, contextPath, fallbackImage }) => {
+const getFallbackImageURL = ({ pagebuilderURL, contextPath, fallbackImage }) => {
 	let targetFallbackImage = fallbackImage;
 
 	if (!targetFallbackImage.includes("http")) {
-		targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
+		targetFallbackImage = pagebuilderURL(`${contextPath}/${targetFallbackImage}`);
 	}
 
 	return targetFallbackImage;
@@ -155,11 +155,11 @@ const NumberedList = (props) => {
 };
 
 const NumberedListWrapper = ({ customFields }) => {
-	const { id, arcSite, contextPath, deployment, isAdmin } = useFusionContext();
+	const { id, arcSite, contextPath, pagebuilderURL, isAdmin } = useFusionContext();
 	const { websiteDomain, fallbackImage } = getProperties(arcSite);
 
 	const targetFallbackImage = getFallbackImageURL({
-		deployment,
+		pagebuilderURL,
 		contextPath,
 		fallbackImage,
 	});

--- a/blocks/numbered-list-block/features/numbered-list/default.test.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.test.jsx
@@ -64,8 +64,9 @@ describe("The numbered-list-block", () => {
 			};
 			isServerSide.mockReturnValue(true);
 
-			const { container } = render(<NumberedList customFields={customFields} />);
-			expect(container.firstChild).toBeNull();
+			render(<NumberedList customFields={customFields} />);
+			// Expect nothing rendered: first item number is absent
+			expect(screen.queryByText("1")).toBeNull();
 		});
 
 		it("should render in Admin with lazyLoad enabled", () => {
@@ -82,8 +83,9 @@ describe("The numbered-list-block", () => {
 				isAdmin: true,
 			});
 
-			const { container } = render(<NumberedList customFields={customFields} />);
-			expect(container.firstChild).not.toBeNull();
+			render(<NumberedList customFields={customFields} />);
+			// Presence check with getBy*
+			expect(screen.getByText("1")).toBeInTheDocument();
 		});
 
 		it("should render list item with headline, image and a number", () => {
@@ -95,8 +97,8 @@ describe("The numbered-list-block", () => {
 
 			expect(screen.getByText("1")).toBeInTheDocument();
 			expect(screen.getByText("Article with only promo_items.basic")).toBeInTheDocument();
-			const image = screen.queryAllByRole("img", { hidden: true });
-			expect(image).toBeTruthy();
+			const images = screen.getAllByRole("img", { hidden: true });
+			expect(images.length).toBeGreaterThan(0);
 
 			unmount();
 		});
@@ -126,7 +128,7 @@ describe("The numbered-list-block", () => {
 			const { unmount } = render(<NumberedList customFields={customFields} />);
 
 			expect(screen.getByText("1")).toBeInTheDocument();
-			expect(screen.queryByText("Article with only promo_items.basic")).toBeInTheDocument();
+			expect(screen.getByText("Article with only promo_items.basic")).toBeInTheDocument();
 			const image = screen.queryAllByRole("img", { hidden: true });
 			expect(image.length).toBe(0);
 
@@ -142,8 +144,8 @@ describe("The numbered-list-block", () => {
 
 			const { unmount } = render(<NumberedList customFields={customFields} />);
 			expect(screen.getByText("1")).toBeInTheDocument();
-			const image = document.querySelectorAll("img[src='pf/placeholder.jpg']");
-			expect(image.length).toBeTruthy();
+			const imgs = screen.getAllByRole("img", { hidden: true });
+			expect(imgs.some((img) => img.getAttribute("src") === "pf/placeholder.jpg")).toBe(true);
 
 			unmount();
 		});
@@ -158,7 +160,7 @@ describe("The numbered-list-block", () => {
 
 			const { unmount } = render(<NumberedList customFields={customFields} />);
 
-			expect(screen.queryByText("Numbered List Title")).toBeInTheDocument();
+			expect(screen.getByText("Numbered List Title")).toBeInTheDocument();
 
 			unmount();
 		});
@@ -176,7 +178,7 @@ describe("The numbered-list-block", () => {
 			});
 
 			const { unmount } = render(<NumberedList customFields={customFields} />);
-			expect(screen.queryByText("Article with only promo_items.basic")).toBeInTheDocument();
+			expect(screen.getByText("Article with only promo_items.basic")).toBeInTheDocument();
 			expect(screen.queryByText("Story with video as the Lead Art")).not.toBeInTheDocument();
 			unmount();
 		});

--- a/blocks/numbered-list-block/features/numbered-list/default.test.jsx
+++ b/blocks/numbered-list-block/features/numbered-list/default.test.jsx
@@ -49,7 +49,7 @@ describe("The numbered-list-block", () => {
 		useFusionContext.mockReturnValue({
 			arcSite: "the-sun",
 			contextPath: "pf",
-			deployment: jest.fn((x) => x),
+			pagebuilderURL: jest.fn((x) => x),
 			isAdmin: false,
 		});
 	});
@@ -78,7 +78,7 @@ describe("The numbered-list-block", () => {
 
 			useFusionContext.mockReturnValue({
 				arcSite: "the-sun",
-				deployment: jest.fn((x) => x),
+				pagebuilderURL: jest.fn((x) => x),
 				isAdmin: true,
 			});
 
@@ -172,7 +172,7 @@ describe("The numbered-list-block", () => {
 
 			useFusionContext.mockReturnValue({
 				arcSite: "dagen",
-				deployment: jest.fn(() => {}),
+				pagebuilderURL: jest.fn(() => {}),
 			});
 
 			const { unmount } = render(<NumberedList customFields={customFields} />);

--- a/blocks/results-list-block/features/results-list/default.jsx
+++ b/blocks/results-list-block/features/results-list/default.jsx
@@ -9,14 +9,14 @@ import { resolveDefaultPromoElements } from "./results/helpers";
 import Results from "./results";
 
 const ResultsList = ({ customFields }) => {
-	const { arcSite, contextPath, deployment, isAdmin } = useFusionContext();
+	const { arcSite, contextPath, pagebuilderURL, isAdmin } = useFusionContext();
 	const {
 		lazyLoad,
 		listContentConfig: { contentService, contentConfigValues },
 	} = customFields;
 	const { fallbackImage } = getProperties(arcSite);
 	const targetFallbackImage = !fallbackImage.includes("http")
-		? deployment(`${contextPath}/${fallbackImage}`)
+		? pagebuilderURL(`${contextPath}/${fallbackImage}`)
 		: fallbackImage;
 	const promoElements = resolveDefaultPromoElements(customFields);
 	const isServerSideLazy = lazyLoad && isServerSide() && !isAdmin;

--- a/blocks/results-list-block/features/results-list/default.test.jsx
+++ b/blocks/results-list-block/features/results-list/default.test.jsx
@@ -42,7 +42,7 @@ describe("Results List", () => {
 		useFusionContext.mockReturnValue({
 			arcSite: "the-sun",
 			contextPath: "/pf",
-			deployment: jest.fn((path) => path),
+			pagebuilderURL: jest.fn((path) => path),
 			isAdmin: false,
 		});
 		const customFields = {
@@ -65,7 +65,7 @@ describe("Results List", () => {
 		useFusionContext.mockReturnValue({
 			arcSite: "the-sun",
 			contextPath: "/pf",
-			deployment: jest.fn((path) => path),
+			pagebuilderURL: jest.fn((path) => path),
 			isAdmin: false,
 		});
 		const customFields = {
@@ -92,7 +92,7 @@ describe("getFallbackImageURL", () => {
 		useFusionContext.mockReturnValue({
 			arcSite: "the-sun",
 			contextPath: "/pf",
-			deployment: mockDeployment,
+			pagebuilderURL: mockDeployment,
 			isAdmin: false,
 		});
 
@@ -168,7 +168,7 @@ describe("isServerSideLazy flag", () => {
 		useFusionContext.mockReturnValue({
 			arcSite: "the-sun",
 			contextPath: "/pf",
-			deployment: jest.fn(),
+			pagebuilderURL: jest.fn(),
 			isAdmin: true,
 		});
 
@@ -188,7 +188,7 @@ describe("isServerSideLazy flag", () => {
 		useFusionContext.mockReturnValue({
 			arcSite: "the-sun",
 			contextPath: "/pf",
-			deployment: jest.fn((path) => path),
+			pagebuilderURL: jest.fn((path) => path),
 			isAdmin: false,
 		});
 

--- a/blocks/simple-list-block/features/simple-list/default.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.jsx
@@ -19,22 +19,22 @@ import {
 
 const BLOCK_CLASS_NAME = "b-simple-list";
 
-const getFallbackImageURL = ({ deployment, contextPath, fallbackImage }) => {
+const getFallbackImageURL = ({ pagebuilderURL, contextPath, fallbackImage }) => {
 	let targetFallbackImage = fallbackImage;
 
 	if (!targetFallbackImage.includes("http")) {
-		targetFallbackImage = deployment(`${contextPath}/${targetFallbackImage}`);
+		targetFallbackImage = pagebuilderURL(`${contextPath}/${targetFallbackImage}`);
 	}
 
 	return targetFallbackImage;
 };
 
 const SimpleListWrapper = ({ customFields }) => {
-	const { id, arcSite, contextPath, deployment, isAdmin } = useFusionContext();
+	const { id, arcSite, contextPath, pagebuilderURL, isAdmin } = useFusionContext();
 	const { websiteDomain, fallbackImage, primaryLogoAlt } = getProperties(arcSite);
 
 	const targetFallbackImage = getFallbackImageURL({
-		deployment,
+		pagebuilderURL,
 		contextPath,
 		fallbackImage,
 	});

--- a/blocks/simple-list-block/features/simple-list/default.test.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.test.jsx
@@ -129,8 +129,9 @@ describe("The simple-list-block", () => {
 			};
 			isServerSide.mockReturnValue(true);
 
-			const { container } = render(<SimpleList customFields={customFields} />);
-			expect(container.firstChild).toBeNull();
+			render(<SimpleList customFields={customFields} />);
+			// Expect nothing rendered when server-side lazy load is enabled
+			expect(screen.queryByText("Video Test")).toBeNull();
 		});
 
 		it("should render in Admin with lazyLoad enabled", () => {
@@ -147,8 +148,8 @@ describe("The simple-list-block", () => {
 				isAdmin: true,
 			});
 
-			const { container } = render(<SimpleList customFields={customFields} />);
-			expect(container.firstChild).not.toBeNull();
+			render(<SimpleList customFields={customFields} />);
+			expect(screen.getByText("Video Test")).toBeInTheDocument();
 		});
 
 		it("should render list item with headline, image and a number", () => {
@@ -188,7 +189,7 @@ describe("The simple-list-block", () => {
 
 			const { unmount } = render(<SimpleList customFields={customFields} />);
 
-			expect(screen.queryByText("Video Test")).toBeInTheDocument();
+			expect(screen.getByText("Video Test")).toBeInTheDocument();
 			const image = screen.queryAllByRole("img", { hidden: true });
 			expect(image.length).toBe(0);
 
@@ -203,8 +204,8 @@ describe("The simple-list-block", () => {
 			};
 
 			const { unmount } = render(<SimpleList customFields={customFields} />);
-			const image = document.querySelectorAll("img[src='pf/placeholder.jpg']");
-			expect(image.length).toBeTruthy();
+			const images = screen.getAllByRole("img", { hidden: true });
+			expect(images.some((img) => img.getAttribute("src") === "pf/placeholder.jpg")).toBe(true);
 
 			unmount();
 		});
@@ -219,7 +220,7 @@ describe("The simple-list-block", () => {
 
 			const { unmount } = render(<SimpleList customFields={customFields} />);
 
-			expect(screen.queryByText("Simple List Title")).toBeInTheDocument();
+			expect(screen.getByText("Simple List Title")).toBeInTheDocument();
 
 			unmount();
 		});
@@ -237,7 +238,7 @@ describe("The simple-list-block", () => {
 			});
 
 			const { unmount } = render(<SimpleList customFields={customFields} />);
-			expect(screen.queryByText("Video Test")).toBeInTheDocument();
+			expect(screen.getByText("Video Test")).toBeInTheDocument();
 			expect(screen.queryByText("Story with video as the Lead Art")).not.toBeInTheDocument();
 			unmount();
 		});

--- a/blocks/simple-list-block/features/simple-list/default.test.jsx
+++ b/blocks/simple-list-block/features/simple-list/default.test.jsx
@@ -114,7 +114,7 @@ describe("The simple-list-block", () => {
 		useFusionContext.mockReturnValue({
 			arcSite: "the-sun",
 			contextPath: "pf",
-			deployment: jest.fn((x) => x),
+			pagebuilderURL: jest.fn((x) => x),
 			isAdmin: false,
 		});
 	});
@@ -143,7 +143,7 @@ describe("The simple-list-block", () => {
 
 			useFusionContext.mockReturnValue({
 				arcSite: "the-sun",
-				deployment: jest.fn((x) => x),
+				pagebuilderURL: jest.fn((x) => x),
 				isAdmin: true,
 			});
 
@@ -233,7 +233,7 @@ describe("The simple-list-block", () => {
 
 			useFusionContext.mockReturnValue({
 				arcSite: "the-sun",
-				deployment: jest.fn(() => {}),
+				pagebuilderURL: jest.fn(() => {}),
 			});
 
 			const { unmount } = render(<SimpleList customFields={customFields} />);


### PR DESCRIPTION
**Be sure to run `npm test`, `npm run lint`, and write detailed test steps before requesting reviewers**

## Description

#### Jira Ticket: [DEVINT-517](https://arcpublishing.atlassian.net/browse/DEVINT-517)

1 to 1 replacement of `deployment` with `pagebuilderURL` plus update tests. 

## Test Steps

_Add detailed test steps a reviewer must complete to test this PR_

1. Checkout this branch `git checkout devint-517-deployment-fn`
2. Navigate to your feature pack. Change the fallback image in the blocks.json to a relative path to an image in the resources folder, eg the sun. 
`"fallbackImage": "resources/images/sun.png",`
4. Run fusion repo with linked blocks `npx fusion start -f -l`
5. Open up your local pagebuilder and examine the modified blocks (list blocks and footer). Look for your relative path image in a list or footer where the fallback image is used. I used the page `All Blocks-Test-TA-Sandbox`. This shows that pagebuilderURL is creating an absolute path from a relative path correctly. 
<img width="503" height="430" alt="Screenshot 2025-08-29 at 10 47 19 AM" src="https://github.com/user-attachments/assets/56731035-efcf-4018-8f78-bbef9d91f0c1" />



[DEVINT-517]: https://arcpublishing.atlassian.net/browse/DEVINT-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ