### PR TITLE
MD-359 Create themes block for schema data feed

### DIFF
--- a/.github/workflows/arc-themes-base-to-new-tag.yml
+++ b/.github/workflows/arc-themes-base-to-new-tag.yml
@@ -20,14 +20,14 @@ jobs:
         id: check-target-tag
         run: |
           if [[ ${{ github.event.inputs.target_release_tag }} =~ ^([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
-              echo ::set-output name=match::true
+              echo "match=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check new release tag name
         id: check-new-tag
         run: |
           if [[ ${{ github.event.inputs.new_release_tag }} =~ ^([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
-              echo ::set-output name=match::true
+              echo "match=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Validate release tag numbers
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node and NPM
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,19 +18,19 @@ jobs:
     # Job steps
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # 👈 Required to retrieve git history
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/generate-intl-files.yml
+++ b/.github/workflows/generate-intl-files.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,0 +1,70 @@
+name: Publish hotfix for previous themes version
+# Usage:
+#   1. Find the tag for the version to hotfix: git tag -l "themes-v*"
+#   2. Create a hotfix branch from that tag: git checkout -b hotfix/4.1.0 themes-v4.1.0
+#   3. Make your fix, commit, and push the branch
+#   4. This workflow runs automatically and publishes under the original dist-tag
+
+on:
+  push:
+    branches:
+      - "hotfix/[0-9]+.[0-9]+"
+      - "hotfix/[0-9]+.[0-9]+.[0-9]+"
+    paths:
+      - "**.js"
+      - "**.json"
+      - "**.jsx"
+      - "**.scss"
+      - "**/intl.json"
+      - "**/README.md"
+
+jobs:
+  publish-hotfix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull tags to give lerna access to git info
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+      - name: Extract version from branch name
+        id: hotfix-version
+        run: |
+          # Branch name is hotfix/X.Y.Z — extract the version part
+          VERSION="${GITHUB_REF_NAME#hotfix/}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=arc-themes-release-version-${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: Cache Node Modules
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Clean install (CI) dependencies if lockfile (above) changed
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run all tests
+        run: npm run test
+
+      - name: Publish hotfix to target tag
+        run: |
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --local user.name "$GITHUB_ACTOR"
+          npx lerna publish --dist-tag ${{ steps.hotfix-version.outputs.dist_tag }} --canary --preid ${{ steps.hotfix-version.outputs.dist_tag }} -y
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -3,13 +3,11 @@ name: "Code security scanning"
 on:
   push:
     branches:
-      - arc-themes-release-version-[0-9]+\.[0-9]+
-      - arc-themes-release-version-[0-9]+\.[0-9]+\.[0-9]+
+      - main
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
-      - arc-themes-release-version-[0-9]+\.[0-9]+
-      - arc-themes-release-version-[0-9]+\.[0-9]+\.[0-9]+
+      - main
 
 jobs:
   analyze:
@@ -27,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/stylelint-pr.yml
+++ b/.github/workflows/stylelint-pr.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Rep
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/sync-themes-branch-with-themes-tag.yml
+++ b/.github/workflows/sync-themes-branch-with-themes-tag.yml
@@ -1,12 +1,8 @@
-name: Publish to themes target tag based off of themes branch name
+name: Publish to themes target tag on merge to main
 on:
   push:
     branches:
-      # only run on branch names that match:
-      # arc-themes-release-version-{numbers}.{numbers} per product
-      - arc-themes-release-version-[0-9]+\.[0-9]+
-      # arc-themes-release-version-{numbers}.{numbers}.{numbers} per product
-      - arc-themes-release-version-[0-9]+\.[0-9]+\.[0-9]+
+      - main
     # only run on changes to these files
     paths:
       - "**.js"
@@ -19,11 +15,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    env:
-      SYNCED_RELEASE_TAG: ${{ github.ref_name }} # targets branch name ref_name
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -32,15 +26,34 @@ jobs:
       - name: Pull tags to give lerna access to git info
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
+      - name: Read themesVersion from package.json
+        id: themes-version
+        run: |
+          THEMES_VERSION=$(node -p "require('./package.json').themesVersion")
+          echo "version=$THEMES_VERSION" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=arc-themes-release-version-${THEMES_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if themesVersion changed
+        id: version-changed
+        run: |
+          PREV_VERSION=$(git show HEAD~1:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).themesVersion" 2>/dev/null || echo "")
+          CURR_VERSION=${{ steps.themes-version.outputs.version }}
+          if [ "$PREV_VERSION" != "$CURR_VERSION" ] && [ -n "$PREV_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "previous_version=$PREV_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
@@ -54,11 +67,22 @@ jobs:
       - name: Run all tests
         run: npm run test
 
+      # Tag the previous version's final commit before publishing under the new version
+      - name: Tag previous themes version
+        if: steps.version-changed.outputs.changed == 'true'
+        run: |
+          PREV_TAG="themes-v${{ steps.version-changed.outputs.previous_version }}"
+          # Tag the commit before the version bump (parent of current HEAD)
+          git tag "$PREV_TAG" HEAD~1
+          git push origin "$PREV_TAG"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # See confluence pages https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/2983788608/How+To+Do+Product-Facing+Tag+Release and https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3013541978/Github+Actions+for+NodeJS+Standards+Best+Practices for documentation
-      - name: Publish to target tag based off of branch name
+      - name: Publish to target tag based off of themesVersion
         run: |
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git config --local user.name "$GITHUB_ACTOR"
-          npx lerna publish --dist-tag ${{ env.SYNCED_RELEASE_TAG }} --canary --preid ${{ env.SYNCED_RELEASE_TAG }} -y
+          npx lerna publish --dist-tag ${{ steps.themes-version.outputs.dist_tag }} --canary --preid ${{ steps.themes-version.outputs.dist_tag }} -y
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-coverage-blocks.yml
+++ b/.github/workflows/test-coverage-blocks.yml
@@ -1,14 +1,11 @@
-name: Test Blocks And Linting - Changed from themes release base
+name: Test Blocks And Linting - Changed from main
 
 on:
   pull_request:
     # synchronize	commit(s) pushed to the pull request
     types: [synchronize, opened]
     branches:
-      # arc-themes-release-version-{numbers}.{numbers} per product
-      - arc-themes-release-version-[0-9]+\.[0-9]+
-      # arc-themes-release-version-{numbers}.{numbers}.{numbers} per product
-      - arc-themes-release-version-[0-9]+\.[0-9]+\.[0-9]+
+      - main
 
 jobs:
   ensure_minimum_test_coverage_linting:
@@ -18,20 +15,20 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           #  0 indicates all history for all branches and tags
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
@@ -42,10 +39,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests on changed since base themes release
+      - name: Run tests on changed since main
         run: npm run test:changed-feature-branch
 
-      - name: Check linting of changed since base themes release
+      - name: Check linting of changed since main
         run: npm run lint:changed-feature-branch
 
       - name: Check failure status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,130 +2,89 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## What This Is
+
+A Lerna monorepo of ~79 Arc Themes blocks published to GitHub Packages (`@wpmedia/*`). Blocks are React components that run inside Arc's Fusion rendering engine. The repo uses independent versioning per block, but all blocks are published together under a shared themes release dist-tag.
+
 ## Commands
 
 ```bash
-# Testing
-npm test                                # run all tests
-npm run test:coverage                   # run with coverage report
-npm run test:watch                      # watch mode (only changed files)
-npm run test:changed-feature-branch    # test only files changed vs origin/arc-themes-release-version-4.1.0
+npm run test                       # Run all tests (jest)
+npm run test -- --testPathPattern=blocks/header-block  # Run tests for one block
+npm run test:watch                 # Watch mode with coverage for changed files
+npm run test:changed-feature-branch # Tests for files changed vs origin/main
 
-# Run a single test file
-npx jest blocks/large-promo-block/features/large-promo/default.test.jsx
+npm run lint                       # ESLint all blocks
+npm run lint:changed-feature-branch # ESLint only files changed vs origin/main
+npm run lint:styles                # Stylelint all SCSS
+npm run lint:styles:fix            # Auto-fix SCSS issues
 
-# Linting
-npm run lint                            # ESLint on blocks/ and .storybook/
-npm run lint:fix                        # auto-fix lint issues
-npm run lint:changed-feature-branch    # lint only changed files vs origin branch
-
-# Formatting
-npm run format                          # Prettier (uses tabs, width 100)
-
-# Storybook
-npm run storybook                       # dev server on port 6006
-npm run build-storybook                 # static build for Chromatic
-
-# Code generation (Hygen templates)
-npm run generate:chain                  # scaffold a new chain block
-npm run generate:feature                # scaffold a new feature block
-npm run generate:content-source         # scaffold a new content source block
+npm run storybook                  # Dev server on port 6006
+npm run format                     # Prettier (uses tabs)
 ```
 
-Node version: 20 (see `.nvmrc`).
+## Release Process
+
+Trunk-based development on `main`. The `themesVersion` field in root `package.json` controls which dist-tag blocks publish under (e.g., `"themesVersion": "4.1.0"` → dist-tag `arc-themes-release-version-4.1.0`).
+
+- **Every merge to `main`** that touches block code auto-publishes via `lerna publish --canary`
+- **Version bump**: change `themesVersion` in a PR; on merge the workflow auto-tags the previous version (e.g., `themes-v4.1.0`) and starts publishing under the new one
+- **Hotfix**: create `hotfix/X.Y.Z` branch from the `themes-vX.Y.Z` tag, push fix, it auto-publishes
 
 ## Architecture
 
-### Monorepo Structure
+### Block Types
 
-This is a Lerna monorepo of 78 independent npm packages under `blocks/`. Each package (`@wpmedia/*-block`) is a self-contained **Arc XP Fusion block** published to GitHub's npm registry.
+Blocks live in `blocks/` and come in four types, each with a corresponding subdirectory:
+- **features/** — UI components (header, promo cards, article body)
+- **chains/** — layout containers that wrap features
+- **sources/** — content sources that fetch data from Arc APIs
+- **output-types/** — page-level output wrappers
 
-The four block types:
+### Block Structure
 
-| Type | Location within block | Purpose |
-|---|---|---|
-| **Feature** | `features/<name>/default.jsx` | Leaf React components rendered on a page |
-| **Chain** | `chains/<name>/default.jsx` | Compositions that arrange features/children |
-| **Layout** | `layouts/<name>/default.jsx` | Full-page structural wrappers with named sections |
-| **Content Source** | `sources/<name>.js` | Data-fetching functions (not React components) |
+Each block is an independent npm package (`@wpmedia/<name>`) with:
+- `features/` or `chains/` or `sources/` containing `default.jsx` + `default.test.jsx`
+- `_index.scss` — styles using BEM naming (`b-block-name`, `b-block-name--variant`)
+- `themes/*.json` — theme token mappings (news.json, commerce.json)
+- `intl.json` — i18n translations (generated from `locale/` via `npm run generate:intl`)
+- `jest.config.js` — extends `../../jest/jest.config.base`
+- `index.story.jsx` — Storybook story
 
-A single block package can contain multiple of these types. Block-level `package.json` files list which directories to publish (`features`, `chains`, `layouts`, `sources`, `themes`, `_index.scss`, `intl.json`).
+### Fusion Integration
 
-### Fusion Framework Integration
+Blocks import from virtual Fusion modules that don't exist on disk — they're provided by the Fusion runtime and mocked in tests via babel module-resolver (`babel.config.js` → `jest/mocks/`):
+- `fusion:content` — `useContent`, `useEditableContent`
+- `fusion:context` — `useFusionContext`, `useAppContext`
+- `fusion:properties` — `getProperties`
+- `fusion:environment` — `RESIZER_TOKEN_VERSION`, `resizerKey`, etc.
+- `fusion:intl` — `usePhrases`
 
-Blocks run inside **Arc XP Fusion**, which injects framework dependencies via `fusion:*` import aliases. These are never installed as npm packages — Fusion resolves them at runtime:
+### Shared Dependencies
 
-- `fusion:content` — `useContent()`, `useEditableContent()` hooks for fetching CMS data
-- `fusion:context` — `useFusionContext()`, `useComponentContext()`, `useAppContext()`
-- `fusion:properties` — `getProperties()` for site-specific configuration
-- `fusion:environment` — env vars like `CONTENT_BASE`, `RESIZER_TOKEN_VERSION`
-- `fusion:themes` — theme injection
-- `fusion:intl` — i18n phrase lookups
+- `@wpmedia/arc-themes-components` — shared component library (LazyLoad, Image, etc.)
+- `@arc-fusion/prop-types` — prop-type helpers with `.tag()` for PageBuilder metadata and `.contentConfig()` for content source config
 
-In tests, `babel.config.js` aliases these to mocks under `jest/mocks/`. In Storybook, `.storybook/alias/` provides stubs. When writing tests, mock them with `jest.mock("fusion:properties", () => jest.fn(() => ({ ... })))`.
+### Testing Patterns
 
-### Component Library
-
-All feature/chain/layout components import UI primitives from `@wpmedia/arc-themes-components` (a peer dependency, not in this repo). Import everything from that single package: `Image`, `Heading`, `Link`, `Stack`, `Grid`, `usePhrases`, `formatURL`, etc.
-
-### Feature Component Pattern
-
-Feature components separate data-fetching from presentation:
-- The **default export** is the Fusion-connected component that calls `useContent()` and `getProperties()`, then passes resolved data as props.
-- A named **`*Presentation`** export is the pure React component used in tests and Storybook.
-
-```jsx
-export const LargePromoPresentation = ({ contentHeading, ... }) => { ... };
-
-const LargePromo = (props) => {
-  const content = useContent({ ... });
-  return <LargePromoPresentation contentHeading={content?.headlines?.basic} ... />;
-};
-
-export default LargePromo;
-```
-
-### Content Sources
-
-Content source files export a plain object (not a React component):
-
+Tests use React Testing Library. Common mocking pattern:
 ```js
-export default {
-  fetch: (params, { cachedCall }) => Promise,
-  params: [{ name: "query", displayName: "Query", type: "text" }],
-  schemaName: "ans-feed",
-};
+jest.mock("fusion:content", () => ({ useContent: jest.fn(() => ({})) }));
+jest.mock("@wpmedia/arc-themes-components", () => ({
+  ...jest.requireActual("@wpmedia/arc-themes-components"),
+  isServerSide: jest.fn(() => false),
+  LazyLoad: ({ children }) => children,
+}));
 ```
 
-### Static Properties for Fusion Registration
+### Styling Rules
 
-Fusion discovers blocks by scanning the filesystem; there is no explicit registry. Components declare metadata via static properties:
-
-```jsx
-Component.label = "Large Promo – Arc Block";
-Component.icon = "picture-feature";
-Component.propTypes = { customFields: PropTypes.shape({ ... }) };
-// Layouts and chains also declare:
-Component.sections = ["navigation", "body", "footer"];
-```
-
-### Theming
-
-Each block has `themes/news.json` and `themes/commerce.json` defining CSS variable overrides per theme. Styles use a BEM-like class naming: blocks use a `BLOCK_CLASS_NAME` constant (`b-<block-name>`).
-
-### Internationalization
-
-Each block has an `intl.json` file with phrase keys and translations. Phrases are consumed via `usePhrases()` from `@wpmedia/arc-themes-components`. The source of truth is Lokalise; `npm run generate:intl` regenerates `intl.json` files from `locale/`.
-
-### Testing Conventions
-
-- Test files live **co-located** with source: `default.test.jsx` next to `default.jsx`
-- Test the **`*Presentation`** component, not the default Fusion-connected export
-- Use React Testing Library with semantic queries (`screen.getByRole`, `screen.getByText`)
-- Each block has its own `jest.config.js` that extends `../../jest/jest.config.base.js`
-- `jest.resetModules()` runs `beforeEach` — each test gets a fresh module registry
-- Coverage thresholds enforced globally: 53% statements, 66% branches, 44% functions, 54% lines
+- CSS logical properties are enforced (use `margin-inline-start` not `margin-left`)
+- Max nesting depth: 5
+- No vendor prefixes
+- `border: none` is disallowed (use `border: 0`)
+- SCSS `@include` calls on the parent selector must precede nested `&` rules (sass 1.92+ hoisting requirement)
 
 ### Code Generation
 
-The Hygen generators under `_templates/` scaffold complete block packages including component, test, Storybook story, SCSS, `package.json`, `intl.json`, and `jest.config.js`. Always prefer generating a new block via `npm run generate:*` rather than copying manually.
+New blocks are scaffolded with hygen: `npm run generate:feature`, `npm run generate:chain`, `npm run generate:content-source`. Variants exist for adding features/sources to existing blocks.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Fixes any stylelint issues that can be fixed automatically from the files mentio
 
 ### `npm run lint:changed-feature-branch`
 
-Similar to `npm run test:changed-feature-branch`, this runs on pre-push and within the GitHub Workflow. It will run `eslint` on all code that have changed since the last commit on the target release branch. See the `.eslintignore` and the `.eslintrc.js` for the configuration.
+Similar to `npm run test:changed-feature-branch`, this runs on pre-push and within the GitHub Workflow. It will run `eslint` on all code that have changed since `origin/main`. See the `.eslintignore` and the `.eslintrc.js` for the configuration.
 
 ### `npm run lint:changed-feature-branch:fix`
 
@@ -82,7 +82,7 @@ Run all tests for code that has changed. Will also show coverage for changed cod
 
 ### `npm run test:changed-feature-branch`
 
-Similar to `npm run test:watch`, but will run tests for all blocks that have changed since the last commit on the target release branch. This should be updated with each new version `"jest --changedSince=origin/arc-themes-release-version-2.0.3 --coverage --passWithNoTests",` -> `"jest --changedSince=origin/arc-themes-release-version-2.0.4 --coverage --passWithNoTests",` for `2.0.3` -> `2.0.4`. This runs in the [GitHub Workflow for testing blocks on Pull Requests](./.github/workflows/test-coverage-blocks.yml). It also runs on pre-push using [Husky](https://github.com/typicode/husky#usage). Note that the Husky pre-push file is located in [root](./.husky/pre-push) and not in the package.json, per version 7 of Husky.
+Runs tests for all blocks that have changed since `origin/main`. This runs in the [GitHub Workflow for testing blocks on Pull Requests](./.github/workflows/test-coverage-blocks.yml). It also runs on pre-push using [Husky](https://github.com/typicode/husky#usage). Note that the Husky pre-push file is located in [root](./.husky/pre-push) and not in the package.json, per version 7 of Husky.
 
 ## Storybook Setup
 
@@ -99,13 +99,64 @@ registry=https://registry.npmjs.org
 3. `npm i` to install packages
 4. `npm run storybook` to show the blocks in Storybook. For more info on Storybook, see [their documentation](https://storybook.js.org/docs/react/get-started/introduction). In confluence, we have Storybook best practices as well for themes.
 
+## Releasing
+
+This repo uses trunk-based development. All work is merged into `main`, and the `themesVersion` field in the root `package.json` determines which themes release version blocks are published under.
+
+### Publishing blocks (automatic)
+
+Every merge to `main` that changes block code (`.js`, `.jsx`, `.json`, `.scss`) triggers the [publish workflow](./.github/workflows/sync-themes-branch-with-themes-tag.yml). It reads `themesVersion` from `package.json` and publishes all changed blocks to GitHub Packages under the dist-tag `arc-themes-release-version-<themesVersion>`.
+
+No manual steps are needed — just merge your PR and blocks are published.
+
+### Bumping to a new themes version
+
+When you're ready to start a new themes release (e.g., moving from `4.1.0` to `4.2.0`):
+
+1. Create a PR that changes `themesVersion` in `package.json` from `"4.1.0"` to `"4.2.0"`
+2. Merge the PR into `main`
+3. The publish workflow will automatically:
+   - Tag the previous version's final commit as `themes-v4.1.0`
+   - Begin publishing blocks under `arc-themes-release-version-4.2.0`
+
+That's it. The git tag provides a permanent record of exactly which commit was the last publish for each version, and can be used to view history or create hotfix branches later.
+
+```bash
+# View what shipped in a specific version
+git log themes-v4.0.0..themes-v4.1.0
+
+# View what's been published in the current version so far
+git log themes-v4.1.0..main
+```
+
+### Hotfixing a previous version
+
+Hotfixes are for the rare case when you need to patch a version you've already moved past. A dedicated [hotfix workflow](./.github/workflows/hotfix.yml) handles publishing.
+
+1. Find the tag for the version you need to fix:
+   ```bash
+   git tag -l "themes-v*"
+   ```
+
+2. Create a hotfix branch from that tag:
+   ```bash
+   git checkout -b hotfix/4.1.0 themes-v4.1.0
+   ```
+
+3. Make your fix, commit, and push:
+   ```bash
+   git push -u origin hotfix/4.1.0
+   ```
+
+4. The hotfix workflow runs automatically and publishes the fix under the original dist-tag (`arc-themes-release-version-4.1.0`).
+
+> **Note:** Hotfix branches are not merged back into `main`. If the fix is also needed on `main`, cherry-pick it into a separate PR targeting `main`.
+
 ## `dist-tags`
 
 Please see the [release notes in Confluence](https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/2344910925/Themes+Releases) if you are a Themes developer.
 
-This package has been published with a number of dist-tags meant for different purposes:
-
-- `arc-themes-release-version-X.XX` - These are versioned versions of all blocks for a given release cycle in the [Theme Manifest repo](https://github.com/WPMedia/arc-themes-manifests).
+Blocks are published with dist-tags in the format `arc-themes-release-version-X.Y.Z`, corresponding to the `themesVersion` in `package.json` at the time of publish. These are used in the [Theme Manifest repo](https://github.com/WPMedia/arc-themes-manifests).
 
 ## License
 

--- a/blocks/schema-feed-content-source-block/CHANGELOG.md
+++ b/blocks/schema-feed-content-source-block/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/blocks/schema-feed-content-source-block/README.md
+++ b/blocks/schema-feed-content-source-block/README.md
@@ -1,0 +1,13 @@
+# `@wpmedia/schema-feed-content-source-block`
+
+Content Source for searching schema documents via the Content API v5 `/search/schemas/` endpoint.
+
+## Configurable Params
+
+| **Param**      | **Type** | **Description**                                                                 |
+| -------------- | -------- | ------------------------------------------------------------------------------- |
+| **schemaName** | text     | The name of the schema to search within (required)                              |
+| **sortBy**     | text     | Sort field. Available values: `publish_date`, `first_publish_date`              |
+| **query**      | text     | ArcSL filter expression (e.g. `schema_content.venv.status:"CONFIRMED"`)         |
+| **size**       | number   | Number of documents per page (1-50, default: 25)                                |
+| **page**       | number   | Page number for pagination (1-100, default: 1)                                  |

--- a/blocks/schema-feed-content-source-block/jest.config.js
+++ b/blocks/schema-feed-content-source-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest/jest.config.base");
+
+module.exports = {
+	...base,
+};

--- a/blocks/schema-feed-content-source-block/package-lock.json
+++ b/blocks/schema-feed-content-source-block/package-lock.json
@@ -1,0 +1,1708 @@
+{
+	"name": "@wpmedia/schema-feed-content-source-block",
+	"version": "0.0.1",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@wpmedia/schema-feed-content-source-block",
+			"version": "0.0.1",
+			"license": "CC-BY-NC-ND-4.0",
+			"dependencies": {
+				"axios": "^1.5.1"
+			},
+			"peerDependencies": {
+				"@wpmedia/arc-themes-components": "*"
+			}
+		},
+		"node_modules/@arc-publishing/sdk-identity": {
+			"version": "1.94.0",
+			"resolved": "https://registry.npmjs.org/@arc-publishing/sdk-identity/-/sdk-identity-1.94.0.tgz",
+			"integrity": "sha512-pvUQxvxsLQ2gsly+ylNuUqT5fxiLn/H34dDqKmxrfvvz0r9xsuIJM+xHqVUWJ/orYbpf114l3JCQ2m6/gpEJPg==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@arc-publishing/sdk-sales": {
+			"version": "1.94.0",
+			"resolved": "https://registry.npmjs.org/@arc-publishing/sdk-sales/-/sdk-sales-1.94.0.tgz",
+			"integrity": "sha512-qB1RFOrmIR/5ljqxwLi+Olq5HcrNFTZoDWJn9M19XMzbLzWrj50j+tnoBMiG/uzCExXYEzu0gJiG9TBgTP4tvA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"@arc-publishing/sdk-identity": "^1.94.0",
+				"@arc-publishing/sdk-subs-core": "^1.94.0",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@arc-publishing/sdk-subs-core": {
+			"version": "1.94.0",
+			"resolved": "https://registry.npmjs.org/@arc-publishing/sdk-subs-core/-/sdk-subs-core-1.94.0.tgz",
+			"integrity": "sha512-maagPyvT+YzTKQ3AzfAL2/SDDwRMM5sdTT/KEPhYUnO2wFLYmSE0c1lrVigPopmOmJn0N36TZufKPaSukTINyA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@jest/environment": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+			"integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"jest-mock": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+			"integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/jsdom": "^21.1.7",
+				"@types/node": "*",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/fake-timers": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+			"integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@sinonjs/fake-timers": "^15.0.0",
+				"@types/node": "*",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@sinonjs/commons": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"node_modules/@sinonjs/fake-timers": {
+			"version": "15.3.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+			"integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@types/istanbul-lib-coverage": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/istanbul-lib-report": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"node_modules/@types/istanbul-reports": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/@types/jsdom": {
+			"version": "21.1.7",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"parse5": "^7.0.0"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
+		},
+		"node_modules/@types/stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/yargs-parser": {
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@wpmedia/arc-themes-components": {
+			"version": "0.0.4-arc-themes-release-version-4-0-0.4",
+			"resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-4-0-0.4/5801ffe679c9fcb558d62e1386a93b909db421fb",
+			"integrity": "sha512-uZkmOBFZuXTtkQIazrIUWOT0FsdXl1UWlgno0ioeP7LWQYuAAbXyk9LTHbmsWa/0RM0WIy1qJD7HHdJAbQ5Dog==",
+			"license": "CC-BY-NC-ND-4.0",
+			"peer": true,
+			"dependencies": {
+				"@arc-publishing/sdk-identity": "^1.89.0",
+				"@arc-publishing/sdk-sales": "^1.89.0",
+				"dom-parser": "^0.1.6",
+				"jest-fixed-jsdom": "^0.0.9",
+				"lazy-child": "^0.3.1",
+				"lodash.get": "^4.4.2",
+				"node-fetch": "^2.7.0",
+				"react-google-recaptcha": "^3.1.0",
+				"react-google-recaptcha-v3": "1.11.0",
+				"react-oembed-container": "^1.0.1",
+				"react-swipeable": "^7.0.1"
+			},
+			"peerDependencies": {
+				"react": "^19.0.0",
+				"react-dom": "^19.0.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"license": "MIT"
+		},
+		"node_modules/axios": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/cssstyle": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/dom-parser": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/dom-parser/-/dom-parser-0.1.6.tgz",
+			"integrity": "sha512-3nVRKbLEwmGfghLoeT1dxlK/0votalnOfasP+8VCHYDfDuCETY4LeMblfOeqww6XZk2ymZ1Uewy/hVad6Dy3yw==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/dom-peekaboo": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/dom-peekaboo/-/dom-peekaboo-0.1.0.tgz",
+			"integrity": "sha512-QGfVWlbeTCC+aH0akKbr3NJuaW7i0GRhWaEwsRHz7AeDr5eX3xkjyZBmU86V1lGTjNq4XUxRWWOdk+JOQhMLSQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"lodash.throttle": "^4.1.1"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"react-is": "^16.7.0"
+			}
+		},
+		"node_modules/hoist-non-react-statics/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/jest-environment-jsdom": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+			"integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/environment-jsdom-abstract": "30.3.0",
+				"jsdom": "^26.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-fixed-jsdom": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/jest-fixed-jsdom/-/jest-fixed-jsdom-0.0.9.tgz",
+			"integrity": "sha512-KPfqh2+sn5q2B+7LZktwDcwhCpOpUSue8a1I+BcixWLOQoEVyAjAGfH+IYZGoxZsziNojoHGRTC8xRbB1wDD4g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"jest-environment-jsdom": ">=28.0.0"
+			}
+		},
+		"node_modules/jest-message-util": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+			"integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.3.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.3.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-mock": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+			"integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-regex-util": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+			"integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/jsdom": {
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^5.1.1",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/lazy-child": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/lazy-child/-/lazy-child-0.3.1.tgz",
+			"integrity": "sha512-noi341qqpeHJEiGC7YPM+iAhv7HgnrKCWLrsRaM6FX8LKC1g2+iuT4g+hcv3BzYjXotpQjn/Ri/I+Bf68mIONg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"react-peekaboo": "^0.4.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+			"deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/lodash.throttle": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+			"integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/node-fetch/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/node-fetch/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause",
+			"peer": true
+		},
+		"node_modules/node-fetch/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/nwsapi": {
+			"version": "2.2.23",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+			"integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pretty-format": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
+			}
+		},
+		"node_modules/prop-types/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/react": {
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-async-script": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/react-async-script/-/react-async-script-1.2.0.tgz",
+			"integrity": "sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"hoist-non-react-statics": "^3.3.0",
+				"prop-types": "^15.5.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.4.1"
+			}
+		},
+		"node_modules/react-dom": {
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+			"integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"scheduler": "^0.27.0"
+			},
+			"peerDependencies": {
+				"react": "^19.2.5"
+			}
+		},
+		"node_modules/react-google-recaptcha": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/react-google-recaptcha/-/react-google-recaptcha-3.1.0.tgz",
+			"integrity": "sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"prop-types": "^15.5.0",
+				"react-async-script": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.4.1"
+			}
+		},
+		"node_modules/react-google-recaptcha-v3": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.11.0.tgz",
+			"integrity": "sha512-kLQqpz/77m8+trpBwzqcxNtvWZYoZ/YO6Vm2cVTHW8hs80BWUfDpC7RDwuAvpswwtSYApWfaSpIDFWAIBNIYxQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"hoist-non-react-statics": "^3.3.2"
+			},
+			"peerDependencies": {
+				"react": "^16.3 || ^17.0 || ^18.0 || ^19.0",
+				"react-dom": "^17.0 || ^18.0 || ^19.0"
+			}
+		},
+		"node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/react-oembed-container": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/react-oembed-container/-/react-oembed-container-1.0.1.tgz",
+			"integrity": "sha512-wU7s2Ql6LZp7bTbf7Hloy7ONDCSb+44iM4Ezdk36qqsVSxOefvN70DBuqf3Z/c7zQdYVwODHryMYawq6sxmG+A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"prop-types": "^15.6.0"
+			},
+			"peerDependencies": {
+				"react": "^16.2.0 || ^17.0.0",
+				"react-dom": "^16.2.0 || ^17.0.0"
+			}
+		},
+		"node_modules/react-peekaboo": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/react-peekaboo/-/react-peekaboo-0.4.1.tgz",
+			"integrity": "sha512-CB/EWYD+3iLKy64HvVC8A0ri/MswbugQZ4QEu48JFbKy8s74L9urfFRBa2CfSpKJVYOy3xbbUR9YSFaa0Vx35w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"dom-peekaboo": "^0.1.0",
+				"lodash.throttle": "^4.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/react-swipeable": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+			"integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
+			}
+		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
+		"node_modules/scheduler": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tldts-core": "^6.1.86"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/tough-cookie": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"tldts": "^6.1.32"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD",
+			"peer": true
+		},
+		"node_modules/type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"license": "MIT",
+			"peer": true
+		}
+	}
+}

--- a/blocks/schema-feed-content-source-block/package.json
+++ b/blocks/schema-feed-content-source-block/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@wpmedia/schema-feed-content-source-block",
+	"version": "0.0.1",
+	"description": "Content source block for Arc Content API v5 schema search",
+	"author": "Arc XP - Themes",
+	"homepage": "https://github.com/WPMedia/arc-themes-blocks",
+	"license": "CC-BY-NC-ND-4.0",
+	"main": "",
+	"files": [
+		"sources"
+	],
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com/",
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+		"directory": "blocks/schema-feed-content-source-block"
+	},
+	"dependencies": {
+		"axios": "^1.5.1"
+	},
+	"peerDependencies": {
+		"@wpmedia/arc-themes-components": "*"
+	}
+}

--- a/blocks/schema-feed-content-source-block/sources/.npmignore
+++ b/blocks/schema-feed-content-source-block/sources/.npmignore
@@ -1,0 +1,3 @@
+*.test.js
+*.test.jsx
+mock*.*

--- a/blocks/schema-feed-content-source-block/sources/schema-feed.js
+++ b/blocks/schema-feed-content-source-block/sources/schema-feed.js
@@ -19,8 +19,8 @@ const params = [
 		type: "text",
 	},
 	{
-		displayName: "Sort Direction",
-		name: "sortDirection",
+		displayName: "Query",
+		name: "query",
 		type: "text",
 	},
 	{
@@ -41,7 +41,7 @@ const params = [
  * Fetches schema data from v5 search schemas endpoint with sorting and pagination
  */
 const fetch = async (
-	{ schemaName, sortBy, sortDirection = "desc", size = 25, page = 1, "arc-site": website },
+	{ schemaName, sortBy, query, size = 25, page = 1, "arc-site": website },
 	{ arcSite },
 ) => {
 	if (!schemaName) {
@@ -61,7 +61,11 @@ const fetch = async (
 	});
 
 	if (sortBy) {
-		urlSearch.set("sort", `${sortBy.trim()}:${sortDirection.trim()}`);
+		urlSearch.set("sort", `${sortBy.trim()}:desc`);
+	}
+
+	if (query) {
+		urlSearch.set("q", query.trim());
 	}
 
 	const url = new URL(`/content/v5/search/schemas/?${urlSearch.toString()}`, CONTENT_BASE);

--- a/blocks/schema-feed-content-source-block/sources/schema-feed.js
+++ b/blocks/schema-feed-content-source-block/sources/schema-feed.js
@@ -1,8 +1,3 @@
-/**
- * Fetches data from Arc Content API /content/v5/search/schemas/ endpoint.
- * Configurable schema name parameter with sort options, size, and pagination.
- * Website is pulled from arc-site like content-api.
- */
 import axios from "axios";
 import { ARC_ACCESS_TOKEN, CONTENT_BASE } from "fusion:environment";
 import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
@@ -37,10 +32,7 @@ const params = [
 	},
 ];
 
-/**
- * Fetches schema data from v5 search schemas endpoint with sorting and pagination
- */
-const fetch = async (
+const fetch = (
 	{ schemaName, sortBy, query, size = 25, page = 1, "arc-site": website },
 	{ arcSite },
 ) => {
@@ -56,8 +48,8 @@ const fetch = async (
 	const urlSearch = new URLSearchParams({
 		schema_name: schemaName.trim(),
 		website: siteValue,
-		size: parseInt(size, 10),
-		page: parseInt(page, 10),
+		size,
+		page,
 	});
 
 	if (sortBy) {
@@ -87,16 +79,7 @@ const fetch = async (
 			}
 			return data;
 		})
-		.catch((error) => {
-			if (error.response && error.response.status >= 400) {
-				const fetchError = new Error(
-					`Schema retrieval failed: ${error.response.status}`,
-				);
-				fetchError.statusCode = error.response.status;
-				throw fetchError;
-			}
-			return handleFetchError(error);
-		});
+		.catch(handleFetchError);
 };
 
 export default {

--- a/blocks/schema-feed-content-source-block/sources/schema-feed.js
+++ b/blocks/schema-feed-content-source-block/sources/schema-feed.js
@@ -1,0 +1,102 @@
+/**
+ * Fetches data from Arc Content API /content/v5/search/schemas/ endpoint.
+ * Configurable schema name parameter with sort options, size, and pagination.
+ * Website is pulled from arc-site like content-api.
+ */
+import axios from "axios";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE } from "fusion:environment";
+import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
+
+const params = [
+	{
+		displayName: "Schema Name",
+		name: "schemaName",
+		type: "text",
+	},
+	{
+		displayName: "Sort By",
+		name: "sortBy",
+		type: "text",
+	},
+	{
+		displayName: "Sort Direction",
+		name: "sortDirection",
+		type: "text",
+	},
+	{
+		displayName: "Size",
+		name: "size",
+		type: "number",
+		default: 25,
+	},
+	{
+		displayName: "Page",
+		name: "page",
+		type: "number",
+		default: 1,
+	},
+];
+
+/**
+ * Fetches schema data from v5 search schemas endpoint with sorting and pagination
+ */
+const fetch = async (
+	{ schemaName, sortBy, sortDirection = "desc", size = 25, page = 1, "arc-site": website },
+	{ arcSite },
+) => {
+	if (!schemaName) {
+		return "";
+	}
+
+	const siteValue = website || arcSite;
+	if (!siteValue) {
+		return "";
+	}
+
+	const urlSearch = new URLSearchParams({
+		schema_name: schemaName.trim(),
+		website: siteValue,
+		size: parseInt(size, 10),
+		page: parseInt(page, 10),
+	});
+
+	if (sortBy) {
+		urlSearch.set("sort", `${sortBy.trim()}:${sortDirection.trim()}`);
+	}
+
+	const url = new URL(`/content/v5/search/schemas/?${urlSearch.toString()}`, CONTENT_BASE);
+
+	return axios({
+		url: url.toString(),
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
+		},
+		method: "GET",
+		timeout: 8000,
+	})
+		.then(({ data }) => {
+			if (!data) {
+				const error = new Error("Failed to retrieve schema data");
+				error.statusCode = 404;
+				throw error;
+			}
+			return data;
+		})
+		.catch((error) => {
+			if (error.response && error.response.status >= 400) {
+				const fetchError = new Error(
+					`Schema retrieval failed: ${error.response.status}`,
+				);
+				fetchError.statusCode = error.response.status;
+				throw fetchError;
+			}
+			return handleFetchError(error);
+		});
+};
+
+export default {
+	fetch,
+	params,
+	ttl: 300,
+};

--- a/blocks/schema-feed-content-source-block/sources/schema-feed.js
+++ b/blocks/schema-feed-content-source-block/sources/schema-feed.js
@@ -72,12 +72,12 @@ const fetch = (
 		timeout: 8000,
 	})
 		.then(({ data }) => {
-			if (!data) {
+			if (!data || !data.data) {
 				const error = new Error("Failed to retrieve schema data");
 				error.statusCode = 404;
 				throw error;
 			}
-			return data;
+			return data.data;
 		})
 		.catch(handleFetchError);
 };

--- a/blocks/schema-feed-content-source-block/sources/schema-feed.test.js
+++ b/blocks/schema-feed-content-source-block/sources/schema-feed.test.js
@@ -41,8 +41,8 @@ describe("the schema-feed content source block", () => {
 				type: "text",
 			},
 			{
-				displayName: "Sort Direction",
-				name: "sortDirection",
+				displayName: "Query",
+				name: "query",
 				type: "text",
 			},
 			{
@@ -106,25 +106,7 @@ describe("the schema-feed content source block", () => {
 	});
 
 	describe("when sortBy is provided", () => {
-		it("should include sort param as field:direction", async () => {
-			const result = await contentSource.fetch(
-				{
-					schemaName: "my-schema",
-					sortBy: "publish_date",
-					sortDirection: "asc",
-					"arc-site": "site1",
-				},
-				{ arcSite: "" },
-			);
-
-			expect(result.request.url.searchObject).toEqual(
-				expect.objectContaining({
-					sort: "publish_date:asc",
-				}),
-			);
-		});
-
-		it("should default sortDirection to desc", async () => {
+		it("should include sort param with hardcoded desc direction", async () => {
 			const result = await contentSource.fetch(
 				{
 					schemaName: "my-schema",
@@ -139,6 +121,39 @@ describe("the schema-feed content source block", () => {
 					sort: "publish_date:desc",
 				}),
 			);
+		});
+	});
+
+	describe("when query is provided", () => {
+		it("should include q param", async () => {
+			const result = await contentSource.fetch(
+				{
+					schemaName: "my-schema",
+					query: 'schema_content.venv.status:"CONFIRMED"',
+					"arc-site": "site1",
+				},
+				{ arcSite: "" },
+			);
+
+			expect(result.request.url.searchObject).toEqual(
+				expect.objectContaining({
+					q: 'schema_content.venv.status:"CONFIRMED"',
+				}),
+			);
+		});
+	});
+
+	describe("when query is not provided", () => {
+		it("should not include q param", async () => {
+			const result = await contentSource.fetch(
+				{
+					schemaName: "my-schema",
+					"arc-site": "site1",
+				},
+				{ arcSite: "" },
+			);
+
+			expect(result.request.url.searchObject).not.toHaveProperty("q");
 		});
 	});
 

--- a/blocks/schema-feed-content-source-block/sources/schema-feed.test.js
+++ b/blocks/schema-feed-content-source-block/sources/schema-feed.test.js
@@ -1,0 +1,194 @@
+import contentSource from "./schema-feed";
+
+jest.mock("fusion:environment", () => ({
+	CONTENT_BASE: "https://content.base",
+	ARC_ACCESS_TOKEN: "test-token",
+}));
+
+jest.mock("axios", () => ({
+	__esModule: true,
+	default: jest.fn((request) => {
+		const requestUrl = new URL(request.url);
+		const url = {
+			hostname: requestUrl.hostname,
+			pathname: requestUrl.pathname,
+			searchObject: Object.fromEntries(requestUrl.searchParams),
+		};
+
+		return Promise.resolve({
+			data: {
+				content_elements: [{ type: "schema" }],
+				request: {
+					...request,
+					url,
+				},
+			},
+		});
+	}),
+}));
+
+describe("the schema-feed content source block", () => {
+	it("should use the proper param types", () => {
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "Schema Name",
+				name: "schemaName",
+				type: "text",
+			},
+			{
+				displayName: "Sort By",
+				name: "sortBy",
+				type: "text",
+			},
+			{
+				displayName: "Sort Direction",
+				name: "sortDirection",
+				type: "text",
+			},
+			{
+				displayName: "Size",
+				name: "size",
+				type: "number",
+				default: 25,
+			},
+			{
+				displayName: "Page",
+				name: "page",
+				type: "number",
+				default: 1,
+			},
+		]);
+	});
+
+	it("should export ttl of 300", () => {
+		expect(contentSource.ttl).toEqual(300);
+	});
+
+	describe("when schemaName and arc-site are provided", () => {
+		it("should build the correct url with query params", async () => {
+			const result = await contentSource.fetch(
+				{
+					schemaName: "my-schema",
+					"arc-site": "site1",
+					size: 10,
+					page: 2,
+				},
+				{ arcSite: "fallback" },
+			);
+
+			expect(result.request.url.pathname).toEqual("/content/v5/search/schemas/");
+			expect(result.request.url.searchObject).toEqual(
+				expect.objectContaining({
+					schema_name: "my-schema",
+					website: "site1",
+					size: "10",
+					page: "2",
+				}),
+			);
+		});
+	});
+
+	describe("when arc-site is not provided but arcSite context is", () => {
+		it("should fall back to arcSite from context", async () => {
+			const result = await contentSource.fetch(
+				{
+					schemaName: "my-schema",
+				},
+				{ arcSite: "fallback-site" },
+			);
+
+			expect(result.request.url.searchObject).toEqual(
+				expect.objectContaining({
+					website: "fallback-site",
+				}),
+			);
+		});
+	});
+
+	describe("when sortBy is provided", () => {
+		it("should include sort param as field:direction", async () => {
+			const result = await contentSource.fetch(
+				{
+					schemaName: "my-schema",
+					sortBy: "publish_date",
+					sortDirection: "asc",
+					"arc-site": "site1",
+				},
+				{ arcSite: "" },
+			);
+
+			expect(result.request.url.searchObject).toEqual(
+				expect.objectContaining({
+					sort: "publish_date:asc",
+				}),
+			);
+		});
+
+		it("should default sortDirection to desc", async () => {
+			const result = await contentSource.fetch(
+				{
+					schemaName: "my-schema",
+					sortBy: "publish_date",
+					"arc-site": "site1",
+				},
+				{ arcSite: "" },
+			);
+
+			expect(result.request.url.searchObject).toEqual(
+				expect.objectContaining({
+					sort: "publish_date:desc",
+				}),
+			);
+		});
+	});
+
+	describe("when sortBy is not provided", () => {
+		it("should not include sort param", async () => {
+			const result = await contentSource.fetch(
+				{
+					schemaName: "my-schema",
+					"arc-site": "site1",
+				},
+				{ arcSite: "" },
+			);
+
+			expect(result.request.url.searchObject).not.toHaveProperty("sort");
+		});
+	});
+
+	describe("when schemaName is missing", () => {
+		it("should return empty string", async () => {
+			const result = await contentSource.fetch({}, { arcSite: "site1" });
+
+			expect(result).toEqual("");
+		});
+	});
+
+	describe("when both website and arcSite are missing", () => {
+		it("should return empty string", async () => {
+			const result = await contentSource.fetch({ schemaName: "my-schema" }, {});
+
+			expect(result).toEqual("");
+		});
+	});
+
+	describe("default values", () => {
+		it("should use size=25 and page=1 when not specified", async () => {
+			const result = await contentSource.fetch(
+				{
+					schemaName: "my-schema",
+					"arc-site": "site1",
+				},
+				{ arcSite: "" },
+			);
+
+			expect(result.request.url.searchObject).toEqual(
+				expect.objectContaining({
+					size: "25",
+					page: "1",
+				}),
+			);
+		});
+	});
+
+});

--- a/blocks/schema-feed-content-source-block/sources/schema-feed.test.js
+++ b/blocks/schema-feed-content-source-block/sources/schema-feed.test.js
@@ -1,3 +1,4 @@
+import axios from "axios";
 import contentSource from "./schema-feed";
 
 jest.mock("fusion:environment", () => ({
@@ -203,6 +204,22 @@ describe("the schema-feed content source block", () => {
 					page: "1",
 				}),
 			);
+		});
+	});
+
+	describe("when the response has no data", () => {
+		it("should throw a not found error", async () => {
+			axios.mockImplementationOnce(() => Promise.resolve({ data: null }));
+
+			await expect(
+				contentSource.fetch(
+					{
+						schemaName: "my-schema",
+						"arc-site": "site1",
+					},
+					{ arcSite: "" },
+				),
+			).rejects.toThrow("Failed to retrieve schema data");
 		});
 	});
 

--- a/blocks/schema-feed-content-source-block/sources/schema-feed.test.js
+++ b/blocks/schema-feed-content-source-block/sources/schema-feed.test.js
@@ -16,15 +16,18 @@ jest.mock("axios", () => ({
 			searchObject: Object.fromEntries(requestUrl.searchParams),
 		};
 
-		return Promise.resolve({
-			data: {
-				content_elements: [{ type: "schema" }],
-				request: {
-					...request,
-					url,
-				},
-			},
-		});
+        return Promise.resolve({
+            data: {
+                _id: "test-feed",
+                data: {
+                    content_elements: [{ type: "schema" }],
+                    request: {
+                        ...request,
+                        url,
+                    },
+                },
+            },
+        });
 	}),
 }));
 

--- a/blocks/schema-item-content-source-block/CHANGELOG.md
+++ b/blocks/schema-item-content-source-block/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/blocks/schema-item-content-source-block/README.md
+++ b/blocks/schema-item-content-source-block/README.md
@@ -1,0 +1,31 @@
+# `@wpmedia/schema-item-content-source-block`
+
+Content source block for fetching a single document from an Arc XP custom schema, by document ID or by website URL.
+
+## Acceptance Criteria
+
+- Given a `Document ID` and `Schema Name`, the content source returns the matching custom schema document (lookup `by-id`).
+- Given a `Website URL` and `Schema Name`, the content source returns the matching custom schema document (lookup `by-url`).
+- When both a `Document ID` and a `Website URL` are provided, the `Document ID` lookup takes precedence.
+- The `website` is resolved from the `arc-site` param, falling back to the current `arcSite` from context.
+
+## Endpoint
+
+- `GET {CONTENT_BASE}/content/v5/search/schemas/by-id/?id={id}&schema_name={schemaName}&website={website}`
+- `GET {CONTENT_BASE}/content/v5/search/schemas/by-url/?url={website_url}&schema_name={schemaName}&website={website}`
+
+## Configurable Params
+
+| **Param**       | **Type** | **Description**                                                                                                            |
+| --------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **id**          | text     | The document ID of the custom schema item to fetch. Used for the `by-id` lookup.                                           |
+| **website_url** | text     | The canonical URL path of the custom schema item to fetch. Used for the `by-url` lookup. ex. `/2020/01/17/this-is-a-story/` |
+| **schemaName**  | text     | The name of the Arc XP custom schema to query against.                                                                     |
+
+## TTL
+
+- `300`
+
+## Additional Considerations
+
+Either `id` or `website_url` must be provided along with `schemaName`. If both `id` and `website_url` are supplied, the `by-id` lookup is used.

--- a/blocks/schema-item-content-source-block/jest.config.js
+++ b/blocks/schema-item-content-source-block/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest/jest.config.base");
+
+module.exports = {
+	...base,
+};

--- a/blocks/schema-item-content-source-block/package-lock.json
+++ b/blocks/schema-item-content-source-block/package-lock.json
@@ -1,0 +1,1537 @@
+{
+	"name": "@wpmedia/schema-item-content-source-block",
+	"version": "5.14.1-beta.1",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@wpmedia/schema-item-content-source-block",
+			"version": "5.14.1-beta.1",
+			"license": "CC-BY-NC-ND-4.0",
+			"dependencies": {
+				"axios": "^1.5.1"
+			},
+			"peerDependencies": {
+				"@wpmedia/arc-themes-components": "*",
+				"@wpmedia/signing-service-content-source-block": "*"
+			}
+		},
+		"node_modules/@arc-publishing/sdk-identity": {
+			"version": "1.94.0",
+			"resolved": "https://registry.npmjs.org/@arc-publishing/sdk-identity/-/sdk-identity-1.94.0.tgz",
+			"integrity": "sha512-pvUQxvxsLQ2gsly+ylNuUqT5fxiLn/H34dDqKmxrfvvz0r9xsuIJM+xHqVUWJ/orYbpf114l3JCQ2m6/gpEJPg==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@arc-publishing/sdk-sales": {
+			"version": "1.94.0",
+			"resolved": "https://registry.npmjs.org/@arc-publishing/sdk-sales/-/sdk-sales-1.94.0.tgz",
+			"integrity": "sha512-qB1RFOrmIR/5ljqxwLi+Olq5HcrNFTZoDWJn9M19XMzbLzWrj50j+tnoBMiG/uzCExXYEzu0gJiG9TBgTP4tvA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"@arc-publishing/sdk-identity": "^1.94.0",
+				"@arc-publishing/sdk-subs-core": "^1.94.0",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@arc-publishing/sdk-subs-core": {
+			"version": "1.94.0",
+			"resolved": "https://registry.npmjs.org/@arc-publishing/sdk-subs-core/-/sdk-subs-core-1.94.0.tgz",
+			"integrity": "sha512-maagPyvT+YzTKQ3AzfAL2/SDDwRMM5sdTT/KEPhYUnO2wFLYmSE0c1lrVigPopmOmJn0N36TZufKPaSukTINyA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@jest/environment": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+			"integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"jest-mock": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+			"integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/jsdom": "^21.1.7",
+				"@types/node": "*",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/fake-timers": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+			"integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@sinonjs/fake-timers": "^15.0.0",
+				"@types/node": "*",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@sinonjs/commons": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"node_modules/@sinonjs/fake-timers": {
+			"version": "15.3.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+			"integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@types/istanbul-lib-coverage": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/istanbul-lib-report": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"node_modules/@types/istanbul-reports": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/@types/jsdom": {
+			"version": "21.1.7",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"parse5": "^7.0.0"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
+		},
+		"node_modules/@types/stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/yargs-parser": {
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@wpmedia/arc-themes-components": {
+			"version": "0.0.4-arc-themes-release-version-4-0-0.4",
+			"resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.4-arc-themes-release-version-4-0-0.4/5801ffe679c9fcb558d62e1386a93b909db421fb",
+			"integrity": "sha512-uZkmOBFZuXTtkQIazrIUWOT0FsdXl1UWlgno0ioeP7LWQYuAAbXyk9LTHbmsWa/0RM0WIy1qJD7HHdJAbQ5Dog==",
+			"license": "CC-BY-NC-ND-4.0",
+			"peer": true,
+			"dependencies": {
+				"@arc-publishing/sdk-identity": "^1.89.0",
+				"@arc-publishing/sdk-sales": "^1.89.0",
+				"dom-parser": "^0.1.6",
+				"jest-fixed-jsdom": "^0.0.9",
+				"lazy-child": "^0.3.1",
+				"lodash.get": "^4.4.2",
+				"node-fetch": "^2.7.0",
+				"react-google-recaptcha": "^3.1.0",
+				"react-google-recaptcha-v3": "1.11.0",
+				"react-oembed-container": "^1.0.1",
+				"react-swipeable": "^7.0.1"
+			},
+			"peerDependencies": {
+				"react": "^19.0.0",
+				"react-dom": "^19.0.0"
+			}
+		},
+		"node_modules/@wpmedia/signing-service-content-source-block": {
+			"version": "0.1.0",
+			"resolved": "https://npm.pkg.github.com/download/@wpmedia/signing-service-content-source-block/0.1.0/6cd83c0dbdc269abb734525f3b97e9367fa6a181",
+			"integrity": "sha512-w0+kqN+Zj2Xnmp8sKkVu8lYRcfQgZ3cnO3TTAITjtVWvNwd6z41lHfoAnw2kD2OYyIZe2Yw/FXIZhpLe4ne9xA==",
+			"license": "CC-BY-NC-ND-4.0",
+			"peer": true,
+			"dependencies": {
+				"axios": "^0.26.0"
+			}
+		},
+		"node_modules/@wpmedia/signing-service-content-source-block/node_modules/axios": {
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"follow-redirects": "^1.14.8"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"node_modules/axios": {
+			"version": "1.6.8",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+			"integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/cssstyle": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/dom-parser": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/dom-parser/-/dom-parser-0.1.6.tgz",
+			"integrity": "sha512-3nVRKbLEwmGfghLoeT1dxlK/0votalnOfasP+8VCHYDfDuCETY4LeMblfOeqww6XZk2ymZ1Uewy/hVad6Dy3yw==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/dom-peekaboo": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/dom-peekaboo/-/dom-peekaboo-0.1.0.tgz",
+			"integrity": "sha512-QGfVWlbeTCC+aH0akKbr3NJuaW7i0GRhWaEwsRHz7AeDr5eX3xkjyZBmU86V1lGTjNq4XUxRWWOdk+JOQhMLSQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"lodash.throttle": "^4.1.1"
+			}
+		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.6",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"react-is": "^16.7.0"
+			}
+		},
+		"node_modules/hoist-non-react-statics/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/jest-environment-jsdom": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+			"integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/environment-jsdom-abstract": "30.3.0",
+				"jsdom": "^26.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-fixed-jsdom": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/jest-fixed-jsdom/-/jest-fixed-jsdom-0.0.9.tgz",
+			"integrity": "sha512-KPfqh2+sn5q2B+7LZktwDcwhCpOpUSue8a1I+BcixWLOQoEVyAjAGfH+IYZGoxZsziNojoHGRTC8xRbB1wDD4g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"jest-environment-jsdom": ">=28.0.0"
+			}
+		},
+		"node_modules/jest-message-util": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+			"integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.3.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.3.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-mock": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+			"integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-regex-util": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+			"integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/jsdom": {
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^5.1.1",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/lazy-child": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/lazy-child/-/lazy-child-0.3.1.tgz",
+			"integrity": "sha512-noi341qqpeHJEiGC7YPM+iAhv7HgnrKCWLrsRaM6FX8LKC1g2+iuT4g+hcv3BzYjXotpQjn/Ri/I+Bf68mIONg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"react-peekaboo": "^0.4.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+			"deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/lodash.throttle": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+			"integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/node-fetch/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/node-fetch/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause",
+			"peer": true
+		},
+		"node_modules/node-fetch/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/nwsapi": {
+			"version": "2.2.23",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+			"integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pretty-format": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
+			}
+		},
+		"node_modules/prop-types/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/react": {
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-async-script": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/react-async-script/-/react-async-script-1.2.0.tgz",
+			"integrity": "sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"hoist-non-react-statics": "^3.3.0",
+				"prop-types": "^15.5.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.4.1"
+			}
+		},
+		"node_modules/react-dom": {
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+			"integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"scheduler": "^0.27.0"
+			},
+			"peerDependencies": {
+				"react": "^19.2.5"
+			}
+		},
+		"node_modules/react-google-recaptcha": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/react-google-recaptcha/-/react-google-recaptcha-3.1.0.tgz",
+			"integrity": "sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"prop-types": "^15.5.0",
+				"react-async-script": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.4.1"
+			}
+		},
+		"node_modules/react-google-recaptcha-v3": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.11.0.tgz",
+			"integrity": "sha512-kLQqpz/77m8+trpBwzqcxNtvWZYoZ/YO6Vm2cVTHW8hs80BWUfDpC7RDwuAvpswwtSYApWfaSpIDFWAIBNIYxQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"hoist-non-react-statics": "^3.3.2"
+			},
+			"peerDependencies": {
+				"react": "^16.3 || ^17.0 || ^18.0 || ^19.0",
+				"react-dom": "^17.0 || ^18.0 || ^19.0"
+			}
+		},
+		"node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/react-oembed-container": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/react-oembed-container/-/react-oembed-container-1.0.1.tgz",
+			"integrity": "sha512-wU7s2Ql6LZp7bTbf7Hloy7ONDCSb+44iM4Ezdk36qqsVSxOefvN70DBuqf3Z/c7zQdYVwODHryMYawq6sxmG+A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"prop-types": "^15.6.0"
+			},
+			"peerDependencies": {
+				"react": "^16.2.0 || ^17.0.0",
+				"react-dom": "^16.2.0 || ^17.0.0"
+			}
+		},
+		"node_modules/react-peekaboo": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/react-peekaboo/-/react-peekaboo-0.4.1.tgz",
+			"integrity": "sha512-CB/EWYD+3iLKy64HvVC8A0ri/MswbugQZ4QEu48JFbKy8s74L9urfFRBa2CfSpKJVYOy3xbbUR9YSFaa0Vx35w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"dom-peekaboo": "^0.1.0",
+				"lodash.throttle": "^4.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/react-swipeable": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+			"integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
+			}
+		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
+		"node_modules/scheduler": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tldts-core": "^6.1.86"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/tough-cookie": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"tldts": "^6.1.32"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD",
+			"peer": true
+		},
+		"node_modules/type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"license": "MIT",
+			"peer": true
+		}
+	}
+}

