### PR TITLE
android-only notice added to gallery block + fixed the broken propert…

### DIFF
--- a/blocks/gallery-block/README.md
+++ b/blocks/gallery-block/README.md
@@ -5,11 +5,13 @@ The Gallery block shows a carousel with images and captions. It is used to displ
 ## Props
 
 | **Prop**                              | **Required** | **Type**              | **Description**                                                                                                                                     |
-| ------------------------------------- | ------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | --- | -------------------------- | --- | ------- | ---------------- | --- | ---------------------------- | --- | ------- | ------------------ |
+| ------------------------------------- | ------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **customFields.inheritGlobalContent** | no           | Boolean               | Determines whether or not the feature will use global content instead of the provided content config at the feature level. This is used by default. |
 | **customFields.galleryContentConfig** | no           | Fusion Content Config | Content config that will be used if `inheritGlobalContent` is false.                                                                                |
 | **customFields.lazyLoad**             | no           | Boolean               | Prevent the block from being rendered on the page until it is nearly in-view for the user                                                           |
-| **customFields.hideCredits**          | no           | Boolean               | Hide image credits                                                                                                                                  |     | **customFields.hideTitle** | no  | Boolean | Hide image title |     | **customFields.hideCaption** | no  | Boolean | Hide image caption |
+| **customFields.hideCredits**          | no           | Boolean               | Hide image credits                                                                                                                                  |
+| **customFields.hideTitle**            | no           | Boolean               | Hide image title                                                                                                                                    |
+| **customFields.hideCaption**          | no           | Boolean               | Hide image caption                                                                                                                                  |
 
 ## Themes Setting
 
@@ -98,3 +100,5 @@ The event object for these events will contain the following information:
 ## Additional Considerations
 
 In case `galleryCubeClicks` is used, an Ad of type `300x250` will be shown on all the cases.
+
+**Note:** The expand button is Android only on mobile devices.


### PR DESCRIPTION
…ies table at the top of the documentation documentation

**Be sure to run `npm test`, `npm run lint`, and write detailed test steps before requesting reviewers**

## Description

#### Jira Ticket: https://arcpublishing.atlassian.net/browse/WF-1938

Updated gallery-block README:
- Added note at the very bottom, about expand button only being available on Android devices on mobile.
- Fixed top table, it was messy, not rendering table in gh pages.

See updated doc: https://github.com/WPMedia/arc-themes-blocks/tree/doc-udpate-gallery-block/blocks/gallery-block