### PR TITLE
updated themes release process

### DIFF
--- a/.github/workflows/arc-themes-base-to-new-tag.yml
+++ b/.github/workflows/arc-themes-base-to-new-tag.yml
@@ -20,14 +20,14 @@ jobs:
         id: check-target-tag
         run: |
           if [[ ${{ github.event.inputs.target_release_tag }} =~ ^([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
-              echo ::set-output name=match::true
+              echo "match=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check new release tag name
         id: check-new-tag
         run: |
           if [[ ${{ github.event.inputs.new_release_tag }} =~ ^([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
-              echo ::set-output name=match::true
+              echo "match=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Validate release tag numbers
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node and NPM
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,19 +18,19 @@ jobs:
     # Job steps
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # 👈 Required to retrieve git history
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/generate-intl-files.yml
+++ b/.github/workflows/generate-intl-files.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,0 +1,70 @@
+name: Publish hotfix for previous themes version
+# Usage:
+#   1. Find the tag for the version to hotfix: git tag -l "themes-v*"
+#   2. Create a hotfix branch from that tag: git checkout -b hotfix/4.1.0 themes-v4.1.0
+#   3. Make your fix, commit, and push the branch
+#   4. This workflow runs automatically and publishes under the original dist-tag
+
+on:
+  push:
+    branches:
+      - "hotfix/[0-9]+.[0-9]+"
+      - "hotfix/[0-9]+.[0-9]+.[0-9]+"
+    paths:
+      - "**.js"
+      - "**.json"
+      - "**.jsx"
+      - "**.scss"
+      - "**/intl.json"
+      - "**/README.md"
+
+jobs:
+  publish-hotfix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull tags to give lerna access to git info
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+      - name: Extract version from branch name
+        id: hotfix-version
+        run: |
+          # Branch name is hotfix/X.Y.Z — extract the version part
+          VERSION="${GITHUB_REF_NAME#hotfix/}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=arc-themes-release-version-${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: Cache Node Modules
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Clean install (CI) dependencies if lockfile (above) changed
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run all tests
+        run: npm run test
+
+      - name: Publish hotfix to target tag
+        run: |
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --local user.name "$GITHUB_ACTOR"
+          npx lerna publish --dist-tag ${{ steps.hotfix-version.outputs.dist_tag }} --canary --preid ${{ steps.hotfix-version.outputs.dist_tag }} -y
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -3,13 +3,11 @@ name: "Code security scanning"
 on:
   push:
     branches:
-      - arc-themes-release-version-[0-9]+\.[0-9]+
-      - arc-themes-release-version-[0-9]+\.[0-9]+\.[0-9]+
+      - main
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
-      - arc-themes-release-version-[0-9]+\.[0-9]+
-      - arc-themes-release-version-[0-9]+\.[0-9]+\.[0-9]+
+      - main
 
 jobs:
   analyze:
@@ -27,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/stylelint-pr.yml
+++ b/.github/workflows/stylelint-pr.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Rep
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/sync-themes-branch-with-themes-tag.yml
+++ b/.github/workflows/sync-themes-branch-with-themes-tag.yml
@@ -1,12 +1,8 @@
-name: Publish to themes target tag based off of themes branch name
+name: Publish to themes target tag on merge to main
 on:
   push:
     branches:
-      # only run on branch names that match:
-      # arc-themes-release-version-{numbers}.{numbers} per product
-      - arc-themes-release-version-[0-9]+\.[0-9]+
-      # arc-themes-release-version-{numbers}.{numbers}.{numbers} per product
-      - arc-themes-release-version-[0-9]+\.[0-9]+\.[0-9]+
+      - main
     # only run on changes to these files
     paths:
       - "**.js"
@@ -19,11 +15,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    env:
-      SYNCED_RELEASE_TAG: ${{ github.ref_name }} # targets branch name ref_name
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -32,15 +26,34 @@ jobs:
       - name: Pull tags to give lerna access to git info
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
+      - name: Read themesVersion from package.json
+        id: themes-version
+        run: |
+          THEMES_VERSION=$(node -p "require('./package.json').themesVersion")
+          echo "version=$THEMES_VERSION" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=arc-themes-release-version-${THEMES_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if themesVersion changed
+        id: version-changed
+        run: |
+          PREV_VERSION=$(git show HEAD~1:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).themesVersion" 2>/dev/null || echo "")
+          CURR_VERSION=${{ steps.themes-version.outputs.version }}
+          if [ "$PREV_VERSION" != "$CURR_VERSION" ] && [ -n "$PREV_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "previous_version=$PREV_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
@@ -54,11 +67,22 @@ jobs:
       - name: Run all tests
         run: npm run test
 
+      # Tag the previous version's final commit before publishing under the new version
+      - name: Tag previous themes version
+        if: steps.version-changed.outputs.changed == 'true'
+        run: |
+          PREV_TAG="themes-v${{ steps.version-changed.outputs.previous_version }}"
+          # Tag the commit before the version bump (parent of current HEAD)
+          git tag "$PREV_TAG" HEAD~1
+          git push origin "$PREV_TAG"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # See confluence pages https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/2983788608/How+To+Do+Product-Facing+Tag+Release and https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/3013541978/Github+Actions+for+NodeJS+Standards+Best+Practices for documentation
-      - name: Publish to target tag based off of branch name
+      - name: Publish to target tag based off of themesVersion
         run: |
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git config --local user.name "$GITHUB_ACTOR"
-          npx lerna publish --dist-tag ${{ env.SYNCED_RELEASE_TAG }} --canary --preid ${{ env.SYNCED_RELEASE_TAG }} -y
+          npx lerna publish --dist-tag ${{ steps.themes-version.outputs.dist_tag }} --canary --preid ${{ steps.themes-version.outputs.dist_tag }} -y
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-coverage-blocks.yml
+++ b/.github/workflows/test-coverage-blocks.yml
@@ -1,14 +1,11 @@
-name: Test Blocks And Linting - Changed from themes release base
+name: Test Blocks And Linting - Changed from main
 
 on:
   pull_request:
     # synchronize	commit(s) pushed to the pull request
     types: [synchronize, opened]
     branches:
-      # arc-themes-release-version-{numbers}.{numbers} per product
-      - arc-themes-release-version-[0-9]+\.[0-9]+
-      # arc-themes-release-version-{numbers}.{numbers}.{numbers} per product
-      - arc-themes-release-version-[0-9]+\.[0-9]+\.[0-9]+
+      - main
 
 jobs:
   ensure_minimum_test_coverage_linting:
@@ -18,20 +15,20 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           #  0 indicates all history for all branches and tags
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://npm.pkg.github.com"
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
@@ -42,10 +39,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests on changed since base themes release
+      - name: Run tests on changed since main
         run: npm run test:changed-feature-branch
 
-      - name: Check linting of changed since base themes release
+      - name: Check linting of changed since main
         run: npm run lint:changed-feature-branch
 
       - name: Check failure status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,130 +2,89 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## What This Is
+
+A Lerna monorepo of ~79 Arc Themes blocks published to GitHub Packages (`@wpmedia/*`). Blocks are React components that run inside Arc's Fusion rendering engine. The repo uses independent versioning per block, but all blocks are published together under a shared themes release dist-tag.
+
 ## Commands
 
 ```bash
-# Testing
-npm test                                # run all tests
-npm run test:coverage                   # run with coverage report
-npm run test:watch                      # watch mode (only changed files)
-npm run test:changed-feature-branch    # test only files changed vs origin/arc-themes-release-version-4.1.0
+npm run test                       # Run all tests (jest)
+npm run test -- --testPathPattern=blocks/header-block  # Run tests for one block
+npm run test:watch                 # Watch mode with coverage for changed files
+npm run test:changed-feature-branch # Tests for files changed vs origin/main
 
-# Run a single test file
-npx jest blocks/large-promo-block/features/large-promo/default.test.jsx
+npm run lint                       # ESLint all blocks
+npm run lint:changed-feature-branch # ESLint only files changed vs origin/main
+npm run lint:styles                # Stylelint all SCSS
+npm run lint:styles:fix            # Auto-fix SCSS issues
 
-# Linting
-npm run lint                            # ESLint on blocks/ and .storybook/
-npm run lint:fix                        # auto-fix lint issues
-npm run lint:changed-feature-branch    # lint only changed files vs origin branch
-
-# Formatting
-npm run format                          # Prettier (uses tabs, width 100)
-
-# Storybook
-npm run storybook                       # dev server on port 6006
-npm run build-storybook                 # static build for Chromatic
-
-# Code generation (Hygen templates)
-npm run generate:chain                  # scaffold a new chain block
-npm run generate:feature                # scaffold a new feature block
-npm run generate:content-source         # scaffold a new content source block
+npm run storybook                  # Dev server on port 6006
+npm run format                     # Prettier (uses tabs)
 ```
 
-Node version: 20 (see `.nvmrc`).
+## Release Process
+
+Trunk-based development on `main`. The `themesVersion` field in root `package.json` controls which dist-tag blocks publish under (e.g., `"themesVersion": "4.1.0"` → dist-tag `arc-themes-release-version-4.1.0`).
+
+- **Every merge to `main`** that touches block code auto-publishes via `lerna publish --canary`
+- **Version bump**: change `themesVersion` in a PR; on merge the workflow auto-tags the previous version (e.g., `themes-v4.1.0`) and starts publishing under the new one
+- **Hotfix**: create `hotfix/X.Y.Z` branch from the `themes-vX.Y.Z` tag, push fix, it auto-publishes
 
 ## Architecture
 
-### Monorepo Structure
+### Block Types
 
-This is a Lerna monorepo of 78 independent npm packages under `blocks/`. Each package (`@wpmedia/*-block`) is a self-contained **Arc XP Fusion block** published to GitHub's npm registry.
+Blocks live in `blocks/` and come in four types, each with a corresponding subdirectory:
+- **features/** — UI components (header, promo cards, article body)
+- **chains/** — layout containers that wrap features
+- **sources/** — content sources that fetch data from Arc APIs
+- **output-types/** — page-level output wrappers
 
-The four block types:
+### Block Structure
 
-| Type | Location within block | Purpose |
-|---|---|---|
-| **Feature** | `features/<name>/default.jsx` | Leaf React components rendered on a page |
-| **Chain** | `chains/<name>/default.jsx` | Compositions that arrange features/children |
-| **Layout** | `layouts/<name>/default.jsx` | Full-page structural wrappers with named sections |
-| **Content Source** | `sources/<name>.js` | Data-fetching functions (not React components) |
+Each block is an independent npm package (`@wpmedia/<name>`) with:
+- `features/` or `chains/` or `sources/` containing `default.jsx` + `default.test.jsx`
+- `_index.scss` — styles using BEM naming (`b-block-name`, `b-block-name--variant`)
+- `themes/*.json` — theme token mappings (news.json, commerce.json)
+- `intl.json` — i18n translations (generated from `locale/` via `npm run generate:intl`)
+- `jest.config.js` — extends `../../jest/jest.config.base`
+- `index.story.jsx` — Storybook story
 
-A single block package can contain multiple of these types. Block-level `package.json` files list which directories to publish (`features`, `chains`, `layouts`, `sources`, `themes`, `_index.scss`, `intl.json`).
+### Fusion Integration
 
-### Fusion Framework Integration
+Blocks import from virtual Fusion modules that don't exist on disk — they're provided by the Fusion runtime and mocked in tests via babel module-resolver (`babel.config.js` → `jest/mocks/`):
+- `fusion:content` — `useContent`, `useEditableContent`
+- `fusion:context` — `useFusionContext`, `useAppContext`
+- `fusion:properties` — `getProperties`
+- `fusion:environment` — `RESIZER_TOKEN_VERSION`, `resizerKey`, etc.
+- `fusion:intl` — `usePhrases`
 
-Blocks run inside **Arc XP Fusion**, which injects framework dependencies via `fusion:*` import aliases. These are never installed as npm packages — Fusion resolves them at runtime:
+### Shared Dependencies
 
-- `fusion:content` — `useContent()`, `useEditableContent()` hooks for fetching CMS data
-- `fusion:context` — `useFusionContext()`, `useComponentContext()`, `useAppContext()`
-- `fusion:properties` — `getProperties()` for site-specific configuration
-- `fusion:environment` — env vars like `CONTENT_BASE`, `RESIZER_TOKEN_VERSION`
-- `fusion:themes` — theme injection
-- `fusion:intl` — i18n phrase lookups
+- `@wpmedia/arc-themes-components` — shared component library (LazyLoad, Image, etc.)
+- `@arc-fusion/prop-types` — prop-type helpers with `.tag()` for PageBuilder metadata and `.contentConfig()` for content source config
 
-In tests, `babel.config.js` aliases these to mocks under `jest/mocks/`. In Storybook, `.storybook/alias/` provides stubs. When writing tests, mock them with `jest.mock("fusion:properties", () => jest.fn(() => ({ ... })))`.
+### Testing Patterns
 
-### Component Library
-
-All feature/chain/layout components import UI primitives from `@wpmedia/arc-themes-components` (a peer dependency, not in this repo). Import everything from that single package: `Image`, `Heading`, `Link`, `Stack`, `Grid`, `usePhrases`, `formatURL`, etc.
-
-### Feature Component Pattern
-
-Feature components separate data-fetching from presentation:
-- The **default export** is the Fusion-connected component that calls `useContent()` and `getProperties()`, then passes resolved data as props.
-- A named **`*Presentation`** export is the pure React component used in tests and Storybook.
-
-```jsx
-export const LargePromoPresentation = ({ contentHeading, ... }) => { ... };
-
-const LargePromo = (props) => {
-  const content = useContent({ ... });
-  return <LargePromoPresentation contentHeading={content?.headlines?.basic} ... />;
-};
-
-export default LargePromo;
-```
-
-### Content Sources
-
-Content source files export a plain object (not a React component):
-
+Tests use React Testing Library. Common mocking pattern:
 ```js
-export default {
-  fetch: (params, { cachedCall }) => Promise,
-  params: [{ name: "query", displayName: "Query", type: "text" }],
-  schemaName: "ans-feed",
-};
+jest.mock("fusion:content", () => ({ useContent: jest.fn(() => ({})) }));
+jest.mock("@wpmedia/arc-themes-components", () => ({
+  ...jest.requireActual("@wpmedia/arc-themes-components"),
+  isServerSide: jest.fn(() => false),
+  LazyLoad: ({ children }) => children,
+}));
 ```
 
-### Static Properties for Fusion Registration
+### Styling Rules
 
-Fusion discovers blocks by scanning the filesystem; there is no explicit registry. Components declare metadata via static properties:
-
-```jsx
-Component.label = "Large Promo – Arc Block";
-Component.icon = "picture-feature";
-Component.propTypes = { customFields: PropTypes.shape({ ... }) };
-// Layouts and chains also declare:
-Component.sections = ["navigation", "body", "footer"];
-```
-
-### Theming
-
-Each block has `themes/news.json` and `themes/commerce.json` defining CSS variable overrides per theme. Styles use a BEM-like class naming: blocks use a `BLOCK_CLASS_NAME` constant (`b-<block-name>`).
-
-### Internationalization
-
-Each block has an `intl.json` file with phrase keys and translations. Phrases are consumed via `usePhrases()` from `@wpmedia/arc-themes-components`. The source of truth is Lokalise; `npm run generate:intl` regenerates `intl.json` files from `locale/`.
-
-### Testing Conventions
-
-- Test files live **co-located** with source: `default.test.jsx` next to `default.jsx`
-- Test the **`*Presentation`** component, not the default Fusion-connected export
-- Use React Testing Library with semantic queries (`screen.getByRole`, `screen.getByText`)
-- Each block has its own `jest.config.js` that extends `../../jest/jest.config.base.js`
-- `jest.resetModules()` runs `beforeEach` — each test gets a fresh module registry
-- Coverage thresholds enforced globally: 53% statements, 66% branches, 44% functions, 54% lines
+- CSS logical properties are enforced (use `margin-inline-start` not `margin-left`)
+- Max nesting depth: 5
+- No vendor prefixes
+- `border: none` is disallowed (use `border: 0`)
+- SCSS `@include` calls on the parent selector must precede nested `&` rules (sass 1.92+ hoisting requirement)
 
 ### Code Generation
 
-The Hygen generators under `_templates/` scaffold complete block packages including component, test, Storybook story, SCSS, `package.json`, `intl.json`, and `jest.config.js`. Always prefer generating a new block via `npm run generate:*` rather than copying manually.
+New blocks are scaffolded with hygen: `npm run generate:feature`, `npm run generate:chain`, `npm run generate:content-source`. Variants exist for adding features/sources to existing blocks.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Fixes any stylelint issues that can be fixed automatically from the files mentio
 
 ### `npm run lint:changed-feature-branch`
 
-Similar to `npm run test:changed-feature-branch`, this runs on pre-push and within the GitHub Workflow. It will run `eslint` on all code that have changed since the last commit on the target release branch. See the `.eslintignore` and the `.eslintrc.js` for the configuration.
+Similar to `npm run test:changed-feature-branch`, this runs on pre-push and within the GitHub Workflow. It will run `eslint` on all code that have changed since `origin/main`. See the `.eslintignore` and the `.eslintrc.js` for the configuration.
 
 ### `npm run lint:changed-feature-branch:fix`
 
@@ -82,7 +82,7 @@ Run all tests for code that has changed. Will also show coverage for changed cod
 
 ### `npm run test:changed-feature-branch`
 
-Similar to `npm run test:watch`, but will run tests for all blocks that have changed since the last commit on the target release branch. This should be updated with each new version `"jest --changedSince=origin/arc-themes-release-version-2.0.3 --coverage --passWithNoTests",` -> `"jest --changedSince=origin/arc-themes-release-version-2.0.4 --coverage --passWithNoTests",` for `2.0.3` -> `2.0.4`. This runs in the [GitHub Workflow for testing blocks on Pull Requests](./.github/workflows/test-coverage-blocks.yml). It also runs on pre-push using [Husky](https://github.com/typicode/husky#usage). Note that the Husky pre-push file is located in [root](./.husky/pre-push) and not in the package.json, per version 7 of Husky.
+Runs tests for all blocks that have changed since `origin/main`. This runs in the [GitHub Workflow for testing blocks on Pull Requests](./.github/workflows/test-coverage-blocks.yml). It also runs on pre-push using [Husky](https://github.com/typicode/husky#usage). Note that the Husky pre-push file is located in [root](./.husky/pre-push) and not in the package.json, per version 7 of Husky.
 
 ## Storybook Setup
 
@@ -99,13 +99,64 @@ registry=https://registry.npmjs.org
 3. `npm i` to install packages
 4. `npm run storybook` to show the blocks in Storybook. For more info on Storybook, see [their documentation](https://storybook.js.org/docs/react/get-started/introduction). In confluence, we have Storybook best practices as well for themes.
 
+## Releasing
+
+This repo uses trunk-based development. All work is merged into `main`, and the `themesVersion` field in the root `package.json` determines which themes release version blocks are published under.
+
+### Publishing blocks (automatic)
+
+Every merge to `main` that changes block code (`.js`, `.jsx`, `.json`, `.scss`) triggers the [publish workflow](./.github/workflows/sync-themes-branch-with-themes-tag.yml). It reads `themesVersion` from `package.json` and publishes all changed blocks to GitHub Packages under the dist-tag `arc-themes-release-version-<themesVersion>`.
+
+No manual steps are needed — just merge your PR and blocks are published.
+
+### Bumping to a new themes version
+
+When you're ready to start a new themes release (e.g., moving from `4.1.0` to `4.2.0`):
+
+1. Create a PR that changes `themesVersion` in `package.json` from `"4.1.0"` to `"4.2.0"`
+2. Merge the PR into `main`
+3. The publish workflow will automatically:
+   - Tag the previous version's final commit as `themes-v4.1.0`
+   - Begin publishing blocks under `arc-themes-release-version-4.2.0`
+
+That's it. The git tag provides a permanent record of exactly which commit was the last publish for each version, and can be used to view history or create hotfix branches later.
+
+```bash
+# View what shipped in a specific version
+git log themes-v4.0.0..themes-v4.1.0
+
+# View what's been published in the current version so far
+git log themes-v4.1.0..main
+```
+
+### Hotfixing a previous version
+
+Hotfixes are for the rare case when you need to patch a version you've already moved past. A dedicated [hotfix workflow](./.github/workflows/hotfix.yml) handles publishing.
+
+1. Find the tag for the version you need to fix:
+   ```bash
+   git tag -l "themes-v*"
+   ```
+
+2. Create a hotfix branch from that tag:
+   ```bash
+   git checkout -b hotfix/4.1.0 themes-v4.1.0
+   ```
+
+3. Make your fix, commit, and push:
+   ```bash
+   git push -u origin hotfix/4.1.0
+   ```
+
+4. The hotfix workflow runs automatically and publishes the fix under the original dist-tag (`arc-themes-release-version-4.1.0`).
+
+> **Note:** Hotfix branches are not merged back into `main`. If the fix is also needed on `main`, cherry-pick it into a separate PR targeting `main`.
+
 ## `dist-tags`
 
 Please see the [release notes in Confluence](https://arcpublishing.atlassian.net/wiki/spaces/TI/pages/2344910925/Themes+Releases) if you are a Themes developer.
 
-This package has been published with a number of dist-tags meant for different purposes:
-
-- `arc-themes-release-version-X.XX` - These are versioned versions of all blocks for a given release cycle in the [Theme Manifest repo](https://github.com/WPMedia/arc-themes-manifests).
+Blocks are published with dist-tags in the format `arc-themes-release-version-X.Y.Z`, corresponding to the `themesVersion` in `package.json` at the time of publish. These are used in the [Theme Manifest repo](https://github.com/WPMedia/arc-themes-manifests).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "arc-themes-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "private": true,
+  "themesVersion": "4.1.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
@@ -23,7 +24,7 @@
     "generate:feature:feature": "hygen feature feature",
     "generate:intl": "node locale/scripts/generate-intl.js",
     "lint": "eslint --ext js --ext jsx blocks .storybook --no-error-on-unmatched-pattern",
-    "lint:changed-feature-branch": "eslint --max-warnings 0 --no-error-on-unmatched-pattern $(git diff --name-only origin/arc-themes-release-version-4.1.0 | grep -E \"(.js$|.jsx$)\" || echo \"no js/jsx files changed\")",
+    "lint:changed-feature-branch": "FILES=$(git diff --name-only origin/main -- '*.js' '*.jsx'); if [ -n \"$FILES\" ]; then eslint --max-warnings 0 --no-error-on-unmatched-pattern $FILES; else echo 'No JS/JSX files changed'; fi",
     "lint:changed-feature-branch:fix": "npm run lint:changed-feature-branch -- --fix",
     "lint:fix": "npm run lint -- --fix",
     "lint:styles": "stylelint '**/*.scss' --formatter verbose",
@@ -32,7 +33,7 @@
     "-ignore-prepare": "husky install",
     "storybook": "storybook dev -p 6006",
     "test": "jest",
-    "test:changed-feature-branch": "jest --changedSince=origin/arc-themes-release-version-4.1.0 --coverage --passWithNoTests",
+    "test:changed-feature-branch": "jest --changedSince=origin/main --coverage --passWithNoTests",
     "test:coverage": "jest --coverage",
     "test:watch": "npm run test -- --watch -o --coverage"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arc-themes-blocks",
   "license": "CC-BY-NC-ND-4.0",
   "private": true,
-  "themesVersion": "4.1.0",
+  "themesVersion": "4.2.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"


### PR DESCRIPTION
**Be sure to run `npm test`, `npm run lint`, and write detailed test steps before requesting reviewers**

## Description

#### Jira Ticket: [THEMES-](https://arcpublishing.atlassian.net/browse/THEMES-)

  Summary
                                                                                                  
  - Moves from branch-based versioning (arc-themes-release-version-X.Y.Z branches) to trunk-based
  development on main                                                                             
  - Adds themesVersion field to root package.json as the single source of truth for which dist-tag
   blocks publish under                                                                           
  - Publish workflow now triggers on merge to main and reads the version from package.json instead
   of the branch name                                                                             
  - Automatically tags the previous version's final commit (e.g., themes-v4.1.0) when
  themesVersion is bumped, enabling git log between versions                                      
  - Adds a new hotfix.yml workflow for rare patches to old versions — create a hotfix/X.Y.Z branch
   from the version tag and push                                                                  
  - Updates test:changed-feature-branch and lint:changed-feature-branch scripts to diff against
  origin/main instead of a hardcoded release branch                                               
  - Bumps all GitHub Actions to current versions (checkout/setup-node/cache v3→v4, codeql
  v1/v2→v3)                                                                                       
  - Fixes deprecated ::set-output syntax in arc-themes-base-to-new-tag.yml
  - Fixes lint:changed-feature-branch script to skip eslint cleanly when no JS/JSX files changed  
  - Adds CLAUDE.md for AI-assisted development context                                            
  - Updates README with release, version bump, and hotfix instructions                            
          

## Test Steps

  - Verify publish workflow triggers on push to main and reads themesVersion correctly
  - Verify PR checks (test coverage, security scan, stylelint) trigger on PRs to main
  - Test version bump: change themesVersion in package.json, confirm previous version gets tagged 
  - Test hotfix flow: create hotfix/X.Y.Z branch from a version tag, push, confirm publish        
  - Verify npm run test:changed-feature-branch and npm run lint:changed-feature-branch work       
  against origin/main                                                                             
  - Confirm arc-themes-base-to-new-tag.yml retag workflow still functions with GITHUB_OUTPUT      
  syntax     