--- a/blocks/schema-item-content-source-block/package.json
+++ b/blocks/schema-item-content-source-block/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@wpmedia/schema-item-content-source-block",
+	"version": "0.0.1",
+	"description": "Content source block for fetching documents by ID from Arc XP custom schemas",
+	"author": "Arc XP - Themes",
+	"homepage": "https://github.com/WPMedia/arc-themes-blocks",
+	"license": "CC-BY-NC-ND-4.0",
+	"main": "",
+	"files": [
+		"sources"
+	],
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com/",
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "ssh://git@github.com/WPMedia/arc-themes-blocks.git",
+		"directory": "blocks/schema-item-content-source-block"
+	},
+	"dependencies": {
+		"axios": "^1.5.1"
+	},
+	"peerDependencies": {
+		"@wpmedia/arc-themes-components": "*"
+	},
+	"gitHead": "83fb8d6685958d85ddbfcfbf01d9a5c864cd6c95"
+}

--- a/blocks/schema-item-content-source-block/sources/.npmignore
+++ b/blocks/schema-item-content-source-block/sources/.npmignore
@@ -1,0 +1,3 @@
+*.test.js
+*.test.jsx
+mock*.*

--- a/blocks/schema-item-content-source-block/sources/schema-item.js
+++ b/blocks/schema-item-content-source-block/sources/schema-item.js
@@ -1,0 +1,78 @@
+import axios from "axios";
+import { ARC_ACCESS_TOKEN, CONTENT_BASE } from "fusion:environment";
+import handleFetchError from "@wpmedia/arc-themes-components/src/utils/handle-fetch-error";
+
+const params = [
+	{
+		displayName: "Document ID",
+		name: "id",
+		type: "text",
+	},
+	{
+		displayName: "Website URL",
+		name: "website_url",
+		type: "text",
+	},
+	{
+		displayName: "Schema Name",
+		name: "schemaName",
+		type: "text",
+	},
+	{
+		default: "2",
+		displayName: "Themes Version",
+		name: "themes",
+		type: "text",
+	},
+];
+
+const fetch = (
+	{ id, schemaName, website_url: websiteUrl, "arc-site": website },
+	{ arcSite }
+) => {
+	if (!schemaName || (!id && !websiteUrl)) {
+		return "";
+	}
+
+	const siteValue = website || arcSite;
+	if (!siteValue) {
+		return "";
+	}
+
+	// Prefer lookup by id when both are provided, matching the content-api source behavior.
+	const useId = Boolean(id);
+	const endpoint = useId
+		? "/content/v5/search/schemas/by-id/"
+		: "/content/v5/search/schemas/by-url/";
+
+	const urlSearch = new URLSearchParams({
+		...(useId ? { id: id.trim() } : { url: websiteUrl.trim() }),
+		schema_name: schemaName.trim(),
+		website: siteValue,
+	});
+
+	return axios({
+		url: `${CONTENT_BASE}${endpoint}?${urlSearch.toString()}`,
+		headers: {
+			"content-type": "application/json",
+			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
+		},
+		method: "GET",
+	})
+		.then(({ data }) => {
+			if (!data || !data.data) {
+				const error = new Error("Document not found");
+				error.statusCode = 404;
+				throw error;
+			}
+			return data.data;
+		})
+		.catch(handleFetchError);
+};
+
+export default {
+	fetch,
+	params,
+	schemaName: "ans-item",
+	ttl: 300,
+};

--- a/blocks/schema-item-content-source-block/sources/schema-item.test.js
+++ b/blocks/schema-item-content-source-block/sources/schema-item.test.js
@@ -1,0 +1,235 @@
+import contentSource from "./schema-item";
+
+jest.mock("fusion:environment", () => ({
+	CONTENT_BASE: "https://content.base",
+}));
+
+jest.mock("axios", () => ({
+	__esModule: true,
+	default: jest.fn((request) => {
+		const requestUrl = new URL(request.url);
+		const url = {
+			hostname: requestUrl.hostname,
+			pathname: requestUrl.pathname,
+			searchObject: Object.fromEntries(requestUrl.searchParams),
+		};
+		if (request.url.includes("404Mode")) {
+			return Promise.resolve({
+				data: null,
+			});
+		}
+		return Promise.resolve({
+			data: {
+				_id: "test-doc",
+				data: {
+					type: "story",
+					request: {
+						...request,
+						url,
+					},
+				},
+			},
+		});
+	}),
+}));
+
+describe("the custom schema item content source block", () => {
+	it("should use the proper param types", () => {
+		expect(contentSource.params).toEqual([
+			{
+				displayName: "Document ID",
+				name: "id",
+				type: "text",
+			},
+			{
+				displayName: "Website URL",
+				name: "website_url",
+				type: "text",
+			},
+			{
+				displayName: "Schema Name",
+				name: "schemaName",
+				type: "text",
+			},
+			{
+				default: "2",
+				displayName: "Themes Version",
+				name: "themes",
+				type: "text",
+			},
+		]);
+	});
+
+	it("should use the proper schema name", () => {
+		expect(contentSource.schemaName).toEqual("ans-item");
+	});
+
+	it("should have the correct ttl", () => {
+		expect(contentSource.ttl).toEqual(300);
+	});
+
+	describe("when id and schemaName are provided with arc-site", () => {
+		it("should build the correct url", async () => {
+			const contentSourceFetch = await contentSource.fetch(
+				{
+					id: "ABC123",
+					schemaName: "my-schema",
+					"arc-site": "the-site",
+				},
+				{ cachedCall: () => {} }
+			);
+
+			expect(contentSourceFetch.request.url.pathname).toEqual(
+				"/content/v5/search/schemas/by-id/"
+			);
+			expect(contentSourceFetch.request.url.searchObject).toEqual(
+				expect.objectContaining({
+					id: "ABC123",
+					schema_name: "my-schema",
+					website: "the-site",
+				})
+			);
+		});
+	});
+
+	describe("when arc-site is not provided", () => {
+		it("should fall back to arcSite from context", async () => {
+			const contentSourceFetch = await contentSource.fetch(
+				{
+					id: "ABC123",
+					schemaName: "my-schema",
+				},
+				{ cachedCall: () => {}, arcSite: "context-site" }
+			);
+
+			expect(contentSourceFetch.request.url.searchObject).toEqual(
+				expect.objectContaining({
+					website: "context-site",
+				})
+			);
+		});
+	});
+
+	describe("when website_url and schemaName are provided with arc-site", () => {
+		it("should build the correct by-url url", async () => {
+			const contentSourceFetch = await contentSource.fetch(
+				{
+					website_url: "/2020/01/17/this-is-a-story/",
+					schemaName: "my-schema",
+					"arc-site": "the-site",
+				},
+				{ cachedCall: () => {} }
+			);
+
+			expect(contentSourceFetch.request.url.pathname).toEqual(
+				"/content/v5/search/schemas/by-url/"
+			);
+			expect(contentSourceFetch.request.url.searchObject).toEqual(
+				expect.objectContaining({
+					url: "/2020/01/17/this-is-a-story/",
+					schema_name: "my-schema",
+					website: "the-site",
+				})
+			);
+		});
+	});
+
+	describe("when both id and website_url are provided", () => {
+		it("should prefer the by-id lookup", async () => {
+			const contentSourceFetch = await contentSource.fetch(
+				{
+					id: "ABC123",
+					website_url: "/2020/01/17/this-is-a-story/",
+					schemaName: "my-schema",
+					"arc-site": "the-site",
+				},
+				{ cachedCall: () => {} }
+			);
+
+			expect(contentSourceFetch.request.url.pathname).toEqual(
+				"/content/v5/search/schemas/by-id/"
+			);
+			expect(contentSourceFetch.request.url.searchObject).toEqual(
+				expect.objectContaining({
+					id: "ABC123",
+				})
+			);
+			expect(contentSourceFetch.request.url.searchObject).not.toHaveProperty("url");
+		});
+	});
+
+	describe("when neither id nor website_url is provided", () => {
+		it("should return empty string", async () => {
+			const contentSourceFetch = await contentSource.fetch(
+				{
+					schemaName: "my-schema",
+					"arc-site": "the-site",
+				},
+				{ cachedCall: () => {} }
+			);
+
+			expect(contentSourceFetch).toEqual("");
+		});
+	});
+
+	describe("when schemaName is not provided", () => {
+		it("should return empty string", async () => {
+			const contentSourceFetch = await contentSource.fetch(
+				{
+					id: "ABC123",
+					"arc-site": "the-site",
+				},
+				{ cachedCall: () => {} }
+			);
+
+			expect(contentSourceFetch).toEqual("");
+		});
+	});
+
+	describe("when no site is available from either source", () => {
+		it("should return empty string", async () => {
+			const contentSourceFetch = await contentSource.fetch(
+				{
+					id: "ABC123",
+					schemaName: "my-schema",
+				},
+				{ cachedCall: () => {} }
+			);
+
+			expect(contentSourceFetch).toEqual("");
+		});
+	});
+
+	describe("when document is not found", () => {
+		it("should throw a 404 error", async () => {
+			await expect(
+				contentSource.fetch(
+					{
+						id: "404Mode",
+						schemaName: "my-schema",
+						"arc-site": "the-site",
+					},
+					{ cachedCall: () => {} }
+				)
+			).rejects.toEqual(new Error("Document not found"));
+		});
+	});
+
+	it("should trim whitespace from id and schemaName", async () => {
+		const contentSourceFetch = await contentSource.fetch(
+			{
+				id: "  ABC123  ",
+				schemaName: "  my-schema  ",
+				"arc-site": "the-site",
+			},
+			{ cachedCall: () => {} }
+		);
+
+		expect(contentSourceFetch.request.url.searchObject).toEqual(
+			expect.objectContaining({
+				id: "ABC123",
+				schema_name: "my-schema",
+			})
+		);
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@wpmedia/results-list-block": "file:blocks/results-list-block",
         "@wpmedia/right-rail-advanced-block": "file:blocks/right-rail-advanced-block",
         "@wpmedia/right-rail-block": "file:blocks/right-rail-block",
+        "@wpmedia/schema-feed-content-source-block": "file:blocks/schema-feed-content-source-block",
         "@wpmedia/search-content-source-block": "file:blocks/search-content-source-block",
         "@wpmedia/search-results-list-block": "file:blocks/search-results-list-block",
         "@wpmedia/section-title-block": "file:blocks/section-title-block",
@@ -585,6 +586,17 @@
       "name": "@wpmedia/right-rail-block",
       "version": "5.16.0",
       "license": "CC-BY-NC-ND-4.0",
+      "peerDependencies": {
+        "@wpmedia/arc-themes-components": "*"
+      }
+    },
+    "blocks/schema-feed-content-source-block": {
+      "name": "@wpmedia/schema-feed-content-source-block",
+      "version": "0.0.1",
+      "license": "CC-BY-NC-ND-4.0",
+      "dependencies": {
+        "axios": "^1.5.1"
+      },
       "peerDependencies": {
         "@wpmedia/arc-themes-components": "*"
       }
@@ -8218,6 +8230,10 @@
     },
     "node_modules/@wpmedia/right-rail-block": {
       "resolved": "blocks/right-rail-block",
+      "link": true
+    },
+    "node_modules/@wpmedia/schema-feed-content-source-block": {
+      "resolved": "blocks/schema-feed-content-source-block",
       "link": true
     },
     "node_modules/@wpmedia/search-content-source-block": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@wpmedia/results-list-block": "file:blocks/results-list-block",
         "@wpmedia/right-rail-advanced-block": "file:blocks/right-rail-advanced-block",
         "@wpmedia/right-rail-block": "file:blocks/right-rail-block",
+        "@wpmedia/schema-item-content-source-block": "file:blocks/schema-item-content-source-block",
         "@wpmedia/search-content-source-block": "file:blocks/search-content-source-block",
         "@wpmedia/search-results-list-block": "file:blocks/search-results-list-block",
         "@wpmedia/section-title-block": "file:blocks/section-title-block",
@@ -587,6 +588,18 @@
       "license": "CC-BY-NC-ND-4.0",
       "peerDependencies": {
         "@wpmedia/arc-themes-components": "*"
+      }
+    },
+    "blocks/schema-item-content-source-block": {
+      "name": "@wpmedia/schema-item-content-source-block",
+      "version": "5.14.1-beta.1",
+      "license": "CC-BY-NC-ND-4.0",
+      "dependencies": {
+        "axios": "^1.5.1"
+      },
+      "peerDependencies": {
+        "@wpmedia/arc-themes-components": "*",
+        "@wpmedia/signing-service-content-source-block": "*"
       }
     },
     "blocks/search-content-source-block": {
@@ -8218,6 +8231,10 @@
     },
     "node_modules/@wpmedia/right-rail-block": {
       "resolved": "blocks/right-rail-block",
+      "link": true
+    },
+    "node_modules/@wpmedia/schema-item-content-source-block": {
+      "resolved": "blocks/schema-item-content-source-block",
       "link": true
     },
     "node_modules/@wpmedia/search-content-source-block": {

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "@wpmedia/results-list-block": "file:blocks/results-list-block",
     "@wpmedia/right-rail-advanced-block": "file:blocks/right-rail-advanced-block",
     "@wpmedia/right-rail-block": "file:blocks/right-rail-block",
+    "@wpmedia/schema-item-content-source-block": "file:blocks/schema-item-content-source-block",
     "@wpmedia/search-content-source-block": "file:blocks/search-content-source-block",
     "@wpmedia/search-results-list-block": "file:blocks/search-results-list-block",
     "@wpmedia/section-title-block": "file:blocks/section-title-block",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "arc-themes-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "private": true,
+  "themesVersion": "4.2.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
@@ -23,7 +24,7 @@
     "generate:feature:feature": "hygen feature feature",
     "generate:intl": "node locale/scripts/generate-intl.js",
     "lint": "eslint --ext js --ext jsx blocks .storybook --no-error-on-unmatched-pattern",
-    "lint:changed-feature-branch": "eslint --max-warnings 0 --no-error-on-unmatched-pattern $(git diff --name-only origin/arc-themes-release-version-4.1.0 | grep -E \"(.js$|.jsx$)\" || echo \"no js/jsx files changed\")",
+    "lint:changed-feature-branch": "FILES=$(git diff --name-only origin/main -- '*.js' '*.jsx'); if [ -n \"$FILES\" ]; then eslint --max-warnings 0 --no-error-on-unmatched-pattern $FILES; else echo 'No JS/JSX files changed'; fi",
     "lint:changed-feature-branch:fix": "npm run lint:changed-feature-branch -- --fix",
     "lint:fix": "npm run lint -- --fix",
     "lint:styles": "stylelint '**/*.scss' --formatter verbose",
@@ -32,7 +33,7 @@
     "-ignore-prepare": "husky install",
     "storybook": "storybook dev -p 6006",
     "test": "jest",
-    "test:changed-feature-branch": "jest --changedSince=origin/arc-themes-release-version-4.1.0 --coverage --passWithNoTests",
+    "test:changed-feature-branch": "jest --changedSince=origin/main --coverage --passWithNoTests",
     "test:coverage": "jest --coverage",
     "test:watch": "npm run test -- --watch -o --coverage"
   },

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "@wpmedia/results-list-block": "file:blocks/results-list-block",
     "@wpmedia/right-rail-advanced-block": "file:blocks/right-rail-advanced-block",
     "@wpmedia/right-rail-block": "file:blocks/right-rail-block",
+    "@wpmedia/schema-feed-content-source-block": "file:blocks/schema-feed-content-source-block",
     "@wpmedia/search-content-source-block": "file:blocks/search-content-source-block",
     "@wpmedia/search-results-list-block": "file:blocks/search-results-list-block",
     "@wpmedia/section-title-block": "file:blocks/section-title-block",


### PR DESCRIPTION
## Description

New Block: schema-feed-content-source-block

#### Jira Ticket: [MD_359](https://arcpublishing.atlassian.net/browse/MD-359)

  - Adds a new content source block (@wpmedia/schema-feed-content-source-block) that integrates with the v5 schema search endpoint
  for fetching schema-based feed content
  - Supports configurable parameters including schemaName, size, page, sortBy and query param
  - Includes full unit test coverage, jest config, and .npmignore
  - Registered in root package.json workspace

## Test Steps

  1. Checkout this branch git checkout MD-359
  2. Run npm install
  3. Run npm test — verify all tests pass, including the new schema-feed-content-source-block tests
  4. Run npm run lint — verify no linting errors
  5. For actually testing pagebuilder block rendering, you can follow Blake's docuement [here](https://arcpublishing.atlassian.net/wiki/spaces/MEDIAOS/pages/6976765978/Testing+Custom+Content+Type+Blocks)
